### PR TITLE
feat(cli): 'vul scan run' command can poll for status

### DIFF
--- a/cli/cmd/vulnerability.go
+++ b/cli/cmd/vulnerability.go
@@ -118,8 +118,23 @@ Arguments:
 				"A new vulnerability scan has been requested. (request_id: %s)\n\n",
 				scan.Data.RequestID,
 			)
-			fmt.Println("To track the progress of the scan, use the command:")
-			fmt.Printf("\t$ lacework vulnerability scan show %s\n", scan.Data.RequestID)
+
+			if vulCmdState.Poll {
+				cli.Log.Infow("tracking scan progress",
+					"param", "--poll",
+					"request_id", scan.Data.RequestID,
+				)
+				report, err := pollScanStatus(scan.Data.RequestID, lacework)
+				if err != nil {
+					return errors.Wrap(err, "unable to track scan status")
+				}
+
+				cli.Log.Info("scan completed, displaying report")
+				fmt.Println(report)
+			} else {
+				fmt.Println("To track the progress of the scan, use the command:")
+				fmt.Printf("  $ lacework vulnerability scan show %s\n", scan.Data.RequestID)
+			}
 			return nil
 		},
 	}
@@ -139,30 +154,10 @@ Arguments:
 			}
 
 			if vulCmdState.Poll {
-				var (
-					report string
-					retry  bool
-					s      = spinner.New(spinner.CharSets[9], 100*time.Millisecond)
-				)
-				s.Suffix = " Scan running..."
-				s.Start()
-
-				for {
-					report, err, retry = checkScanStatus(args[0], lacework)
-					if err != nil {
-						return err
-					}
-
-					if retry {
-						time.Sleep(vulCmdState.PollInterval)
-						continue
-					}
-
-					break
+				report, err := pollScanStatus(args[0], lacework)
+				if err != nil {
+					return errors.Wrap(err, "unable to poll scan status")
 				}
-
-				s.Stop()
-
 				// To make the report easy to read,  add an empty carrier return
 				fmt.Println("")
 				fmt.Println(report)
@@ -258,6 +253,10 @@ func init() {
 	vulScanCmd.AddCommand(vulScanRunCmd)
 	vulScanCmd.AddCommand(vulScanShowCmd)
 
+	vulScanRunCmd.Flags().BoolVar(&vulCmdState.Poll, "poll", false,
+		fmt.Sprintf("poll until the vulnerability scan completes (%vs intervals)",
+			vulCmdState.PollInterval.Seconds()),
+	)
 	vulScanShowCmd.Flags().BoolVar(&vulCmdState.Poll, "poll", false,
 		fmt.Sprintf("poll until the vulnerability scan completes (%vs intervals)",
 			vulCmdState.PollInterval.Seconds()),
@@ -267,6 +266,27 @@ func init() {
 		&vulCmdState.Digest, "digest", false,
 		"tread the provided sha256 hash as image digest",
 	)
+}
+
+func pollScanStatus(requestID string, lacework *api.Client) (string, error) {
+	s := spinner.New(spinner.CharSets[9], 100*time.Millisecond)
+	s.Suffix = " Scan running..."
+	s.Start()
+	defer s.Stop()
+
+	for {
+		report, err, retry := checkScanStatus(requestID, lacework)
+		if err != nil {
+			return "", err
+		}
+
+		if retry {
+			time.Sleep(vulCmdState.PollInterval)
+			continue
+		}
+
+		return report, nil
+	}
 }
 
 func checkScanStatus(requestID string, lacework *api.Client) (string, error, bool) {


### PR DESCRIPTION
The command `lacework vul scan run` has now a `--poll` flag that will
lock the command and track the progress of the scan until completion.

```
$ lacework vulnerability scan run index.docker.io techallylw/lacework-cli-ubuntu18 latest --poll
A new vulnerability scan has been requested. (request_id: 7ac5dac2-7381-432f-8e64-d24105faf44a)

                                  CONTAINER IMAGE DETAILS                                 |        VULNERABILITIES
------------------------------------------------------------------------------------------+---------------------------------
    ID          sha256:8691d91057442af854be19c2d75c976e7cfca7c5aca8a6ef4498d9bd4d56a644   |   SEVERITY   COUNT   FIXABLE
    Digest      sha256:9781fc23fc36970652acdfba82432637c059ea9f66bed9c5500a9d9cd6106f37   | -----------+-------+----------
    Registry    index.docker.io                                                           |   Critical       0         0
    Repository  techallylw/lacework-cli-ubuntu18                                          |   High           0         0
    Size        32.5 MB                                                                   |   Medium         5         0
    Created At  2020-04-21T18:00:00+0000                                                  |   Low           18         0
    Tags        latest                                                                    |   Info          11         0
                                                                                          |
```

## Test this change

* Checkout this branch `git checkout -t origin/afiune/pipelines`
* Build and install the Lacework CLI `make install-cli`
* Run the above command `lacework vul scan run`

Here is an example of all the commands, the scan should take 3-5m to run! 🙌🏽
```
$ git checkout -t origin/afiune/pipelines
$ make install-cli
$ lacework vul scan run index.docker.io techallylw/lacework-cli-ubuntu18 latest --poll
```

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>