### PR TITLE
style: avoid mixing duties between api/ and cli/

### DIFF
--- a/cli/cmd/vulnerability.go
+++ b/cli/cmd/vulnerability.go
@@ -340,7 +340,7 @@ func buildVulnerabilityReport(report *api.VulContainerReport) string {
 	t = tablewriter.NewWriter(imageDetailsTable)
 	t.SetBorder(false)
 	t.SetColumnSeparator("")
-	t.AppendBulk(report.Image.Table())
+	t.AppendBulk(vulContainerImageToTable(&report.Image))
 	t.Render()
 
 	t = tablewriter.NewWriter(vulCountsTable)
@@ -349,7 +349,7 @@ func buildVulnerabilityReport(report *api.VulContainerReport) string {
 	t.SetHeader([]string{
 		"Severity", "Count", "Fixable",
 	})
-	t.AppendBulk(report.VulCountsTable())
+	t.AppendBulk(vulContainerReportToCountsTable(report))
 	t.Render()
 
 	t = tablewriter.NewWriter(mainReport)
@@ -366,4 +366,45 @@ func buildVulnerabilityReport(report *api.VulContainerReport) string {
 	t.Render()
 
 	return mainReport.String()
+}
+
+func vulContainerReportToCountsTable(report *api.VulContainerReport) [][]string {
+	return [][]string{
+		[]string{"Critical", fmt.Sprint(report.CriticalVulnerabilities),
+			fmt.Sprint(report.VulFixableCount("critical"))},
+		[]string{"High", fmt.Sprint(report.HighVulnerabilities),
+			fmt.Sprint(report.VulFixableCount("high"))},
+		[]string{"Medium", fmt.Sprint(report.MediumVulnerabilities),
+			fmt.Sprint(report.VulFixableCount("medium"))},
+		[]string{"Low", fmt.Sprint(report.LowVulnerabilities),
+			fmt.Sprint(report.VulFixableCount("low"))},
+		[]string{"Info", fmt.Sprint(report.InfoVulnerabilities),
+			fmt.Sprint(report.VulFixableCount("info"))},
+	}
+}
+
+func vulContainerImageToTable(image *api.VulContainerImage) [][]string {
+	info := image.ImageInfo
+	return [][]string{
+		[]string{"ID", info.ImageID},
+		[]string{"Digest", info.ImageDigest},
+		[]string{"Registry", info.Registry},
+		[]string{"Repository", info.Repository},
+		[]string{"Size", byteCountBinary(info.Size)},
+		[]string{"Created At", info.CreatedTime},
+		[]string{"Tags", strings.Join(info.Tags, ",")},
+	}
+}
+
+func byteCountBinary(b int64) string {
+	const unit = 1024
+	if b < unit {
+		return fmt.Sprintf("%d B", b)
+	}
+	div, exp := int64(unit), 0
+	for n := b / unit; n >= unit; n /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %cB", float64(b)/float64(div), "KMGTPE"[exp])
 }


### PR DESCRIPTION
The Go api client shouldn't have anything related to the Lacework CLI,
the Go api should be an identical copy of the Lacework API as much as
possible. This change is moving the formatting of Tables from the api to
the cli go package.

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>