### PR TITLE
docs(cli): remove the need to install using sudo

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ reports, external integrations, vulnerability scans, and other operations.
 
 #### Bash:
 ```
-$ curl https://raw.githubusercontent.com/lacework/go-sdk/master/cli/install.sh | sudo bash
+$ curl https://raw.githubusercontent.com/lacework/go-sdk/master/cli/install.sh | bash
 ```
 
 #### Powershell:

--- a/cli/README.md
+++ b/cli/README.md
@@ -11,7 +11,7 @@ reports, external integrations, vulnerability scans, and other operations.
 ### Bash:
 
 ```
-$ curl https://raw.githubusercontent.com/lacework/go-sdk/master/cli/install.sh | sudo bash
+$ curl https://raw.githubusercontent.com/lacework/go-sdk/master/cli/install.sh | bash
 ```
 
 ### Powershell:

--- a/cli/cmd/cli_unix.go
+++ b/cli/cmd/cli_unix.go
@@ -30,6 +30,6 @@ var promptIconsFunc = func(icons *survey.IconSet) {
 // to the latest available version (unix specific command)
 func (c *cliState) UpdateCommand() string {
 	return `
-  $ curl https://raw.githubusercontent.com/lacework/go-sdk/master/cli/install.sh | sudo bash
+  $ curl https://raw.githubusercontent.com/lacework/go-sdk/master/cli/install.sh | bash
 `
 }


### PR DESCRIPTION
Since the Lacework CLI is being installed at `/usr/local/bin`, there is
no need for users to run the install script via `sudo`.

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>