### PR TITLE
refactor(api): request and response log messages

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -18,7 +18,11 @@
 
 package api
 
-import "fmt"
+import (
+	"fmt"
+
+	"go.uber.org/zap"
+)
 
 const (
 	apiIntegrations       = "external/integrations"
@@ -39,6 +43,7 @@ const (
 // WithApiV2 configures the client to use the API version 2 (/api/v2)
 func WithApiV2() Option {
 	return clientFunc(func(c *Client) error {
+		c.log.Debug("setting up client", zap.String("api_version", "v2"))
 		c.apiVersion = "v2"
 		return nil
 	})

--- a/api/client.go
+++ b/api/client.go
@@ -115,6 +115,7 @@ func WithURL(baseURL string) Option {
 			return err
 		}
 
+		c.log.Debug("setting up client", zap.String("url", baseURL))
 		c.baseURL = u
 		return nil
 	})

--- a/api/events.go
+++ b/api/events.go
@@ -41,7 +41,7 @@ func (svc *EventsService) List() (EventsResponse, error) {
 	return svc.ListRange(from, now)
 }
 
-// ListRange returns a list of Lacework events during the specified date range.
+// ListRange returns a list of Lacework events during the specified date range
 //
 // Requirements and specifications:
 // * The dates format should be: yyyy-MM-ddTHH:mm:ssZ (example 2019-07-11T21:11:00Z)

--- a/api/logging.go
+++ b/api/logging.go
@@ -43,6 +43,7 @@ func WithLogLevel(level string) Option {
 			return fmt.Errorf("invalid log level '%s'", level)
 		}
 
+		c.log.Debug("setting up client", zap.String("log_level", level))
 		c.logLevel = level
 		c.initLogger()
 		return nil
@@ -57,6 +58,7 @@ func WithLogLevelAndWriter(level string, w io.Writer) Option {
 			return fmt.Errorf("invalid log level '%s'", level)
 		}
 
+		c.log.Debug("setting up client", zap.String("log_level", level))
 		c.logLevel = level
 		c.initLoggerWithWriter(w)
 		return nil
@@ -99,6 +101,7 @@ func WithLogFile(filename string) Option {
 			return errors.Wrap(err, "unable to open file to initialize api logger ")
 		}
 
+		c.log.Debug("setting up client redirect logger", zap.String("file", filename))
 		c.initLoggerWithWriter(logWriter)
 		return nil
 	})
@@ -115,6 +118,15 @@ func (c *Client) initLogger() {
 			zap.Field(zap.String("account", c.account)),
 		),
 	)
+
+	// verify if the log level has been configure through environment variable
+	if envLevel := lwlogger.LogLevelFromEnvironment(); envLevel != "" {
+		c.log.Debug("setting up client, override log level",
+			zap.String("before", c.logLevel),
+			zap.String("after", envLevel),
+		)
+		c.logLevel = envLevel
+	}
 }
 
 // initLoggerWithWriter initializes a new logger with a set
@@ -129,6 +141,15 @@ func (c *Client) initLoggerWithWriter(w io.Writer) {
 			zap.Field(zap.String("account", c.account)),
 		),
 	)
+
+	// verify if the log level has been configure through environment variable
+	if envLevel := lwlogger.LogLevelFromEnvironment(); envLevel != "" {
+		c.log.Debug("setting up client, override log level",
+			zap.String("before", c.logLevel),
+			zap.String("after", envLevel),
+		)
+		c.logLevel = envLevel
+	}
 }
 
 // debugMode returns true if the client is configured to display debug level logs

--- a/lwlogger/logger.go
+++ b/lwlogger/logger.go
@@ -33,7 +33,7 @@ import (
 var (
 	// LogLevelEnv represents the level that the logger is configured
 	LogLevelEnv        = "LW_LOG"
-	SupportedLogLevels = [2]string{"INFO", "DEBUG"}
+	SupportedLogLevels = [3]string{"", "INFO", "DEBUG"}
 
 	// LogFormatEnv controls the format of the logger
 	LogFormatEnv        = "LW_LOG_FORMAT"

--- a/lwlogger/logger_test.go
+++ b/lwlogger/logger_test.go
@@ -223,8 +223,8 @@ func TestLoggerNewWithOptions(t *testing.T) {
 func TestValidLevel(t *testing.T) {
 	assert.True(t, lwlogger.ValidLevel("INFO"))
 	assert.True(t, lwlogger.ValidLevel("DEBUG"))
+	assert.True(t, lwlogger.ValidLevel(""))
 	assert.False(t, lwlogger.ValidLevel("FOO"))
-	assert.False(t, lwlogger.ValidLevel(""))
 }
 
 // captureOutput executes a function and captures the STDOUT and STDERR,


### PR DESCRIPTION
To help the Go api client to log information messages that do not
overload the output we display, we are suppressing headers and body of
requests on `INFO` log level. If users wants to see those details, they
will have to set `DEBUG` to sniff inside the request and response
headers and bodies.

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>