### PR TITLE
Updating and Deleting GCP CFG Integration

### DIFF
--- a/api/integrations.go
+++ b/api/integrations.go
@@ -135,6 +135,33 @@ func (c *Client) getIntegration(intgGuid string, response interface{}) error {
 	return c.RequestDecoder("GET", apiPath, nil, response)
 }
 
+// UpdateGCPConfigIntegration updates a single integration on the server
+func (c *Client) UpdateGCPConfigIntegration(data gcpIntegrationData) (response gcpIntegrationsResponse, err error) {
+	err = c.updateIntegration(data, &response)
+	return
+}
+
+func (c *Client) updateIntegration(data interface{}, response interface{}) error {
+	body, err := jsonReader(data)
+	if err != nil {
+		return err
+	}
+
+	err = c.RequestDecoder("PATCH", apiIntegrations, body, response)
+	return err
+}
+
+// DeleteGCPConfigIntegration gets a single integration matching the integration guid available on the server
+func (c *Client) DeleteGCPConfigIntegration(intgGuid string) (response gcpIntegrationsResponse, err error) {
+	err = c.deleteIntegration(intgGuid, &response)
+	return
+}
+
+func (c *Client) deleteIntegration(intgGuid string, response interface{}) error {
+	apiPath := fmt.Sprintf(apiIntegrationByGUID, intgGuid)
+	return c.RequestDecoder("DELETE", apiPath, nil, response)
+}
+
 type commonIntegrationData struct {
 	IntgGuid             string `json:"INTG_GUID"`
 	Name                 string `json:"NAME"`

--- a/api/integrations_test.go
+++ b/api/integrations_test.go
@@ -36,38 +36,7 @@ func TestCreateGCPConfigIntegration(t *testing.T) {
 
 	fakeAPI := NewLaceworkServer()
 	fakeAPI.MockAPI("external/integrations", func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintf(w, `
-			{
-				"data": [
-					{
-						"INTG_GUID": "`+intgGUID+`",
-						"NAME": "integration_name",
-						"CREATED_OR_UPDATED_TIME": "2020-Mar-10 01:00:00 UTC",
-						"CREATED_OR_UPDATED_BY": "user@email.com",
-						"TYPE": "GCP_CFG",
-						"ENABLED": 1,
-						"STATE": {
-							"ok": true,
-							"lastUpdatedTime": "2020-Mar-10 01:00:00 UTC",
-							"lastSuccessfulTime": "2020-Mar-10 01:00:00 UTC"
-						},
-						"IS_ORG": 0,
-						"DATA": {
-							"CREDENTIALS": {
-								"CLIENT_ID": "xxxxxxxxx",
-								"CLIENT_EMAIL": "xxxxxx@xxxxx.iam.gserviceaccount.com",
-								"PRIVATE_KEY_ID": "xxxxxxxxxxxxxxxx"
-							},
-							"ID_TYPE": "PROJECT",
-							"ID": "xxxxxxxxxx"
-						},
-						"TYPE_NAME": "GCP Compliance"
-					}
-				],
-				"ok": true,
-				"message": "SUCCESS"
-			}
-		`)
+		fmt.Fprintf(w, createGCPCFGJson(intgGUID))
 	})
 	defer fakeAPI.Close()
 
@@ -95,38 +64,7 @@ func TestGetGCPConfigIntegration(t *testing.T) {
 
 	fakeAPI := NewLaceworkServer()
 	fakeAPI.MockAPI(apiPath, func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintf(w, `
-			{
-				"data": [
-					{
-						"INTG_GUID": "`+intgGUID+`",
-						"NAME": "integration_name",
-						"CREATED_OR_UPDATED_TIME": "2020-Mar-10 01:00:00 UTC",
-						"CREATED_OR_UPDATED_BY": "user@email.com",
-						"TYPE": "GCP_CFG",
-						"ENABLED": 1,
-						"STATE": {
-							"ok": true,
-							"lastUpdatedTime": "2020-Mar-10 01:00:00 UTC",
-							"lastSuccessfulTime": "2020-Mar-10 01:00:00 UTC"
-						},
-						"IS_ORG": 0,
-						"DATA": {
-							"CREDENTIALS": {
-								"CLIENT_ID": "xxxxxxxxx",
-								"CLIENT_EMAIL": "xxxxxx@xxxxx.iam.gserviceaccount.com",
-								"PRIVATE_KEY_ID": "xxxxxxxxxxxxxxxx"
-							},
-							"ID_TYPE": "PROJECT",
-							"ID": "xxxxxxxxxx"
-						},
-						"TYPE_NAME": "GCP Compliance"
-					}
-				],
-				"ok": true,
-				"message": "SUCCESS"
-			}
-		`)
+		fmt.Fprintf(w, createGCPCFGJson(intgGUID))
 	})
 	defer fakeAPI.Close()
 
@@ -139,4 +77,87 @@ func TestGetGCPConfigIntegration(t *testing.T) {
 	assert.True(t, response.Ok)
 	assert.Equal(t, 1, len(response.Data))
 	assert.Equal(t, intgGUID, response.Data[0].IntgGuid)
+}
+
+func TestUpdateGCPConfigIntegration(t *testing.T) {
+	intgGUID := "12345"
+
+	fakeAPI := NewLaceworkServer()
+	fakeAPI.MockAPI("external/integrations", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, createGCPCFGJson(intgGUID))
+	})
+	defer fakeAPI.Close()
+
+	c, err := api.NewClient("test", api.WithToken("xxxxxx"), api.WithURL(fakeAPI.URL()))
+	assert.Nil(t, err)
+
+	data := api.NewGCPIntegrationData("integration_name", api.GcpProject)
+	assert.Equal(t, "GCP_CFG", data.Type, "a new GCP integration should match its type")
+	data.Data.ID = "xxxxxxxxxx"
+	data.Data.Credentials.ClientId = "xxxxxxxxx"
+	data.Data.Credentials.ClientEmail = "xxxxxx@xxxxx.iam.gserviceaccount.com"
+	data.Data.Credentials.PrivateKeyId = "xxxxxxxxxxxxxxxx"
+
+	response, err := c.UpdateGCPConfigIntegration(data)
+	assert.Nil(t, err)
+	assert.NotNil(t, response)
+	assert.True(t, response.Ok)
+	assert.Equal(t, 1, len(response.Data))
+	assert.Equal(t, intgGUID, response.Data[0].IntgGuid)
+}
+
+func TestDeleteGCPConfigIntegration(t *testing.T) {
+	intgGUID := "12345"
+	apiPath := fmt.Sprintf("external/integrations/%s", intgGUID)
+
+	fakeAPI := NewLaceworkServer()
+	fakeAPI.MockAPI(apiPath, func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, createGCPCFGJson(intgGUID))
+	})
+	defer fakeAPI.Close()
+
+	c, err := api.NewClient("test", api.WithToken("xxxxxx"), api.WithURL(fakeAPI.URL()))
+	assert.Nil(t, err)
+
+	response, err := c.DeleteGCPConfigIntegration(intgGUID)
+	assert.Nil(t, err)
+	assert.NotNil(t, response)
+	assert.True(t, response.Ok)
+	assert.Equal(t, 1, len(response.Data))
+	assert.Equal(t, intgGUID, response.Data[0].IntgGuid)
+}
+
+func createGCPCFGJson(intgGUID string) string {
+	return `
+		{
+			"data": [
+				{
+					"INTG_GUID": "` + intgGUID + `",
+					"NAME": "integration_name",
+					"CREATED_OR_UPDATED_TIME": "2020-Mar-10 01:00:00 UTC",
+					"CREATED_OR_UPDATED_BY": "user@email.com",
+					"TYPE": "GCP_CFG",
+					"ENABLED": 1,
+					"STATE": {
+						"ok": true,
+						"lastUpdatedTime": "2020-Mar-10 01:00:00 UTC",
+						"lastSuccessfulTime": "2020-Mar-10 01:00:00 UTC"
+					},
+					"IS_ORG": 0,
+					"DATA": {
+						"CREDENTIALS": {
+							"CLIENT_ID": "xxxxxxxxx",
+							"CLIENT_EMAIL": "xxxxxx@xxxxx.iam.gserviceaccount.com",
+							"PRIVATE_KEY_ID": "xxxxxxxxxxxxxxxx"
+						},
+						"ID_TYPE": "PROJECT",
+						"ID": "xxxxxxxxxx"
+					},
+					"TYPE_NAME": "GCP Compliance"
+				}
+			],
+			"ok": true,
+			"message": "SUCCESS"
+		}
+	`
 }


### PR DESCRIPTION
Very much like Create and Get.

### UpdateGCPConfigIntegration
calls `/api/v2/external/integrations/<INTG_GUID>` Lacework API to get a GCP integration with integration guid
Example (similarly in integration_test.go):
```golang
// just some setup
intgGUID := "integration guid"
account := "test"
token := "token"
c, err := api.NewClient(account, api.WithToken(token))

// getting new gcpIntegrationData instance from api
data := api.NewGCPIntegrationData("integration_name", api.GcpProject)
data.Data.ID = "xxxxxxxxxx"
data.Data.Credentials.ClientId = "xxxxxxxxx"
data.Data.Credentials.ClientEmail = "xxxxxx@xxxxx.iam.gserviceaccount.com"
data.Data.Credentials.PrivateKeyId = "xxxxxxxxxxxxxxxx"
data.Data.Credentials.PrivateKey = "xxxxxxxxxxxxxxxx"

// calling actual client code
response, err := c.UpdateGCPConfigIntegration(data)
```

### DeleteGCPConfigIntegration
calls `/api/v2/external/integrations/<INTG_GUID>` Lacework API to get a GCP integration with integration guid
Example (similarly in integration_test.go):
```golang
// just some setup
intgGUID := "integration guid"
account := "test"
token := "token"
c, err := api.NewClient(account, api.WithToken(token))

// calling actual client code
response, err := c.DeleteGCPConfigIntegration(intgGUID)
```

Closes #19 