### PR TITLE
fix(install.ps1) copy lacework.exe to ProgramData

### DIFF
--- a/cli/install.ps1
+++ b/cli/install.ps1
@@ -96,8 +96,8 @@ Function Install-Lacework-CLI {
     $laceworkPath = Join-Path $env:ProgramData Lacework
     if (Test-Path $laceworkPath) { Remove-Item $laceworkPath -Recurse -Force }
     New-Item $laceworkPath -ItemType Directory | Out-Null
-    $folder = (Get-ChildItem (Join-Path ($workdir) "bin"))
-    Copy-Item "$($folder.FullName)\*" $laceworkPath
+    $exe = (Get-ChildItem (Join-Path ($workdir) "bin"))
+    Copy-Item "$($exe.FullName)" $laceworkPath
     $env:PATH = New-PathString -StartingPath $env:PATH -Path $laceworkPath
     $machinePath = [System.Environment]::GetEnvironmentVariable("PATH", "Machine")
     $machinePath = New-PathString -StartingPath $machinePath -Path $laceworkPath


### PR DESCRIPTION
Fix a small bug inside the `install.ps1`, after this PR is merged the PowerShell
install script should work:
```powershell
C:\> Set-ExecutionPolicy Bypass -Scope Process -Force
C:\> iex ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/lacework/go-sdk/master/cli/install.ps1'))
```

## Test this Change
Spin up a Windows VM, or if you are running on Windows already, follow these steps
to test this change locally:
* Clone this repo and checkout this branch
* Open a PowerShell terminal as an Administrator
* Run the following commands:
```powershell
C:\> Set-ExecutionPolicy Bypass -Scope Process -Force
C:\> ./cli/install.ps1
```

### NOTE: No release needed.

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>