### PR TITLE
feat(cli): noninteractive mode flag

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -88,7 +88,7 @@ To override the profile to use:
 $ export LW_PROFILE=prod
 ```
 
-This is a list of all environment variables that can be user to modify the
+This is a list of all environment variables that can be used to modify the
 operation of the Lacework CLI.
 
 | Environment Variable | Description |

--- a/cli/README.md
+++ b/cli/README.md
@@ -78,15 +78,29 @@ overriden by setting environment variables prefixed with `LW_`.
 
 To override the `account`, `api_key`, and `api_secret`  configurations:
 ```
-$ export LW_ACCOUNT='<MY_ACCOUNT>'
-$ export LW_API_KEY='<MY_API_KEY>'
-$ export LW_API_SECRET='<MY_API_SECRET>'
+$ export LW_ACCOUNT="<YOUR_ACCOUNT>"
+$ export LW_API_KEY="<YOUR_API_KEY>"
+$ export LW_API_SECRET="<YOUR_API_SECRET>"
 ```
 
 To override the profile to use:
 ```
 $ export LW_PROFILE=prod
 ```
+
+This is a list of all environment variables that can be user to modify the
+operation of the Lacework CLI.
+
+| Environment Variable | Description |
+|----------------------|-------------|
+|`LW_NOCOLOR=1`|turn off colors|
+|`LW_DEBUG=1`|turn on debug logging|
+|`LW_JSON=1`|switch commands output from human-readable to JSON format|
+|`LW_NONINTERACTIVE=1`|disable interactive progress bars (i.e. spinners)|
+|`LW_PROFILE="<name>"`|switch between profiles configured at `~/.lacework.toml`|
+|`LW_ACCOUNT="<account>"`|account subdomain of URL (i.e. `<ACCOUNT>.lacework.net`)|
+|`LW_API_KEY="<key>"`|access key id|
+|`LW_API_SECRET="<secret>"`|secret access key|
 
 ## Basic Usage
 A few basic commands are:

--- a/cli/cmd/api.go
+++ b/cli/cmd/api.go
@@ -39,7 +39,7 @@ var (
 	// apiCmd represents the api command
 	apiCmd = &cobra.Command{
 		Use:   "api <method> <path>",
-		Short: "Helper to call Lacework's RestfulAPI",
+		Short: "helper to call Lacework's RestfulAPI",
 		Long: `Use this command as a helper to call any available Lacework API endpoint.
 
 For example, to list all integrations configured in your account run:

--- a/cli/cmd/configure.go
+++ b/cli/cmd/configure.go
@@ -57,7 +57,7 @@ var (
 	// configureCmd represents the configure command
 	configureCmd = &cobra.Command{
 		Use:   "configure",
-		Short: "Configure the Lacework CLI",
+		Short: "configure the Lacework CLI",
 		Args:  cobra.NoArgs,
 		Long: `
 Configure settings that the Lacework CLI uses to interact with the Lacework

--- a/cli/cmd/event.go
+++ b/cli/cmd/event.go
@@ -33,13 +33,14 @@ var (
 	// eventCmd represents the event command
 	eventCmd = &cobra.Command{
 		Use:   "event",
-		Short: "Inspect Lacework events",
+		Short: "inspect Lacework events",
+		Long:  `Inspect events reported by the Lacework platform`,
 	}
 
 	// eventListCmd represents the list sub-command inside the event command
 	eventListCmd = &cobra.Command{
 		Use:   "list",
-		Short: "List all events from a date range (default last 7 days)",
+		Short: "list all events from a date range (default last 7 days)",
 		Long: `List all events from a data range, by default it displays the last
 7 days, but you can specify a different time range.`,
 		Args: cobra.NoArgs,

--- a/cli/cmd/integration.go
+++ b/cli/cmd/integration.go
@@ -33,14 +33,14 @@ var (
 	integrationCmd = &cobra.Command{
 		Use:     "integration",
 		Aliases: []string{"int"},
-		Short:   "Manage external integrations",
-		Long:    ``,
+		Short:   "manage external integrations",
+		Long:    `Manage external integrations with the Lacework platform`,
 	}
 
 	// integrationListCmd represents the list sub-command inside the integration command
 	integrationListCmd = &cobra.Command{
 		Use:   "list",
-		Short: "List all available external integrations",
+		Short: "list all available external integrations",
 		Args:  cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			lacework, err := api.NewClient(cli.Account,
@@ -73,7 +73,7 @@ var (
 	integrationCreateCmd = &cobra.Command{
 		Use:    "create",
 		Hidden: true,
-		Short:  "Create an external integrations",
+		Short:  "create an external integrations",
 		Args:   cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			return nil
@@ -84,7 +84,7 @@ var (
 	integrationUpdateCmd = &cobra.Command{
 		Use:    "update",
 		Hidden: true,
-		Short:  "Update an external integrations",
+		Short:  "update an external integrations",
 		Args:   cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			return nil
@@ -95,7 +95,7 @@ var (
 	integrationDeleteCmd = &cobra.Command{
 		Use:    "delete",
 		Hidden: true,
-		Short:  "Delete an external integrations",
+		Short:  "delete an external integrations",
 		Args:   cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			return nil

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -82,6 +82,9 @@ func init() {
 	rootCmd.PersistentFlags().Bool("nocolor", false,
 		"turn off colors",
 	)
+	rootCmd.PersistentFlags().Bool("noninteractive", false,
+		"disable interactive progress bars (i.e. 'spinners')",
+	)
 	rootCmd.PersistentFlags().Bool("json", false,
 		"switch commands output from human readable to json format",
 	)
@@ -100,6 +103,7 @@ func init() {
 
 	errcheckWARN(viper.BindPFlag("debug", rootCmd.PersistentFlags().Lookup("debug")))
 	errcheckWARN(viper.BindPFlag("nocolor", rootCmd.PersistentFlags().Lookup("nocolor")))
+	errcheckWARN(viper.BindPFlag("noninteractive", rootCmd.PersistentFlags().Lookup("noninteractive")))
 	errcheckWARN(viper.BindPFlag("json", rootCmd.PersistentFlags().Lookup("json")))
 	errcheckWARN(viper.BindPFlag("profile", rootCmd.PersistentFlags().Lookup("profile")))
 	errcheckWARN(viper.BindPFlag("account", rootCmd.PersistentFlags().Lookup("account")))
@@ -131,6 +135,10 @@ func initConfig() {
 	if viper.GetBool("nocolor") {
 		cli.Log.Info("turning off colors")
 		cli.JsonF.DisabledColor = true
+	}
+
+	if viper.GetBool("noninteractive") {
+		cli.NonInteractive()
 	}
 
 	if viper.GetBool("json") {

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -86,7 +86,7 @@ func init() {
 		"disable interactive progress bars (i.e. 'spinners')",
 	)
 	rootCmd.PersistentFlags().Bool("json", false,
-		"switch commands output from human readable to json format",
+		"switch commands output from human-readable to json format",
 	)
 	rootCmd.PersistentFlags().StringP("profile", "p", "",
 		"switch between profiles configured at ~/.lacework.toml",

--- a/cli/cmd/vulnerability.go
+++ b/cli/cmd/vulnerability.go
@@ -23,7 +23,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/briandowns/spinner"
 	"github.com/olekukonko/tablewriter"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -277,13 +276,7 @@ func init() {
 }
 
 func pollScanStatus(requestID string, lacework *api.Client) error {
-	var s *spinner.Spinner
-	if cli.HumanOutput() {
-		// humans like spinners (\o/)
-		s = spinner.New(spinner.CharSets[9], 100*time.Millisecond)
-		s.Suffix = " Scan running..."
-		s.Start()
-	}
+	cli.StartProgress(" Scan running...")
 
 	for {
 		report, err, retry := checkScanStatus(requestID, lacework)
@@ -300,7 +293,7 @@ func pollScanStatus(requestID string, lacework *api.Client) error {
 			return cli.OutputJSON(report)
 		}
 
-		s.Stop()
+		cli.StopProgress()
 		cli.OutputHuman(buildVulnerabilityReport(report))
 		return nil
 	}


### PR DESCRIPTION
Introducing a new flag called `--noninteractive` that will disable interactive
progress bars (i.e. 'spinners'). This parameter can be configured via environment
variables using `LW_NONINTERACTIVE=1`.

Additionally, updated the `README.md` to display a list of all environment variables
available:
| Environment Variable | Description |
|----------------------|-------------|
|`LW_NOCOLOR=1`|turn off colors|
|`LW_DEBUG=1`|turn on debug logging|
|`LW_JSON=1`|switch commands output from human-readable to JSON format|
|`LW_NONINTERACTIVE=1`|disable interactive progress bars (i.e. spinners)|
|`LW_PROFILE="<name>"`|switch between profiles configured at `~/.lacework.toml`|
|`LW_ACCOUNT="<account>"`|account subdomain of URL (i.e. `<ACCOUNT>.lacework.net`)|
|`LW_API_KEY="<key>"`|access key id|
|`LW_API_SECRET="<secret>"`|secret access key|

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>