### PR TITLE
API Events Details imp + New `event show` CMD

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -32,6 +32,7 @@ const (
 	apiVulnerabilitiesReportFromID     = "external/vulnerabilities/container/imageId/%s"
 	apiVulnerabilitiesReportFromDigest = "external/vulnerabilities/container/imageDigest/%s"
 
+	apiEventsDetails   = "external/events/GetEventDetails"
 	apiEventsDateRange = "external/events/GetEventsForDateRange"
 )
 

--- a/api/events.go
+++ b/api/events.go
@@ -68,6 +68,187 @@ func (svc *EventsService) ListRange(start, end time.Time) (
 	return
 }
 
+// Details returns details about the specified event_id
+func (svc *EventsService) Details(eventID string) (response EventDetailsResponse, err error) {
+	if eventID == "" {
+		err = errors.New("event_id cannot be empty")
+		return
+	}
+
+	apiPath := fmt.Sprintf("%s?EVENT_ID=%s", apiEventsDetails, eventID)
+	err = svc.client.RequestDecoder("GET", apiPath, nil, &response)
+	return
+}
+
+type EventDetailsResponse struct {
+	Events []EventDetails `json:"data"`
+}
+
+type EventDetails struct {
+	EventID    string         `json:"event_id"`
+	EventActor string         `json:"event_actor"`
+	EventModel string         `json:"event_model"`
+	EventType  string         `json:"event_type"`
+	StartTime  time.Time      `json:"start_time"`
+	EndTime    time.Time      `json:"end_time"`
+	EntityMap  EventEntityMap `json:"entity_map"`
+}
+
+type EventEntityMap struct {
+	User            []eventUserEntity            `json:"user,omitempty"`
+	Application     []eventApplicationEntity     `json:"application,omitempty"`
+	Machine         []eventMachineEntity         `json:"machine,omitempty"`
+	Container       []eventContainerEntity       `json:"container,omitempty"`
+	DnsName         []eventDnsNameEntity         `json:"DnsName,omitempty"`   // @afiune not in standard
+	IpAddress       []eventIpAddressEntity       `json:"IpAddress,omitempty"` // @afiune not in standard
+	Process         []eventProcessEntity         `json:"process,omitempty"`
+	FileDataHash    []eventFileDataHashEntity    `json:"FileDataHash,omitempty"`    // @afiune not in standard
+	FileExePath     []eventFileExePathEntity     `json:"FileExePath,omitempty"`     // @afiune not in standard
+	SourceIpAddress []eventSourceIpAddressEntity `json:"SourceIpAddress,omitempty"` // @afiune not in standard
+	API             []eventAPIEntity             `json:"api,omitempty"`
+	Region          []eventRegionEntity          `json:"region,omitempty"`
+	CTUser          []eventCTUserEntity          `json:"ct_user,omitempty"`
+	Resource        []eventResourceEntity        `json:"resource,omitempty"`
+	RecID           []eventRecIDEntity           `json:"RecId,omitempty"`           // @afiune not in standard
+	CustomRule      []eventCustomRuleEntity      `json:"CustomRule,omitempty"`      // @afiune not in standard
+	NewViolation    []eventNewViolationEntity    `json:"NewViolation,omitempty"`    // @afiune not in standard
+	ViolationReason []eventViolationReasonEntity `json:"ViolationReason,omitempty"` // @afiune not in standard
+}
+type eventUserEntity struct {
+	MachineHostname string `json:"machine_hostname"`
+	Username        string `json:"username"`
+}
+
+type eventApplicationEntity struct {
+	Application       string    `json:"application"`
+	HasExternalConns  int32     `json:"has_external_conns"`
+	IsClient          int32     `json:"is_client"`
+	IsServer          int32     `json:"is_server"`
+	EarliestKnownTime time.Time `json:"earliest_known_time"`
+}
+
+type eventMachineEntity struct {
+	Hostname          string  `json:"hostname"`
+	ExternalIp        string  `json:"external_ip"`
+	InstanceID        string  `json:"instance_id"`
+	InstanceName      string  `json:"instance_name"`
+	CpuPercentage     float32 `json:"cpu_percentage"`
+	InternalIpAddress string  `json:"internal_ip_address"`
+}
+
+type eventContainerEntity struct {
+	ImageRepo        string    `json:"image_repo"`
+	ImageTag         string    `json:"image_tag"`
+	HasExternalConns int32     `json:"has_external_conns"`
+	IsClient         int32     `json:"is_client"`
+	IsServer         int32     `json:"is_server"`
+	FirstSeenTime    time.Time `json:"first_seen_time"`
+	PodNamespace     string    `json:"pod_namespace"`
+	PodIpAddr        string    `json:"pod_ip_addr"`
+}
+
+type eventDnsNameEntity struct {
+	Hostname      string  `json:"hostname"`
+	PortList      []int32 `json:"port_list"`
+	TotalInBytes  int32   `json:"total_in_bytes"`
+	TotalOutBytes int32   `json:"total_out_bytes"`
+}
+
+type eventIpAddressEntity struct {
+	IpAddress     string                 `json:"ip_address"`
+	TotalInBytes  int32                  `json:"total_in_bytes"`
+	TotalOutBytes int32                  `json:"total_out_bytes"`
+	ThreatTags    []string               `json:"threat_tags"`
+	ThreatSource  map[string]interface{} `json:"threat_source"`
+	Country       string                 `json:"country"`
+	Region        string                 `json:"region"`
+	PortList      []int32                `json:"port_list"`
+	FirstSeenTime time.Time              `json:"first_seen_time"`
+}
+
+type eventProcessEntity struct {
+	Hostname         string    `json:"hostname"`
+	ProcessId        int32     `json:"process_id"`
+	ProcessStartTime time.Time `json:"process_start_time"`
+	Cmdline          string    `json:"cmdline"`
+	CpuPercentage    int32     `json:"cpu_percentage"`
+}
+
+type eventFileDataHashEntity struct {
+	FiledataHash  string    `json:"filedata_hash"`
+	MachineCount  int32     `json:"machine_count"`
+	ExePathList   []string  `json:"exe_path_list"`
+	FirstSeenTime time.Time `json:"first_seen_time"`
+	IsKnownBad    int32     `json:"is_known_bad"`
+}
+
+type eventFileExePathEntity struct {
+	ExePath          string    `json:"exe_path"`
+	FirstSeenTime    time.Time `json:"first_seen_time"`
+	LastFiledataHash string    `json:"last_filedata_hash"`
+	LastPackageName  string    `json:"last_package_name"`
+	LastVersion      string    `json:"last_version"`
+	LastFileOwner    string    `json:"last_file_owner"`
+}
+
+type eventSourceIpAddressEntity struct {
+	IpAddress string `json:"ip_address"`
+	Region    string `json:"region"`
+	Country   string `json:"country"`
+}
+
+type eventAPIEntity struct {
+	Service string `json:"service"`
+	Api     string `json:"api"`
+}
+
+type eventRegionEntity struct {
+	Region      string   `json:"region"`
+	AccountList []string `json:"account_list"`
+}
+
+type eventCTUserEntity struct {
+	Username    string   `json:"username"`
+	AccoutId    string   `json:"accout_id"`
+	Mfa         int32    `json:"mfa"`
+	ApiList     []string `json:"api_list"`
+	RegionList  []string `json:"region_list"`
+	PrincipalId string   `json:"principal_id"`
+}
+
+type eventResourceEntity struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
+type eventRecIDEntity struct {
+	RecId        string `json:"rec_id"`
+	AccountId    string `json:"account_id"`
+	AccountAlias string `json:"account_alias"`
+	Title        string `json:"title"`
+	Status       string `json:"status"`
+	EvalType     string `json:"eval_type"`
+	EvalGuid     string `json:"eval_guid"`
+}
+
+type eventCustomRuleEntity struct {
+	LastUpdatedTime time.Time `json:"last_updated_time"`
+	LastUpdatedUser string    `json:"last_updated_user"`
+	DisplayFilter   string    `json:"display_filter"`
+	RuleGuid        string    `json:"rule_guid"`
+}
+
+type eventNewViolationEntity struct {
+	RecId    string `json:"rec_id"`
+	Reason   string `json:"reason"`
+	Resource string `json:"resource"`
+}
+
+type eventViolationReasonEntity struct {
+	RecId  string `json:"rec_id"`
+	Reason string `json:"reason"`
+}
+
 type EventsResponse struct {
 	Events []Event `json:"data"`
 }


### PR DESCRIPTION
This change is adding a new `Events.Details(ID)` function that returns details
about the specified `event_id` plus adding a new `show` sub-command to the
`event` command inside the Lacework CLI. Such sub-command will show details
of a specific event.

Example: Human readable output
```
$ lacework event show 5
  EVENT ID |               TYPE               |     ACTOR     |      MODEL       |      START TIME      |       END TIME
-----------+----------------------------------+---------------+------------------+----------------------+-----------------------
         5 | CloudStorageIAMPermissionChanged | GcpAuditTrail | GcpAuditTrailCep | 2020-04-17T19:00:00Z | 2020-04-17T20:00:00Z
```

Example: Machine/JSON format
```
$ lacework event show 5 --json
{
  "end_time": "2020-04-17T20:00:00Z",
  "entity_map": {
    "resource": [
      {
        "name": "gcs_bucket.location",
        "value": "us"
      },
      {
        "name": "gcs_bucket.project_id",
        "value": "gcr-jenkins-sandbox-1234"
      },
      {
        "name": "gcs_bucket.bucket_name",
        "value": "us.artifacts.gcr-jenkins-sandbox-1234.appspot.com"
      }
    ]
  },
  "event_actor": "GcpAuditTrail",
  "event_id": "5",
  "event_model": "GcpAuditTrailCep",
  "event_type": "CloudStorageIAMPermissionChanged",
  "start_time": "2020-04-17T19:00:00Z"
}
```

Closes https://github.com/lacework/go-sdk/issues/68

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>