### PR TITLE
fix(cli): use correct variable inside install.sh

### DIFF
--- a/cli/install.ps1
+++ b/cli/install.ps1
@@ -10,4 +10,4 @@ $ErrorActionPreference="stop"
 
 Set-Variable GithubReleasesRootUrl -Option ReadOnly -value "https://github.com/lacework/go-sdk/releases"
 
-Write-Host "Comming soon! (Installatiohn of the Lacework cli tool)"
+Write-Host "Installation of the Lacework cli tool is comming soon!"

--- a/cli/install.sh
+++ b/cli/install.sh
@@ -169,7 +169,7 @@ extract_archive() {
 install_cli() {
   log "Installing Lacework cli into $installation_dir"
   mkdir -pv "$installation_dir"
-  install -v "${archive_dir}/${cli_name}" "${installation_dir}/${cli_name}"
+  install -v "${archive_dir}/${binary_name}" "${installation_dir}/${binary_name}"
 }
 
 print_cli_version() {


### PR DESCRIPTION
During some editing of the `install.sh` script I missed one variable name,
this PR is fixing that typo and using the correct variable name.

To run a local test, checkout this branch and run:
```
$ cat ./cli/install.sh | sudo bash
--> install: Installing the Lacework cli tool
--> install: Downloading via curl: https://github.com/lacework/go-sdk/releases/latest/download/lacework-cli-darwin-amd64.zip
--> install: Downloading via curl: https://github.com/lacework/go-sdk/releases/latest/download/lacework-cli-darwin-amd64.zip.sha256sum
/var/tmp/lacework.Jo1H/lacework-cli-latest.zip -> lacework-cli-darwin-amd64.zip
/var/tmp/lacework.Jo1H/lacework-cli-latest.zip.sha256sum -> lacework-cli-darwin-amd64.zip.sha256sum
--> install: Verifying the shasum digest matches the downloaded archive
lacework-cli-darwin-amd64.zip: OK
--> install: Extracting lacework-cli-darwin-amd64.zip
Archive:  lacework-cli-darwin-amd64.zip
  inflating: lacework-cli-darwin-amd64/lacework
--> install: Installing Lacework cli into /usr/local/bin
install: lacework-cli-darwin-amd64/lacework -> /usr/local/bin/lacework
lacework v0.1.3 (sha:3bdce009f2dd7c07bcbc62f903fbb343f44c047c) (time:20200416172945)
--> install: The Lacework cli tool has been successfully installed.
```

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>