### PR TITLE
feat(cli): preconfigure using key file from the WebUI

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -30,10 +30,12 @@ CLI installation. The command prompts you for three things:
 * `api_key`: API Access Key
 * `api_secret`: API Access Secret
 
->To create a set of API keys, log in to your Lacework account and navigate to
->Settings -> API Keys, then click + Create New. Enter a name for the key and
->an optional description and click Save. To get the secret key, download the
->generated API key file and open it in an editor.
+>To create a set of API keys, log in to your Lacework account via WebUI and
+>navigate to Settings > API Keys and click + Create New. Enter a name for
+>the key and an optional description, then click Save. To get the secret key,
+>download the generated API key file.
+
+_**NOTE:** Use the argument `--json_file` to preload the downloaded API key file._
 
 The following example shows sample values. Replace them with your own.
 


### PR DESCRIPTION
This change is adding an extra flag called `--json_file`, short that `-j`
that will allow users to load a generated API key JSON file from the WebUI.

Example: On this example, we create a set of API keys by logging in into
the Lacework WebUI, then download the keys and pass them to the Lacework
CLI to preconfigure it.
```
$ lacework configure --json_file /path/to/EXAMPLE_D3EFA214SD12DFSGRD3EFA214SD12DFSGR.json
```

The result of the above command is to only provide the "Account"
information, the API access key, and access secret will be preloaded.

**Jira Ticket: ALLY-104**

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>