### PR TITLE
fix(api): parsing event details 'cpu_percentage' 

### DIFF
--- a/api/events.go
+++ b/api/events.go
@@ -171,7 +171,7 @@ type eventProcessEntity struct {
 	ProcessId        int32     `json:"process_id"`
 	ProcessStartTime time.Time `json:"process_start_time"`
 	Cmdline          string    `json:"cmdline"`
-	CpuPercentage    int32     `json:"cpu_percentage"`
+	CpuPercentage    float32   `json:"cpu_percentage"`
 }
 
 type eventFileDataHashEntity struct {

--- a/api/events_test.go
+++ b/api/events_test.go
@@ -274,14 +274,14 @@ func eventDetailsResponse(id string) string {
           },
           {
             "CMDLINE": "chef-client worker: ppid=5328;start=19:54:08;",
-            "CPU_PERCENTAGE": 0,
+            "CPU_PERCENTAGE": 0.1,
             "HOSTNAME": "default-centos-8.vagrantup.com",
             "PROCESS_ID": 5346,
             "PROCESS_START_TIME": "2020-04-20T19:54:08Z"
           },
           {
             "CMDLINE": "chef-client worker: ppid=12057;start=19:47:54;",
-            "CPU_PERCENTAGE": 0,
+            "CPU_PERCENTAGE": 0.87,
             "HOSTNAME": "default-centos-8.vagrantup.com",
             "PROCESS_ID": 12062,
             "PROCESS_START_TIME": "2020-04-20T19:47:54Z"

--- a/scripts/release_containers.sh
+++ b/scripts/release_containers.sh
@@ -30,7 +30,7 @@ distros=(
 )
 for dist in "${distros[@]}"; do
   log "releasing container for ${dist}"
-  docker build -f "cli/images/${dist}/Dockerfile" --no-cache -t "${repository}:ubi-8" .
+  docker build -f "cli/images/${dist}/Dockerfile" --no-cache -t "${repository}:${dist}" .
   docker push "${repository}:${dist}"
 done
 


### PR DESCRIPTION
The `cpu_percentage` field inside the `entity_map` is a `float32`
not `int32`, this commit is fixing the following error:
```
ERROR unable to get event details: json: cannot unmarshal number 0.02 into Go struct field eventProcessEntity.data.entity_map.process.cpu_percentage of type int32
```

Closes #78

Additionally, I included a super quick fix to the build/release of our CLI containers. 

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>