### PR TITLE
feat(cli): add --details flag to vulnerability cmd

### DIFF
--- a/cli/cmd/vulnerability.go
+++ b/cli/cmd/vulnerability.go
@@ -20,12 +20,14 @@ package cmd
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
 	"github.com/olekukonko/tablewriter"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	flag "github.com/spf13/pflag"
 
 	"github.com/lacework/go-sdk/api"
 )
@@ -40,6 +42,9 @@ var (
 
 		// when enabled we tread the provided sha256 hash as image digest
 		Digest bool
+
+		// display extended details about a vulnerability scan/report
+		Details bool
 	}{PollInterval: time.Second * 5}
 
 	// vulnerability represents the vulnerability command
@@ -260,19 +265,42 @@ func init() {
 	vulScanCmd.AddCommand(vulScanRunCmd)
 	vulScanCmd.AddCommand(vulScanShowCmd)
 
-	vulScanRunCmd.Flags().BoolVar(&vulCmdState.Poll, "poll", false,
-		fmt.Sprintf("poll until the vulnerability scan completes (%vs intervals)",
-			vulCmdState.PollInterval.Seconds()),
+	setPollFlag(
+		vulScanRunCmd.Flags(),
+		vulScanShowCmd.Flags(),
 	)
-	vulScanShowCmd.Flags().BoolVar(&vulCmdState.Poll, "poll", false,
-		fmt.Sprintf("poll until the vulnerability scan completes (%vs intervals)",
-			vulCmdState.PollInterval.Seconds()),
+
+	setDetailsFlag(
+		vulScanRunCmd.Flags(),
+		vulScanShowCmd.Flags(),
+		vulReportCmd.Flags(),
 	)
 
 	vulReportCmd.Flags().BoolVar(
 		&vulCmdState.Digest, "digest", false,
 		"tread the provided sha256 hash as image digest",
 	)
+}
+
+func setPollFlag(cmds ...*flag.FlagSet) {
+	for _, cmd := range cmds {
+		if cmd != nil {
+			cmd.BoolVar(&vulCmdState.Poll, "poll", false,
+				fmt.Sprintf("poll until the vulnerability scan completes (%vs intervals)",
+					vulCmdState.PollInterval.Seconds()),
+			)
+		}
+	}
+}
+
+func setDetailsFlag(cmds ...*flag.FlagSet) {
+	for _, cmd := range cmds {
+		if cmd != nil {
+			cmd.BoolVar(&vulCmdState.Details, "details", false,
+				"display extended details about a vulnerability report",
+			)
+		}
+	}
 }
 
 func pollScanStatus(requestID string, lacework *api.Client) error {
@@ -334,7 +362,7 @@ func buildVulnerabilityReport(report *api.VulContainerReport) string {
 		t                 *tablewriter.Table
 		imageDetailsTable = &strings.Builder{}
 		vulCountsTable    = &strings.Builder{}
-		mainReport        = &strings.Builder{}
+		summaryReport     = &strings.Builder{}
 	)
 
 	t = tablewriter.NewWriter(imageDetailsTable)
@@ -352,7 +380,7 @@ func buildVulnerabilityReport(report *api.VulContainerReport) string {
 	t.AppendBulk(vulContainerReportToCountsTable(report))
 	t.Render()
 
-	t = tablewriter.NewWriter(mainReport)
+	t = tablewriter.NewWriter(summaryReport)
 	t.SetBorder(false)
 	t.SetAutoWrapText(false)
 	t.SetHeader([]string{
@@ -365,7 +393,73 @@ func buildVulnerabilityReport(report *api.VulContainerReport) string {
 	})
 	t.Render()
 
-	return mainReport.String()
+	summary := summaryReport.String()
+
+	if vulCmdState.Details {
+		cveDetailsTable, length := buildVulnerabilityReportDetails(report)
+		// if the extended report is bigger than 100 rows,
+		// lets repeat the summary table at the bottom
+		if length > 100 {
+			return summary + cveDetailsTable + "\n" + summary
+		}
+
+		return summary + cveDetailsTable + "\n"
+	}
+
+	return summary
+}
+
+func buildVulnerabilityReportDetails(report *api.VulContainerReport) (string, int) {
+	var (
+		imageLayersTable = vulContainerImageLayersToTable(&report.Image)
+		detailsTable     = &strings.Builder{}
+		t                = tablewriter.NewWriter(detailsTable)
+	)
+
+	t.SetRowLine(true)
+	t.SetBorders(tablewriter.Border{
+		Left:   false,
+		Right:  false,
+		Top:    true,
+		Bottom: true,
+	})
+	t.SetHeader([]string{
+		"CVE",
+		"Severity",
+		"Package",
+		"Current Version",
+		"Fix Version",
+		"Introduced in Layer (sha256)",
+	})
+	t.AppendBulk(imageLayersTable)
+	t.Render()
+
+	return detailsTable.String(), len(imageLayersTable)
+}
+
+func vulContainerImageLayersToTable(image *api.VulContainerImage) [][]string {
+	out := [][]string{}
+	for _, layer := range image.ImageLayers {
+		for _, pkg := range layer.Packages {
+			for _, vul := range pkg.Vulnerabilities {
+				out = append(out, []string{
+					vul.Name,
+					strings.Title(vul.Severity),
+					pkg.Name,
+					pkg.Version,
+					vul.FixVersion,
+					layer.Hash,
+				})
+			}
+		}
+	}
+
+	// @afiune change
+	sort.Slice(out, func(i, j int) bool {
+		return out[i][1] < out[j][1]
+	})
+
+	return out
 }
 
 func vulContainerReportToCountsTable(report *api.VulContainerReport) [][]string {

--- a/cli/cmd/vulnerability.go
+++ b/cli/cmd/vulnerability.go
@@ -454,12 +454,28 @@ func vulContainerImageLayersToTable(image *api.VulContainerImage) [][]string {
 		}
 	}
 
-	// @afiune change
 	sort.Slice(out, func(i, j int) bool {
-		return out[i][1] < out[j][1]
+		return severityOrder(out[i][1]) < severityOrder(out[j][1])
 	})
 
 	return out
+}
+
+func severityOrder(severity string) int {
+	switch strings.ToLower(severity) {
+	case "critical":
+		return 1
+	case "high":
+		return 2
+	case "medium":
+		return 3
+	case "low":
+		return 4
+	case "info":
+		return 5
+	default:
+		return 6
+	}
 }
 
 func vulContainerReportToCountsTable(report *api.VulContainerReport) [][]string {

--- a/cli/cmd/vulnerability.go
+++ b/cli/cmd/vulnerability.go
@@ -368,6 +368,7 @@ func buildVulnerabilityReport(report *api.VulContainerReport) string {
 	t = tablewriter.NewWriter(imageDetailsTable)
 	t.SetBorder(false)
 	t.SetColumnSeparator("")
+	t.SetAlignment(tablewriter.ALIGN_LEFT)
 	t.AppendBulk(vulContainerImageToTable(&report.Image))
 	t.Render()
 

--- a/cli/cmd/vulnerability.go
+++ b/cli/cmd/vulnerability.go
@@ -20,6 +20,7 @@ package cmd
 
 import (
 	"fmt"
+	"regexp"
 	"sort"
 	"strings"
 	"time"
@@ -297,7 +298,7 @@ func setDetailsFlag(cmds ...*flag.FlagSet) {
 	for _, cmd := range cmds {
 		if cmd != nil {
 			cmd.BoolVar(&vulCmdState.Details, "details", false,
-				"display extended details about a vulnerability report",
+				"increase details about the vulnerability report",
 			)
 		}
 	}
@@ -362,7 +363,7 @@ func buildVulnerabilityReport(report *api.VulContainerReport) string {
 		t                 *tablewriter.Table
 		imageDetailsTable = &strings.Builder{}
 		vulCountsTable    = &strings.Builder{}
-		summaryReport     = &strings.Builder{}
+		mainReport        = &strings.Builder{}
 	)
 
 	t = tablewriter.NewWriter(imageDetailsTable)
@@ -381,7 +382,7 @@ func buildVulnerabilityReport(report *api.VulContainerReport) string {
 	t.AppendBulk(vulContainerReportToCountsTable(report))
 	t.Render()
 
-	t = tablewriter.NewWriter(summaryReport)
+	t = tablewriter.NewWriter(mainReport)
 	t.SetBorder(false)
 	t.SetAutoWrapText(false)
 	t.SetHeader([]string{
@@ -394,14 +395,16 @@ func buildVulnerabilityReport(report *api.VulContainerReport) string {
 	})
 	t.Render()
 
-	summary := summaryReport.String()
-
 	if vulCmdState.Details {
-		cveDetailsTable := buildVulnerabilityReportDetails(report)
-		return summary + cveDetailsTable + "\n"
+		mainReport.WriteString(buildVulnerabilityReportDetails(report))
+		mainReport.WriteString("\n")
+	} else {
+		mainReport.WriteString(
+			"Try using --details to increase details shown about the vulnerability report.\n",
+		)
 	}
 
-	return summary
+	return mainReport.String()
 }
 
 func buildVulnerabilityReportDetails(report *api.VulContainerReport) string {
@@ -417,13 +420,14 @@ func buildVulnerabilityReportDetails(report *api.VulContainerReport) string {
 		Top:    true,
 		Bottom: true,
 	})
+	t.SetAlignment(tablewriter.ALIGN_LEFT)
 	t.SetHeader([]string{
 		"CVE",
 		"Severity",
 		"Package",
 		"Current Version",
 		"Fix Version",
-		"Introduced in Layer (sha256)",
+		"Introduced in Layer",
 	})
 	t.AppendBulk(vulContainerImageLayersToTable(&report.Image))
 	t.Render()
@@ -436,13 +440,16 @@ func vulContainerImageLayersToTable(image *api.VulContainerImage) [][]string {
 	for _, layer := range image.ImageLayers {
 		for _, pkg := range layer.Packages {
 			for _, vul := range pkg.Vulnerabilities {
+				space := regexp.MustCompile(`\s+`)
+				createdBy := space.ReplaceAllString(layer.CreatedBy, " ")
+
 				out = append(out, []string{
 					vul.Name,
 					strings.Title(vul.Severity),
 					pkg.Name,
 					pkg.Version,
 					vul.FixVersion,
-					layer.Hash,
+					createdBy,
 				})
 			}
 		}

--- a/cli/cmd/vulnerability.go
+++ b/cli/cmd/vulnerability.go
@@ -396,24 +396,17 @@ func buildVulnerabilityReport(report *api.VulContainerReport) string {
 	summary := summaryReport.String()
 
 	if vulCmdState.Details {
-		cveDetailsTable, length := buildVulnerabilityReportDetails(report)
-		// if the extended report is bigger than 100 rows,
-		// lets repeat the summary table at the bottom
-		if length > 100 {
-			return summary + cveDetailsTable + "\n" + summary
-		}
-
+		cveDetailsTable := buildVulnerabilityReportDetails(report)
 		return summary + cveDetailsTable + "\n"
 	}
 
 	return summary
 }
 
-func buildVulnerabilityReportDetails(report *api.VulContainerReport) (string, int) {
+func buildVulnerabilityReportDetails(report *api.VulContainerReport) string {
 	var (
-		imageLayersTable = vulContainerImageLayersToTable(&report.Image)
-		detailsTable     = &strings.Builder{}
-		t                = tablewriter.NewWriter(detailsTable)
+		detailsTable = &strings.Builder{}
+		t            = tablewriter.NewWriter(detailsTable)
 	)
 
 	t.SetRowLine(true)
@@ -431,10 +424,10 @@ func buildVulnerabilityReportDetails(report *api.VulContainerReport) (string, in
 		"Fix Version",
 		"Introduced in Layer (sha256)",
 	})
-	t.AppendBulk(imageLayersTable)
+	t.AppendBulk(vulContainerImageLayersToTable(&report.Image))
 	t.Render()
 
-	return detailsTable.String(), len(imageLayersTable)
+	return detailsTable.String()
 }
 
 func vulContainerImageLayersToTable(image *api.VulContainerImage) [][]string {


### PR DESCRIPTION
This change is adding a new flag to the vulnerability command called
`--details`, this flag will extend the report shown to the end-user.

The new information presented with this flag is the list of CVE's with
its severity, version and, if any, fix version, plus the layer that the
vulnerability was introduced by.

Example:
```
$ lacework vulnerability report sha256:123ab...xyz --details
```

![Screen Shot 2020-04-28 at 8 47 52 AM](https://user-images.githubusercontent.com/61525522/80517061-b32a6100-8941-11ea-9065-617a60c0fde2.png)

This flag is available to all sub-commands inside the `vulnerability`
cmd. (`lacework vul scan run`, `lacework vul scan show`, and 
`lacework vul report`, as shown above 👆🏽)

Closes https://github.com/lacework/go-sdk/issues/82

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>