### PR TITLE
fix: vulnerability scans of unsupported images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,16 +1,42 @@
 version: 2.1
 
-jobs:
-  build:
+executors:
+  go-executor:
     docker:
       - image: circleci/golang:1.14
     working_directory: /go/src/github.com/lacework/go-sdk
+
+
+jobs:
+  unit-test:
+    executor: go-executor
     steps:
       - checkout
       - run: make prepare
-      - run: make ci
+      - run: make test
+  build-cli:
+    executor: go-executor
+    steps:
+      - checkout
+      - run: make prepare
+      - run: make build-cli-cross-platform
+  integration-test:
+    executor: go-executor
+    steps:
+      - checkout
+      - run: make prepare
+      - run: make integration
 
 workflows:
   build-and-test:
     jobs:
-      - build
+      - unit-test
+      - build-cli
+      - hold:
+          type: approval
+          requires:
+           - unit-test
+           - build-cli
+      - integration-test:
+          requires:
+           - hold

--- a/cli/cmd/vulnerability.go
+++ b/cli/cmd/vulnerability.go
@@ -243,6 +243,14 @@ lookup a report by its image id, provided the flag '--image_id'.
 				}
 
 				cli.OutputHuman(buildVulnerabilityReport(&report.Data))
+			case "Unsupported":
+				return errors.Errorf(
+					`unable to retrieve report for the provided container image. (unsupported distribution)
+
+For more information about supported distributions, visit:
+    https://support.lacework.com/hc/en-us/articles/360035472393-Container-Vulnerability-Assessment-Overview
+`,
+				)
 			case "NotFound":
 				msg := fmt.Sprintf(
 					"unable to find any container vulnerability report with %s '%s'",
@@ -362,6 +370,14 @@ func checkScanStatus(requestID string, lacework *api.Client) (*api.VulContainerR
 		return &scan.Data, nil, false
 	case "Scanning":
 		return &scan.Data, nil, true
+	case "Unsupported":
+		return nil, errors.Errorf(
+			`unable to run assessment for the provided container image. (unsupported distribution)
+
+For more information about supported distributions, visit:
+    https://support.lacework.com/hc/en-us/articles/360035472393-Container-Vulnerability-Assessment-Overview
+`,
+		), false
 	case "NotFound":
 		return nil, errors.Errorf(
 			"unable to find any vulnerability scan with request id '%s'",

--- a/cli/cmd/vulnerability.go
+++ b/cli/cmd/vulnerability.go
@@ -41,10 +41,6 @@ var (
 		// pollInterval is the time is seconds to wait between polls
 		PollInterval time.Duration
 
-		// when enabled we tread the provided sha256 hash as image digest
-		// DEPRECATED
-		Digest bool
-
 		// when enabled we tread the provided sha256 hash as image id
 		ImageID bool
 
@@ -301,10 +297,6 @@ func init() {
 		vulReportCmd.Flags(),
 	)
 
-	vulReportCmd.Flags().BoolVar(
-		&vulCmdState.Digest, "digest", true,
-		"tread the provided sha256 hash as image digest (DEPRECATED)",
-	)
 	vulReportCmd.Flags().BoolVar(
 		&vulCmdState.ImageID, "image_id", false,
 		"tread the provided sha256 hash as image id",

--- a/integration/event_test.go
+++ b/integration/event_test.go
@@ -19,7 +19,6 @@
 package integration
 
 import (
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -40,12 +39,6 @@ func TestEventCommandAliases(t *testing.T) {
 }
 
 func TestEventCommandList(t *testing.T) {
-	// @afiune shippable doesn't allow us to have encrypted variables inside our build jobs,
-	// and because of that, we are disabling a few tests when running inside our "CI" pipeline
-	if os.Getenv("CI") == "true" {
-		return
-	}
-
 	out, err, exitcode := LaceworkCLIWithTOMLConfig("event", "list")
 	assert.Contains(t, out.String(), "EVENT ID",
 		"STDOUT table headers changed, please check")

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -19,7 +19,6 @@
 package integration
 
 import (
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -46,11 +45,6 @@ func TestIntegrationCommandAliases(t *testing.T) {
 }
 
 func TestIntegrationCommandList(t *testing.T) {
-	// @afiune shippable doesn't allow us to have encrypted variables inside our build jobs,
-	// and because of that, we are disabling a few tests when running inside our "CI" pipeline
-	if os.Getenv("CI") == "true" {
-		return
-	}
 	out, err, exitcode := LaceworkCLIWithTOMLConfig("integration", "list")
 	assert.Contains(t, out.String(), "INTEGRATION GUID",
 		"STDOUT table headers changed, please check")
@@ -68,11 +62,6 @@ func TestIntegrationCommandList(t *testing.T) {
 }
 
 func TestIntegrationCommandListWithTypeFlag(t *testing.T) {
-	// @afiune shippable doesn't allow us to have encrypted variables inside our build jobs,
-	// and because of that, we are disabling a few tests when running inside our "CI" pipeline
-	if os.Getenv("CI") == "true" {
-		return
-	}
 	out, err, exitcode := LaceworkCLIWithTOMLConfig("integration", "list", "--type", "AWS_CFG")
 	assert.Contains(t, out.String(), "INTEGRATION GUID",
 		"STDOUT table headers changed, please check")


### PR DESCRIPTION
Lacework runs vulnerability scans only against the following list of
supported distributions:

* https://support.lacework.com/hc/en-us/articles/360035472393-Container-Vulnerability-Assessment-Overview

Any other container image that is not listed there is unsupported and we
will be displaying an error message similar to:
```
$ lacework vul report sha256:04e8df550c7b52cd8ec64143a1c853cd76b234b29ad9e37149ffe04786acd142
Usage:
  lacework vulnerability report <sha256:hash> [flags]

Flags:
      --details    increase details about the vulnerability report
      --digest     tread the provided sha256 hash as image digest (DEPRECATED) (default true)
  -h, --help       help for report
      --image_id   tread the provided sha256 hash as image id

Global Flags:
  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
  -k, --api_key string      access key id
  -s, --api_secret string   secret access key
      --debug               turn on debug logging
      --json                switch commands output from human-readable to json format
      --nocolor             turn off colors
      --noninteractive      disable interactive progress bars (i.e. 'spinners')
  -p, --profile string      switch between profiles configured at ~/.lacework.toml

ERROR unable to get report for the provided container image. (unsupported distribution)

For more information about supported distributions, visit:
    https://support.lacework.com/hc/en-us/articles/360035472393-Container-Vulnerability-Assessment-Overview
```

Closes https://github.com/lacework/go-sdk/issues/132

### I've included a CI change to enable integration tests in CircleCI

With our previous CI/CD tool we were unable to run our CI integrations
tests, this commit enables our integration tests in CircleCI.

CI environment variables have already been configured.

Additionally, we will have a hold/approval step that Lacework Employees
need to approve before running these tests.

The flow for our pipeline looks like this:

## Run Unit Test & Build Lacework CLI
![Screen Shot 2020-06-05 at 12 55 32 PM](https://user-images.githubusercontent.com/5712253/83914445-77e43480-a72e-11ea-8809-c6d5625bcb49.png)

## Hold for Approval

![Screen Shot 2020-06-05 at 12 55 45 PM](https://user-images.githubusercontent.com/5712253/83926090-1b8d0f00-a746-11ea-899f-e0cf3cc089b6.png)

## Approve
![Screen Shot 2020-06-05 at 12 55 54 PM](https://user-images.githubusercontent.com/5712253/83926109-25af0d80-a746-11ea-8298-787bb6f9203a.png)

## Run Integration Tests
![Screen Shot 2020-06-05 at 12 56 06 PM](https://user-images.githubusercontent.com/5712253/83926120-2e9fdf00-a746-11ea-9616-345766f27ee1.png)

![image](https://user-images.githubusercontent.com/5712253/83926137-3e1f2800-a746-11ea-85b1-51682f1d79b7.png)

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>