### PR TITLE
fix(api): omitempty integration responses fields

### DIFF
--- a/api/integrations.go
+++ b/api/integrations.go
@@ -161,31 +161,31 @@ func (svc *IntegrationsService) listByType(iType integrationType, response inter
 }
 
 type commonIntegrationData struct {
-	IntgGuid             string `json:"INTG_GUID,omitempty"`
-	Name                 string `json:"NAME"`
-	CreatedOrUpdatedTime string `json:"CREATED_OR_UPDATED_TIME,omitempty"`
-	CreatedOrUpdatedBy   string `json:"CREATED_OR_UPDATED_BY,omitempty"`
-	Type                 string `json:"TYPE"`
-	Enabled              int    `json:"ENABLED"`
-	State                state  `json:"STATE,omitempty"`
-	IsOrg                int    `json:"IS_ORG,omitempty"`
-	TypeName             string `json:"TYPE_NAME,omitempty"`
+	IntgGuid             string            `json:"INTG_GUID,omitempty"`
+	Name                 string            `json:"NAME"`
+	CreatedOrUpdatedTime string            `json:"CREATED_OR_UPDATED_TIME,omitempty"`
+	CreatedOrUpdatedBy   string            `json:"CREATED_OR_UPDATED_BY,omitempty"`
+	Type                 string            `json:"TYPE"`
+	Enabled              int               `json:"ENABLED"`
+	State                *IntegrationState `json:"STATE,omitempty"`
+	IsOrg                int               `json:"IS_ORG,omitempty"`
+	TypeName             string            `json:"TYPE_NAME,omitempty"`
 }
 
-func (iData commonIntegrationData) Status() string {
-	if iData.Enabled == 1 {
+func (c commonIntegrationData) Status() string {
+	if c.Enabled == 1 {
 		return "Enabled"
 	}
 	return "Disabled"
 }
 
-type state struct {
+type IntegrationState struct {
 	Ok                 bool   `json:"ok"`
 	LastUpdatedTime    string `json:"lastUpdatedTime"`
 	LastSuccessfulTime string `json:"lastSuccessfulTime"`
 }
 
-func (s state) String() string {
+func (s IntegrationState) String() string {
 	if s.Ok {
 		return "Ok"
 	}

--- a/api/vulnerabilities.go
+++ b/api/vulnerabilities.go
@@ -156,7 +156,7 @@ type VulContainerReport struct {
 
 	// ScanStatus is a property that will appear when the vulnerability scan finished
 	// running, this status indicates whether the scan finished successfully or not
-	ScanStatus string `json:"scan_status"`
+	ScanStatus string `json:"scan_status,omitempty"`
 
 	// @afiune why we can't parse the time?
 	//LastEvaluationTime      time.Time         `json:"last_evaluation_time"`
@@ -252,16 +252,16 @@ type vulContainerPackage struct {
 	Vulnerabilities []containerVulnerability `json:"vulnerabilities"`
 
 	// @afiune maybe these fields are host related information and not container
-	FixAvailable  string `json:"fix_available"`
-	FixedVersion  string `json:"fixed_version"`
-	HostCount     string `json:"host_count"`
-	Severity      string `json:"severity"`
-	Status        string `json:"status"`
-	CveLink       string `json:"cve_link"`
-	CveScore      string `json:"cve_score"`
-	CvssV3Score   string `json:"cvss_v3_score"`
-	CvssV2Score   string `json:"cvss_v2_score"`
-	FirstSeenTime string `json:"first_seen_time"`
+	FixAvailable  string `json:"fix_available,omitempty"`
+	FixedVersion  string `json:"fixed_version,omitempty"`
+	HostCount     string `json:"host_count,omitempty"`
+	Severity      string `json:"severity,omitempty"`
+	Status        string `json:"status,omitempty"`
+	CveLink       string `json:"cve_link,omitempty"`
+	CveScore      string `json:"cve_score,omitempty"`
+	CvssV3Score   string `json:"cvss_v3_score,omitempty"`
+	CvssV2Score   string `json:"cvss_v2_score,omitempty"`
+	FirstSeenTime string `json:"first_seen_time,omitempty"`
 }
 
 type containerVulnerability struct {


### PR DESCRIPTION
Our API Server returns responses that can change 100%, this behavior is
making us omit a number of fields if they are empty so that we don't
present them to the end user.

There is a current bug that this change is fixing where if you try to
create a new Lacework Integration with the Go client, the request
generated will send the following body and the API Server will through a
500 Internal Server Error (in the k8s logs, Schema validation failure)
```json
{
  "NAME": "Azure Activity Log",
  "TYPE": "AZURE_AL_SEQ",
  "ENABLED": 1,
  "STATE": {
    "ok": false,
    "lastUpdatedTime": "",
    "lastSuccessfulTime": ""
  },
  "DATA": {
    "CREDENTIALS": {},
    "TENANT_ID": "ID",
    "QUEUE_URL": "URL"
  }
}
```

We are avoiding adding the `STATE` field if it is empty so that we send
this request body instead:
```json
{
  "NAME": "Azure Activity Log",
  "TYPE": "AZURE_AL_SEQ",
  "ENABLED": 1,
  "DATA": {
    "CREDENTIALS": {},
    "TENANT_ID": "ID",
    "QUEUE_URL": "URL"
  }
}
```

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>