### PR TITLE
feat: understand vuln reports with 0 vulnerabilities

### DIFF
--- a/api/vulnerabilities.go
+++ b/api/vulnerabilities.go
@@ -144,15 +144,15 @@ func (res *VulContainerReportResponse) CheckStatus() string {
 }
 
 type VulContainerReport struct {
-	TotalVulnerabilities    int32             `json:"total_vulnerabilities"`
-	CriticalVulnerabilities int32             `json:"critical_vulnerabilities"`
-	HighVulnerabilities     int32             `json:"high_vulnerabilities"`
-	MediumVulnerabilities   int32             `json:"medium_vulnerabilities"`
-	LowVulnerabilities      int32             `json:"low_vulnerabilities"`
-	InfoVulnerabilities     int32             `json:"info_vulnerabilities"`
-	FixableVulnerabilities  int32             `json:"fixable_vulnerabilities"`
-	LastEvaluationTime      string            `json:"last_evaluation_time"`
-	Image                   VulContainerImage `json:"image"`
+	TotalVulnerabilities    int32              `json:"total_vulnerabilities"`
+	CriticalVulnerabilities int32              `json:"critical_vulnerabilities"`
+	HighVulnerabilities     int32              `json:"high_vulnerabilities"`
+	MediumVulnerabilities   int32              `json:"medium_vulnerabilities"`
+	LowVulnerabilities      int32              `json:"low_vulnerabilities"`
+	InfoVulnerabilities     int32              `json:"info_vulnerabilities"`
+	FixableVulnerabilities  int32              `json:"fixable_vulnerabilities"`
+	LastEvaluationTime      string             `json:"last_evaluation_time,omitempty"`
+	Image                   *VulContainerImage `json:"image,omitempty"`
 
 	// @afiune these two parameters, Status and Message will appear when
 	// the vulnerability scan is still running. ugh. why?
@@ -191,8 +191,8 @@ func (report *VulContainerReport) VulFixableCount(severity string) int32 {
 }
 
 type VulContainerImage struct {
-	ImageInfo   vulContainerImageInfo    `json:"image_info"`
-	ImageLayers []vulContainerImageLayer `json:"image_layers"`
+	ImageInfo   *vulContainerImageInfo   `json:"image_info,omitempty"`
+	ImageLayers []vulContainerImageLayer `json:"image_layers,omitempty"`
 }
 
 type vulContainerImageInfo struct {

--- a/cli/cmd/vulnerability.go
+++ b/cli/cmd/vulnerability.go
@@ -185,10 +185,10 @@ Arguments:
 					args[0],
 				)
 				cli.OutputHuman("Use '--poll' to poll until the vulnerability scan completes.\n")
-			} else {
-				cli.OutputHuman("\n")
-				cli.OutputHuman(buildVulnerabilityReport(report))
+				return nil
 			}
+
+			cli.OutputHuman(buildVulnerabilityReport(report))
 			return nil
 		},
 	}
@@ -242,7 +242,6 @@ lookup a report by its image id, provided the flag '--image_id'.
 					return cli.OutputJSON(report.Data)
 				}
 
-				cli.OutputHuman("\n")
 				cli.OutputHuman(buildVulnerabilityReport(&report.Data))
 			case "NotFound":
 				msg := fmt.Sprintf(
@@ -387,11 +386,15 @@ func buildVulnerabilityReport(report *api.VulContainerReport) string {
 		mainReport        = &strings.Builder{}
 	)
 
+	if report.TotalVulnerabilities == 0 {
+		return "Great news! This container image has no vulnerabilities.\n"
+	}
+
 	t = tablewriter.NewWriter(imageDetailsTable)
 	t.SetBorder(false)
 	t.SetColumnSeparator("")
 	t.SetAlignment(tablewriter.ALIGN_LEFT)
-	t.AppendBulk(vulContainerImageToTable(&report.Image))
+	t.AppendBulk(vulContainerImageToTable(report.Image))
 	t.Render()
 
 	t = tablewriter.NewWriter(vulCountsTable)
@@ -450,13 +453,17 @@ func buildVulnerabilityReportDetails(report *api.VulContainerReport) string {
 		"Fix Version",
 		"Introduced in Layer",
 	})
-	t.AppendBulk(vulContainerImageLayersToTable(&report.Image))
+	t.AppendBulk(vulContainerImageLayersToTable(report.Image))
 	t.Render()
 
 	return detailsTable.String()
 }
 
 func vulContainerImageLayersToTable(image *api.VulContainerImage) [][]string {
+	if image == nil {
+		return [][]string{}
+	}
+
 	out := [][]string{}
 	for _, layer := range image.ImageLayers {
 		for _, pkg := range layer.Packages {
@@ -516,6 +523,10 @@ func vulContainerReportToCountsTable(report *api.VulContainerReport) [][]string 
 }
 
 func vulContainerImageToTable(image *api.VulContainerImage) [][]string {
+	if image == nil || image.ImageInfo == nil {
+		return [][]string{}
+	}
+
 	info := image.ImageInfo
 	return [][]string{
 		[]string{"ID", info.ImageID},


### PR DESCRIPTION
Make the Go API and the CLI to understand new payloads from the vuln
reports API endpoints that displays reports with 0 vulnerabilities,
we are now displaying a message to the user that explains that the
report has no vulnerabilities

The output shown to the end-user is for reports with 0 vulnerabilities:
```
$ lacework vul report sha256:32c5a42735581453d1e9ea664604fa81f4b635459dc88799ee1f8c373dca4819
Great news! This container image has no vulnerabilities.
```

And for the JSON format:
```
$ lacework vul report sha256:32c5a42735581453d1e9ea664604fa81f4b635459dc88799ee1f8c373dca4819 --json
{
  "critical_vulnerabilities": 0,
  "fixable_vulnerabilities": 0,
  "high_vulnerabilities": 0,
  "info_vulnerabilities": 0,
  "low_vulnerabilities": 0,
  "medium_vulnerabilities": 0,
  "scan_status": "Success",
  "total_vulnerabilities": 0
}
```

Closes https://github.com/lacework/go-sdk/issues/123

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>