### PR TITLE
feat(cli): new 'integration show' cmd 

### DIFF
--- a/api/integrations_aws.go
+++ b/api/integrations_aws.go
@@ -125,14 +125,14 @@ type AwsIntegration struct {
 }
 
 type AwsIntegrationData struct {
-	Credentials AwsIntegrationCreds `json:"CROSS_ACCOUNT_CREDENTIALS"`
+	Credentials AwsIntegrationCreds `json:"CROSS_ACCOUNT_CREDENTIALS" mapstructure:"CROSS_ACCOUNT_CREDENTIALS"`
 
 	// QueueUrl is a field that exists and is required for the AWS_CT_SQS integration,
 	// though, it doesn't exist for AWS_CFG integrations, that's why we omit it if empty
-	QueueUrl string `json:"QUEUE_URL,omitempty"`
+	QueueUrl string `json:"QUEUE_URL,omitempty" mapstructure:"QUEUE_URL"`
 }
 
 type AwsIntegrationCreds struct {
-	RoleArn    string `json:"ROLE_ARN"`
-	ExternalId string `json:"EXTERNAL_ID"`
+	RoleArn    string `json:"ROLE_ARN" mapstructure:"ROLE_ARN"`
+	ExternalId string `json:"EXTERNAL_ID" mapstructure:"EXTERNAL_ID"`
 }

--- a/api/integrations_azure.go
+++ b/api/integrations_azure.go
@@ -136,15 +136,15 @@ type AzureIntegration struct {
 }
 
 type AzureIntegrationData struct {
-	Credentials AzureIntegrationCreds `json:"CREDENTIALS"`
-	TenantID    string                `json:"TENANT_ID"`
+	Credentials AzureIntegrationCreds `json:"CREDENTIALS" mapstructure:"CREDENTIALS"`
+	TenantID    string                `json:"TENANT_ID" mapstructure:"TENANT_ID"`
 
 	// QueueUrl is a field that exists and is required for the AWS_CT_SQS integration,
 	// though, it doesn't exist for AZURE_CFG integrations, that's why we omit it if empty
-	QueueUrl string `json:"QUEUE_URL,omitempty"`
+	QueueUrl string `json:"QUEUE_URL,omitempty" mapstructure:"QUEUE_URL"`
 }
 
 type AzureIntegrationCreds struct {
-	ClientID     string `json:"CLIENT_ID"`
-	ClientSecret string `json:"CLIENT_SECRET"`
+	ClientID     string `json:"CLIENT_ID" mapstructure:"CLIENT_ID"`
+	ClientSecret string `json:"CLIENT_SECRET" mapstructure:"CLIENT_SECRET"`
 }

--- a/api/integrations_cont_reg.go
+++ b/api/integrations_cont_reg.go
@@ -92,20 +92,20 @@ type ContainerRegIntegration struct {
 }
 
 type ContainerRegData struct {
-	Credentials    ContainerRegCreds `json:"CREDENTIALS"`
-	RegistryType   string            `json:"REGISTRY_TYPE"`
-	RegistryDomain string            `json:"REGISTRY_DOMAIN"`
-	LimitByTag     string            `json:"LIMIT_BY_TAG"`
-	LimitByLabel   string            `json:"LIMIT_BY_LABEL"`
-	LimitByRep     string            `json:"LIMIT_BY_REP,omitempty"`
-	LimitNumImg    int               `json:"LIMIT_NUM_IMG"`
+	Credentials    ContainerRegCreds `json:"CREDENTIALS" mapstructure:"CREDENTIALS"`
+	RegistryType   string            `json:"REGISTRY_TYPE" mapstructure:"REGISTRY_TYPE"`
+	RegistryDomain string            `json:"REGISTRY_DOMAIN" mapstructure:"REGISTRY_DOMAIN"`
+	LimitByTag     string            `json:"LIMIT_BY_TAG" mapstructure:"LIMIT_BY_TAG"`
+	LimitByLabel   string            `json:"LIMIT_BY_LABEL" mapstructure:"LIMIT_BY_LABEL"`
+	LimitByRep     string            `json:"LIMIT_BY_REP,omitempty" mapstructure:"LIMIT_BY_REP"`
+	LimitNumImg    int               `json:"LIMIT_NUM_IMG"` // @afiune we can't parse this field
 }
 
 type ContainerRegCreds struct {
-	Username string `json:"USERNAME"`
-	Password string `json:"PASSWORD"`
+	Username string `json:"USERNAME" mapstructure:"USERNAME"`
+	Password string `json:"PASSWORD" mapstructure:"PASSWORD"`
 	// @afiune this is for docker V2 registry
-	SSL bool `json:"SSL,omitempty"`
+	SSL bool `json:"SSL,omitempty" mapstructure:"SSL"`
 }
 
 // @afiune we can't use this response since the request sent to the

--- a/api/integrations_gcp.go
+++ b/api/integrations_gcp.go
@@ -151,18 +151,18 @@ type GcpIntegration struct {
 
 type GcpIntegrationData struct {
 	ID          string         `json:"ID"`
-	IdType      string         `json:"ID_TYPE"`
-	Credentials GcpCredentials `json:"CREDENTIALS"`
+	IdType      string         `json:"ID_TYPE" mapstructure:"ID_TYPE"`
+	Credentials GcpCredentials `json:"CREDENTIALS" mapstructure:"CREDENTIALS"`
 
 	// SubscriptionName is a field that exists and is required for the GCP_AT_SES
 	// integration, though, it doesn't exist for GCP_CFG integrations, that's why
 	// we omit it if empty
-	SubscriptionName string `json:"SUBSCRIPTION_NAME,omitempty"`
+	SubscriptionName string `json:"SUBSCRIPTION_NAME,omitempty" mapstructure:"SUBSCRIPTION_NAME"`
 }
 
 type GcpCredentials struct {
-	ClientId     string `json:"CLIENT_ID"`
-	ClientEmail  string `json:"CLIENT_EMAIL"`
-	PrivateKeyId string `json:"PRIVATE_KEY_ID"`
-	PrivateKey   string `json:"PRIVATE_KEY"`
+	ClientId     string `json:"CLIENT_ID" mapstructure:"CLIENT_ID"`
+	ClientEmail  string `json:"CLIENT_EMAIL" mapstructure:"CLIENT_EMAIL"`
+	PrivateKeyId string `json:"PRIVATE_KEY_ID" mapstructure:"PRIVATE_KEY_ID"`
+	PrivateKey   string `json:"PRIVATE_KEY" mapstructure:"PRIVATE_KEY"`
 }

--- a/cli/cmd/event.go
+++ b/cli/cmd/event.go
@@ -79,7 +79,7 @@ time range.`,
 	// eventShowCmd represents the show sub-command inside the event command
 	eventShowCmd = &cobra.Command{
 		Use:   "show <event_id>",
-		Short: "Show details about an specific event",
+		Short: "Show details about a specific event",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
 			lacework, err := api.NewClient(cli.Account,

--- a/cli/cmd/integration.go
+++ b/cli/cmd/integration.go
@@ -19,9 +19,10 @@
 package cmd
 
 import (
-	"os"
+	"strings"
 
 	"github.com/AlecAivazis/survey/v2"
+	"github.com/mitchellh/mapstructure"
 	"github.com/olekukonko/tablewriter"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -61,11 +62,37 @@ var (
 				return cli.OutputJSON(integrations.Data)
 			}
 
-			table := tablewriter.NewWriter(os.Stdout)
-			table.SetHeader([]string{"Integration GUID", "Name", "Type", "Status", "State"})
-			table.SetBorder(false)
-			table.AppendBulk(integrationsTable(integrations.Data))
-			table.Render()
+			cli.OutputHuman(buildIntegrationsTable(integrations.Data))
+			return nil
+		},
+	}
+
+	// integrationShowCmd represents the show sub-command inside the integration command
+	integrationShowCmd = &cobra.Command{
+		Use:   "show <int_guid>",
+		Short: "Show details about a specific external integration",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			lacework, err := api.NewClient(cli.Account,
+				api.WithLogLevel(cli.LogLevel),
+				api.WithApiKeys(cli.KeyID, cli.Secret),
+			)
+			if err != nil {
+				return errors.Wrap(err, "unable to generate api client")
+			}
+
+			integration, err := lacework.Integrations.Get(args[0])
+			if err != nil {
+				return errors.Wrap(err, "unable to get integration")
+			}
+
+			if cli.JSONOutput() {
+				return cli.OutputJSON(integration.Data)
+			}
+
+			cli.OutputHuman(buildIntegrationsTable(integration.Data))
+			cli.OutputHuman("\n")
+			cli.OutputHuman(buildIntDetailsTable(integration.Data))
 			return nil
 		},
 	}
@@ -149,6 +176,7 @@ func init() {
 
 	// add sub-commands to the integration command
 	integrationCmd.AddCommand(integrationListCmd)
+	integrationCmd.AddCommand(integrationShowCmd)
 	integrationCmd.AddCommand(integrationCreateCmd)
 	integrationCmd.AddCommand(integrationUpdateCmd)
 	integrationCmd.AddCommand(integrationDeleteCmd)
@@ -214,5 +242,168 @@ func integrationsTable(integrations []api.RawIntegration) [][]string {
 			idata.StateString(),
 		})
 	}
+	return out
+}
+
+func buildIntegrationsTable(integrations []api.RawIntegration) string {
+	var (
+		tableBuilder = &strings.Builder{}
+		t            = tablewriter.NewWriter(tableBuilder)
+	)
+
+	t.SetHeader([]string{
+		"Integration GUID",
+		"Name",
+		"Type",
+		"Status",
+		"State",
+	})
+	t.SetBorder(false)
+	t.AppendBulk(integrationsTable(integrations))
+	t.Render()
+
+	return tableBuilder.String()
+}
+
+func buildIntDetailsTable(integrations []api.RawIntegration) string {
+	var (
+		main    = &strings.Builder{}
+		details = &strings.Builder{}
+		t       = tablewriter.NewWriter(details)
+	)
+
+	t.SetBorder(false)
+	t.SetAlignment(tablewriter.ALIGN_LEFT)
+	if len(integrations) != 0 {
+		integration := integrations[0]
+		t.AppendBulk(reflectIntegrationData(integration))
+		t.AppendBulk(buildIntegrationState(integration.State))
+	}
+	t.Render()
+
+	t = tablewriter.NewWriter(main)
+	t.SetBorder(false)
+	t.SetAutoWrapText(false)
+	t.SetHeader([]string{"INTEGRATION DETAILS"})
+	t.Append([]string{details.String()})
+	t.Render()
+
+	return main.String()
+}
+
+func buildIntegrationState(state *api.IntegrationState) [][]string {
+	if state != nil {
+		return [][]string{
+			[]string{"LAST UPDATED TIME", state.LastUpdatedTime},
+			[]string{"LAST SUCCESSFUL TIME", state.LastSuccessfulTime},
+		}
+	}
+
+	return [][]string{}
+}
+
+func reflectIntegrationData(raw api.RawIntegration) [][]string {
+	switch raw.Type {
+
+	case api.GcpCfgIntegration.String(),
+		api.GcpAuditLogIntegration.String():
+
+		var iData api.GcpIntegrationData
+		err := mapstructure.Decode(raw.Data, &iData)
+		if err != nil {
+			cli.Log.Debugw("unable to decode integration data",
+				"integration_type", raw.Type,
+				"raw_data", raw.Data,
+				"error", err,
+			)
+			break
+		}
+		out := [][]string{
+			[]string{"LEVEL", iData.IdType},
+			[]string{"ORG/PROJECT ID", iData.ID},
+			[]string{"CLIENT ID", iData.Credentials.ClientId},
+			[]string{"CLIENT EMAIL", iData.Credentials.ClientEmail},
+			[]string{"PRIVATE KEY ID", iData.Credentials.PrivateKeyId},
+		}
+		if iData.SubscriptionName != "" {
+			return append(out, []string{"SUBSCRIPTION NAME", iData.SubscriptionName})
+		}
+		return out
+
+	case api.AwsCfgIntegration.String(),
+		api.AwsCloudTrailIntegration.String():
+
+		var iData api.AwsIntegrationData
+		err := mapstructure.Decode(raw.Data, &iData)
+		if err != nil {
+			cli.Log.Debugw("unable to decode integration data",
+				"integration_type", raw.Type,
+				"raw_data", raw.Data,
+				"error", err,
+			)
+			break
+		}
+		out := [][]string{
+			[]string{"ROLE ARN", iData.Credentials.RoleArn},
+			[]string{"EXTERNAL ID", iData.Credentials.ExternalId},
+		}
+		if iData.QueueUrl != "" {
+			return append(out, []string{"QUEUE URL", iData.QueueUrl})
+		}
+		return out
+
+	case api.AzureCfgIntegration.String(),
+		api.AzureActivityLogIntegration.String():
+
+		var iData api.AzureIntegrationData
+		err := mapstructure.Decode(raw.Data, &iData)
+		if err != nil {
+			cli.Log.Debugw("unable to decode integration data",
+				"integration_type", raw.Type,
+				"raw_data", raw.Data,
+				"error", err,
+			)
+			break
+		}
+		out := [][]string{
+			[]string{"CLIENT ID", iData.Credentials.ClientID},
+			[]string{"CLIENT SECRET", iData.Credentials.ClientSecret},
+			[]string{"TENANT ID", iData.TenantID},
+		}
+		if iData.QueueUrl != "" {
+			return append(out, []string{"QUEUE URL", iData.QueueUrl})
+		}
+		return out
+
+	default:
+		out := [][]string{}
+		for key, value := range deepKeyValueExtract(raw.Data) {
+			out = append(out, []string{key, value})
+		}
+		return out
+	}
+
+	return [][]string{}
+}
+
+func deepKeyValueExtract(v interface{}) map[string]string {
+	out := map[string]string{}
+
+	m, ok := v.(map[string]interface{})
+	if !ok {
+		return out
+	}
+
+	for key, value := range m {
+		if s, ok := value.(string); ok {
+			out[key] = s
+		} else {
+			deepMap := deepKeyValueExtract(value)
+			for deepK, deepV := range deepMap {
+				out[deepK] = deepV
+			}
+		}
+	}
+
 	return out
 }

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/mattn/go-colorable v0.1.6 // indirect
 	github.com/mattn/go-runewidth v0.0.9 // indirect
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/mitchellh/mapstructure v1.2.2 // indirect
+	github.com/mitchellh/mapstructure v1.3.0
 	github.com/olekukonko/tablewriter v0.0.4
 	github.com/pelletier/go-toml v1.6.0 // indirect
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -102,8 +102,8 @@ github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b/go.mod h1:01TrycV0kFyex
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
-github.com/mitchellh/mapstructure v1.2.2 h1:dxe5oCinTXiTIcfgmZecdCzPmAJKd46KsCWc35r0TV4=
-github.com/mitchellh/mapstructure v1.2.2/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
+github.com/mitchellh/mapstructure v1.3.0 h1:iDwIio/3gk2QtLLEsqU5lInaMzos0hDTz8a6lazSFVw=
+github.com/mitchellh/mapstructure v1.3.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/olekukonko/tablewriter v0.0.4 h1:vHD/YYe1Wolo78koG299f7V/VAS08c6IpCLn+Ejf/w8=

--- a/scripts/release_containers.sh
+++ b/scripts/release_containers.sh
@@ -12,8 +12,12 @@ log() {
   echo "--> ${project_name}: $1"
 }
 
+
+log "building Lacework CLI cross-platform"
+make build-cli-cross-platform
+
 log "releasing container from SCRATCH"
-docker build -t "${repository}:scratch" .
+docker build -t "${repository}:scratch" --no-cache .
 docker push "${repository}:scratch"
 
 distros=(
@@ -26,7 +30,7 @@ distros=(
 )
 for dist in "${distros[@]}"; do
   log "releasing container for ${dist}"
-  docker build -f "cli/images/${dist}/Dockerfile" -t "${repository}:ubi-8" .
+  docker build -f "cli/images/${dist}/Dockerfile" --no-cache -t "${repository}:ubi-8" .
   docker push "${repository}:${dist}"
 done
 

--- a/vendor/github.com/mitchellh/mapstructure/.travis.yml
+++ b/vendor/github.com/mitchellh/mapstructure/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - "1.11.x"
+  - "1.14.x"
   - tip
 
 script:

--- a/vendor/github.com/mitchellh/mapstructure/CHANGELOG.md
+++ b/vendor/github.com/mitchellh/mapstructure/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 1.3.0
+
+* Added `",omitempty"` support. This will ignore zero values in the source
+  structure when encoding. [GH-145]
+
+## 1.2.3
+
+* Fix duplicate entries in Keys list with pointer values. [GH-185]
+
 ## 1.2.2
 
 * Do not add unsettable (unexported) values to the unused metadata key

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -50,7 +50,7 @@ github.com/mgutz/ansi
 # github.com/mitchellh/go-homedir v1.1.0
 ## explicit
 github.com/mitchellh/go-homedir
-# github.com/mitchellh/mapstructure v1.2.2
+# github.com/mitchellh/mapstructure v1.3.0
 ## explicit
 github.com/mitchellh/mapstructure
 # github.com/olekukonko/tablewriter v0.0.4


### PR DESCRIPTION
Adding a new sub-command `lacework integration show <int_guid>` to show
details about a specific external integration, example:
```
$ lacework int show TECHALLY_1234567890ABCDEF1234567890ABCDEF1234567890ABCDE
                      INTEGRATION GUID                     |    NAME    |  TYPE   | STATUS  | STATE
-----------------------------------------------------------+------------+---------+---------+--------
  TECHALLY_1234567890ABCDEF1234567890ABCDEF1234567890ABCDE | GCP config | GCP_CFG | Enabled | Ok

                                            INTEGRATION DETAILS
----------------------------------------------------------------------------------------------------------
    LEVEL                | PROJECT
    ORG/PROJECT ID       | techally-hipstershop
    CLIENT ID            | 123456789001234567890
    CLIENT EMAIL         | hipster-lacework@techally-hipstershop.iam.gserviceaccount.com
    PRIVATE KEY ID       | abcd12349abcd1234abcd1234abcd1234abcd1234a
    LAST UPDATED TIME    | 2020-May-04 13:26:38 UTC
    LAST SUCCESSFUL TIME | 2020-May-04 13:26:38 UTC
```