### PR TITLE
feat: Lacework updater, keep users up-to-date

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,27 @@ This repository provides a set of tools, libraries, relevant documentation, code
 samples, processes, and/or guides that allow users and developers to interact with
 the Lacework platform.
 
+## Lacework CLI ([`cli`](cli/))
+
+The Lacework Command Line Interface is a tool that helps you manage the
+Lacework cloud security platform. You can use it to manage compliance
+reports, external integrations, vulnerability scans, and other operations.
+
+### Install
+
+#### Bash:
+```
+$ curl https://raw.githubusercontent.com/lacework/go-sdk/master/cli/install.sh | sudo bash
+```
+
+#### Powershell:
+```
+C:\> Set-ExecutionPolicy Bypass -Scope Process -Force
+C:\> iex ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/lacework/go-sdk/master/cli/install.ps1'))
+```
+
+Look at the [cli/](cli/) folder for more documentation.
+
 ## API Client ([`api`](api/))
 
 A Golang API client for interacting with the [Lacework API](https://support.lacework.com/hc/en-us/categories/360002496114-Lacework-API-).
@@ -38,40 +59,56 @@ func main() {
 ```
 Look at the [api/](api/) folder for more documentation.
 
-## Lacework CLI ([`cli`](cli/))
-
-The Lacework Command Line Interface is a tool that helps you manage the
-Lacework cloud security platform. You can use it to manage compliance
-reports, external integrations, vulnerability scans, and other operations.
-
-### Install
-
-#### Bash:
-```
-$ curl https://raw.githubusercontent.com/lacework/go-sdk/master/cli/install.sh | sudo bash
-```
-
-#### Powershell:
-```
-C:\> Set-ExecutionPolicy Bypass -Scope Process -Force
-C:\> iex ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/lacework/go-sdk/master/cli/install.ps1'))
-```
-
-Look at the [cli/](cli/) folder for more documentation.
-
 ## Lacework Logger ([`lwlogger`](lwlogger/))
 
 A Logger wrapper for Lacework based of zap logger Go package.
 
 ### Basic Usage
 ```go
+package main
+
 import "github.com/lacework/go-sdk/lwlogger"
 
 func main() {
 	lwL := lwlogger.New("INFO")
+
+	// Output: {"level":"info","ts":"[timestamp]","caller":"main.go:9","msg":"interesting info"}
 	lwL.Info("interesting info")
 }
 ```
+
+## Lacework Updater ([`lwupdater`](lwupdater/))
+
+A Go library to check for available updates of Lacework projects.
+
+### Basic Usage
+```go
+package main
+
+import (
+	"fmt"
+
+	"github.com/lacework/go-sdk/lwupdater"
+)
+
+func main() {
+	var (
+		project  = "go-sdk"
+		sdk, err = lwupdater.Check(project, "v0.1.0")
+	)
+
+	if err != nil {
+		fmt.Println("Unable to check for updates: %s", err)
+	} else {
+		// Output: The latest release of the go-sdk project is v0.1.7
+		fmt.Printf("The latest release of the %s project is %s\n",
+			project, sdk.Latest,
+		)
+	}
+}
+```
+
+Set the environment variable `LW_UPDATES_DISABLE=1` to avoid checking for updates.
 
 ## License and Copyright
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ C:\> iex ((New-Object System.Net.WebClient).DownloadString('https://raw.githubus
 
 Look at the [cli/](cli/) folder for more documentation.
 
-## API Client ([`api`](api/))
+## Lacework API Client ([`api`](api/))
 
 A Golang API client for interacting with the [Lacework API](https://support.lacework.com/hc/en-us/categories/360002496114-Lacework-API-).
 

--- a/cli/cmd/api.go
+++ b/cli/cmd/api.go
@@ -56,6 +56,7 @@ For a complete list of available API endpoints visit:
 )
 
 func init() {
+	// add the api command
 	rootCmd.AddCommand(apiCmd)
 
 	apiCmd.Flags().StringVarP(&apiData,

--- a/cli/cmd/cli_state.go
+++ b/cli/cmd/cli_state.go
@@ -130,7 +130,7 @@ func (c *cliState) VerifySettings() error {
 
 // NonInteractive turns off interactive mode, that is, no progress bars and spinners
 func (c *cliState) NonInteractive() {
-	cli.Log.Info("turning off interactive mode")
+	c.Log.Info("turning off interactive mode")
 	c.nonInteractive = true
 }
 
@@ -138,7 +138,7 @@ func (c *cliState) NonInteractive() {
 // into the cli state, make sure to run StopSpinner when you are done processing
 func (c *cliState) StartProgress(suffix string) {
 	if c.nonInteractive {
-		cli.Log.Debugw("skipping spinner",
+		c.Log.Debugw("skipping spinner",
 			"noninteractive", c.nonInteractive,
 			"action", "start_progress",
 		)
@@ -146,21 +146,21 @@ func (c *cliState) StartProgress(suffix string) {
 	}
 
 	// humans like spinners (^.^)
-	if cli.HumanOutput() {
+	if c.HumanOutput() {
 		// make sure there is not a spinner already running
-		cli.StopProgress()
+		c.StopProgress()
 
-		cli.Log.Debug("starting spinner")
-		cli.spinner = spinner.New(spinner.CharSets[9], 100*time.Millisecond)
-		cli.spinner.Suffix = suffix
-		cli.spinner.Start()
+		c.Log.Debug("starting spinner")
+		c.spinner = spinner.New(spinner.CharSets[9], 100*time.Millisecond)
+		c.spinner.Suffix = suffix
+		c.spinner.Start()
 	}
 }
 
 // StopProgress stops the running progress spinner, if any
 func (c *cliState) StopProgress() {
 	if c.nonInteractive {
-		cli.Log.Debugw("skipping spinner",
+		c.Log.Debugw("skipping spinner",
 			"noninteractive", c.nonInteractive,
 			"action", "stop_progress",
 		)
@@ -168,31 +168,35 @@ func (c *cliState) StopProgress() {
 	}
 
 	// humans like spinners (^.^)
-	if cli.HumanOutput() {
-		if cli.spinner != nil {
-			cli.Log.Debug("stopping spinner")
-			cli.spinner.Stop()
-			cli.spinner = nil
+	if c.HumanOutput() {
+		if c.spinner != nil {
+			c.Log.Debug("stopping spinner")
+			c.spinner.Stop()
+			c.spinner = nil
 		}
 	}
 }
 
+// EnableJSONOutput enables the cli to display JSON output
 func (c *cliState) EnableJSONOutput() {
-	cli.Log.Info("switch output to json format")
-	cli.jsonOutput = true
+	c.Log.Info("switch output to json format")
+	c.jsonOutput = true
 }
 
+// EnableJSONOutput enables the cli to display human readable output
 func (c *cliState) EnableHumanOutput() {
-	cli.Log.Info("switch output to human format")
-	cli.jsonOutput = false
+	c.Log.Info("switch output to human format")
+	c.jsonOutput = false
 }
 
+// JSONOutput returns true if the cli is configured to display JSON output
 func (c *cliState) JSONOutput() bool {
-	return cli.jsonOutput
+	return c.jsonOutput
 }
 
+// HumanOutput returns true if the cli is configured to siplay human readable output
 func (c *cliState) HumanOutput() bool {
-	return !cli.jsonOutput
+	return !c.jsonOutput
 }
 
 // loadStateFromViper loads parameters and environment variables

--- a/cli/cmd/cli_update_cmd.go
+++ b/cli/cmd/cli_update_cmd.go
@@ -1,0 +1,26 @@
+// +build !windows
+//
+// Author:: Salim Afiune Maya (<afiune@lacework.net>)
+// Copyright:: Copyright 2020, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cmd
+
+func (c *cliState) UpdateCommand() string {
+	return `
+  $ curl https://raw.githubusercontent.com/lacework/go-sdk/master/cli/install.sh | sudo bash
+`
+}

--- a/cli/cmd/cli_update_cmd.go
+++ b/cli/cmd/cli_update_cmd.go
@@ -19,6 +19,8 @@
 
 package cmd
 
+// UpdateCommand returns the command that a user should run to update the cli
+// to the latest available version (unix specific command)
 func (c *cliState) UpdateCommand() string {
 	return `
   $ curl https://raw.githubusercontent.com/lacework/go-sdk/master/cli/install.sh | sudo bash

--- a/cli/cmd/cli_update_cmd_windows.go
+++ b/cli/cmd/cli_update_cmd_windows.go
@@ -1,0 +1,26 @@
+//
+// Author:: Salim Afiune Maya (<afiune@lacework.net>)
+// Copyright:: Copyright 2020, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cmd
+
+func (c *cliState) UpdateCommand() string {
+	return `
+  C:\> Set-ExecutionPolicy Bypass -Scope Process -Force
+  C:\> iex ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/lacework/go-sdk/master/cli/install.ps1'))
+`
+}

--- a/cli/cmd/cli_update_cmd_windows.go
+++ b/cli/cmd/cli_update_cmd_windows.go
@@ -18,6 +18,8 @@
 
 package cmd
 
+// UpdateCommand returns the command that a user should run to update the cli
+// to the latest available version (windows specific command)
 func (c *cliState) UpdateCommand() string {
 	return `
   C:\> Set-ExecutionPolicy Bypass -Scope Process -Force

--- a/cli/cmd/event.go
+++ b/cli/cmd/event.go
@@ -41,8 +41,10 @@ var (
 	eventListCmd = &cobra.Command{
 		Use:   "list",
 		Short: "list all events from a date range (default last 7 days)",
-		Long: `List all events from a data range, by default it displays the last
-7 days, but you can specify a different time range.`,
+		Long: `
+List all events from a time range, by default this command displays the
+events from the last 7 days, but it is possible to specify a different
+time range.`,
 		Args: cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			lacework, err := api.NewClient(cli.Account,

--- a/cli/cmd/outputs.go
+++ b/cli/cmd/outputs.go
@@ -29,7 +29,7 @@ import (
 func (c *cliState) OutputJSON(v interface{}) error {
 	pretty, err := c.JsonF.Marshal(v)
 	if err != nil {
-		cli.Log.Debugw("unable to pretty print JSON object", "raw", v)
+		c.Log.Debugw("unable to pretty print JSON object", "raw", v)
 		return err
 	}
 	fmt.Fprintln(color.Output, string(pretty))
@@ -42,4 +42,15 @@ func (c *cliState) OutputHuman(format string, a ...interface{}) {
 	if c.HumanOutput() {
 		fmt.Fprintf(os.Stdout, format, a...)
 	}
+}
+
+// OutputJSONString just like OutputJSON but passing a JSON string
+func (c *cliState) OutputJSONString(s string) error {
+	pretty, err := c.JsonF.Format([]byte(s))
+	if err != nil {
+		c.Log.Debugw("unable to pretty print JSON string", "raw", s)
+		return err
+	}
+	fmt.Fprintln(color.Output, string(pretty))
+	return nil
 }

--- a/cli/cmd/outputs.go
+++ b/cli/cmd/outputs.go
@@ -44,7 +44,7 @@ func (c *cliState) OutputHuman(format string, a ...interface{}) {
 	}
 }
 
-// OutputJSONString just like OutputJSON but passing a JSON string
+// OutputJSONString is just like OutputJSON but from a JSON string
 func (c *cliState) OutputJSONString(s string) error {
 	pretty, err := c.JsonF.Format([]byte(s))
 	if err != nil {

--- a/cli/cmd/version.go
+++ b/cli/cmd/version.go
@@ -44,8 +44,11 @@ var (
 	versionCmd = &cobra.Command{
 		Use:   "version",
 		Short: "print the Lacework CLI version",
-		Long: `Prints out the installed version of the Lacework CLI and checks for newer
-versions available for update.`,
+		Long: `
+Prints out the installed version of the Lacework CLI and checks for newer
+versions available for update.
+
+Set the environment variable 'LW_UPDATES_DISABLE=1' to avoid checking for updates.`,
 		Args: cobra.NoArgs,
 		Run: func(_ *cobra.Command, _ []string) {
 			if cli.JSONOutput() {

--- a/cli/cmd/vulnerability.go
+++ b/cli/cmd/vulnerability.go
@@ -46,7 +46,7 @@ var (
 	vulnerabilityCmd = &cobra.Command{
 		Use:     "vulnerability",
 		Aliases: []string{"vul"},
-		Short:   "View vulnerability reports and run on-demand scans",
+		Short:   "view vulnerability reports and run on-demand scans",
 		Long: `
 Request on-demand vulnerability scans and vizualize previous reports
 from published images.

--- a/cli/cmd/vulnerability.go
+++ b/cli/cmd/vulnerability.go
@@ -69,7 +69,7 @@ Then navigate to Settings > Integrations > Container Registry.`,
 	// vulScanCmd represents the scan sub-command inside the vulnerability command
 	vulScanCmd = &cobra.Command{
 		Use:   "scan",
-		Short: "Manage on-demand vulnerability scans",
+		Short: "manage on-demand vulnerability scans",
 		Long: `Request on-demand vulnerability scans and view the generated report.
 
 NOTE: Scans can take up to 15 minutes to return results.`,
@@ -78,13 +78,13 @@ NOTE: Scans can take up to 15 minutes to return results.`,
 	// vulScanRunCmd represents the run sub-command inside the scan vulnerability command
 	vulScanRunCmd = &cobra.Command{
 		Use:   "run <registry> <repository> <tag|image_id>",
-		Short: "Request an on-demand vulnerability scan",
-		Long: `Request an on-demand vulnerability scan
+		Short: "request an on-demand vulnerability scan",
+		Long: `Request an on-demand vulnerability scan.
 
 Arguments:
-  <registry>      container registry where the container image is published
+  <registry>      container registry where the container image has been published
   <repository>    repository name that contains the container image
-  <tag|image_id>  either the tag or the image ID to scan (image_id format: sha256:1ee...1d3b)`,
+  <tag|image_id>  either a tag or an image ID to scan (image_id format: sha256:1ee...1d3b)`,
 		Args: cobra.ExactArgs(3),
 		RunE: func(_ *cobra.Command, args []string) error {
 			lacework, err := api.NewClient(cli.Account,
@@ -139,7 +139,8 @@ Arguments:
 	// vulScanShowCmd represents the show sub-command inside the scan vulnerability command
 	vulScanShowCmd = &cobra.Command{
 		Use:   "show <request_id>",
-		Short: "Return data about an on-demand vulnerability scan",
+		Short: "return results about an on-demand vulnerability scan",
+		Long:  "Return results about an on-demand vulnerability scan.",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
 			lacework, err := api.NewClient(cli.Account,
@@ -185,7 +186,7 @@ Arguments:
 	// vulReportCmd represents the report sub-command inside the vulnerability command
 	vulReportCmd = &cobra.Command{
 		Use:   "report <sha256:hash>",
-		Short: "Show vulnerability reports of a container image",
+		Short: "show vulnerability reports of a container image",
 		Long: `Review vulnerability reports from container image scans that run previously either
 by the preriodic scan mechanism that Lacework runs every hour, or a requested
 on-demand vulnerability scan.

--- a/lwlogger/_examples/main.go
+++ b/lwlogger/_examples/main.go
@@ -1,0 +1,10 @@
+package main
+
+import "github.com/lacework/go-sdk/lwlogger"
+
+func main() {
+	lwL := lwlogger.New("INFO")
+
+	// Output: {"level":"info","ts":"[timestamp]","caller":"main.go:9","msg":"interesting info"}
+	lwL.Info("interesting info")
+}

--- a/lwupdater/_examples/main.go
+++ b/lwupdater/_examples/main.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/lacework/go-sdk/lwupdater"
+)
+
+func main() {
+	var (
+		project  = "go-sdk"
+		sdk, err = lwupdater.Check(project, "v0.1.0")
+	)
+
+	if err != nil {
+		fmt.Println("Unable to check for updates: %s", err)
+	} else {
+		// Output: The latest release of the go-sdk project is v0.1.7
+		fmt.Printf("The latest release of the %s project is %s\n",
+			project, sdk.Latest,
+		)
+	}
+}

--- a/lwupdater/updater.go
+++ b/lwupdater/updater.go
@@ -1,0 +1,141 @@
+//
+// Author:: Salim Afiune Maya (<afiune@lacework.net>)
+// Copyright:: Copyright 2020, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package lwupdater
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+const (
+	// GithubOrganization is the default Github organization where
+	// Lacework stores their open source projects
+	GithubOrganization = "lacework"
+
+	// DisableEnv controls the overall check for updates behavior, when
+	// this environment variable is set, we do not check for updates
+	DisableEnv = "LW_UPDATES_DISABLE"
+)
+
+type info struct {
+	Project  string
+	Version  string
+	Latest   string
+	Outdated bool
+}
+
+// Check verifies if the a project is outdated based of the current version
+func Check(project, current string) (*info, error) {
+	if disabled := os.Getenv(DisableEnv); disabled != "" {
+		return new(info), nil
+	}
+
+	release, err := getGitRelease(project, "latest")
+	if err != nil {
+		return new(info), err
+	}
+
+	return &info{
+		Project:  project,
+		Version:  current,
+		Latest:   release.TagName,
+		Outdated: current != release.TagName,
+	}, nil
+}
+
+// getGitRelease uses the git API to fetch the release information of a project.
+// This function could hit request rate limits wich are roughly 60 every 30m, to
+// check your current rate limits run: curl https://api.github.com/rate_limit
+//
+// TODO @afiune implement a cache mechanism
+func getGitRelease(project, version string) (*gitReleaseResponse, error) {
+	if project == "" {
+		return nil, errors.New("specify a valid project")
+	}
+	if version == "" {
+		version = "latest"
+	}
+
+	var (
+		c = http.Client{}
+		u = url.URL{
+			Scheme: "https",
+			Host:   "api.github.com",
+			Path: fmt.Sprintf(
+				"/repos/%s/%s/releases/latest",
+				GithubOrganization, project,
+			),
+		}
+	)
+	if version != "latest" {
+		u.Path = fmt.Sprintf("/repos/%s/%s/releases/tags/%s",
+			GithubOrganization, project, version)
+	}
+
+	req, err := http.NewRequest("GET", u.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// Set the user agent since it is required
+	// https://developer.github.com/v3/#user-agent-required
+	req.Header.Set("User-Agent", "lacework-updater")
+
+	resp, err := c.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	if c := resp.StatusCode; c >= 200 && c <= 299 {
+		var gitRelRes gitReleaseResponse
+		if err := json.NewDecoder(resp.Body).Decode(&gitRelRes); err != nil {
+			return nil, err
+		}
+
+		return &gitRelRes, nil
+	}
+
+	// not a successful response, throw an error
+	return nil, errors.New(resp.Status)
+}
+
+type gitReleaseResponse struct {
+	ID              int32     `json:"id"`
+	Url             string    `json:"url"`
+	HtmlUrl         string    `json:"html_url"`
+	AssetsUrl       string    `json:"assets_url"`
+	UploadUrl       string    `json:"upload_url"`
+	TarballUrl      string    `json:"tarball_url"`
+	ZipballUrl      string    `json:"zipball_url"`
+	NodeId          string    `json:"node_id"`
+	TagName         string    `json:"tag_name"`
+	TargetCommitish string    `json:"target_commitish"`
+	Name            string    `json:"name"`
+	Body            string    `json:"body"`
+	Draft           bool      `json:"draft"`
+	Prerelease      bool      `json:"prerelease"`
+	CreatedAt       time.Time `json:"created_at"`
+	PublishedAt     time.Time `json:"published_at"`
+}

--- a/lwupdater/updater_test.go
+++ b/lwupdater/updater_test.go
@@ -1,0 +1,60 @@
+//
+// Author:: Salim Afiune Maya (<afiune@lacework.net>)
+// Copyright:: Copyright 2020, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package lwupdater_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/lacework/go-sdk/lwupdater"
+)
+
+func TestCheckErrorEmptyProject(t *testing.T) {
+	info, err := lwupdater.Check("", "")
+	assert.Empty(t, info)
+	if assert.NotNil(t, err) {
+		assert.Equal(t, "specify a valid project", err.Error())
+	}
+}
+
+// @afiune this test requires to actually have internet access,
+// I wonder if this will cause problems in the future, if so,
+// we should disable it.
+//
+// TODO @afiune implement a cache mechanism
+func TestCheck(t *testing.T) {
+	info, err := lwupdater.Check("go-sdk", "v0.1.6")
+	if assert.Nil(t, err) {
+		assert.Equal(t, "go-sdk", info.Project)
+		assert.Equal(t, "v0.1.6", info.Version)
+		assert.Regexp(t, `^v?([0-9]+)(\.[0-9]+)?(\.[0-9]+)$`, info.Latest)
+		assert.True(t, info.Outdated)
+	}
+}
+
+func TestCheckDisabled(t *testing.T) {
+	// disable the updater
+	os.Setenv(lwupdater.DisableEnv, "1")
+	defer os.Setenv(lwupdater.DisableEnv, "")
+	info, err := lwupdater.Check("go-sdk", "v0.1.0")
+	assert.Nil(t, err)
+	assert.Empty(t, info)
+}


### PR DESCRIPTION
## Motivation
```
As a Lacework CLI user,
I would like to be kept up-to-date with the latest available versions,
So I can be aware of newer available versions and I can easily update.
```
## Description
How do we ensure that our users will update constantly? Software updates are
important because they often include critical patches to security holes, new
features, stability enhancements, and remove outdated features. All of these
updates are aimed at making the user experience better.

## Lacework Updater
Introducing a new Go library called `lwupdater` that will check for available
updates of Lacework projects.

This new library aims to help our users to be kept up-to-date with the latest
version of our products, when users check for the current version installed on
their workstations, we are going to check if there are new versions available
for them, and provide the command to run to update the product. As simple
as a copy and paste.

In this example, we check the version of the Lacework CLI when it is the latest
available version:
```
$ lacework version
lacework v0.1.7 (sha:861ce9e227a3f1cd95c78011d95f0f54e6b72ec2) (time:20200427020330)
```

As releases come, users will wanna know for newer available version of the
Lacework CLI, and when they run the `version` command we will display a
message similar to:
```
$ lacework version
lacework v0.1.7 (sha:861ce9e227a3f1cd95c78011d95f0f54e6b72ec2) (time:20200427020330)

A newer version of the Lacework CLI is available! The latest version is v0.1.8,
to update execute the following command:

  $ curl https://raw.githubusercontent.com/lacework/go-sdk/master/cli/install.sh | sudo bash

```