### PR TITLE
feat(cli): implement JSON format for all commands

### DIFF
--- a/cli/cmd/api.go
+++ b/cli/cmd/api.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/fatih/color"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
@@ -96,13 +95,9 @@ func runApiCommand(_ *cobra.Command, args []string) error {
 		return errors.Wrap(err, "unable to send the request")
 	}
 
-	pretty, err := cli.JsonF.Marshal(*response)
-	if err != nil {
-		cli.Log.Debugw("unable to pretty print JSON response", "raw", response)
+	if err := cli.OutputJSON(*response); err != nil {
 		return errors.Wrap(err, "unable to format json response")
 	}
-
-	fmt.Fprintln(color.Output, string(pretty))
 	return nil
 }
 

--- a/cli/cmd/cli_state.go
+++ b/cli/cmd/cli_state.go
@@ -40,6 +40,7 @@ type cliState struct {
 	JsonF *prettyjson.Formatter
 	Log   *zap.SugaredLogger
 
+	jsonOutput     bool
 	profileDetails map[string]interface{}
 }
 
@@ -121,6 +122,24 @@ func (c *cliState) VerifySettings() error {
 	}
 
 	return nil
+}
+
+func (c *cliState) EnableJSONOutput() {
+	cli.Log.Info("switch output to json format")
+	cli.jsonOutput = true
+}
+
+func (c *cliState) EnableHumanOutput() {
+	cli.Log.Info("switch output to human format")
+	cli.jsonOutput = false
+}
+
+func (c *cliState) JSONOutput() bool {
+	return cli.jsonOutput
+}
+
+func (c *cliState) HumanOutput() bool {
+	return !cli.jsonOutput
 }
 
 // loadStateFromViper loads parameters and environment variables

--- a/cli/cmd/integration.go
+++ b/cli/cmd/integration.go
@@ -56,6 +56,10 @@ var (
 				return errors.Wrap(err, "unable to get integrations")
 			}
 
+			if cli.JSONOutput() {
+				return cli.OutputJSON(integrations.Data)
+			}
+
 			table := tablewriter.NewWriter(os.Stdout)
 			table.SetHeader([]string{"Integration GUID", "Name", "Type", "Status", "State"})
 			table.SetBorder(false)

--- a/cli/cmd/outputs.go
+++ b/cli/cmd/outputs.go
@@ -1,0 +1,45 @@
+//
+// Author:: Salim Afiune Maya (<afiune@lacework.net>)
+// Copyright:: Copyright 2020, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/fatih/color"
+)
+
+// OutputJSON will print out the JSON representation of the provided data
+func (c *cliState) OutputJSON(v interface{}) error {
+	pretty, err := c.JsonF.Marshal(v)
+	if err != nil {
+		cli.Log.Debugw("unable to pretty print JSON object", "raw", v)
+		return err
+	}
+	fmt.Fprintln(color.Output, string(pretty))
+	return nil
+}
+
+// OutputHumanRead will print out the provided message if the cli state is
+// configured to talk to humans, to switch to json format use --json
+func (c *cliState) OutputHuman(format string, a ...interface{}) {
+	if c.HumanOutput() {
+		fmt.Fprintf(os.Stdout, format, a...)
+	}
+}

--- a/cli/cmd/vulnerability.go
+++ b/cli/cmd/vulnerability.go
@@ -114,7 +114,7 @@ Arguments:
 				)
 			}
 
-			fmt.Printf(
+			cli.OutputHuman(
 				"A new vulnerability scan has been requested. (request_id: %s)\n\n",
 				scan.Data.RequestID,
 			)
@@ -124,17 +124,15 @@ Arguments:
 					"param", "--poll",
 					"request_id", scan.Data.RequestID,
 				)
-				report, err := pollScanStatus(scan.Data.RequestID, lacework)
-				if err != nil {
-					return errors.Wrap(err, "unable to track scan status")
-				}
-
-				cli.Log.Info("scan completed, displaying report")
-				fmt.Println(report)
-			} else {
-				fmt.Println("To track the progress of the scan, use the command:")
-				fmt.Printf("  $ lacework vulnerability scan show %s\n", scan.Data.RequestID)
+				return pollScanStatus(scan.Data.RequestID, lacework)
 			}
+
+			if cli.JSONOutput() {
+				return cli.OutputJSON(scan.Data)
+			}
+
+			cli.OutputHuman("To track the progress of the scan, use the command:\n")
+			cli.OutputHuman("  $ lacework vulnerability scan show %s\n", scan.Data.RequestID)
 			return nil
 		},
 	}
@@ -154,14 +152,11 @@ Arguments:
 			}
 
 			if vulCmdState.Poll {
-				report, err := pollScanStatus(args[0], lacework)
-				if err != nil {
-					return errors.Wrap(err, "unable to poll scan status")
-				}
-				// To make the report easy to read,  add an empty carrier return
-				fmt.Println("")
-				fmt.Println(report)
-				return nil
+				cli.Log.Infow("tracking scan progress",
+					"param", "--poll",
+					"request_id", args[0],
+				)
+				return pollScanStatus(args[0], lacework)
 			}
 
 			report, err, scanning := checkScanStatus(args[0], lacework)
@@ -169,12 +164,21 @@ Arguments:
 				return err
 			}
 
-			// if the returned scan report is not scanning, add an empty carrier
-			// return to make the report easy to read
-			if !scanning {
-				fmt.Println("")
+			if cli.JSONOutput() {
+				return cli.OutputJSON(report)
 			}
-			fmt.Println(report)
+
+			// if the scan is still running, display a nice message
+			if scanning {
+				cli.OutputHuman(
+					"The vulnerability scan is still running. (request_id: %s)\n\n",
+					args[0],
+				)
+				cli.OutputHuman("Use --poll to poll until the vulnerability scan completes.\n")
+			} else {
+				cli.OutputHuman("\n")
+				cli.OutputHuman(buildVulnerabilityReport(report))
+			}
 			return nil
 		},
 	}
@@ -219,8 +223,12 @@ Arguments:
 			status := report.CheckStatus()
 			switch status {
 			case "Success":
-				fmt.Println("")
-				fmt.Println(buildVulnerabilityReport(&report.Data))
+				if cli.JSONOutput() {
+					return cli.OutputJSON(report.Data)
+				}
+
+				cli.OutputHuman("\n")
+				cli.OutputHuman(buildVulnerabilityReport(&report.Data))
 			case "NotFound":
 				return errors.Errorf(
 					"unable to find any vulnerability report for image '%s'",
@@ -268,16 +276,19 @@ func init() {
 	)
 }
 
-func pollScanStatus(requestID string, lacework *api.Client) (string, error) {
-	s := spinner.New(spinner.CharSets[9], 100*time.Millisecond)
-	s.Suffix = " Scan running..."
-	s.Start()
-	defer s.Stop()
+func pollScanStatus(requestID string, lacework *api.Client) error {
+	var s *spinner.Spinner
+	if cli.HumanOutput() {
+		// humans like spinners (\o/)
+		s = spinner.New(spinner.CharSets[9], 100*time.Millisecond)
+		s.Suffix = " Scan running..."
+		s.Start()
+	}
 
 	for {
 		report, err, retry := checkScanStatus(requestID, lacework)
 		if err != nil {
-			return "", err
+			return err
 		}
 
 		if retry {
@@ -285,37 +296,41 @@ func pollScanStatus(requestID string, lacework *api.Client) (string, error) {
 			continue
 		}
 
-		return report, nil
+		if cli.JSONOutput() {
+			return cli.OutputJSON(report)
+		}
+
+		s.Stop()
+		cli.OutputHuman(buildVulnerabilityReport(report))
+		return nil
 	}
 }
 
-func checkScanStatus(requestID string, lacework *api.Client) (string, error, bool) {
-	cli.Log.Debugw("verifying status of vulnerability scan", "request_id", requestID)
+func checkScanStatus(requestID string, lacework *api.Client) (*api.VulContainerReport, error, bool) {
+	cli.Log.Infow("verifying status of vulnerability scan", "request_id", requestID)
 	scan, err := lacework.Vulnerabilities.ScanStatus(requestID)
 	if err != nil {
-		return "", errors.Wrap(err, "unable to verify status of the vulnerability scan"), false
+		return nil, errors.Wrap(err, "unable to verify status of the vulnerability scan"), false
 	}
 
 	cli.Log.Debugw("vulnerability scan", "details", scan)
 	status := scan.CheckStatus()
 	switch status {
 	case "Success":
-		return buildVulnerabilityReport(&scan.Data), nil, false
+		return &scan.Data, nil, false
 	case "Scanning":
-		msg := "The vulnerability scan is still running.\n\n"
-		msg = msg + "Use --poll to poll until the vulnerability scan completes."
-		return msg, nil, true
+		return &scan.Data, nil, true
 	case "NotFound":
-		return "", errors.Errorf(
+		return nil, errors.Errorf(
 			"unable to find any vulnerability scan with request id '%s'",
 			requestID,
 		), false
 	case "Failed":
-		return "", errors.New(
+		return nil, errors.New(
 			"the vulnerability scan failed to execute. Use '--debug' to troubleshoot.",
 		), false
 	default:
-		return "", errors.New(
+		return nil, errors.New(
 			"unable to get status from vulnerability scan. Use '--debug' to troubleshoot.",
 		), false
 	}


### PR DESCRIPTION
We are adding a new Global Flag called `--json` that users can use to
switch the CLI output format to display JSON instead of the default,
human-readable format.

To make this setting persistent on the current terminal, a user can
export the environment variable `LW_JSON=1`.

An example of the JSON output when requesting an on-deman
vulnerability scan:
```
$ lacework vulnerability scan run index.docker.io techallylw/lacework-cli-ubuntu18 latest --json
{
  "requestId": "241d943d-1b8f-42cc-be34-c1a1d9ae5297",
  "status": "Scanning"
}
```
Signed-off-by: Salim Afiune Maya <afiune@lacework.net>