### PR TITLE
chore(timeout): increase api timeout to 60s

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -30,7 +30,7 @@ import (
 	"go.uber.org/zap"
 )
 
-const defaultTimeout = 10 * time.Second
+const defaultTimeout = 60 * time.Second
 
 type Client struct {
 	id         string


### PR DESCRIPTION
We have been seeing a number of client timeouts on the Go API client,
this PR is increasing the default timeout from `10s` to `60s`.

Example error:
```
ERROR unable to send the request: Get "https://tech-ally.lacework.net/api/v1/external/integrations": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
```

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>