### PR TITLE
feat: incident analysis, visualize event details

### DIFF
--- a/api/events.go
+++ b/api/events.go
@@ -95,31 +95,31 @@ type EventDetails struct {
 }
 
 type EventEntityMap struct {
-	User            []eventUserEntity            `json:"user,omitempty"`
-	Application     []eventApplicationEntity     `json:"application,omitempty"`
-	Machine         []eventMachineEntity         `json:"machine,omitempty"`
-	Container       []eventContainerEntity       `json:"container,omitempty"`
-	DnsName         []eventDnsNameEntity         `json:"DnsName,omitempty"`   // @afiune not in standard
-	IpAddress       []eventIpAddressEntity       `json:"IpAddress,omitempty"` // @afiune not in standard
-	Process         []eventProcessEntity         `json:"process,omitempty"`
-	FileDataHash    []eventFileDataHashEntity    `json:"FileDataHash,omitempty"`    // @afiune not in standard
-	FileExePath     []eventFileExePathEntity     `json:"FileExePath,omitempty"`     // @afiune not in standard
-	SourceIpAddress []eventSourceIpAddressEntity `json:"SourceIpAddress,omitempty"` // @afiune not in standard
-	API             []eventAPIEntity             `json:"api,omitempty"`
-	Region          []eventRegionEntity          `json:"region,omitempty"`
-	CTUser          []eventCTUserEntity          `json:"ct_user,omitempty"`
-	Resource        []eventResourceEntity        `json:"resource,omitempty"`
-	RecID           []eventRecIDEntity           `json:"RecId,omitempty"`           // @afiune not in standard
-	CustomRule      []eventCustomRuleEntity      `json:"CustomRule,omitempty"`      // @afiune not in standard
-	NewViolation    []eventNewViolationEntity    `json:"NewViolation,omitempty"`    // @afiune not in standard
-	ViolationReason []eventViolationReasonEntity `json:"ViolationReason,omitempty"` // @afiune not in standard
+	User            []EventUserEntity            `json:"user,omitempty"`
+	Application     []EventApplicationEntity     `json:"application,omitempty"`
+	Machine         []EventMachineEntity         `json:"machine,omitempty"`
+	Container       []EventContainerEntity       `json:"container,omitempty"`
+	DnsName         []EventDnsNameEntity         `json:"DnsName,omitempty"`   // @afiune not in standard
+	IpAddress       []EventIpAddressEntity       `json:"IpAddress,omitempty"` // @afiune not in standard
+	Process         []EventProcessEntity         `json:"process,omitempty"`
+	FileDataHash    []EventFileDataHashEntity    `json:"FileDataHash,omitempty"`    // @afiune not in standard
+	FileExePath     []EventFileExePathEntity     `json:"FileExePath,omitempty"`     // @afiune not in standard
+	SourceIpAddress []EventSourceIpAddressEntity `json:"SourceIpAddress,omitempty"` // @afiune not in standard
+	API             []EventAPIEntity             `json:"api,omitempty"`
+	Region          []EventRegionEntity          `json:"region,omitempty"`
+	CTUser          []EventCTUserEntity          `json:"ct_user,omitempty"`
+	Resource        []EventResourceEntity        `json:"resource,omitempty"`
+	RecID           []EventRecIDEntity           `json:"RecId,omitempty"`           // @afiune not in standard
+	CustomRule      []EventCustomRuleEntity      `json:"CustomRule,omitempty"`      // @afiune not in standard
+	NewViolation    []EventNewViolationEntity    `json:"NewViolation,omitempty"`    // @afiune not in standard
+	ViolationReason []EventViolationReasonEntity `json:"ViolationReason,omitempty"` // @afiune not in standard
 }
-type eventUserEntity struct {
+type EventUserEntity struct {
 	MachineHostname string `json:"machine_hostname"`
 	Username        string `json:"username"`
 }
 
-type eventApplicationEntity struct {
+type EventApplicationEntity struct {
 	Application       string    `json:"application"`
 	HasExternalConns  int32     `json:"has_external_conns"`
 	IsClient          int32     `json:"is_client"`
@@ -127,7 +127,7 @@ type eventApplicationEntity struct {
 	EarliestKnownTime time.Time `json:"earliest_known_time"`
 }
 
-type eventMachineEntity struct {
+type EventMachineEntity struct {
 	Hostname          string  `json:"hostname"`
 	ExternalIp        string  `json:"external_ip"`
 	InstanceID        string  `json:"instance_id"`
@@ -136,7 +136,7 @@ type eventMachineEntity struct {
 	InternalIpAddress string  `json:"internal_ip_address"`
 }
 
-type eventContainerEntity struct {
+type EventContainerEntity struct {
 	ImageRepo        string    `json:"image_repo"`
 	ImageTag         string    `json:"image_tag"`
 	HasExternalConns int32     `json:"has_external_conns"`
@@ -147,14 +147,14 @@ type eventContainerEntity struct {
 	PodIpAddr        string    `json:"pod_ip_addr"`
 }
 
-type eventDnsNameEntity struct {
+type EventDnsNameEntity struct {
 	Hostname      string  `json:"hostname"`
 	PortList      []int32 `json:"port_list"`
 	TotalInBytes  float32 `json:"total_in_bytes"`
 	TotalOutBytes float32 `json:"total_out_bytes"`
 }
 
-type eventIpAddressEntity struct {
+type EventIpAddressEntity struct {
 	IpAddress     string        `json:"ip_address"`
 	TotalInBytes  float32       `json:"total_in_bytes"`
 	TotalOutBytes float32       `json:"total_out_bytes"`
@@ -166,7 +166,7 @@ type eventIpAddressEntity struct {
 	FirstSeenTime time.Time     `json:"first_seen_time"`
 }
 
-type eventProcessEntity struct {
+type EventProcessEntity struct {
 	Hostname         string    `json:"hostname"`
 	ProcessID        int32     `json:"process_id"`
 	ProcessStartTime time.Time `json:"process_start_time"`
@@ -174,7 +174,7 @@ type eventProcessEntity struct {
 	CpuPercentage    float32   `json:"cpu_percentage"`
 }
 
-type eventFileDataHashEntity struct {
+type EventFileDataHashEntity struct {
 	FiledataHash  string    `json:"filedata_hash"`
 	MachineCount  int32     `json:"machine_count"`
 	ExePathList   []string  `json:"exe_path_list"`
@@ -182,7 +182,7 @@ type eventFileDataHashEntity struct {
 	IsKnownBad    int32     `json:"is_known_bad"`
 }
 
-type eventFileExePathEntity struct {
+type EventFileExePathEntity struct {
 	ExePath          string    `json:"exe_path"`
 	FirstSeenTime    time.Time `json:"first_seen_time"`
 	LastFiledataHash string    `json:"last_filedata_hash"`
@@ -191,23 +191,23 @@ type eventFileExePathEntity struct {
 	LastFileOwner    string    `json:"last_file_owner"`
 }
 
-type eventSourceIpAddressEntity struct {
+type EventSourceIpAddressEntity struct {
 	IpAddress string `json:"ip_address"`
 	Region    string `json:"region"`
 	Country   string `json:"country"`
 }
 
-type eventAPIEntity struct {
+type EventAPIEntity struct {
 	Service string `json:"service"`
 	Api     string `json:"api"`
 }
 
-type eventRegionEntity struct {
+type EventRegionEntity struct {
 	Region      string   `json:"region"`
 	AccountList []string `json:"account_list"`
 }
 
-type eventCTUserEntity struct {
+type EventCTUserEntity struct {
 	Username    string   `json:"username"`
 	AccoutID    string   `json:"accout_id"`
 	Mfa         int32    `json:"mfa"`
@@ -216,14 +216,14 @@ type eventCTUserEntity struct {
 	PrincipalID string   `json:"principal_id"`
 }
 
-type eventResourceEntity struct {
+type EventResourceEntity struct {
 	Name string `json:"name"`
 	// @afiune the API documentation says this field is a string, but there are
 	// many events that has this field as a number, boolean, etc.  :sadpanda:
 	Value interface{} `json:"value"`
 }
 
-type eventRecIDEntity struct {
+type EventRecIDEntity struct {
 	RecID        string `json:"rec_id"`
 	AccountID    string `json:"account_id"`
 	AccountAlias string `json:"account_alias"`
@@ -233,20 +233,20 @@ type eventRecIDEntity struct {
 	EvalGuid     string `json:"eval_guid"`
 }
 
-type eventCustomRuleEntity struct {
+type EventCustomRuleEntity struct {
 	LastUpdatedTime time.Time `json:"last_updated_time"`
 	LastUpdatedUser string    `json:"last_updated_user"`
 	DisplayFilter   string    `json:"display_filter"`
 	RuleGuid        string    `json:"rule_guid"`
 }
 
-type eventNewViolationEntity struct {
+type EventNewViolationEntity struct {
 	RecID    string `json:"rec_id"`
 	Reason   string `json:"reason"`
 	Resource string `json:"resource"`
 }
 
-type eventViolationReasonEntity struct {
+type EventViolationReasonEntity struct {
 	RecID  string `json:"rec_id"`
 	Reason string `json:"reason"`
 }

--- a/cli/cmd/outputs.go
+++ b/cli/cmd/outputs.go
@@ -21,6 +21,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/fatih/color"
 )
@@ -46,11 +47,20 @@ func (c *cliState) OutputHuman(format string, a ...interface{}) {
 
 // OutputJSONString is just like OutputJSON but from a JSON string
 func (c *cliState) OutputJSONString(s string) error {
-	pretty, err := c.JsonF.Format([]byte(s))
+	pretty, err := c.FormatJSONString(s)
 	if err != nil {
-		c.Log.Debugw("unable to pretty print JSON string", "raw", s)
 		return err
 	}
 	fmt.Fprintln(color.Output, string(pretty))
 	return nil
+}
+
+// FormatJSONString formats a JSON string into a pretty JSON format
+func (c *cliState) FormatJSONString(s string) (string, error) {
+	pretty, err := c.JsonF.Format([]byte(strings.Trim(s, "'")))
+	if err != nil {
+		c.Log.Debugw("unable to pretty print JSON string", "raw", s)
+		return "", err
+	}
+	return string(pretty), nil
 }

--- a/internal/array/join.go
+++ b/internal/array/join.go
@@ -1,0 +1,31 @@
+//
+// Author:: Salim Afiune Maya (<afiune@lacework.net>)
+// Copyright:: Copyright 2020, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package array
+
+import (
+	"fmt"
+	"strings"
+)
+
+func JoinInt32(array []int32, delim string) string {
+	return strings.Trim(
+		strings.Replace(fmt.Sprint(array), " ", delim, -1),
+		"[]",
+	)
+}


### PR DESCRIPTION
This change is making the `lacework event show ID` command more verbose
for our Human Readable Format. It will now display all entities.

Example:
```
$ lacework event show 78
+----------+---------------+------------+---------------+----------------------+----------------------+
| EVENT ID |     TYPE      |   ACTOR    |     MODEL     |      START TIME      |       END TIME       |
+----------+---------------+------------+---------------+----------------------+----------------------+
|       78 | NewViolations | Compliance | AwsCompliance | 2020-05-11T13:00:00Z | 2020-05-11T14:00:00Z |
+----------+---------------+------------+---------------+----------------------+----------------------+

+--------------+-----------------------------------------+----------------------------------------+
| VIOLATION ID |                 REASON                  |                RESOURCE                |
+--------------+-----------------------------------------+----------------------------------------+
| LW_AWS_IAM_1 | LW_AWS_IAM_1_AccessKey1NotRotated30Days | arn:aws:iam::123456789011:user/safiune |
+--------------+-----------------------------------------+----------------------------------------+

+--------------+--------------+---------------+--------------------------------+--------+-----------------+----------------------------------+
|  RECORD ID   |  ACCOUNT ID  | ACCOUNT ALIAS |          DESCRIPTION           | STATUS | EVALUATION TYPE |         EVALUATION GUID          |
+--------------+--------------+---------------+--------------------------------+--------+-----------------+----------------------------------+
| LW_AWS_IAM_1 | 123456789011 | tech-ally     | Ensure access keys are rotated |        | LW_SA           | abc123c881b74444972513c4ee7e317c |
|              |              |               | every 30 days or less          |        |                 |                                  |
+--------------+--------------+---------------+--------------------------------+--------+-----------------+----------------------------------+

+--------------+-----------------------------------------+
| VIOLATION ID |                 REASON                  |
+--------------+-----------------------------------------+
| LW_AWS_IAM_1 | LW_AWS_IAM_1_AccessKey1NotRotated30Days |
+--------------+-----------------------------------------+

+----------+----------------------------------------------------------------------------------------+
|   NAME   |                                         VALUE                                          |
+----------+----------------------------------------------------------------------------------------+
| iam:user | arn:aws:iam::123456789011:user/safiune                                                 |
| iam:user | arn:aws:iam::123456789011:user/cpedigo                                                 |
| iam:user | arn:aws:iam::123456789011:user/openshift4-mbbhw-openshift-machine-api-aws-8ccxk        |
| iam:user | arn:aws:iam::123456789011:user/openshift4-mbbhw-cloud-credential-operator-iam-ro-nf449 |
| iam:user | arn:aws:iam::123456789011:user/openshift4-mbbhw-openshift-ingress-4vmrx                |
| iam:user | arn:aws:iam::123456789011:user/openshift4-mbbhw-openshift-image-registry-6mjws         |
+----------+----------------------------------------------------------------------------------------+
```

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>