### PR TITLE
fix(client): expose Client struct for provider to use

### DIFF
--- a/client/api.go
+++ b/client/api.go
@@ -10,18 +10,18 @@ const (
 
 // WithApiV2 configures the client to use the API version 2 (/api/v2)
 func WithApiV2() Option {
-	return clientFunc(func(c *client) error {
+	return clientFunc(func(c *Client) error {
 		c.apiVersion = "v2"
 		return nil
 	})
 }
 
 // ApiVersion returns the API client version
-func (c *client) ApiVersion() string {
+func (c *Client) ApiVersion() string {
 	return c.apiVersion
 }
 
 // apiPath builds a path by using the current API version
-func (c *client) apiPath(p string) string {
+func (c *Client) apiPath(p string) string {
 	return fmt.Sprintf("/api/%s/%s", c.apiVersion, p)
 }

--- a/client/auth.go
+++ b/client/auth.go
@@ -15,7 +15,7 @@ type authConfig struct {
 
 // WithApiKeys sets the key_id and secret used to generate API access tokens
 func WithApiKeys(id, secret string) Option {
-	return clientFunc(func(c *client) error {
+	return clientFunc(func(c *Client) error {
 		if c.auth == nil {
 			c.auth = &authConfig{}
 		}
@@ -28,7 +28,7 @@ func WithApiKeys(id, secret string) Option {
 // WithTokenFromKeys sets the API access keys and triggers a new token generation
 // NOTE: Order matters when using this option, use it at the end of the New() func
 func WithTokenFromKeys(id, secret string) Option {
-	return clientFunc(func(c *client) error {
+	return clientFunc(func(c *Client) error {
 		if c.auth == nil {
 			c.auth = &authConfig{}
 		}
@@ -40,7 +40,7 @@ func WithTokenFromKeys(id, secret string) Option {
 
 // WithToken sets the token used to authenticate the API requests
 func WithToken(token string) Option {
-	return clientFunc(func(c *client) error {
+	return clientFunc(func(c *Client) error {
 		c.auth.token = token
 		return nil
 	})
@@ -48,14 +48,14 @@ func WithToken(token string) Option {
 
 // WithExpirationTime configures the token expiration time
 func WithExpirationTime(t int) Option {
-	return clientFunc(func(c *client) error {
+	return clientFunc(func(c *Client) error {
 		c.auth.expiration = t
 		return nil
 	})
 }
 
 // GenerateToken generates a new access token
-func (c *client) GenerateToken() (response tokenResponse, err error) {
+func (c *Client) GenerateToken() (response tokenResponse, err error) {
 	if c.auth.keyID == "" || c.auth.secret == "" {
 		err = fmt.Errorf("unable to generate access token: auth keys missing")
 		return
@@ -80,7 +80,7 @@ func (c *client) GenerateToken() (response tokenResponse, err error) {
 }
 
 // GenerateTokenWithKeys generates a new access token with the provided keys
-func (c *client) GenerateTokenWithKeys(keyID, secretKey string) (tokenResponse, error) {
+func (c *Client) GenerateTokenWithKeys(keyID, secretKey string) (tokenResponse, error) {
 	c.auth.keyID = keyID
 	c.auth.secret = secretKey
 	return c.GenerateToken()

--- a/client/auth_internal_test.go
+++ b/client/auth_internal_test.go
@@ -7,14 +7,14 @@ import (
 )
 
 func TestApiPath(t *testing.T) {
-	c1 := &client{apiVersion: "v1"}
+	c1 := &Client{apiVersion: "v1"}
 	assert.Equal(t, "/api/v1/foo", c1.apiPath("foo"), "api path mismatch")
 	assert.Equal(t,
 		"/api/v1/access/tokens",
 		c1.apiPath(apiTokens),
 		"token api path mismatch")
 
-	c2 := &client{apiVersion: "v2"}
+	c2 := &Client{apiVersion: "v2"}
 	assert.Equal(t, "/api/v2/bar", c2.apiPath("bar"), "api path mismatch")
 	assert.Equal(t,
 		"/api/v2/external/integrations",

--- a/client/client.go
+++ b/client/client.go
@@ -9,7 +9,7 @@ import (
 
 const defaultTimeout = 10 * time.Second
 
-type client struct {
+type Client struct {
 	account    string
 	apiVersion string
 	baseURL    *url.URL
@@ -18,12 +18,12 @@ type client struct {
 }
 
 type Option interface {
-	apply(c *client) error
+	apply(c *Client) error
 }
 
-type clientFunc func(c *client) error
+type clientFunc func(c *Client) error
 
-func (fn clientFunc) apply(c *client) error {
+func (fn clientFunc) apply(c *Client) error {
 	return fn(c)
 }
 
@@ -35,13 +35,13 @@ func (fn clientFunc) apply(c *client) error {
 //   if err == nil {
 //       lacework.GetIntegrations()
 //   }
-func New(account string, opts ...Option) (*client, error) {
+func New(account string, opts ...Option) (*Client, error) {
 	baseURL, err := url.Parse(fmt.Sprintf("https://%s.lacework.net", account))
 	if err != nil {
 		return nil, err
 	}
 
-	c := &client{
+	c := &Client{
 		account:    account,
 		baseURL:    baseURL,
 		apiVersion: "v1",
@@ -62,7 +62,7 @@ func New(account string, opts ...Option) (*client, error) {
 
 // WithURL sets the base URL, this options is only available for test purposes
 func WithURL(baseURL string) Option {
-	return clientFunc(func(c *client) error {
+	return clientFunc(func(c *Client) error {
 		u, err := url.Parse(baseURL)
 		if err != nil {
 			return err

--- a/client/http.go
+++ b/client/http.go
@@ -9,7 +9,7 @@ import (
 )
 
 // NewRequest generates a new http request
-func (c *client) NewRequest(method string, apiURL string, body io.Reader) (*http.Request, error) {
+func (c *Client) NewRequest(method string, apiURL string, body io.Reader) (*http.Request, error) {
 	apiPath, err := url.Parse(c.apiPath(apiURL))
 	if err != nil {
 		return nil, err
@@ -59,7 +59,7 @@ func (c *client) NewRequest(method string, apiURL string, body io.Reader) (*http
 
 // DoDecoder is used to execute (aka Do) the http request and
 // decode it into the provided interface, all at once
-func (c *client) DoDecoder(req *http.Request, v interface{}) (*http.Response, error) {
+func (c *Client) DoDecoder(req *http.Request, v interface{}) (*http.Response, error) {
 	res, err := c.Do(req)
 	if err != nil {
 		return nil, err
@@ -90,7 +90,7 @@ func (c *client) DoDecoder(req *http.Request, v interface{}) (*http.Response, er
 
 // requestDecoder performs an http request on an endpoint, and
 // decodes the response into the provided interface, all at once
-func (c *client) RequestDecoder(method, path string, body io.Reader, v interface{}) error {
+func (c *Client) RequestDecoder(method, path string, body io.Reader, v interface{}) error {
 	request, err := c.NewRequest(method, path, body)
 	if err != nil {
 		return err
@@ -106,6 +106,6 @@ func (c *client) RequestDecoder(method, path string, body io.Reader, v interface
 }
 
 // Do calls request.Do() directly
-func (c *client) Do(req *http.Request) (*http.Response, error) {
+func (c *Client) Do(req *http.Request) (*http.Response, error) {
 	return c.c.Do(req)
 }

--- a/client/integrations.go
+++ b/client/integrations.go
@@ -6,18 +6,18 @@ import (
 )
 
 // GetIntegrations lists the external integrations available on the server
-func (c *client) GetIntegrations() (response integrationsResponse, err error) {
+func (c *Client) GetIntegrations() (response integrationsResponse, err error) {
 	err = c.RequestDecoder("GET", apiIntegrations, nil, &response)
 	return
 }
 
-func (c *client) GetGCPIntegrations() (response gcpIntegrationsResponse, err error) {
+func (c *Client) GetGCPIntegrations() (response gcpIntegrationsResponse, err error) {
 	return
 }
-func (c *client) GetAzureIntegrations() (response azureIntegrationsResponse, err error) {
+func (c *Client) GetAzureIntegrations() (response azureIntegrationsResponse, err error) {
 	return
 }
-func (c *client) GetAwsIntegrations() (response awsIntegrationsResponse, err error) {
+func (c *Client) GetAWSIntegrations() (response awsIntegrationsResponse, err error) {
 	return
 }
 


### PR DESCRIPTION
Basic requirement from Terraform-Provider-Lacework -> cast `interface{}` into your client

This is how we set it up on provider.go:
```golang
func providerConfigure(d *schema.ResourceData) (interface{}, error) {
	client, err := client.New(
		d.Get("account").(string),
		client.WithApiKeys(d.Get("key_id").(string), d.Get("secret").(string)),
	)
	if err != nil {
		return nil, err
	}

	return client, nil
}
```

Example:
```golang
func resourceLaceworkIntegrationAWSCFGCreate(d *schema.ResourceData, meta interface{}) error {
	client := meta.(*client.Client)
	client.GetIntegrations()
	return nil
}
```

I think exposing Client should be enough. I don't think we need to do anything extravagant:
```golang
type Client struct {
	account    string
	apiVersion string
	baseURL    *url.URL
	auth       *authConfig
	c          *http.Client
}
```

Thoughts? @afiunelw, @scottford-lw, @lwmobeent 