### PR TITLE
fix(spelling) Fixes event header misspelling

### DIFF
--- a/cli/cmd/event.go
+++ b/cli/cmd/event.go
@@ -297,7 +297,7 @@ func eventCTUserEntitiesTable(users []api.EventCTUserEntity) string {
 	t.SetHeader([]string{
 		"Username",
 		"Account ID",
-		"Pincipal ID",
+		"Principal ID",
 		"MFA",
 		"List of APIs",
 		"Regions",


### PR DESCRIPTION
This fixes a misspelling of event header when showing details of an event. The word `Principal` was misspelled as `Pincipal`

Closes Issue [#118](https://github.com/lacework/go-sdk/issues/118) 

Signed-off-by: Scott Ford <scott.ford@lacework.net>