### PR TITLE
fix(cli): CVEs for centos-8 

### DIFF
--- a/cli/images/centos-8/Dockerfile
+++ b/cli/images/centos-8/Dockerfile
@@ -11,4 +11,7 @@ COPY ./LICENSE /
 ADD cli/images/centos-8/centos-8-stream.repo /etc/yum.repos.d/
 RUN yum update -y
 
+# Fix CVE-2019-6477
+RUN yum remove bind-export-libs -y
+
 RUN curl https://raw.githubusercontent.com/lacework/go-sdk/master/cli/install.sh | bash

--- a/cli/images/centos-8/Dockerfile
+++ b/cli/images/centos-8/Dockerfile
@@ -2,6 +2,13 @@ FROM  centos:8
 LABEL maintainer="tech-ally@lacework.net" \
       description="The Lacework CLI helps you manage the Lacework cloud security platform"
 
-RUN yum update -y
 COPY ./LICENSE /
+
+# Fix (curl, libcurl-minimal)
+# * CVE-2019-5436
+# * CVE-2019-5482
+# * CVE-2019-5481
+ADD cli/images/centos-8/centos-8-stream.repo /etc/yum.repos.d/
+RUN yum update -y
+
 RUN curl https://raw.githubusercontent.com/lacework/go-sdk/master/cli/install.sh | bash

--- a/cli/images/centos-8/centos-8-stream.repo
+++ b/cli/images/centos-8/centos-8-stream.repo
@@ -1,0 +1,6 @@
+[centos-8-stream]
+name=Extras packages for CentOS-8-stream
+baseurl=http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os
+gpgcheck=1
+enabled=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial


### PR DESCRIPTION
* fix (curl, libcurl-minimal) the following CVEs:
    * CVE-2019-5436
    * CVE-2019-5482
    * CVE-2019-5481
* fix(cli): CVE-2019-6477 for centos-8
  >We do not need the bind-export-libs package, we are resolving this CVE
  >by removing the package

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>
