### PR TITLE
style: avoid mixing duties between api and cli

### DIFF
--- a/api/integrations.go
+++ b/api/integrations.go
@@ -101,14 +101,14 @@ func (svc *IntegrationsService) Delete(guid string) (
 }
 
 // List lists the external integrations available on the Lacework Server
-func (svc *IntegrationsService) List() (response IntegrationsResponse, err error) {
+func (svc *IntegrationsService) List() (response RawIntegrationsResponse, err error) {
 	err = svc.client.RequestDecoder("GET", apiIntegrations, nil, &response)
 	return
 }
 
 // ListByType lists the external integrations from the provided type that are available
 // on the Lacework Server
-func (svc *IntegrationsService) ListByType(iType integrationType) (response IntegrationsResponse, err error) {
+func (svc *IntegrationsService) ListByType(iType integrationType) (response RawIntegrationsResponse, err error) {
 	err = svc.listByType(iType, &response)
 	return
 }
@@ -190,26 +190,6 @@ type IntegrationState struct {
 	Ok                 bool   `json:"ok"`
 	LastUpdatedTime    string `json:"lastUpdatedTime"`
 	LastSuccessfulTime string `json:"lastSuccessfulTime"`
-}
-
-type IntegrationsResponse struct {
-	Data    []commonIntegrationData `json:"data"`
-	Ok      bool                    `json:"ok"`
-	Message string                  `json:"message"`
-}
-
-func (integrations *IntegrationsResponse) Table() [][]string {
-	out := [][]string{}
-	for _, idata := range integrations.Data {
-		out = append(out, []string{
-			idata.IntgGuid,
-			idata.Name,
-			idata.Type,
-			idata.Status(),
-			idata.StateString(),
-		})
-	}
-	return out
 }
 
 type RawIntegration struct {

--- a/cli/cmd/integration.go
+++ b/cli/cmd/integration.go
@@ -63,7 +63,7 @@ var (
 			table := tablewriter.NewWriter(os.Stdout)
 			table.SetHeader([]string{"Integration GUID", "Name", "Type", "Status", "State"})
 			table.SetBorder(false)
-			table.AppendBulk(integrations.Table())
+			table.AppendBulk(integrationsTable(integrations.Data))
 			table.Render()
 			return nil
 		},
@@ -112,4 +112,18 @@ func init() {
 	integrationCmd.AddCommand(integrationCreateCmd)
 	integrationCmd.AddCommand(integrationUpdateCmd)
 	integrationCmd.AddCommand(integrationDeleteCmd)
+}
+
+func integrationsTable(integrations []api.RawIntegration) [][]string {
+	out := [][]string{}
+	for _, idata := range integrations {
+		out = append(out, []string{
+			idata.IntgGuid,
+			idata.Name,
+			idata.Type,
+			idata.Status(),
+			idata.StateString(),
+		})
+	}
+	return out
 }


### PR DESCRIPTION
The Go api client shouldn't have anything related to the Lacework CLI,
the Go api should be an identical copy of the Lacework API as much as
possible. This change is moving the formatting of Tables from the api to
the cli go package.

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>