### PR TITLE
style(cli): show help without errors

### DIFF
--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -51,7 +51,7 @@ Start by configuring the Lacework CLI with the command:
 This will prompt you for your Lacework account and a set of API access keys.`,
 		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
 			switch cmd.Use {
-			case "configure", "version":
+			case "help [command]", "configure", "version":
 				return nil
 			default:
 				return cli.VerifySettings()


### PR DESCRIPTION
This small change will allow users to run `lacework help` without
failing with an error message. Just a nice UX addition! 😄 

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>