### PR TITLE
feat: Add lacework-cli containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM alpine:3.6 as alpine
+RUN apk add -U --no-cache ca-certificates
+
+FROM  scratch
+LABEL maintainer="tech-ally@lacework.net" \
+      description="The Lacework CLI helps you manage the Lacework cloud security platform"
+
+COPY LICENSE /
+COPY --from=alpine /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+ADD bin/lacework-cli-linux-amd64 /usr/local/bin/lacework
+ENTRYPOINT ["/usr/local/bin/lacework"]

--- a/Makefile
+++ b/Makefile
@@ -56,11 +56,14 @@ else
 endif
 	@echo "\nThe lacework cli has been installed at /usr/local/bin"
 
-prepare-release: lint fmt-check imports-check test
+release-prepare: lint fmt-check imports-check test
 	scripts/release.sh prepare
 
-do-release: lint fmt-check imports-check test
+release-do: lint fmt-check imports-check test
 	scripts/release.sh release
+
+release-containers:
+	scripts/release_containers.sh
 
 install-tools:
 ifeq (, $(shell which golangci-lint))

--- a/cli/images/amazonlinux-2/Dockerfile
+++ b/cli/images/amazonlinux-2/Dockerfile
@@ -1,0 +1,8 @@
+FROM  amazonlinux:2
+LABEL maintainer="tech-ally@lacework.net" \
+      description="The Lacework CLI helps you manage the Lacework cloud security platform"
+
+RUN yum update -y
+RUN yum install -y gzip tar
+COPY ./LICENSE /
+RUN curl https://raw.githubusercontent.com/lacework/go-sdk/master/cli/install.sh | bash

--- a/cli/images/centos-8/Dockerfile
+++ b/cli/images/centos-8/Dockerfile
@@ -1,0 +1,7 @@
+FROM  centos:8
+LABEL maintainer="tech-ally@lacework.net" \
+      description="The Lacework CLI helps you manage the Lacework cloud security platform"
+
+RUN yum update -y
+COPY ./LICENSE /
+RUN curl https://raw.githubusercontent.com/lacework/go-sdk/master/cli/install.sh | bash

--- a/cli/images/debian-10/Dockerfile
+++ b/cli/images/debian-10/Dockerfile
@@ -1,0 +1,8 @@
+FROM  debian:10
+LABEL maintainer="tech-ally@lacework.net" \
+      description="The Lacework CLI helps you manage the Lacework cloud security platform"
+
+RUN apt-get update
+RUN apt-get install curl -y
+COPY ./LICENSE /
+RUN curl https://raw.githubusercontent.com/lacework/go-sdk/master/cli/install.sh | bash

--- a/cli/images/ubi-8/Dockerfile
+++ b/cli/images/ubi-8/Dockerfile
@@ -1,0 +1,7 @@
+FROM registry.access.redhat.com/ubi8/ubi
+LABEL maintainer="tech-ally@lacework.net" \
+      description="The Lacework CLI helps you manage the Lacework cloud security platform"
+
+RUN yum update -y
+COPY ./LICENSE /
+RUN curl https://raw.githubusercontent.com/lacework/go-sdk/master/cli/install.sh | bash

--- a/cli/images/ubuntu-1804/Dockerfile
+++ b/cli/images/ubuntu-1804/Dockerfile
@@ -1,0 +1,8 @@
+FROM  ubuntu:18.04
+LABEL maintainer="tech-ally@lacework.net" \
+      description="The Lacework CLI helps you manage the Lacework cloud security platform"
+
+RUN apt-get update
+RUN apt-get install curl -y
+COPY ./LICENSE /
+RUN curl https://raw.githubusercontent.com/lacework/go-sdk/master/cli/install.sh | bash

--- a/cli/images/windows-nanoserver/Dockerfile
+++ b/cli/images/windows-nanoserver/Dockerfile
@@ -1,0 +1,7 @@
+FROM  mcr.microsoft.com/windows/nanoserver:1903
+LABEL maintainer="tech-ally@lacework.net" \
+      description="The Lacework CLI helps you manage the Lacework cloud security platform"
+
+COPY ./LICENSE /
+RUN Set-ExecutionPolicy Bypass -Scope Process -Force
+RUN iex ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/lacework/go-sdk/master/cli/install.ps1'))

--- a/scripts/release_containers.sh
+++ b/scripts/release_containers.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+#
+
+set -eou pipefail
+
+# The repository where we are hosting the lacework-cli containers
+# TODO @afiune switch it to "lacework/lacework-cli" repository
+readonly repository="techallylw/lacework-cli"
+readonly project_name=lacework-cli
+
+log() {
+  echo "--> ${project_name}: $1"
+}
+
+log "releasing container from SCRATCH"
+docker build -t "${repository}:scratch" .
+docker push "${repository}:scratch"
+
+distros=(
+  ubi-8
+  centos-8
+  debian-10
+  ubuntu-1804
+  amazonlinux-2
+#  windows-nanoserver
+)
+for dist in "${distros[@]}"; do
+  log "releasing container for ${dist}"
+  docker build -f "cli/images/${dist}/Dockerfile" -t "${repository}:ubi-8" .
+  docker push "${repository}:${dist}"
+done
+
+if ! docker manifest inspect "$repository"; then
+  log "creating docker manifest"
+  docker manifest create "${repository}:latest"      \
+                         "${repository}:scratch"     \
+                         "${repository}:ubi-8"       \
+                         "${repository}:centos-8"    \
+                         "${repository}:debian-10"   \
+                         "${repository}:ubuntu-1804" \
+                         "${repository}:amazonlinux-2"
+fi
+
+log "pushing docker manifest"
+docker manifest push "${repository}:latest"
+
+log "All docker containers have been released! (https://hub.docker.com/repository/docker/${repository})"


### PR DESCRIPTION
Adding a number of docker containers with the Lacework CLI packaged
inside them, the list of containers we are adding:

- scratch (https://hub.docker.com/_/scratch)
- ubi-8
- debian-10
- centos-8
- ubuntu-1804
- amazonlinux-2
- windows-nanoserver

During release, we will be able to run the `make release-containers`
directive to build and push all these new docker containers.

By default, the docker container built from SCRATCH will be our main
image for our CI/CD pipeline story, any user or machine will be able to
run `docker run techallylw/lacework-cli` and have a 7MB container
running the latest Lacework CLI:
```
$ docker run techallylw/lacework-cli

The Lacework Command Line Interface is a tool that helps you manage the
Lacework cloud security platform. Use it to manage compliance reports,
external integrations, vulnerability scans, and other operations.

Start by configuring the Lacework CLI with the command:

    $ lacework configure

This will prompt you for your Lacework account and a set of API access keys.

Usage:
  lacework [command]

Available Commands:
  api           helper to call Lacework's RestfulAPI
  configure     configure the Lacework CLI
  event         inspect Lacework events
  integration   manage external integrations
  version       print the Lacework CLI version
  vulnerability view vulnerability reports and run on-demand scans

Flags:
  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
  -k, --api_key string      access key id
  -s, --api_secret string   secret access key
      --debug               turn on debug logging
      --json                switch commands output from human-readable to json format
      --nocolor             turn off colors
      --noninteractive      disable interactive progress bars (i.e. 'spinners')
  -p, --profile string      switch between profiles configured at ~/.lacework.toml

Use "lacework [command] --help" for more information about a command.
```

Closes https://github.com/lacework/go-sdk/issues/75

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>