### PR TITLE
fix(cli): access integration state securely

### DIFF
--- a/api/integrations.go
+++ b/api/integrations.go
@@ -179,18 +179,17 @@ func (c commonIntegrationData) Status() string {
 	return "Disabled"
 }
 
+func (c commonIntegrationData) StateString() string {
+	if c.State != nil && c.State.Ok {
+		return "Ok"
+	}
+	return "Check"
+}
+
 type IntegrationState struct {
 	Ok                 bool   `json:"ok"`
 	LastUpdatedTime    string `json:"lastUpdatedTime"`
 	LastSuccessfulTime string `json:"lastSuccessfulTime"`
-}
-
-func (s IntegrationState) String() string {
-	if s.Ok {
-		return "Ok"
-	}
-	return "Check"
-
 }
 
 type IntegrationsResponse struct {
@@ -207,7 +206,7 @@ func (integrations *IntegrationsResponse) Table() [][]string {
 			idata.Name,
 			idata.Type,
 			idata.Status(),
-			idata.State.String(),
+			idata.StateString(),
 		})
 	}
 	return out


### PR DESCRIPTION
This change is fixing a bug introduced with https://github.com/lacework/go-sdk/pull/67 where the `State` of the 
integration struct is now a pointer, and therefore we need to access it safely.

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>