### PR TITLE
feat(cli): add aliases to integration and event cmds

### DIFF
--- a/cli/cmd/event.go
+++ b/cli/cmd/event.go
@@ -32,9 +32,10 @@ import (
 var (
 	// eventCmd represents the event command
 	eventCmd = &cobra.Command{
-		Use:   "event",
-		Short: "inspect Lacework events",
-		Long:  `Inspect events reported by the Lacework platform`,
+		Use:     "event",
+		Aliases: []string{"events"},
+		Short:   "inspect Lacework events",
+		Long:    `Inspect events reported by the Lacework platform`,
 	}
 
 	// eventListCmd represents the list sub-command inside the event command

--- a/cli/cmd/integration.go
+++ b/cli/cmd/integration.go
@@ -34,7 +34,7 @@ var (
 	// integrationCmd represents the integration command
 	integrationCmd = &cobra.Command{
 		Use:     "integration",
-		Aliases: []string{"int"},
+		Aliases: []string{"integrations", "int"},
 		Short:   "manage external integrations",
 		Long:    `Manage external integrations with the Lacework platform`,
 	}


### PR DESCRIPTION
To help users access both commands, `integration` and `event`, we are
adding aliases in plural since the natural thing to type when trying to
access all integrations or events is to write the command in plural.

Having aliases will allow users to run:
```
$ lacework events list
$ lacework integrations list
```

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>