### PR TITLE
refactor(cli): consistency between image ID & Digest

### DIFF
--- a/cli/cmd/vulnerability.go
+++ b/cli/cmd/vulnerability.go
@@ -42,7 +42,11 @@ var (
 		PollInterval time.Duration
 
 		// when enabled we tread the provided sha256 hash as image digest
+		// DEPRECATED
 		Digest bool
+
+		// when enabled we tread the provided sha256 hash as image id
+		ImageID bool
 
 		// display extended details about a vulnerability scan/report
 		Details bool
@@ -57,9 +61,9 @@ var (
 Request on-demand vulnerability scans and vizualize previous reports
 from published images.
 
-**PREREQUISITE: Your Lacework account should already be configured with
-a Container Registry Integration of the container images your are trying
-to scan or visualize.
+(*) PREREQUISITE: Your Lacework account should already be configured
+with a Container Registry Integration of the container images you are
+trying to scan or visualize.
 
 To create a new integration use the following command:
 
@@ -83,14 +87,14 @@ NOTE: Scans can take up to 15 minutes to return results.`,
 
 	// vulScanRunCmd represents the run sub-command inside the scan vulnerability command
 	vulScanRunCmd = &cobra.Command{
-		Use:   "run <registry> <repository> <tag|image_id>",
+		Use:   "run <registry> <repository> <tag|digest>",
 		Short: "request an on-demand vulnerability scan",
 		Long: `Request an on-demand vulnerability scan.
 
 Arguments:
-  <registry>      container registry where the container image has been published
-  <repository>    repository name that contains the container image
-  <tag|image_id>  either a tag or an image ID to scan (image_id format: sha256:1ee...1d3b)`,
+  <registry>    container registry where the container image has been published
+  <repository>  repository name that contains the container image
+  <tag|digest>  either a tag or an image digest to scan (digest format: sha256:1ee...1d3b)`,
 		Args: cobra.ExactArgs(3),
 		RunE: func(_ *cobra.Command, args []string) error {
 			lacework, err := api.NewClient(cli.Account,
@@ -104,7 +108,7 @@ Arguments:
 			cli.Log.Debugw("requesting vulnerability scan",
 				"registry", args[0],
 				"repository", args[1],
-				"tag_or_image_id", args[2],
+				"tag_or_digest", args[2],
 			)
 			scan, err := lacework.Vulnerabilities.Scan(args[0], args[1], args[2])
 			if err != nil {
@@ -180,7 +184,7 @@ Arguments:
 					"The vulnerability scan is still running. (request_id: %s)\n\n",
 					args[0],
 				)
-				cli.OutputHuman("Use --poll to poll until the vulnerability scan completes.\n")
+				cli.OutputHuman("Use '--poll' to poll until the vulnerability scan completes.\n")
 			} else {
 				cli.OutputHuman("\n")
 				cli.OutputHuman(buildVulnerabilityReport(report))
@@ -194,11 +198,14 @@ Arguments:
 		Use:   "report <sha256:hash>",
 		Short: "show vulnerability reports of a container image",
 		Long: `Review vulnerability reports from container image scans that run previously either
-by the preriodic scan mechanism that Lacework runs every hour, or a requested
+by the periodic scan mechanism that Lacework runs every hour, or a requested
 on-demand vulnerability scan.
 
 Arguments:
   <sha256:hash> a sha256 hash of a container image (format: sha256:1ee...1d3b)
+
+By default, this command treads the provided sha256 as image digest, when trying to
+lookup a report by its image id, provided the flag '--image_id'.
 `,
 		Args: cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
@@ -210,19 +217,21 @@ Arguments:
 				return errors.Wrap(err, "unable to generate api client")
 			}
 
-			var report api.VulContainerReportResponse
-			if vulCmdState.Digest {
-				cli.Log.Debugw("retrieve vulnerability report", "image_digest", args[0])
-				report, err = lacework.Vulnerabilities.ReportFromDigest(args[0])
-				if err != nil {
-					return errors.Wrap(err, "unable to show vulnerability report")
-				}
-			} else {
-				cli.Log.Debugw("retrieve vulnerability report", "image_id", args[0])
+			var (
+				report      api.VulContainerReportResponse
+				searchField string
+			)
+			if vulCmdState.ImageID {
+				searchField = "image_id"
+				cli.Log.Debugw("retrieve vulnerability report", searchField, args[0])
 				report, err = lacework.Vulnerabilities.ReportFromID(args[0])
-				if err != nil {
-					return errors.Wrap(err, "unable to show vulnerability report")
-				}
+			} else {
+				searchField = "digest"
+				cli.Log.Debugw("retrieve vulnerability report", searchField, args[0])
+				report, err = lacework.Vulnerabilities.ReportFromDigest(args[0])
+			}
+			if err != nil {
+				return errors.Wrap(err, "unable to show vulnerability report")
 			}
 
 			cli.Log.Debugw("vulnerability report", "details", report)
@@ -236,10 +245,17 @@ Arguments:
 				cli.OutputHuman("\n")
 				cli.OutputHuman(buildVulnerabilityReport(&report.Data))
 			case "NotFound":
-				return errors.Errorf(
-					"unable to find any vulnerability report for image '%s'",
-					args[0],
+				msg := fmt.Sprintf(
+					"unable to find any container vulnerability report with %s '%s'",
+					searchField, args[0],
 				)
+
+				// add a suggestion to the user in regards of the image_id vs digest
+				if !vulCmdState.ImageID {
+					msg = fmt.Sprintf("%s\n\n(?) Are you trying to lookup a report using an image id? Try adding '--image_id'", msg)
+				}
+
+				return errors.New(msg)
 			case "Failed":
 				return errors.New(
 					"the vulnerability report failed to execute. Use '--debug' to troubleshoot.",
@@ -279,8 +295,12 @@ func init() {
 	)
 
 	vulReportCmd.Flags().BoolVar(
-		&vulCmdState.Digest, "digest", false,
-		"tread the provided sha256 hash as image digest",
+		&vulCmdState.Digest, "digest", true,
+		"tread the provided sha256 hash as image digest (DEPRECATED)",
+	)
+	vulReportCmd.Flags().BoolVar(
+		&vulCmdState.ImageID, "image_id", false,
+		"tread the provided sha256 hash as image id",
 	)
 }
 
@@ -401,7 +421,7 @@ func buildVulnerabilityReport(report *api.VulContainerReport) string {
 		mainReport.WriteString("\n")
 	} else {
 		mainReport.WriteString(
-			"Try using --details to increase details shown about the vulnerability report.\n",
+			"Try using '--details' to increase details shown about the vulnerability report.\n",
 		)
 	}
 


### PR DESCRIPTION
By default, on-demand vulnerability scans are requested by providing the
tag or digest of an image, therefore this change is modifying the
`vulnerability` command to be focused in digest as much as possible.
Though, we will provide a way to retrieve reports from image IDs.

## Run on-demand scans
To run an on-demand scan, a user will need the following information:
```
<registry>    container registry where the container image has been published
<repository>  repository name that contains the container image
<tag|digest>  either a tag or an image digest to scan (digest format: sha256:1ee...1d3b)
```
Note that we can't trigger scans with an image ID.

## Review vulnerability reports
To review vulnerability reports from container image scans that run previously either
by the periodic scan mechanism that Lacework runs every hour, or a requested
on-demand vulnerability scan, a user will need to provide a SHA256 hash of a
container with format `sha256:1ee...1d3b`.

Example:
```
$ lacework vul report sha256:8d8f5b08727272389bc2788561bd60a8f012d3c68675dccce7dd7ee2d47a9f4d
```
By default, this command treads the provided SHA256 as the image digest, when a
user is trying to lookup a report by its image ID, they can use the flag `--image_id` that
will tread the provided SHA256 hash as an image ID.

## DEPRECATIONS
The flag `--digest` will be deprecated, and in fact, enabled by default for the command
`lacework vulnerability report`.

Closes https://github.com/lacework/go-sdk/issues/80

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>