### PR TITLE
fix(api): use correct types on events response

### DIFF
--- a/api/events.go
+++ b/api/events.go
@@ -150,20 +150,20 @@ type eventContainerEntity struct {
 type eventDnsNameEntity struct {
 	Hostname      string  `json:"hostname"`
 	PortList      []int32 `json:"port_list"`
-	TotalInBytes  int32   `json:"total_in_bytes"`
-	TotalOutBytes int32   `json:"total_out_bytes"`
+	TotalInBytes  float32 `json:"total_in_bytes"`
+	TotalOutBytes float32 `json:"total_out_bytes"`
 }
 
 type eventIpAddressEntity struct {
-	IpAddress     string                 `json:"ip_address"`
-	TotalInBytes  int32                  `json:"total_in_bytes"`
-	TotalOutBytes int32                  `json:"total_out_bytes"`
-	ThreatTags    []string               `json:"threat_tags"`
-	ThreatSource  map[string]interface{} `json:"threat_source"`
-	Country       string                 `json:"country"`
-	Region        string                 `json:"region"`
-	PortList      []int32                `json:"port_list"`
-	FirstSeenTime time.Time              `json:"first_seen_time"`
+	IpAddress     string        `json:"ip_address"`
+	TotalInBytes  float32       `json:"total_in_bytes"`
+	TotalOutBytes float32       `json:"total_out_bytes"`
+	ThreatTags    string        `json:"threat_tags"`
+	ThreatSource  []interface{} `json:"threat_source"` // @afiune this field could be anything...
+	Country       string        `json:"country"`
+	Region        string        `json:"region"`
+	PortList      []int32       `json:"port_list"`
+	FirstSeenTime time.Time     `json:"first_seen_time"`
 }
 
 type eventProcessEntity struct {
@@ -217,8 +217,10 @@ type eventCTUserEntity struct {
 }
 
 type eventResourceEntity struct {
-	Name  string `json:"name"`
-	Value string `json:"value"`
+	Name string `json:"name"`
+	// @afiune the API documentation says this field is a string, but there are
+	// many events that has this field as a number, boolean, etc.  :sadpanda:
+	Value interface{} `json:"value"`
 }
 
 type eventRecIDEntity struct {


### PR DESCRIPTION
This PR is fixing the case where events with type `NewExternalServerDNSConn`
are sending the `bytes` field with a scientific notation format.

The error we are seeing is the following:
```
$ lacework event show 37
ERROR unable to get event details: json: cannot unmarshal number 6.873831E7 into Go struct field eventDnsNameEntity.data.entity_map.DnsName.total_out_bytes of type int32
```

Switching these fields to be `float32` seems to fix the parsing problem.

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>