### PR TITLE
chore: consistency with ID fields in Go structs

### DIFF
--- a/api/auth.go
+++ b/api/auth.go
@@ -144,6 +144,6 @@ type tokenData struct {
 }
 
 type tokenRequest struct {
-	KeyId      string `json:"keyId"`
+	KeyID      string `json:"keyId"`
 	ExpiryTime int    `json:"expiryTime"`
 }

--- a/api/client.go
+++ b/api/client.go
@@ -126,7 +126,7 @@ func (c *Client) URL() string {
 	return c.baseURL.String()
 }
 
-// newID generates a new client ID, this id is useful for logging purposes
+// newID generates a new client id, this id is useful for logging purposes
 // when there are more than one client running on the same machine
 func newID() string {
 	now := time.Now().UTC().UnixNano()

--- a/api/events.go
+++ b/api/events.go
@@ -168,7 +168,7 @@ type eventIpAddressEntity struct {
 
 type eventProcessEntity struct {
 	Hostname         string    `json:"hostname"`
-	ProcessId        int32     `json:"process_id"`
+	ProcessID        int32     `json:"process_id"`
 	ProcessStartTime time.Time `json:"process_start_time"`
 	Cmdline          string    `json:"cmdline"`
 	CpuPercentage    float32   `json:"cpu_percentage"`
@@ -209,11 +209,11 @@ type eventRegionEntity struct {
 
 type eventCTUserEntity struct {
 	Username    string   `json:"username"`
-	AccoutId    string   `json:"accout_id"`
+	AccoutID    string   `json:"accout_id"`
 	Mfa         int32    `json:"mfa"`
 	ApiList     []string `json:"api_list"`
 	RegionList  []string `json:"region_list"`
-	PrincipalId string   `json:"principal_id"`
+	PrincipalID string   `json:"principal_id"`
 }
 
 type eventResourceEntity struct {
@@ -222,8 +222,8 @@ type eventResourceEntity struct {
 }
 
 type eventRecIDEntity struct {
-	RecId        string `json:"rec_id"`
-	AccountId    string `json:"account_id"`
+	RecID        string `json:"rec_id"`
+	AccountID    string `json:"account_id"`
 	AccountAlias string `json:"account_alias"`
 	Title        string `json:"title"`
 	Status       string `json:"status"`
@@ -239,13 +239,13 @@ type eventCustomRuleEntity struct {
 }
 
 type eventNewViolationEntity struct {
-	RecId    string `json:"rec_id"`
+	RecID    string `json:"rec_id"`
 	Reason   string `json:"reason"`
 	Resource string `json:"resource"`
 }
 
 type eventViolationReasonEntity struct {
-	RecId  string `json:"rec_id"`
+	RecID  string `json:"rec_id"`
 	Reason string `json:"reason"`
 }
 

--- a/api/integrations_aws.go
+++ b/api/integrations_aws.go
@@ -35,7 +35,7 @@ package api
 //     api.AwsIntegrationData{
 //       Credentials: api.AwsIntegrationCreds {
 //         RoleArn: "arn:aws:XYZ",
-//         ExternalId: "1",
+//         ExternalID: "1",
 //       },
 //     },
 //   )
@@ -134,5 +134,5 @@ type AwsIntegrationData struct {
 
 type AwsIntegrationCreds struct {
 	RoleArn    string `json:"ROLE_ARN" mapstructure:"ROLE_ARN"`
-	ExternalId string `json:"EXTERNAL_ID" mapstructure:"EXTERNAL_ID"`
+	ExternalID string `json:"EXTERNAL_ID" mapstructure:"EXTERNAL_ID"`
 }

--- a/api/integrations_aws_test.go
+++ b/api/integrations_aws_test.go
@@ -36,7 +36,7 @@ func TestIntegrationsNewAwsCfgIntegration(t *testing.T) {
 		api.AwsIntegrationData{
 			Credentials: api.AwsIntegrationCreds{
 				RoleArn:    "arn:foo:bar",
-				ExternalId: "0123456789",
+				ExternalID: "0123456789",
 			},
 		},
 	)
@@ -75,7 +75,7 @@ func TestIntegrationsCreateAws(t *testing.T) {
 		api.AwsIntegrationData{
 			Credentials: api.AwsIntegrationCreds{
 				RoleArn:    "arn:foo:bar",
-				ExternalId: "0123456789",
+				ExternalID: "0123456789",
 			},
 		},
 	)
@@ -93,7 +93,7 @@ func TestIntegrationsCreateAws(t *testing.T) {
 		assert.Equal(t, "integration_name", resData.Name)
 		assert.True(t, resData.State.Ok)
 		assert.Equal(t, "arn:foo:bar", resData.Data.Credentials.RoleArn)
-		assert.Equal(t, "0123456789", resData.Data.Credentials.ExternalId)
+		assert.Equal(t, "0123456789", resData.Data.Credentials.ExternalID)
 	}
 }
 
@@ -125,7 +125,7 @@ func TestIntegrationsGetAws(t *testing.T) {
 		assert.Equal(t, "integration_name", resData.Name)
 		assert.True(t, resData.State.Ok)
 		assert.Equal(t, "arn:foo:bar", resData.Data.Credentials.RoleArn)
-		assert.Equal(t, "0123456789", resData.Data.Credentials.ExternalId)
+		assert.Equal(t, "0123456789", resData.Data.Credentials.ExternalID)
 	}
 }
 
@@ -144,7 +144,7 @@ func TestIntegrationsUpdateAws(t *testing.T) {
 			assert.Contains(t, body, "integration_name", "integration name is missing")
 			assert.Contains(t, body, "AWS_CT_SQS", "wrong integration type")
 			assert.Contains(t, body, "arn:foo:bar", "wrong role arn")
-			assert.Contains(t, body, "0123456789", "wrong external id")
+			assert.Contains(t, body, "0123456789", "wrong external ID")
 			assert.Contains(t, body, "ENABLED\":1", "integration is not enabled")
 		}
 
@@ -163,7 +163,7 @@ func TestIntegrationsUpdateAws(t *testing.T) {
 		api.AwsIntegrationData{
 			Credentials: api.AwsIntegrationCreds{
 				RoleArn:    "arn:foo:bar",
-				ExternalId: "0123456789",
+				ExternalID: "0123456789",
 			},
 		},
 	)

--- a/api/integrations_gcp.go
+++ b/api/integrations_gcp.go
@@ -55,11 +55,11 @@ func (g gcpResourceLevel) String() string {
 //     api.GcpCfgIntegration,
 //     api.GcpIntegrationData{
 //       ID: "1234",
-//       IdType: api.GcpProjectIntegration.String(),
+//       IDType: api.GcpProjectIntegration.String(),
 //       Credentials: api.GcpCredentials{
-//         ClientId: "id",
+//         ClientID: "id",
 //         ClientEmail: "email",
-//         PrivateKeyId: "key_id",
+//         PrivateKeyID: "key_id",
 //         PrivateKey: "key",
 //       },
 //     },
@@ -151,7 +151,7 @@ type GcpIntegration struct {
 
 type GcpIntegrationData struct {
 	ID          string         `json:"ID"`
-	IdType      string         `json:"ID_TYPE" mapstructure:"ID_TYPE"`
+	IDType      string         `json:"ID_TYPE" mapstructure:"ID_TYPE"`
 	Credentials GcpCredentials `json:"CREDENTIALS" mapstructure:"CREDENTIALS"`
 
 	// SubscriptionName is a field that exists and is required for the GCP_AT_SES
@@ -161,8 +161,8 @@ type GcpIntegrationData struct {
 }
 
 type GcpCredentials struct {
-	ClientId     string `json:"CLIENT_ID" mapstructure:"CLIENT_ID"`
+	ClientID     string `json:"CLIENT_ID" mapstructure:"CLIENT_ID"`
 	ClientEmail  string `json:"CLIENT_EMAIL" mapstructure:"CLIENT_EMAIL"`
-	PrivateKeyId string `json:"PRIVATE_KEY_ID" mapstructure:"PRIVATE_KEY_ID"`
+	PrivateKeyID string `json:"PRIVATE_KEY_ID" mapstructure:"PRIVATE_KEY_ID"`
 	PrivateKey   string `json:"PRIVATE_KEY" mapstructure:"PRIVATE_KEY"`
 }

--- a/api/integrations_gcp_test.go
+++ b/api/integrations_gcp_test.go
@@ -68,13 +68,13 @@ func TestIntegrationsCreateGcp(t *testing.T) {
 	data := api.NewGcpAuditLogIntegration("integration_name",
 		api.GcpIntegrationData{
 			ID:               "data_id",
-			IdType:           "id_type",
+			IDType:           "id_type",
 			SubscriptionName: "subscription_name",
 			Credentials: api.GcpCredentials{
-				ClientId:     "client_id",
+				ClientID:     "client_id",
 				ClientEmail:  "foo@example.iam.gserviceaccount.com",
 				PrivateKey:   "priv_key",
-				PrivateKeyId: "p_key_id",
+				PrivateKeyID: "p_key_id",
 			},
 		},
 	)
@@ -92,7 +92,7 @@ func TestIntegrationsCreateGcp(t *testing.T) {
 		assert.Equal(t, "integration_name", resData.Name)
 		assert.True(t, resData.State.Ok)
 		assert.Equal(t, "data_id", resData.Data.ID)
-		assert.Equal(t, "PROJECT", resData.Data.IdType)
+		assert.Equal(t, "PROJECT", resData.Data.IDType)
 		assert.Equal(t,
 			"foo@example.iam.gserviceaccount.com",
 			resData.Data.Credentials.ClientEmail,
@@ -128,7 +128,7 @@ func TestIntegrationsGetGcp(t *testing.T) {
 		assert.Equal(t, "integration_name", resData.Name)
 		assert.True(t, resData.State.Ok)
 		assert.Equal(t, "data_id", resData.Data.ID)
-		assert.Equal(t, "PROJECT", resData.Data.IdType)
+		assert.Equal(t, "PROJECT", resData.Data.IDType)
 		assert.Equal(t,
 			"foo@example.iam.gserviceaccount.com",
 			resData.Data.Credentials.ClientEmail,
@@ -176,12 +176,12 @@ func TestIntegrationsUpdateGcp(t *testing.T) {
 		api.GcpCfgIntegration,
 		api.GcpIntegrationData{
 			ID:     "data_id",
-			IdType: "id_type",
+			IDType: "id_type",
 			Credentials: api.GcpCredentials{
-				ClientId:     "client_id",
+				ClientID:     "client_id",
 				ClientEmail:  "foo@example.iam.gserviceaccount.com",
 				PrivateKey:   "priv_key",
-				PrivateKeyId: "p_key_id",
+				PrivateKeyID: "p_key_id",
 			},
 		},
 	)

--- a/cli/cmd/integration.go
+++ b/cli/cmd/integration.go
@@ -319,11 +319,11 @@ func reflectIntegrationData(raw api.RawIntegration) [][]string {
 			break
 		}
 		out := [][]string{
-			[]string{"LEVEL", iData.IdType},
+			[]string{"LEVEL", iData.IDType},
 			[]string{"ORG/PROJECT ID", iData.ID},
-			[]string{"CLIENT ID", iData.Credentials.ClientId},
+			[]string{"CLIENT ID", iData.Credentials.ClientID},
 			[]string{"CLIENT EMAIL", iData.Credentials.ClientEmail},
-			[]string{"PRIVATE KEY ID", iData.Credentials.PrivateKeyId},
+			[]string{"PRIVATE KEY ID", iData.Credentials.PrivateKeyID},
 		}
 		if iData.SubscriptionName != "" {
 			return append(out, []string{"SUBSCRIPTION NAME", iData.SubscriptionName})
@@ -345,7 +345,7 @@ func reflectIntegrationData(raw api.RawIntegration) [][]string {
 		}
 		out := [][]string{
 			[]string{"ROLE ARN", iData.Credentials.RoleArn},
-			[]string{"EXTERNAL ID", iData.Credentials.ExternalId},
+			[]string{"EXTERNAL ID", iData.Credentials.ExternalID},
 		}
 		if iData.QueueUrl != "" {
 			return append(out, []string{"QUEUE URL", iData.QueueUrl})

--- a/cli/cmd/integration_aws.go
+++ b/cli/cmd/integration_aws.go
@@ -59,7 +59,7 @@ func createAwsConfigIntegration(lacework *api.Client) error {
 		api.AwsIntegrationData{
 			Credentials: api.AwsIntegrationCreds{
 				RoleArn:    answers.RoleArn,
-				ExternalId: answers.ExternalID,
+				ExternalID: answers.ExternalID,
 			},
 		},
 	)
@@ -113,7 +113,7 @@ func createAwsCloudTrailIntegration(lacework *api.Client) error {
 			QueueUrl: answers.QueueUrl,
 			Credentials: api.AwsIntegrationCreds{
 				RoleArn:    answers.RoleArn,
-				ExternalId: answers.ExternalID,
+				ExternalID: answers.ExternalID,
 			},
 		},
 	)

--- a/cli/cmd/integration_gcp.go
+++ b/cli/cmd/integration_gcp.go
@@ -88,11 +88,11 @@ func createGcpConfigIntegration(lacework *api.Client) error {
 	gcp := api.NewGcpCfgIntegration(answers.Name,
 		api.GcpIntegrationData{
 			ID:     answers.OrgProjectID,
-			IdType: answers.IntegrationLevel,
+			IDType: answers.IntegrationLevel,
 			Credentials: api.GcpCredentials{
-				ClientId:     answers.ClientID,
+				ClientID:     answers.ClientID,
 				ClientEmail:  answers.ClientEmail,
-				PrivateKeyId: answers.PrivateKeyID,
+				PrivateKeyID: answers.PrivateKeyID,
 				PrivateKey:   answers.PrivateKey,
 			},
 		},
@@ -175,12 +175,12 @@ func createGcpAuditLogIntegration(lacework *api.Client) error {
 	gcp := api.NewGcpAuditLogIntegration(answers.Name,
 		api.GcpIntegrationData{
 			ID:               answers.OrgProjectID,
-			IdType:           answers.IntegrationLevel,
+			IDType:           answers.IntegrationLevel,
 			SubscriptionName: answers.SubscriptionName,
 			Credentials: api.GcpCredentials{
-				ClientId:     answers.ClientID,
+				ClientID:     answers.ClientID,
 				ClientEmail:  answers.ClientEmail,
-				PrivateKeyId: answers.PrivateKeyID,
+				PrivateKeyID: answers.PrivateKeyID,
 				PrivateKey:   answers.PrivateKey,
 			},
 		},

--- a/lwupdater/updater.go
+++ b/lwupdater/updater.go
@@ -129,7 +129,7 @@ type gitReleaseResponse struct {
 	UploadUrl       string    `json:"upload_url"`
 	TarballUrl      string    `json:"tarball_url"`
 	ZipballUrl      string    `json:"zipball_url"`
-	NodeId          string    `json:"node_id"`
+	NodeID          string    `json:"node_id"`
 	TagName         string    `json:"tag_name"`
 	TargetCommitish string    `json:"target_commitish"`
 	Name            string    `json:"name"`


### PR DESCRIPTION
This PR is just helping with the consistency of the ID field in Go
structs, the best practices says to call them `ID` and not `Id`.

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>