### PR TITLE
feat: auto-populate account with --profile flag

### DIFF
--- a/cli/cmd/configure.go
+++ b/cli/cmd/configure.go
@@ -106,6 +106,12 @@ func init() {
 func promptConfigureSetup() error {
 	cli.Log.Debugw("configuring cli", "profile", cli.Profile)
 
+	// if the Lacework account is empty, and the profile that is being configured is
+	// not the 'default' profile, auto-populate the account with the provided profile
+	if cli.Account == "" && cli.Profile != "default" {
+		cli.Account = cli.Profile
+	}
+
 	if len(configureJsonFile) != 0 {
 		auth, err := loadKeysFromJsonFile(configureJsonFile)
 		if err != nil {

--- a/integration/configure_test.go
+++ b/integration/configure_test.go
@@ -80,17 +80,17 @@ func TestConfigureCommandWithJSONFileFlag(t *testing.T) {
 	_, laceworkTOML := runConfigureTest(t,
 		func(c *expect.Console) {
 			c.ExpectString("Account:")
-			c.SendLine("web-ui-test")
+			c.SendLine("") // using the default, which should be auto-populated from the provided --profile flag
 			c.ExpectString("Access Key ID:")
 			c.SendLine("") // using the default, which should be loaded from the JSON file
 			c.ExpectString("Secret Access Key:")
 			c.SendLine("") // using the default, which should be loaded from the JSON file
 			c.ExpectString("You are all set!")
 		},
-		"configure", "--json_file", s,
+		"configure", "--json_file", s, "--profile", "web-ui-test",
 	)
 
-	assert.Equal(t, `[default]
+	assert.Equal(t, `[web-ui-test]
   account = "web-ui-test"
   api_key = "INTTEST_ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890AAABBBCCC00"
   api_secret = "_cccccccccccccccccccccccccccccccc"


### PR DESCRIPTION
When users pass the `--profile` flag, the CLI will automatically
populate the account name with the provided profile:

```
$ lacework configure --profile new-account
▸ Account: new-account
```

Closes https://github.com/lacework/go-sdk/issues/98

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>