### PR TITLE
Update docs and `install.ps1` to add Windows supports

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,9 @@
 
 # Lacework Go SDK
 
-This repository provides a Go API client, tools, libraries, relevant documentation, code
-samples, processes, and/or guides that allow developers to interact with Lacework.
+This repository provides a set of tools, libraries, relevant documentation, code
+samples, processes, and/or guides that allow users and developers to interact with
+the Lacework platform.
 
 ## API Client ([`api`](api/))
 
@@ -11,6 +12,8 @@ A Golang API client for interacting with the [Lacework API](https://support.lace
 
 ### Basic Usage
 ```go
+package main
+
 import (
 	"fmt"
 	"log"
@@ -18,18 +21,20 @@ import (
 	"github.com/lacework/go-sdk/api"
 )
 
-lacework, err := api.NewClient("account")
-if err == nil {
-	log.Fatal(err)
-}
+func main() {
+	lacework, err := api.NewClient("account")
+	if err != nil {
+		log.Fatal(err)
+	}
 
-tokenRes, err := lacework.GenerateTokenWithKeys("KEY", "SECRET")
-if err != nil {
-	log.Fatal(err)
-}
+	tokenRes, err := lacework.GenerateTokenWithKeys("KEY", "SECRET")
+	if err != nil {
+		log.Fatal(err)
+	}
 
-// Output: YOUR-ACCESS-TOKEN
-fmt.Println(tokenRes.Token())
+	// Output: YOUR-ACCESS-TOKEN
+	fmt.Println(tokenRes.Token())
+}
 ```
 Look at the [api/](api/) folder for more documentation.
 
@@ -39,15 +44,19 @@ The Lacework Command Line Interface is a tool that helps you manage the
 Lacework cloud security platform. You can use it to manage compliance
 reports, external integrations, vulnerability scans, and other operations.
 
-### Basic Usage
+### Install
 
-Build and install the CLI by running `make install-cli`, the automation will
-install the tool at `/usr/local/bin/lacework`:
+#### Bash:
 ```
-$ make install-cli
-$ lacework version
-lacework v0.1.1 (sha:ca9f95d17f4f2092f89dba7b64eaed6db7493a5a) (time:20200406091143)
+$ curl https://raw.githubusercontent.com/lacework/go-sdk/master/cli/install.sh | sudo bash
 ```
+
+#### Powershell:
+```
+C:\> Set-ExecutionPolicy Bypass -Scope Process -Force
+C:\> iex ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/lacework/go-sdk/master/cli/install.ps1'))
+```
+
 Look at the [cli/](cli/) folder for more documentation.
 
 ## Lacework Logger ([`lwlogger`](lwlogger/))

--- a/api/_examples/token-generation/main.go
+++ b/api/_examples/token-generation/main.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/lacework/go-sdk/api"
+)
+
+func main() {
+	lacework, err := api.NewClient("account")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	tokenRes, err := lacework.GenerateTokenWithKeys("KEY", "SECRET")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Output: YOUR-ACCESS-TOKEN
+	fmt.Println(tokenRes.Token())
+}

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,6 +1,6 @@
 <img src="https://techally-content.s3-us-west-1.amazonaws.com/public-content/lacework_logo_full.png" width="600">
 
-# Lacework cli
+# Lacework CLI
 
 The Lacework Command Line Interface is a tool that helps you manage the
 Lacework cloud security platform. You can use it to manage compliance
@@ -9,39 +9,73 @@ reports, external integrations, vulnerability scans, and other operations.
 ## Install
 
 ### Bash:
+
 ```
 $ curl https://raw.githubusercontent.com/lacework/go-sdk/master/cli/install.sh | sudo bash
 ```
 
 ### Powershell:
+
 ```
 C:\> Set-ExecutionPolicy Bypass -Scope Process -Force
 C:\> iex ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/lacework/go-sdk/master/cli/install.ps1'))
 ```
 
-## Configuration File
+## Quick Configuration
 
-The Lacework cli looks for a file named `.lacework.toml` inside your home
-directory (`$HOME/.lacework.toml`) to access the following settings:
+The `lacework configure` command is the fastest way to set up your Lacework
+CLI installation. The command prompts you for three things:
+
 * `account`: Account subdomain of URL (i.e. `<ACCOUNT>.lacework.net`)
 * `api_key`: API Access Key
 * `api_secret`: API Access Secret
 
+>To create a set of API keys, log in to your Lacework account and navigate to
+>Settings -> API Keys, then click + Create New. Enter a name for the key and
+>an optional description and click Save. To get the secret key, download the
+>generated API key file and open it in an editor.
 
-An example of a Lacework configuration file:
-```toml
-account = "example"
-api_key = "EXAMPLE_1234567890ABC"
-api_secret = "_super_secret_key"
+The following example shows sample values. Replace them with your own.
+
+```bash
+$ lacework configure
+Account: example
+Access Key ID: EXAMPLE_1234567890ABCDE1EXAMPLE1EXAMPLE123456789EXAMPLE
+Secret Access Key: _d12345dcbde000d1232bbbe51234a609
+
+You are all set!
 ```
 
-You can provide a different configuration file with the option `--config`.
+The result of this command is the generation of a file named `.lacework.toml`
+inside your home directory (`$HOME/.lacework.toml`) with a single profile
+named `default`.
+
+### Multiple Profiles
+You can add additional profiles that you can refer to with a name by specifying
+the `--profile` option. The following example creates a profile named `prod`.
+
+```bash
+$ lacework configure --profile prod
+Account: prod.example
+Access Key ID: PROD_1234567890ABCDE1EXAMPLE1EXAMPLE123456789EXAMPLE
+Secret Access Key: _12345prode11111232bbbe51234a609
+
+You are all set!
+```
+
+Then, when you run a command, you can specify a `--profile prod` and use the
+credentials and settings stored under that name.
+
+```bash
+$ lacework integration list --profile prod
+```
+
+If there is no `--profile` option, the CLI will default to the `default` profile.
 
 ### Environment Variables
 Default configuration parameters found in the `.lacework.toml` may also be 
 overriden by setting environment variables prefixed with `LW_`. 
 
-#### Example
 To override the `account`, `api_key`, and `api_secret`  configurations:
 ```
 $ export LW_ACCOUNT='<MY_ACCOUNT>'
@@ -49,26 +83,37 @@ $ export LW_API_KEY='<MY_API_KEY>'
 $ export LW_API_SECRET='<MY_API_SECRET>'
 ```
 
+To override the profile to use:
+```
+$ export LW_PROFILE=prod
+```
+
 ## Basic Usage
-Once you have created your configuration file `$HOME/.lacework.toml`,
-you are ready to use the Lacework cli, a few basic commands are:
+A few basic commands are:
 
 1) List all integration in your account:
 ```bash
 $ lacework integration list
 ```
-2) Use the `api` command to access Lacework's RestfulAPI, for example,
+2) Request an on-demand vulnerability scan:
+```bash
+$ lacework vulnerability scan run index.docker.io techallylw/lacework-cli latest
+```
+3) Use the `api` command to access Lacework's RestfulAPI, for example,
 to get details about a specific event:
 ```bash
 $ lacework api get '/external/events/GetEventDetails?EVENT_ID=16700'
 ```
 
 ## Development
+
 To build and install the CLI from source, use the `make install-cli` directive
-defined at the top level of this repository:
+defined at the top level of this repository, the automation will install the
+tool at `/usr/local/bin/lacework`:
 ```
 $ make install-cli
-$ lacework help
+$ lacework version
+lacework v.dev (sha:ca9f95d17f4f2092f89dba7b64eaed6db7493a5a) (time:20200406091143)
 ```
 
 ## License and Copyright

--- a/cli/install.ps1
+++ b/cli/install.ps1
@@ -1,13 +1,165 @@
 <#
 .SYNOPSIS
-Installs the Lacework cli tool.
+Installs the Lacework CLI.
+
+Authors: Technology Alliances <tech-ally@lacework.net>
+
+.DESCRIPTION
+This script installs the Lacework Command Line Interface.
 
 .Parameter Version
 Specifies a version (ex: 0.1.0)
 #>
 
+param (
+    [Alias("v")]
+    [string]$Version
+)
+
 $ErrorActionPreference="stop"
 
 Set-Variable GithubReleasesRootUrl -Option ReadOnly -value "https://github.com/lacework/go-sdk/releases"
+Set-Variable PackageName -Option ReadOnly -value "lacework-cli-windows-amd64.exe.zip"
 
-Write-Host "Installation of the Lacework cli tool is comming soon!"
+Function Get-File($url, $dst) {
+    Write-Host "Downloading $url"
+    try {
+        [System.Net.ServicePointManager]::SecurityProtocol = [Enum]::ToObject([System.Net.SecurityProtocolType], 3072)
+    } catch {
+        Write-Error "TLS 1.2 is not supported on this operating system. Upgrade or patch your Windows installation."
+    }
+    $wc = New-Object System.Net.WebClient
+    $wc.DownloadFile($url, $dst)
+}
+
+Function Get-WorkDir {
+    $parent = [System.IO.Path]::GetTempPath()
+    [string] $name = [System.Guid]::NewGuid()
+    New-Item -ItemType Directory -Path (Join-Path $parent $name)
+}
+
+Function Get-Archive($version) {
+    $url = $GithubReleasesRootUrl
+    $package_name = $PackageName
+    if(!$version -Or $version -eq "latest") {
+        $lacework_cli_url="$url/latest/download/${package_name}"
+    } else {
+        $lacework_cli_url="$url/download/${version}/${package_name}"
+    }
+    $sha_url="$lacework_cli_url.sha256sum"
+    $cli_dest = (Join-Path ($workdir) "lacework-cli.zip")
+    $sha_dest = (Join-Path ($workdir) "lacework-cli.zip.shasum256")
+
+    Get-File $lacework_cli_url $cli_dest
+    $result = @{ "zip" = $cli_dest }
+
+    try {
+        Get-File $sha_url $sha_dest
+        $result["shasum"] = (Get-Content $sha_dest).Split()[0]
+    } catch {
+        Write-Warning "No shasum exists for $version. Skipping validation."
+    }
+    $result
+}
+
+function Get-SHA256Converter {
+    if($PSVersionTable.PSEdition -eq 'Core') {
+        [System.Security.Cryptography.SHA256]::Create()
+    } else {
+        New-Object -TypeName Security.Cryptography.SHA256Managed
+    }
+}
+
+Function Get-Sha256($src) {
+    $converter = Get-SHA256Converter
+    try {
+        $bytes = $converter.ComputeHash(($in = (Get-Item $src).OpenRead()))
+        return ([System.BitConverter]::ToString($bytes)).Replace("-", "").ToLower()
+    } finally {
+        # Older .Net versions do not expose Dispose()
+        if($PSVersionTable.PSEdition -eq 'Core' -Or ($PSVersionTable.CLRVersion.Major -ge 4)) {
+            $converter.Dispose()
+        }
+        if ($null -ne $in) { $in.Dispose() }
+    }
+}
+
+Function Assert-Shasum($archive) {
+    Write-Host "Verifying the shasum digest matches the downloaded archive"
+    $actualShasum = Get-Sha256 $archive.zip
+    if ($actualShasum -ne $archive.shasum) {
+        Write-Error "Checksum '$($archive.shasum)' invalid."
+    }
+}
+
+Function Install-Lacework-CLI {
+    $laceworkPath = Join-Path $env:ProgramData Lacework
+    if (Test-Path $laceworkPath) { Remove-Item $laceworkPath -Recurse -Force }
+    New-Item $laceworkPath -ItemType Directory | Out-Null
+    $folder = (Get-ChildItem (Join-Path ($workdir) "bin"))
+    Copy-Item "$($folder.FullName)\*" $laceworkPath
+    $env:PATH = New-PathString -StartingPath $env:PATH -Path $laceworkPath
+    $machinePath = [System.Environment]::GetEnvironmentVariable("PATH", "Machine")
+    $machinePath = New-PathString -StartingPath $machinePath -Path $laceworkPath
+    [System.Environment]::SetEnvironmentVariable("PATH", $machinePath, "Machine")
+}
+
+Function New-PathString([string]$StartingPath, [string]$Path) {
+    if (-not [string]::IsNullOrEmpty($path)) {
+        if (-not [string]::IsNullOrEmpty($StartingPath)) {
+            [string[]]$PathCollection = "$path;$StartingPath" -split ';'
+            $Path = ($PathCollection |
+                    Select-Object -Unique |
+                    Where-Object {-not [string]::IsNullOrEmpty($_.trim())} |
+                    Where-Object {Test-Path "$_"}
+            ) -join ';'
+        }
+        $path
+    } else {
+        $StartingPath
+    }
+}
+
+Function Expand-Zip($zipPath) {
+    $dest = $workdir
+    try {
+        [System.Reflection.Assembly]::LoadWithPartialName("System.IO.Compression.FileSystem") | Out-Null
+        [System.IO.Compression.ZipFile]::ExtractToDirectory($zipPath, $dest)
+    } catch {
+        try {
+            $shellApplication = New-Object -com shell.application
+            $zipPackage = $shellApplication.NameSpace($zipPath)
+            $destinationFolder = $shellApplication.NameSpace($dest)
+            $destinationFolder.CopyHere($zipPackage.Items())
+        } catch{
+            Write-Error "Unable to unzip files on this OS"
+        }
+    }
+}
+
+Function Assert-Lacework-CLI {
+    Write-Host "Verifying installed Lacework CLI version"
+    try { lacework version } catch {
+        Write-Error "Unable to verify that the Lacework CLI was succesfully installed"
+    }
+}
+
+Write-Host "Installing the Lacework CLI"
+
+$workdir = Get-WorkDir
+New-Item $workdir -ItemType Directory -Force | Out-Null
+try {
+    $archive = Get-Archive $version
+    if($archive.shasum) {
+        Assert-Shasum $archive
+    }
+    Expand-zip $archive.zip
+    Install-Lacework-CLI
+    Assert-Lacework-CLI
+
+    Write-Host "The Lacework CLI has been successfully installed."
+} finally {
+    try { Remove-Item $workdir -Recurse -Force } catch {
+        Write-Warning "Unable to delete $workdir"
+    }
+}

--- a/cli/install.sh
+++ b/cli/install.sh
@@ -16,6 +16,8 @@ usage() {
   cat <<USAGE
 ${_cmd}: Installs the Lacework Command Line Interface.
 
+Authors: Technology Alliances <tech-ally@lacework.net>
+
 USAGE:
     ${_cmd} [FLAGS]
 

--- a/cli/install.sh
+++ b/cli/install.sh
@@ -14,7 +14,7 @@ usage() {
   local _cmd
   _cmd="$(basename "${0}")"
   cat <<USAGE
-${_cmd}: Installs the Lacework cli tool.
+${_cmd}: Installs the Lacework Command Line Interface.
 
 USAGE:
     ${_cmd} [FLAGS]
@@ -50,7 +50,7 @@ main() {
     esac
   done
 
-  log "Installing the Lacework cli tool"
+  log "Installing the Lacework CLI"
   create_workdir
   check_platform
   download_archive "$version" "$target"
@@ -58,7 +58,7 @@ main() {
   extract_archive
   install_cli
   print_cli_version
-  log "The Lacework cli tool has been successfully installed."
+  log "The Lacework CLI has been successfully installed."
 }
 
 create_workdir() {
@@ -167,14 +167,14 @@ extract_archive() {
 }
 
 install_cli() {
-  log "Installing Lacework cli into $installation_dir"
+  log "Installing Lacework CLI into $installation_dir"
   mkdir -pv "$installation_dir"
   install -v "${archive_dir}/${binary_name}" "${installation_dir}/${binary_name}"
 }
 
 print_cli_version() {
-  info "Verifying installed lacework cli version"
-  "${installation_dir}/lacework" version
+  info "Verifying installed Lacework CLI version"
+  "${installation_dir}/${binary_name}" version
 }
 
 download_file() {


### PR DESCRIPTION
This PR is updating documentation and the `install.ps1` script to add Windows
support for the Lacework CLI. 

To install the Lacework CLI, open a Powershell session as Administrator and run:
```
C:\> Set-ExecutionPolicy Bypass -Scope Process -Force
C:\> iex ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/lacework/go-sdk/master/cli/install.ps1'))
```