### PR TITLE
Fix Update Operation for GCP CFG

### DIFF
--- a/api/integrations.go
+++ b/api/integrations.go
@@ -137,17 +137,18 @@ func (c *Client) getIntegration(intgGuid string, response interface{}) error {
 
 // UpdateGCPConfigIntegration updates a single integration on the server
 func (c *Client) UpdateGCPConfigIntegration(data gcpIntegrationData) (response gcpIntegrationsResponse, err error) {
-	err = c.updateIntegration(data, &response)
+	err = c.updateIntegration(data.IntgGuid, data, &response)
 	return
 }
 
-func (c *Client) updateIntegration(data interface{}, response interface{}) error {
+func (c *Client) updateIntegration(intgGuid string, data interface{}, response interface{}) error {
 	body, err := jsonReader(data)
 	if err != nil {
 		return err
 	}
 
-	err = c.RequestDecoder("PATCH", apiIntegrations, body, response)
+	apiPath := fmt.Sprintf(apiIntegrationByGUID, intgGuid)
+	err = c.RequestDecoder("PATCH", apiPath, body, response)
 	return err
 }
 

--- a/api/integrations_test.go
+++ b/api/integrations_test.go
@@ -81,9 +81,10 @@ func TestGetGCPConfigIntegration(t *testing.T) {
 
 func TestUpdateGCPConfigIntegration(t *testing.T) {
 	intgGUID := "12345"
+	apiPath := fmt.Sprintf("external/integrations/%s", intgGUID)
 
 	fakeAPI := NewLaceworkServer()
-	fakeAPI.MockAPI("external/integrations", func(w http.ResponseWriter, r *http.Request) {
+	fakeAPI.MockAPI(apiPath, func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(w, createGCPCFGJson(intgGUID))
 	})
 	defer fakeAPI.Close()
@@ -93,6 +94,7 @@ func TestUpdateGCPConfigIntegration(t *testing.T) {
 
 	data := api.NewGCPIntegrationData("integration_name", api.GcpProject)
 	assert.Equal(t, "GCP_CFG", data.Type, "a new GCP integration should match its type")
+	data.IntgGuid = intgGUID
 	data.Data.ID = "xxxxxxxxxx"
 	data.Data.Credentials.ClientId = "xxxxxxxxx"
 	data.Data.Credentials.ClientEmail = "xxxxxx@xxxxx.iam.gserviceaccount.com"


### PR DESCRIPTION
Bug on updating GCP CFG integration
- wrong api path used
- api path needs to include integration guid but currently doesn't