### PR TITLE
feat: manage compliance reports for GCP, Azure, and AWS

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -36,6 +36,16 @@ const (
 	apiVulnerabilitiesReportFromID     = "external/vulnerabilities/container/imageId/%s"
 	apiVulnerabilitiesReportFromDigest = "external/vulnerabilities/container/imageDigest/%s"
 
+	apiComplianceAwsLatestReport        = "external/compliance/aws/GetLatestComplianceReport?AWS_ACCOUNT_ID=%s"
+	apiComplianceGcpLatestReport        = "external/compliance/gcp/GetLatestComplianceReport?GCP_ORG_ID=%s&GCP_PROJ_ID=%s"
+	apiComplianceGcpListProjects        = "external/compliance/gcp/ListProjectsForOrganization?GCP_ORG_ID=%s"
+	apiComplianceAzureLatestReport      = "external/compliance/azure/GetLatestComplianceReport?AZURE_TENANT_ID=%s&AZURE_SUBS_ID=%s"
+	apiComplianceAzureListSubscriptions = "external/compliance/azure/ListSubscriptionsForTenant?AZURE_TENANT_ID=%s"
+
+	apiRunReportGcp   = "external/runReport/gcp/%s"
+	apiRunReportAws   = "external/runReport/aws/%s"
+	apiRunReportAzure = "external/runReport/azure/%s"
+
 	apiEventsDetails   = "external/events/GetEventDetails"
 	apiEventsDateRange = "external/events/GetEventsForDateRange"
 )

--- a/api/client.go
+++ b/api/client.go
@@ -43,6 +43,7 @@ type Client struct {
 	log        *zap.Logger
 
 	Events          *EventsService
+	Compliance      *ComplianceService
 	Integrations    *IntegrationsService
 	Vulnerabilities *VulnerabilitiesService
 }
@@ -86,6 +87,7 @@ func NewClient(account string, opts ...Option) (*Client, error) {
 		c: &http.Client{Timeout: defaultTimeout},
 	}
 	c.Events = &EventsService{c}
+	c.Compliance = &ComplianceService{c}
 	c.Integrations = &IntegrationsService{c}
 	c.Vulnerabilities = &VulnerabilitiesService{c}
 

--- a/api/compliance.go
+++ b/api/compliance.go
@@ -1,0 +1,99 @@
+//
+// Author:: Salim Afiune Maya (<afiune@lacework.net>)
+// Copyright:: Copyright 2020, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package api
+
+import "fmt"
+
+// ComplianceService is a service that interacts with the compliance
+// endpoints from the Lacework Server
+type ComplianceService struct {
+	client *Client
+}
+
+func (svc *ComplianceService) ListGcpProjects(orgID string) (
+	response compGcpProjectsResponse,
+	err error,
+) {
+	apiPath := fmt.Sprintf(apiComplianceGcpListProjects, orgID)
+	err = svc.client.RequestDecoder("GET", apiPath, nil, &response)
+	return
+}
+
+type compGcpProjectsResponse struct {
+	Data    []CompGcpProjects `json:"data"`
+	Ok      bool              `json:"ok"`
+	Message string            `json:"message"`
+}
+
+type CompGcpProjects struct {
+	Organization string   `json:"organization"`
+	Projects     []string `json:"projects"`
+}
+
+type ComplianceSummary struct {
+	AssessedResourceCount     int `json:"assessed_resource_count"`
+	NumCompliant              int `json:"num_compliant"`
+	NumNotCompliant           int `json:"num_not_compliant"`
+	NumRecommendations        int `json:"num_recommendations"`
+	NumSeverity1NonCompliance int `json:"num_severity_1_non_compliance"`
+	NumSeverity2NonCompliance int `json:"num_severity_2_non_compliance"`
+	NumSeverity3NonCompliance int `json:"num_severity_3_non_compliance"`
+	NumSeverity4NonCompliance int `json:"num_severity_4_non_compliance"`
+	NumSeverity5NonCompliance int `json:"num_severity_5_non_compliance"`
+	NumSuppressed             int `json:"num_suppressed"`
+	SuppressedResourceCount   int `json:"suppressed_resource_count"`
+	ViolatedResourceCount     int `json:"violated_resource_count"`
+}
+
+type ComplianceRecommendation struct {
+	RecID                 string                `json:"rec_id"`
+	AssessedResourceCount int                   `json:"assessed_resource_count"`
+	ResourceCount         int                   `json:"resource_count"`
+	Category              string                `json:"category"`
+	InfoLink              string                `json:"info_link"`
+	Service               string                `json:"service"`
+	Severity              int                   `json:"severity"`
+	Status                string                `json:"status"`
+	Suppressions          []string              `json:"suppressions"`
+	Title                 string                `json:"title"`
+	Violations            []ComplianceViolation `json:"violations"`
+}
+
+func (r *ComplianceRecommendation) SeverityString() string {
+	switch r.Severity {
+	case 1:
+		return "Critical"
+	case 2:
+		return "High"
+	case 3:
+		return "Medium"
+	case 4:
+		return "Low"
+	case 5:
+		return "Info"
+	default:
+		return "Unknown"
+	}
+}
+
+type ComplianceViolation struct {
+	Region   string   `json:"region"`
+	Resource string   `json:"resource"`
+	Reasons  []string `json:"reasons"`
+}

--- a/api/compliance_aws.go
+++ b/api/compliance_aws.go
@@ -1,0 +1,117 @@
+//
+// Author:: Salim Afiune Maya (<afiune@lacework.net>)
+// Copyright:: Copyright 2020, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package api
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+type ComplianceAwsReportConfig struct {
+	AccountID string
+	Type      string
+}
+
+func (svc *ComplianceService) GetAwsReport(config ComplianceAwsReportConfig) (
+	response complianceAwsReportResponse,
+	err error,
+) {
+	if config.AccountID == "" {
+		err = errors.New("account_id is required")
+		return
+	}
+	apiPath := fmt.Sprintf(apiComplianceAwsLatestReport, config.AccountID)
+
+	if config.Type != "" {
+		apiPath = fmt.Sprintf("%s&REPORT_TYPE=%s", apiPath, config.Type)
+	}
+
+	// add JSON format, if not, the default is PDF
+	apiPath = fmt.Sprintf("%s&FILE_FORMAT=json", apiPath)
+	err = svc.client.RequestDecoder("GET", apiPath, nil, &response)
+	return
+}
+
+func (svc *ComplianceService) DownloadAwsReportPDF(filepath string, config ComplianceAwsReportConfig) error {
+	if config.AccountID == "" {
+		return errors.New("account_id is required")
+	}
+
+	apiPath := fmt.Sprintf(apiComplianceAwsLatestReport, config.AccountID)
+
+	if config.Type != "" {
+		apiPath = fmt.Sprintf("%s&REPORT_TYPE=%s", apiPath, config.Type)
+	}
+
+	request, err := svc.client.NewRequest("GET", apiPath, nil)
+	if err != nil {
+		return err
+	}
+
+	response, err := svc.client.Do(request)
+	if err != nil {
+		return err
+	}
+	defer response.Body.Close()
+
+	err = checkErrorInResponse(response)
+	if err != nil {
+		return err
+	}
+
+	// Create the file
+	out, err := os.Create(filepath)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	// Write the body to file
+	_, err = io.Copy(out, response.Body)
+	return err
+}
+
+func (svc *ComplianceService) RunAwsReport(accountID string) (
+	response map[string]interface{}, // @afiune not consistent with the other cloud providers
+	err error,
+) {
+	apiPath := fmt.Sprintf(apiRunReportAws, accountID)
+	err = svc.client.RequestDecoder("POST", apiPath, nil, &response)
+	return
+}
+
+type complianceAwsReportResponse struct {
+	Data    []ComplianceAwsReport `json:"data"`
+	Ok      bool                  `json:"ok"`
+	Message string                `json:"message"`
+}
+
+type ComplianceAwsReport struct {
+	ReportTitle     string                     `json:"reportTitle"`
+	ReportType      string                     `json:"reportType"`
+	ReportTime      time.Time                  `json:"reportTime"`
+	AccountID       string                     `json:"accountId"`
+	AccountAlias    string                     `json:"accountAlias"`
+	Summary         []ComplianceSummary        `json:"summary"`
+	Recommendations []ComplianceRecommendation `json:"recommendations"`
+}

--- a/api/compliance_azure.go
+++ b/api/compliance_azure.go
@@ -1,0 +1,159 @@
+//
+// Author:: Salim Afiune Maya (<afiune@lacework.net>)
+// Copyright:: Copyright 2020, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package api
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+type ComplianceAzureReportConfig struct {
+	TenantID       string
+	SubscriptionID string
+	Type           string
+}
+
+func (svc *ComplianceService) ListAzureSubscriptions(tenantID string) (
+	response compAzureSubsResponse,
+	err error,
+) {
+	apiPath := fmt.Sprintf(apiComplianceAzureListSubscriptions, tenantID)
+	err = svc.client.RequestDecoder("GET", apiPath, nil, &response)
+	return
+}
+
+func (svc *ComplianceService) GetAzureReport(config ComplianceAzureReportConfig) (
+	response complianceAzureReportResponse,
+	err error,
+) {
+	if config.TenantID == "" || config.SubscriptionID == "" {
+		err = errors.New("tenant_id and subscription_id are required")
+		return
+	}
+	apiPath := fmt.Sprintf(apiComplianceAzureLatestReport, config.TenantID, config.SubscriptionID)
+
+	if config.Type != "" {
+		apiPath = fmt.Sprintf("%s&REPORT_TYPE=%s", apiPath, config.Type)
+	}
+
+	// add JSON format, if not, the default is PDF
+	apiPath = fmt.Sprintf("%s&FILE_FORMAT=json", apiPath)
+	err = svc.client.RequestDecoder("GET", apiPath, nil, &response)
+	return
+}
+
+func (svc *ComplianceService) DownloadAzureReportPDF(filepath string, config ComplianceAzureReportConfig) error {
+	if config.TenantID == "" || config.SubscriptionID == "" {
+		return errors.New("tenant_id and subscription_id are required")
+	}
+
+	apiPath := fmt.Sprintf(apiComplianceAzureLatestReport, config.TenantID, config.SubscriptionID)
+
+	if config.Type != "" {
+		apiPath = fmt.Sprintf("%s&REPORT_TYPE=%s", apiPath, config.Type)
+	}
+
+	request, err := svc.client.NewRequest("GET", apiPath, nil)
+	if err != nil {
+		return err
+	}
+
+	response, err := svc.client.Do(request)
+	if err != nil {
+		return err
+	}
+	defer response.Body.Close()
+
+	err = checkErrorInResponse(response)
+	if err != nil {
+		return err
+	}
+
+	// Create the file
+	out, err := os.Create(filepath)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	// Write the body to file
+	_, err = io.Copy(out, response.Body)
+	return err
+}
+
+func (svc *ComplianceService) RunAzureReport(tenantID string) (
+	response complianceRunAzureReportResponse,
+	err error,
+) {
+	apiPath := fmt.Sprintf(apiRunReportAzure, tenantID)
+	err = svc.client.RequestDecoder("POST", apiPath, nil, &response)
+	return
+}
+
+type complianceRunAzureReportResponse struct {
+	IntgGuid             string                       `json:"intgGuid"`
+	MultiContextEvalGuid string                       `json:"multiContextEvalGuid"`
+	EvalRequests         []complianceAzureEvalRequest `json:"evalRequests"`
+}
+
+type complianceAzureEvalRequest struct {
+	EvalGuid       string                         `json:"evalGuid"`
+	EvalCtx        complianceRunReportAzureContex `json:"evalCtx"`
+	SubmitErrorMsg interface{}                    `json:"submitErrorMsg"`
+}
+
+type complianceRunReportAzureContex struct {
+	SubscriptionID   string `json:"subscriptionId"`
+	SubscriptionName string `json:"subscriptionName"`
+	TenantID         string `json:"tenantId"`
+	TenantName       string `json:"tenantName"`
+}
+
+type compAzureSubsResponse struct {
+	Data    []CompAzureSubscriptions `json:"data"`
+	Ok      bool                     `json:"ok"`
+	Message string                   `json:"message"`
+}
+
+type CompAzureSubscriptions struct {
+	Tenant        string   `json:"tenant"`
+	Subscriptions []string `json:"subscriptions"`
+}
+
+type complianceAzureReportResponse struct {
+	Data    []ComplianceAzureReport `json:"data"`
+	Ok      bool                    `json:"ok"`
+	Message string                  `json:"message"`
+}
+
+type ComplianceAzureReport struct {
+	ReportTitle      string                     `json:"reportTitle"`
+	ReportType       string                     `json:"reportType"`
+	ReportTime       time.Time                  `json:"reportTime"`
+	TenantID         string                     `json:"tenantId"`
+	TenantName       string                     `json:"tenantName"`
+	SubscriptionID   string                     `json:"subscriptionId"`
+	SubscriptionName string                     `json:"subscriptionName"`
+	Summary          []ComplianceSummary        `json:"summary"`
+	Recommendations  []ComplianceRecommendation `json:"recommendations"`
+}

--- a/api/compliance_gcp.go
+++ b/api/compliance_gcp.go
@@ -1,0 +1,139 @@
+//
+// Author:: Salim Afiune Maya (<afiune@lacework.net>)
+// Copyright:: Copyright 2020, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package api
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+type ComplianceGcpReportConfig struct {
+	OrganizationID string
+	ProjectID      string
+	Type           string
+}
+
+func (svc *ComplianceService) GetGcpReport(config ComplianceGcpReportConfig) (
+	response complianceGcpReportResponse,
+	err error,
+) {
+	if config.OrganizationID == "" || config.ProjectID == "" {
+		err = errors.New("organization_id and project_id is required")
+		return
+	}
+	apiPath := fmt.Sprintf(apiComplianceGcpLatestReport, config.OrganizationID, config.ProjectID)
+
+	if config.Type != "" {
+		apiPath = fmt.Sprintf("%s&REPORT_TYPE=%s", apiPath, config.Type)
+	}
+
+	// add JSON format, if not, the default is PDF
+	apiPath = fmt.Sprintf("%s&FILE_FORMAT=json", apiPath)
+	err = svc.client.RequestDecoder("GET", apiPath, nil, &response)
+	return
+}
+
+func (svc *ComplianceService) DownloadGcpReportPDF(filepath string, config ComplianceGcpReportConfig) error {
+	if config.OrganizationID == "" || config.ProjectID == "" {
+		return errors.New("organization_id and project_id is required")
+	}
+
+	apiPath := fmt.Sprintf(apiComplianceGcpLatestReport, config.OrganizationID, config.ProjectID)
+
+	if config.Type != "" {
+		apiPath = fmt.Sprintf("%s&REPORT_TYPE=%s", apiPath, config.Type)
+	}
+
+	request, err := svc.client.NewRequest("GET", apiPath, nil)
+	if err != nil {
+		return err
+	}
+
+	response, err := svc.client.Do(request)
+	if err != nil {
+		return err
+	}
+	defer response.Body.Close()
+
+	err = checkErrorInResponse(response)
+	if err != nil {
+		return err
+	}
+
+	// Create the file
+	out, err := os.Create(filepath)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	// Write the body to file
+	_, err = io.Copy(out, response.Body)
+	return err
+}
+
+func (svc *ComplianceService) RunGcpReport(projectID string) (
+	response complianceRunGcpReportResponse,
+	err error,
+) {
+	apiPath := fmt.Sprintf(apiRunReportGcp, projectID)
+	err = svc.client.RequestDecoder("POST", apiPath, nil, &response)
+	return
+}
+
+type complianceRunGcpReportResponse struct {
+	IntgGuid             string                     `json:"intgGuid"`
+	MultiContextEvalGuid string                     `json:"multiContextEvalGuid"`
+	EvalRequests         []complianceGcpEvalRequest `json:"evalRequests"`
+}
+
+type complianceGcpEvalRequest struct {
+	EvalGuid       string                       `json:"evalGuid"`
+	EvalCtx        complianceRunReportGcpContex `json:"evalCtx"`
+	SubmitErrorMsg interface{}                  `json:"submitErrorMsg"`
+}
+
+type complianceRunReportGcpContex struct {
+	OrganizationID   string `json:"organizationId"`
+	OrganizationName string `json:"organizationName"`
+	ProjectID        string `json:"projectId"`
+	ProjectName      string `json:"projectName"`
+}
+
+type complianceGcpReportResponse struct {
+	Data    []ComplianceGcpReport `json:"data"`
+	Ok      bool                  `json:"ok"`
+	Message string                `json:"message"`
+}
+
+type ComplianceGcpReport struct {
+	ReportTitle      string                     `json:"reportTitle"`
+	ReportType       string                     `json:"reportType"`
+	ReportTime       time.Time                  `json:"reportTime"`
+	OrganizationID   string                     `json:"organizationId"`
+	OrganizationName string                     `json:"organizationName"`
+	ProjectID        string                     `json:"projectId"`
+	ProjectName      string                     `json:"projectName"`
+	Summary          []ComplianceSummary        `json:"summary"`
+	Recommendations  []ComplianceRecommendation `json:"recommendations"`
+}

--- a/cli/cmd/compliance.go
+++ b/cli/cmd/compliance.go
@@ -1,0 +1,286 @@
+//
+// Author:: Salim Afiune Maya (<afiune@lacework.net>)
+// Copyright:: Copyright 2020, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cmd
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/lacework/go-sdk/api"
+	"github.com/olekukonko/tablewriter"
+	"github.com/spf13/cobra"
+)
+
+var (
+	compCmdState = struct {
+		// the report type to display, supported are: CIS, SOC, or PCI
+		// default: CIS
+		Type string
+
+		// download the report as PDF format with the provided filename
+		PdfName string
+
+		// display extended details about a compliance report
+		Details bool
+	}{Type: "CIS"}
+
+	// complianceCmd represents the compliance command
+	complianceCmd = &cobra.Command{
+		Use:     "compliance",
+		Aliases: []string{"comp"},
+		Short:   "manage compliance reports",
+		Long: `Manage compliance reports for GCP, Azure, or AWS cloud providers.
+
+To start sending data about your environment to Lacework for compliance reporting
+analysis, configure one or more cloud integration using the following command:
+
+  $ lacework integration create
+
+Or, if you prefer to do it via the WebUI, log in to your account at:
+
+    https://<ACCOUNT>.lacework.net
+
+Then navigate to Settings > Integrations > Cloud Accounts.
+
+Use the following command to list all available integrations in your account:
+
+  $ lacework integrations list
+`,
+	}
+
+	// complianceAzureCmd represents the azure sub-command inside the compliance command
+	complianceAzureCmd = &cobra.Command{
+		Use:     "azure",
+		Aliases: []string{"az"},
+		Short:   "compliance for Microsoft Azure",
+		Long: `Manage compliance reports for Microsoft Azure.
+
+To get the latest Azure compliance assessment report, use the command:
+
+  $ lacework compliance azure get-report <tenant_id> <subscriptions_id>
+
+These reports run on a regular schedule, typically once a day.
+
+To find out which Azure tenants/subscriptions are connected to your
+Lacework account, use the following command:
+
+  $ lacework integrations list --type AZURE_CFG
+
+Then, choose one integration, copy the GUID and visualize its details
+using the command:
+
+  $ lacework integration show <int_guid>
+
+To list all Azure subscriptions from a tenant, use the command:
+
+  $ lacework compliance azure list-subscriptions <tenant_id>
+
+To run an ad-hoc compliance assessment use the command:
+
+  $ lacework compliance azure run-assessment <tenant_id>
+`,
+	}
+
+	// complianceGcpCmd represents the gcp sub-command inside the compliance command
+	complianceGcpCmd = &cobra.Command{
+		Use:   "gcp",
+		Short: "compliance for Google Cloud",
+		Long: `Manage compliance reports for Google Cloud.
+
+To get the latest GCP compliance assessment report, use the command:
+
+  $ lacework compliance gcp get-report <organization_id> <project_id>
+
+These reports run on a regular schedule, typically once a day.
+
+To find out which GCP organizations/projects are connected to your
+Lacework account, use the following command:
+
+  $ lacework integrations list --type GCP_CFG
+
+Then, choose one integration, copy the GUID and visualize its details
+using the command:
+
+  $ lacework integration show <int_guid>
+
+To list all GCP projects from an organization, use the command:
+
+  $ lacework compliance gcp list-projects <organization_id>
+
+To run an ad-hoc compliance assessment use the command:
+
+  $ lacework compliance gcp run-assessment <org_or_project_id>
+`,
+	}
+
+	// complianceAwsCmd represents the aws sub-command inside the compliance command
+	complianceAwsCmd = &cobra.Command{
+		Use:   "aws",
+		Short: "compliance for AWS",
+		Long: `Manage compliance reports for Amazon Web Services.
+
+To get the latest AWS compliance assessment report, use the command:
+
+  $ lacework compliance aws get-report <account_id>
+
+These reports run on a regular schedule, typically once a day.
+
+To find out which AWS accounts are connected to you Lacework account,
+use the following command:
+
+  $ lacework integrations list --type AWS_CFG
+
+Then, choose one integration, copy the GUID and visualize its details
+using the command:
+
+  $ lacework integration show <int_guid>
+
+To run an ad-hoc compliance assessment use the command:
+
+  $ lacework compliance aws run-assessment <account_id>
+`,
+	}
+)
+
+func init() {
+	// add the compliance command
+	rootCmd.AddCommand(complianceCmd)
+
+	// add sub-commands to the compliance command
+	complianceCmd.AddCommand(complianceAzureCmd)
+	complianceCmd.AddCommand(complianceAwsCmd)
+	complianceCmd.AddCommand(complianceGcpCmd)
+}
+
+func complianceReportSummaryTable(summaries []api.ComplianceSummary) [][]string {
+	if len(summaries) == 0 {
+		return [][]string{}
+	}
+	summary := summaries[0]
+	return [][]string{
+		[]string{"Critical", fmt.Sprint(summary.NumSeverity1NonCompliance)},
+		[]string{"High", fmt.Sprint(summary.NumSeverity2NonCompliance)},
+		[]string{"Medium", fmt.Sprint(summary.NumSeverity3NonCompliance)},
+		[]string{"Low", fmt.Sprint(summary.NumSeverity4NonCompliance)},
+		[]string{"Info", fmt.Sprint(summary.NumSeverity5NonCompliance)},
+	}
+}
+
+func complianceReportRecommendationsTable(recommendations []api.ComplianceRecommendation) [][]string {
+	out := [][]string{}
+	for _, recommend := range recommendations {
+		out = append(out, []string{
+			recommend.RecID,
+			recommend.Title,
+			recommend.Status,
+			recommend.SeverityString(),
+			recommend.Service,
+			fmt.Sprint(recommend.ResourceCount),
+			fmt.Sprint(recommend.AssessedResourceCount),
+		})
+	}
+
+	sort.Slice(out, func(i, j int) bool {
+		return severityOrder(out[i][3]) < severityOrder(out[j][3])
+	})
+
+	return out
+}
+
+func buildComplianceReportRecommandations(recommendationsTable [][]string) string {
+	var (
+		detailsTable = &strings.Builder{}
+		t            = tablewriter.NewWriter(detailsTable)
+	)
+
+	t.SetRowLine(true)
+	t.SetBorders(tablewriter.Border{
+		Left:   false,
+		Right:  false,
+		Top:    true,
+		Bottom: true,
+	})
+	t.SetAlignment(tablewriter.ALIGN_LEFT)
+	t.SetHeader([]string{
+		"ID",
+		"Recommendation",
+		"Status",
+		"Severity",
+		"Service",
+		"Affected",
+		"Assessed",
+	})
+	t.AppendBulk(recommendationsTable)
+	t.Render()
+
+	return detailsTable.String()
+}
+
+func buildComplianceReportTable(detailsTable, summaryTable, recommendationsTable [][]string) string {
+	var (
+		t             *tablewriter.Table
+		mainReport    = &strings.Builder{}
+		summaryReport = &strings.Builder{}
+		reportDetails = &strings.Builder{}
+	)
+
+	t = tablewriter.NewWriter(reportDetails)
+	t.SetBorder(false)
+	t.SetColumnSeparator("")
+	t.SetAlignment(tablewriter.ALIGN_LEFT)
+	t.AppendBulk(detailsTable)
+	t.Render()
+
+	t = tablewriter.NewWriter(summaryReport)
+	t.SetBorder(false)
+	t.SetColumnSeparator(" ")
+	t.SetHeader([]string{
+		"Severity", "Count",
+	})
+	t.AppendBulk(summaryTable)
+	t.Render()
+
+	t = tablewriter.NewWriter(mainReport)
+	t.SetBorder(false)
+	t.SetAutoWrapText(false)
+	t.SetHeader([]string{
+		"Compliance Report Details",
+		"Non-Compliant Recommendations",
+	})
+	t.Append([]string{
+		reportDetails.String(),
+		summaryReport.String(),
+	})
+	t.Render()
+
+	if compCmdState.Details {
+		mainReport.WriteString(buildComplianceReportRecommandations(recommendationsTable))
+		mainReport.WriteString("\n")
+		mainReport.WriteString(
+			"Try using '--pdf-file <filename>' to download the report in PDF format.",
+		)
+		mainReport.WriteString("\n")
+	} else {
+		mainReport.WriteString(
+			"Try using '--details' to increase details shown about the compliance report.\n",
+		)
+	}
+	return mainReport.String()
+}

--- a/cli/cmd/compliance_aws.go
+++ b/cli/cmd/compliance_aws.go
@@ -1,0 +1,196 @@
+//
+// Author:: Salim Afiune Maya (<afiune@lacework.net>)
+// Copyright:: Copyright 2020, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cmd
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/lacework/go-sdk/api"
+	"github.com/olekukonko/tablewriter"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+var (
+	// complianceAwsGetReportCmd represents the get-report sub-command inside the aws command
+	complianceAwsGetReportCmd = &cobra.Command{
+		Use:     "get-report <account_id>",
+		Aliases: []string{"get"},
+		PreRunE: func(_ *cobra.Command, _ []string) error {
+			switch compCmdState.Type {
+			case "CIS":
+				compCmdState.Type = fmt.Sprintf("AWS_%s_S3", compCmdState.Type)
+				return nil
+			case "AWS_CIS_S3", "NIST_800-53_Rev4", "ISO_2700", "HIPAA", "SOC", "PCI":
+				return nil
+			default:
+				return errors.New("supported report types are: CIS, NIST_800-53_Rev4, ISO_2700, HIPAA, SOC, or PCI")
+			}
+		},
+		Short: "get the latest AWS compliance report",
+		Long: `Get the latest AWS compliance assessment report, these reports run on a regular schedule,
+typically once a day. The available report formats are human-readable (default), json and pdf.
+
+To find out which AWS accounts are connected to you Lacework account, use the following command:
+
+  $ lacework integrations list --type AWS_CFG
+
+Then, choose one integration, copy the GUID and visialize its details using the command:
+
+  $ lacework integration show <int_guid>
+
+To run an ad-hoc compliance assessment use the command:
+
+  $ lacework compliance aws run-assessment <account_id>
+`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			lacework, err := api.NewClient(cli.Account,
+				api.WithLogLevel(cli.LogLevel),
+				api.WithApiKeys(cli.KeyID, cli.Secret),
+			)
+			if err != nil {
+				return errors.Wrap(err, "unable to generate api client")
+			}
+
+			config := api.ComplianceAwsReportConfig{
+				AccountID: args[0],
+				Type:      compCmdState.Type,
+			}
+
+			if compCmdState.PdfName != "" {
+				cli.StartProgress(" Downloading compliance report...")
+				err := lacework.Compliance.DownloadAwsReportPDF(compCmdState.PdfName, config)
+				cli.StopProgress()
+				if err != nil {
+					return errors.Wrap(err, "unable to get aws pdf compliance report")
+				}
+
+				cli.OutputHuman("The AWS compliance report was downloaded at '%s'.\n", compCmdState.PdfName)
+				return nil
+			}
+
+			cli.StartProgress(" Getting compliance report...")
+			response, err := lacework.Compliance.GetAwsReport(config)
+			cli.StopProgress()
+			if err != nil {
+				return errors.Wrap(err, "unable to get aws compliance report")
+			}
+
+			if len(response.Data) == 0 {
+				return errors.New("there is no data found in the report")
+			}
+
+			if cli.JSONOutput() {
+				return cli.OutputJSON(response.Data[0])
+			}
+
+			report := response.Data[0]
+			cli.OutputHuman("\n")
+			cli.OutputHuman(
+				buildComplianceReportTable(
+					complianceAwsReportDetailsTable(&report),
+					complianceReportSummaryTable(report.Summary),
+					complianceReportRecommendationsTable(report.Recommendations),
+				),
+			)
+			return nil
+		},
+	}
+
+	// complianceAwsRunAssessmentCmd represents the run-assessment sub-command inside the aws command
+	complianceAwsRunAssessmentCmd = &cobra.Command{
+		Use:     "run-assessment <account_id>",
+		Aliases: []string{"run"},
+		Short:   "run a new AWS compliance report",
+		Long:    `Run a compliance assessment for the provided AWS account.`,
+		Args:    cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			lacework, err := api.NewClient(cli.Account,
+				api.WithLogLevel(cli.LogLevel),
+				api.WithApiKeys(cli.KeyID, cli.Secret),
+			)
+			if err != nil {
+				return errors.Wrap(err, "unable to generate api client")
+			}
+
+			response, err := lacework.Compliance.RunAwsReport(args[0])
+			if err != nil {
+				return errors.Wrap(err, "unable to run aws compliance report")
+			}
+
+			if cli.JSONOutput() {
+				return cli.OutputJSON(response)
+			}
+
+			cli.OutputHuman("A new AWS compliance report has been initiated.\n")
+			// @afiune not consistent with the other cloud providers
+			for key := range response {
+				cli.OutputHuman("\n")
+				cli.OutputHuman(buildAwsRunAssessmentTable(key, args[0]))
+			}
+			return nil
+		},
+	}
+)
+
+func init() {
+	// add sub-commands to the aws command
+	complianceAwsCmd.AddCommand(complianceAwsGetReportCmd)
+	complianceAwsCmd.AddCommand(complianceAwsRunAssessmentCmd)
+
+	complianceAwsGetReportCmd.Flags().BoolVar(&compCmdState.Details, "details", false,
+		"increase details about the compliance report",
+	)
+	complianceAwsGetReportCmd.Flags().StringVar(&compCmdState.PdfName, "pdf-file", "",
+		"download the report as PDF format with the provided filename",
+	)
+
+	// AWS report types: AWS_CIS_S3, NIST_800-53_Rev4, ISO_2700, HIPAA, SOC, or PCI
+	complianceAwsGetReportCmd.Flags().StringVar(&compCmdState.Type, "type", "CIS",
+		"report type to display, supported types: CIS, NIST_800-53_Rev4, ISO_2700, HIPAA, SOC, or PCI",
+	)
+}
+
+func buildAwsRunAssessmentTable(intGuid, id string) string {
+	var (
+		tBuilder = &strings.Builder{}
+		t        = tablewriter.NewWriter(tBuilder)
+	)
+
+	t.SetHeader([]string{"INTEGRATION GUID", "ACCOUNT ID"})
+	t.SetBorder(false)
+	t.SetAutoWrapText(false)
+	t.Append([]string{intGuid, id})
+	t.Render()
+
+	return tBuilder.String()
+}
+
+func complianceAwsReportDetailsTable(report *api.ComplianceAwsReport) [][]string {
+	return [][]string{
+		[]string{"Report Type", report.ReportType},
+		[]string{"Report Title", report.ReportTitle},
+		[]string{"Account ID", report.AccountID},
+		[]string{"Account Alias", report.AccountAlias},
+		[]string{"Report Time", report.ReportTime.UTC().Format(time.RFC3339)},
+	}
+}

--- a/cli/cmd/compliance_azure.go
+++ b/cli/cmd/compliance_azure.go
@@ -1,0 +1,247 @@
+//
+// Author:: Salim Afiune Maya (<afiune@lacework.net>)
+// Copyright:: Copyright 2020, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cmd
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/lacework/go-sdk/api"
+	"github.com/olekukonko/tablewriter"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+var (
+	// complianceAzureListSubsCmd represents the list-subscriptions sub-command inside the azure command
+	complianceAzureListSubsCmd = &cobra.Command{
+		Use:     "list-subscriptions <tenant_id>",
+		Aliases: []string{"list-subs", "list"},
+		Short:   "list subscriptions from tenant",
+		Long: `List all Azure subscriptions from the provided tenant ID.
+
+Use the following command to list all Azure integrations in your account:
+
+  $ lacework integrations list --type AZURE_CFG
+
+Then, select one GUID from an integration and visialize its details using the command:
+
+  $ lacework integration show <int_guid>
+`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			lacework, err := api.NewClient(cli.Account,
+				api.WithLogLevel(cli.LogLevel),
+				api.WithApiKeys(cli.KeyID, cli.Secret),
+			)
+			if err != nil {
+				return errors.Wrap(err, "unable to generate api client")
+			}
+
+			response, err := lacework.Compliance.ListAzureSubscriptions(args[0])
+			if err != nil {
+				return errors.Wrap(err, "unable to list azure subscriptions")
+			}
+
+			if cli.JSONOutput() {
+				return cli.OutputJSON(response.Data[0])
+			}
+
+			cli.OutputHuman(buildAzureSubscriptionsTable(response.Data))
+			return nil
+		},
+	}
+
+	// complianceAzureGetReportCmd represents the get-report sub-command inside the azure command
+	complianceAzureGetReportCmd = &cobra.Command{
+		Use:     "get-report <tenant_id> <subscriptions_id>",
+		Aliases: []string{"get"},
+		PreRunE: func(_ *cobra.Command, _ []string) error {
+			switch compCmdState.Type {
+			case "CIS", "SOC", "PCI":
+				compCmdState.Type = fmt.Sprintf("AZURE_%s", compCmdState.Type)
+				return nil
+			case "AZURE_CIS", "AZURE_SOC", "AZURE_PCI":
+				return nil
+			default:
+				return errors.New("supported report types are: CIS, SOC, or PCI")
+			}
+		},
+		Short: "get the latest Azure compliance report",
+		Long: `Get the latest Azure compliance assessment report, these reports run on a regular schedule,
+typically once a day. The available report formats are human-readable (default), json and pdf.
+
+To run an ad-hoc compliance assessment use the command:
+
+  $ lacework compliance azure run-assessment <tenant_id>
+`,
+		Args: cobra.ExactArgs(2),
+		RunE: func(_ *cobra.Command, args []string) error {
+			lacework, err := api.NewClient(cli.Account,
+				api.WithLogLevel(cli.LogLevel),
+				api.WithApiKeys(cli.KeyID, cli.Secret),
+			)
+			if err != nil {
+				return errors.Wrap(err, "unable to generate api client")
+			}
+
+			config := api.ComplianceAzureReportConfig{
+				TenantID:       args[0],
+				SubscriptionID: args[1],
+				Type:           compCmdState.Type,
+			}
+
+			if compCmdState.PdfName != "" {
+				cli.StartProgress(" Downloading compliance report...")
+				err := lacework.Compliance.DownloadAzureReportPDF(compCmdState.PdfName, config)
+				cli.StopProgress()
+				if err != nil {
+					return errors.Wrap(err, "unable to get azure pdf compliance report")
+				}
+
+				cli.OutputHuman("The Azure compliance report was downloaded at '%s'.\n", compCmdState.PdfName)
+				return nil
+			}
+
+			cli.StartProgress(" Getting compliance report...")
+			response, err := lacework.Compliance.GetAzureReport(config)
+			cli.StopProgress()
+			if err != nil {
+				return errors.Wrap(err, "unable to get azure compliance report")
+			}
+
+			if len(response.Data) == 0 {
+				return errors.New("there is no data found in the report")
+			}
+
+			if cli.JSONOutput() {
+				return cli.OutputJSON(response.Data[0])
+			}
+
+			report := response.Data[0]
+			cli.OutputHuman("\n")
+			cli.OutputHuman(
+				buildComplianceReportTable(
+					complianceAzureReportDetailsTable(&report),
+					complianceReportSummaryTable(report.Summary),
+					complianceReportRecommendationsTable(report.Recommendations),
+				),
+			)
+			return nil
+		},
+	}
+
+	// complianceAzureRunAssessmentCmd represents the run-assessment sub-command inside the azure command
+	complianceAzureRunAssessmentCmd = &cobra.Command{
+		Use:     "run-assessment <tenant_id>",
+		Aliases: []string{"run"},
+		Short:   "run a new Azure compliance assessment",
+		Long:    `Run a compliance assessment of the provided Azure tenant.`,
+		Args:    cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			lacework, err := api.NewClient(cli.Account,
+				api.WithLogLevel(cli.LogLevel),
+				api.WithApiKeys(cli.KeyID, cli.Secret),
+			)
+			if err != nil {
+				return errors.Wrap(err, "unable to generate api client")
+			}
+
+			response, err := lacework.Compliance.RunAzureReport(args[0])
+			if err != nil {
+				return errors.Wrap(err, "unable to run azure compliance assessment")
+			}
+
+			if cli.JSONOutput() {
+				return cli.OutputJSON(response)
+			}
+
+			cli.OutputHuman("A new Azure compliance assessment has been initiated.\n")
+			cli.OutputHuman("\n")
+			cli.OutputHuman(buildAzureRunAssessmentTable(response.IntgGuid, args[0]))
+			return nil
+		},
+	}
+)
+
+func init() {
+	// add sub-commands to the azure command
+	complianceAzureCmd.AddCommand(complianceAzureListSubsCmd)
+	complianceAzureCmd.AddCommand(complianceAzureGetReportCmd)
+	complianceAzureCmd.AddCommand(complianceAzureRunAssessmentCmd)
+
+	complianceAzureGetReportCmd.Flags().BoolVar(&compCmdState.Details, "details", false,
+		"increase details about the compliance report",
+	)
+	complianceAzureGetReportCmd.Flags().StringVar(&compCmdState.PdfName, "pdf-file", "",
+		"download the report as PDF format with the provided filename",
+	)
+
+	// Azure report types: AZURE_CIS, AZURE_SOC, or AZURE_PCI
+	complianceAzureGetReportCmd.Flags().StringVar(&compCmdState.Type, "type", "CIS",
+		"report type to display, supported types: CIS, SOC, or PCI",
+	)
+}
+
+func buildAzureRunAssessmentTable(intGuid, id string) string {
+	var (
+		tBuilder = &strings.Builder{}
+		t        = tablewriter.NewWriter(tBuilder)
+	)
+
+	t.SetHeader([]string{"INTEGRATION GUID", "TENANT ID"})
+	t.SetBorder(false)
+	t.SetAutoWrapText(false)
+	t.Append([]string{intGuid, id})
+	t.Render()
+
+	return tBuilder.String()
+}
+
+func buildAzureSubscriptionsTable(azureSubs []api.CompAzureSubscriptions) string {
+	var (
+		tBuilder = &strings.Builder{}
+		t        = tablewriter.NewWriter(tBuilder)
+	)
+
+	t.SetHeader([]string{"Subscriptions"})
+	t.SetBorder(false)
+	t.SetAutoWrapText(false)
+	for _, azure := range azureSubs {
+		for _, subs := range azure.Subscriptions {
+			t.Append([]string{subs})
+		}
+	}
+	t.Render()
+
+	return tBuilder.String()
+}
+
+func complianceAzureReportDetailsTable(report *api.ComplianceAzureReport) [][]string {
+	return [][]string{
+		[]string{"Report Type", report.ReportType},
+		[]string{"Report Title", report.ReportTitle},
+		[]string{"Tenant ID", report.TenantID},
+		[]string{"Tenant Name", report.TenantName},
+		[]string{"Subscription ID", report.SubscriptionID},
+		[]string{"Subscription Name", report.SubscriptionName},
+		[]string{"Report Time", report.ReportTime.UTC().Format(time.RFC3339)},
+	}
+}

--- a/cli/cmd/compliance_gcp.go
+++ b/cli/cmd/compliance_gcp.go
@@ -1,0 +1,248 @@
+//
+// Author:: Salim Afiune Maya (<afiune@lacework.net>)
+// Copyright:: Copyright 2020, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cmd
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/olekukonko/tablewriter"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
+	"github.com/lacework/go-sdk/api"
+)
+
+var (
+	// complianceGcpListProjCmd represents the list-projects sub-command inside the gcp command
+	complianceGcpListProjCmd = &cobra.Command{
+		Use:     "list-projects <organization_id>",
+		Aliases: []string{"list-proj", "list"},
+		Short:   "list projects from an organization",
+		Long: `List all GCP projects from the provided organization ID.
+
+Use the following command to list all GCP integrations in your account:
+
+  $ lacework integrations list --type GCP_CFG
+
+Then, select one GUID from an integration and visialize its details using the command:
+
+  $ lacework integration show <int_guid>
+`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			lacework, err := api.NewClient(cli.Account,
+				api.WithLogLevel(cli.LogLevel),
+				api.WithApiKeys(cli.KeyID, cli.Secret),
+			)
+			if err != nil {
+				return errors.Wrap(err, "unable to generate api client")
+			}
+
+			response, err := lacework.Compliance.ListGcpProjects(args[0])
+			if err != nil {
+				return errors.Wrap(err, "unable to list gcp projects")
+			}
+
+			if cli.JSONOutput() {
+				return cli.OutputJSON(response.Data[0])
+			}
+
+			cli.OutputHuman(buildGcpProjectsTable(response.Data))
+			return nil
+		},
+	}
+
+	// complianceGcpGetReportCmd represents the get-report sub-command inside the gcp command
+	complianceGcpGetReportCmd = &cobra.Command{
+		Use:     "get-report <organization_id> <project_id>",
+		Aliases: []string{"get"},
+		PreRunE: func(_ *cobra.Command, _ []string) error {
+			switch compCmdState.Type {
+			case "CIS", "SOC", "PCI":
+				compCmdState.Type = fmt.Sprintf("GCP_%s", compCmdState.Type)
+				return nil
+			case "GCP_CIS", "GCP_SOC", "GCP_PCI":
+				return nil
+			default:
+				return errors.New("supported report types are: CIS, SOC, or PCI")
+			}
+		},
+		Short: "get the latest GCP compliance report",
+		Long: `Get the latest compliance assessment report, these reports run on a regular schedule,
+typically once a day. The available report formats are human-readable (default), json and pdf.
+
+To run an ad-hoc compliance assessment use the command:
+
+  $ lacework compliance gcp run-assessment <project_id>
+`,
+		Args: cobra.ExactArgs(2),
+		RunE: func(_ *cobra.Command, args []string) error {
+			lacework, err := api.NewClient(cli.Account,
+				api.WithLogLevel(cli.LogLevel),
+				api.WithApiKeys(cli.KeyID, cli.Secret),
+			)
+			if err != nil {
+				return errors.Wrap(err, "unable to generate api client")
+			}
+
+			config := api.ComplianceGcpReportConfig{
+				OrganizationID: args[0],
+				ProjectID:      args[1],
+				Type:           compCmdState.Type,
+			}
+
+			if compCmdState.PdfName != "" {
+				cli.StartProgress(" Downloading compliance report...")
+				err := lacework.Compliance.DownloadGcpReportPDF(compCmdState.PdfName, config)
+				cli.StopProgress()
+				if err != nil {
+					return errors.Wrap(err, "unable to get gcp pdf compliance report")
+				}
+
+				cli.OutputHuman("The GCP compliance report was downloaded at '%s'.\n", compCmdState.PdfName)
+				return nil
+			}
+
+			cli.StartProgress(" Getting compliance report...")
+			response, err := lacework.Compliance.GetGcpReport(config)
+			cli.StopProgress()
+			if err != nil {
+				return errors.Wrap(err, "unable to get gcp compliance report")
+			}
+
+			if len(response.Data) == 0 {
+				return errors.New("there is no data found in the report")
+			}
+
+			if cli.JSONOutput() {
+				return cli.OutputJSON(response.Data[0])
+			}
+
+			report := response.Data[0]
+			cli.OutputHuman("\n")
+			cli.OutputHuman(
+				buildComplianceReportTable(
+					complianceGcpReportDetailsTable(&report),
+					complianceReportSummaryTable(report.Summary),
+					complianceReportRecommendationsTable(report.Recommendations),
+				),
+			)
+			return nil
+		},
+	}
+
+	// complianceGcpRunAssessmentCmd represents the run-assessment sub-command inside the gcp command
+	complianceGcpRunAssessmentCmd = &cobra.Command{
+		Use:     "run-assessment <org_or_project_id>",
+		Aliases: []string{"run"},
+		Short:   "run a new GCP compliance assessment",
+		Long:    `Run a compliance assessment for the provided GCP organization or project.`,
+		Args:    cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			lacework, err := api.NewClient(cli.Account,
+				api.WithLogLevel(cli.LogLevel),
+				api.WithApiKeys(cli.KeyID, cli.Secret),
+			)
+			if err != nil {
+				return errors.Wrap(err, "unable to generate api client")
+			}
+
+			response, err := lacework.Compliance.RunGcpReport(args[0])
+			if err != nil {
+				return errors.Wrap(err, "unable to run gcp compliance assessment")
+			}
+
+			if cli.JSONOutput() {
+				return cli.OutputJSON(response)
+			}
+
+			cli.OutputHuman("A new GCP compliance assessment has been initiated.\n")
+			cli.OutputHuman("\n")
+			cli.OutputHuman(buildGcpRunAssessmentTable(response.IntgGuid, args[0]))
+			return nil
+		},
+	}
+)
+
+func init() {
+	// add sub-commands to the gcp command
+	complianceGcpCmd.AddCommand(complianceGcpListProjCmd)
+	complianceGcpCmd.AddCommand(complianceGcpRunAssessmentCmd)
+	complianceGcpCmd.AddCommand(complianceGcpGetReportCmd)
+
+	complianceGcpGetReportCmd.Flags().BoolVar(&compCmdState.Details, "details", false,
+		"increase details about the compliance report",
+	)
+	complianceGcpGetReportCmd.Flags().StringVar(&compCmdState.PdfName, "pdf-file", "",
+		"download the report as PDF format with the provided filename",
+	)
+
+	// GCP report types: GCP_CIS, GCP_SOC, or GCP_PCI.
+	complianceGcpGetReportCmd.Flags().StringVar(&compCmdState.Type, "type", "CIS",
+		"report type to display, supported types: CIS, SOC, or PCI",
+	)
+}
+
+func buildGcpRunAssessmentTable(intGuid, id string) string {
+	var (
+		tBuilder = &strings.Builder{}
+		t        = tablewriter.NewWriter(tBuilder)
+	)
+
+	t.SetHeader([]string{"INTEGRATION GUID", "ORG/PROJECT ID"})
+	t.SetBorder(false)
+	t.SetAutoWrapText(false)
+	t.Append([]string{intGuid, id})
+	t.Render()
+
+	return tBuilder.String()
+}
+
+func buildGcpProjectsTable(gcpProjects []api.CompGcpProjects) string {
+	var (
+		tableBuilder = &strings.Builder{}
+		t            = tablewriter.NewWriter(tableBuilder)
+	)
+
+	t.SetHeader([]string{"Projects"})
+	t.SetBorder(false)
+	t.SetAutoWrapText(false)
+	for _, gcp := range gcpProjects {
+		for _, proj := range gcp.Projects {
+			t.Append([]string{proj})
+		}
+	}
+	t.Render()
+
+	return tableBuilder.String()
+}
+
+func complianceGcpReportDetailsTable(report *api.ComplianceGcpReport) [][]string {
+	return [][]string{
+		[]string{"Report Type", report.ReportType},
+		[]string{"Report Title", report.ReportTitle},
+		[]string{"Organization ID", report.OrganizationID},
+		[]string{"Organization Name", report.OrganizationName},
+		[]string{"Project ID", report.ProjectID},
+		[]string{"Project Name", report.ProjectName},
+		[]string{"Report Time", report.ReportTime.UTC().Format(time.RFC3339)},
+	}
+}

--- a/cli/cmd/configure.go
+++ b/cli/cmd/configure.go
@@ -97,7 +97,7 @@ Lacework CLI will create it for you.`,
 func init() {
 	rootCmd.AddCommand(configureCmd)
 
-	configureCmd.PersistentFlags().StringVarP(&configureJsonFile,
+	configureCmd.Flags().StringVarP(&configureJsonFile,
 		"json_file", "j", "", "loads the generated API key JSON file from the WebUI",
 	)
 }

--- a/integration/compliance_test.go
+++ b/integration/compliance_test.go
@@ -1,0 +1,80 @@
+//
+// Author:: Salim Afiune Maya (<afiune@lacework.net>)
+// Copyright:: Copyright 2020, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package integration
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestComplianceCommandHelp(t *testing.T) {
+	out, err, exitcode := LaceworkCLI("help", "compliance")
+	assert.Equal(t,
+		`Manage compliance reports for GCP, Azure, or AWS cloud providers.
+
+To start sending data about your environment to Lacework for compliance reporting
+analysis, configure one or more cloud integration using the following command:
+
+  $ lacework integration create
+
+Or, if you prefer to do it via the WebUI, log in to your account at:
+
+    https://<ACCOUNT>.lacework.net
+
+Then navigate to Settings > Integrations > Cloud Accounts.
+
+Use the following command to list all available integrations in your account:
+
+  $ lacework integrations list
+
+Usage:
+  lacework compliance [command]
+
+Aliases:
+  compliance, comp
+
+Available Commands:
+  aws         compliance for AWS
+  azure       compliance for Microsoft Azure
+  gcp         compliance for Google Cloud
+
+Flags:
+  -h, --help   help for compliance
+
+Global Flags:
+  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -k, --api_key string      access key id
+  -s, --api_secret string   secret access key
+      --debug               turn on debug logging
+      --json                switch commands output from human-readable to json format
+      --nocolor             turn off colors
+      --noninteractive      disable interactive progress bars (i.e. 'spinners')
+  -p, --profile string      switch between profiles configured at ~/.lacework.toml
+
+Use "lacework compliance [command] --help" for more information about a command.
+`,
+		out.String(),
+		"the compliance help message changed, please update")
+	assert.Empty(t,
+		err.String(),
+		"STDERR should be empty")
+	assert.Equal(t, 0, exitcode,
+		"EXITCODE is not the expected one")
+}

--- a/integration/framework_test.go
+++ b/integration/framework_test.go
@@ -66,6 +66,13 @@ func LaceworkCLIWithTOMLConfig(args ...string) (bytes.Buffer, bytes.Buffer, int)
 	return runLaceworkCLI(dir, args...)
 }
 
+func LaceworkCLIWithDummyConfig(args ...string) (bytes.Buffer, bytes.Buffer, int) {
+	dir := createDummyTOMLConfig()
+	defer os.RemoveAll(dir)
+
+	return runLaceworkCLI(dir, args...)
+}
+
 func LaceworkCLIWithHome(dir string, args ...string) (bytes.Buffer, bytes.Buffer, int) {
 	return runLaceworkCLI(dir, args...)
 }
@@ -152,4 +159,23 @@ ERROR
   more information.
 
 `
+}
+
+func createDummyTOMLConfig() string {
+	dir, err := ioutil.TempDir("", "lacework-toml")
+	if err != nil {
+		panic(err)
+	}
+
+	configFile := filepath.Join(dir, ".lacework.toml")
+	c := []byte(`[default]
+account = 'dummy'
+api_key = 'DUMMY_1234567890abcdefg'
+api_secret = '_superdummysecret'
+`)
+	err = ioutil.WriteFile(configFile, c, 0644)
+	if err != nil {
+		panic(err)
+	}
+	return dir
 }

--- a/integration/help_test.go
+++ b/integration/help_test.go
@@ -136,6 +136,7 @@ Usage:
 
 Available Commands:
   api           helper to call Lacework's RestfulAPI
+  compliance    manage compliance reports
   configure     configure the Lacework CLI
   event         inspect Lacework events
   integration   manage external integrations

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -66,3 +66,40 @@ func TestIntegrationCommandList(t *testing.T) {
 	assert.Equal(t, 0, exitcode,
 		"EXITCODE is not the expected one")
 }
+
+func TestIntegrationCommandListWithTypeFlag(t *testing.T) {
+	// @afiune shippable doesn't allow us to have encrypted variables inside our build jobs,
+	// and because of that, we are disabling a few tests when running inside our "CI" pipeline
+	if os.Getenv("CI") == "true" {
+		return
+	}
+	out, err, exitcode := LaceworkCLIWithTOMLConfig("integration", "list", "--type", "AWS_CFG")
+	assert.Contains(t, out.String(), "INTEGRATION GUID",
+		"STDOUT table headers changed, please check")
+	assert.Contains(t, out.String(), "NAME",
+		"STDOUT table headers changed, please check")
+	assert.Contains(t, out.String(), "TYPE",
+		"STDOUT table headers changed, please check")
+	assert.Contains(t, out.String(), "STATUS",
+		"STDOUT table headers changed, please check")
+
+	// TODO @afiune lets try to create an environment where we can be 100% sure that
+	// integrations will exist and assert against it
+
+	assert.Empty(t,
+		err.String(),
+		"STDERR should be empty")
+	assert.Equal(t, 0, exitcode,
+		"EXITCODE is not the expected one")
+}
+
+func TestIntegrationCommandListWithTypeFlagErrorUnknownType(t *testing.T) {
+	out, err, exitcode := LaceworkCLIWithDummyConfig("integration", "list", "--type", "FOO_BAR")
+	assert.Emptyf(t, out.String(),
+		"STDOUT should be empty")
+	assert.Contains(t, err.String(),
+		"ERROR unknown integration type 'FOO_BAR'",
+		"STDERR should contain the unknown type")
+	assert.Equal(t, 1, exitcode,
+		"EXITCODE is not the expected one")
+}


### PR DESCRIPTION
This change is adding the ability to manage compliance reports from the
Lacework CLI. As a prerequisite to start sending data about your
environment to Lacework for compliance reporting analysis, a user has to
configure one or more cloud integration using the following command:
```
$ lacework integration create
```

Or, do it via the WebUI by logging in to Lacework at:

https://ACCOUNT.lacework.net

Then navigate to Settings > Integrations > Cloud Accounts.

Use the following command to list all available integrations in your
account:
```
$ lacework integrations list
```

# AWS Compliance
To get the latest AWS compliance assessment report, use the new command
```
$ lacework compliance aws get-report <account_id>
```
These reports run on a regular schedule, typically once a day.

The available report formats are human-readable (default), json and pdf.

To find out which AWS accounts are connected to you Lacework account,
use the following command:
```
$ lacework integrations list --type AWS_CFG
```

Then, choose one integration, copy the GUID and visualize its details
using the command:
```
$ lacework integration show <int_guid>
```

To run an ad-hoc compliance assessment use the command:
```
$ lacework compliance aws run-assessment <account_id>
```

# GCP Compliance
To get the latest GCP compliance assessment report, use the new command:
```
$ lacework compliance gcp get-report <organization_id> <project_id>
```

These reports run on a regular schedule, typically once a day.

The available report formats are human-readable (default), json, and pdf.

To find out which GCP organizations/projects are connected to your
Lacework account, use the following command:
```
$ lacework integrations list --type GCP_CFG
```

Then, choose one integration, copy the GUID and visualize its details
using the command:
```
$ lacework integration show <int_guid>
```

To list all GCP projects from an organization, use the command: 
```
$ lacework compliance gcp list-projects <organization_id>
```

To run an ad-hoc compliance assessment use the command:
```
$ lacework compliance gcp run-assessment <org_or_project_id>
```

# Azure Compliance
To get the latest Azure compliance assessment report, use the new
command:
```
$ lacework compliance azure get-report <tenant_id> <subscriptions_id>
```

These reports run on a regular schedule, typically once a day.

The available report formats are human-readable (default), json, and pdf.

To find out which Azure tenants/subscriptions are connected to your
Lacework account, use the following command:
```
$ lacework integrations list --type AZURE_CFG
```

Then, choose one integration, copy the GUID and visualize its details
using the command:
```
$ lacework integration show <int_guid>
```

To list all Azure subscriptions from a tenant, use the command: 
```
$ lacework compliance azure list-subscriptions <tenant_id>
```

To run an ad-hoc compliance assessment use the command:
```
$ lacework compliance azure run-assessment <tenant_id>
```
# Download PDF reports
Every compliance sub-command (`azure`, `gcp`, and `aws`) has a command
to get the latest compliance report (`get-report`), such commands have a flag
to download the report in PDF format, the flag is `--pdf-file <filename>` and
it accepts the name of the file that the PDF will be saved as.
```
$ lacework compliance aws get-report 1234567890 --type SOC --pdf-file AWS-1234567890-SOC.pdf
The AWS compliance report was downloaded at 'AWS-1234567890-SOC.pdf'.
```

# Additional features in this PR

**New CLI Feature:** list integrations of a specific type

We are adding a new flag called `--type` to list integration of a specific
type:
```
$ lacework integrations list --type AWS_CFG
                      INTEGRATION GUID                     |         NAME   |  TYPE   | STATUS  | STATE
-----------------------------------------------------------+----------------+---------+---------+--------
  EXAMPLE_1234567890349160DB36ED6FA9A4D9E8D9901234567890AA | Account 12345  | AWS_CFG | Enabled | Ok
  EXAMPLE_1234567890D93FC8A5456CB57DCF29C831111234567890AA | Account 67890  | AWS_CFG | Enabled | Ok
  EXAMPLE_1234567890DB3189294EA10698A7BEF7FD9C1234567890AA | Account abcde  | AWS_CFG | Enabled | Ok
```

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>