### PR TITLE
feat(cli): add --fixable flag to vulnerability cmd

### DIFF
--- a/cli/cmd/vulnerability.go
+++ b/cli/cmd/vulnerability.go
@@ -46,6 +46,9 @@ var (
 
 		// display extended details about a vulnerability scan/report
 		Details bool
+
+		// display only fixable vulnerabilities
+		Fixable bool
 	}{PollInterval: time.Second * 5}
 
 	// vulnerability represents the vulnerability command
@@ -297,6 +300,12 @@ func init() {
 		vulReportCmd.Flags(),
 	)
 
+	setFixableFlag(
+		vulScanRunCmd.Flags(),
+		vulScanShowCmd.Flags(),
+		vulReportCmd.Flags(),
+	)
+
 	vulReportCmd.Flags().BoolVar(
 		&vulCmdState.ImageID, "image_id", false,
 		"tread the provided sha256 hash as image id",
@@ -309,6 +318,16 @@ func setPollFlag(cmds ...*flag.FlagSet) {
 			cmd.BoolVar(&vulCmdState.Poll, "poll", false,
 				fmt.Sprintf("poll until the vulnerability scan completes (%vs intervals)",
 					vulCmdState.PollInterval.Seconds()),
+			)
+		}
+	}
+}
+
+func setFixableFlag(cmds ...*flag.FlagSet) {
+	for _, cmd := range cmds {
+		if cmd != nil {
+			cmd.BoolVar(&vulCmdState.Fixable, "fixable", false,
+				"display only fixable vulnerabilities",
 			)
 		}
 	}
@@ -427,7 +446,7 @@ func buildVulnerabilityReport(report *api.VulContainerReport) string {
 	})
 	t.Render()
 
-	if vulCmdState.Details {
+	if vulCmdState.Details || vulCmdState.Fixable {
 		mainReport.WriteString(buildVulnerabilityReportDetails(report))
 		mainReport.WriteString("\n")
 	} else {
@@ -476,6 +495,9 @@ func vulContainerImageLayersToTable(image *api.VulContainerImage) [][]string {
 	for _, layer := range image.ImageLayers {
 		for _, pkg := range layer.Packages {
 			for _, vul := range pkg.Vulnerabilities {
+				if vulCmdState.Fixable && vul.FixVersion == "" {
+					continue
+				}
 				space := regexp.MustCompile(`\s+`)
 				createdBy := space.ReplaceAllString(layer.CreatedBy, " ")
 


### PR DESCRIPTION
Adding the ability to display only fixable vulnerabilities by providing
the new flag `--fixable`.

Example: From a total of 15 vulnerabilities, display only the 5 that are
fixable.
```
lacework vul report sha256:62dce44a0d2df7e3e3146817cc35681579c15a4ccd2c5d1f0bddb619fdd6dab8 --fixable
                                  CONTAINER IMAGE DETAILS                                 |        VULNERABILITIES
------------------------------------------------------------------------------------------+---------------------------------
    ID          sha256:1f40f2c68a11e338b7eda2264e71546ab1b5d6bc4c458bbd3785fd5efb3fc632   |   SEVERITY   COUNT   FIXABLE
    Digest      sha256:62dce44a0d2df7e3e3146817cc35681579c15a4ccd2c5d1f0bddb619fdd6dab8   | -----------+-------+----------
    Registry    index.docker.io                                                           |   Critical       0         0
    Repository  techallylw/lacework-cli                                                   |   High           0         0
    Size        58.2 MB                                                                   |   Medium         4         1
    Created At  2020-05-04T17:00:00+0000                                                  |   Low            9         4
    Tags        ubuntu-1804                                                               |   Info           2         0
                                                                                          |
-----------------+----------+----------+--------------------------+--------------------------+--------------------------
       CVE       | SEVERITY | PACKAGE  |     CURRENT VERSION      |       FIX VERSION        |   INTRODUCED IN LAYER
-----------------+----------+----------+--------------------------+--------------------------+--------------------------
  CVE-2020-12243 | Medium   | openldap | 2.4.45+dfsg-1ubuntu1.4   | 2.4.45+dfsg-1ubuntu1.5   | apt-get install curl -y
-----------------+----------+----------+--------------------------+--------------------------+--------------------------
  CVE-2019-1563  | Low      | openssl  | 1.1.1-1ubuntu2.1~18.04.5 | 1.1.1-1ubuntu2.1~18.04.6 | apt-get install curl -y
-----------------+----------+----------+--------------------------+--------------------------+--------------------------
  CVE-2019-1547  | Low      | openssl  | 1.1.1-1ubuntu2.1~18.04.5 | 1.1.1-1ubuntu2.1~18.04.6 | apt-get install curl -y
-----------------+----------+----------+--------------------------+--------------------------+--------------------------
  CVE-2019-1551  | Low      | openssl  | 1.1.1-1ubuntu2.1~18.04.5 | 1.1.1-1ubuntu2.1~18.04.6 | apt-get install curl -y
-----------------+----------+----------+--------------------------+--------------------------+--------------------------
  CVE-2019-1549  | Low      | openssl  | 1.1.1-1ubuntu2.1~18.04.5 | 1.1.1-1ubuntu2.1~18.04.6 | apt-get install curl -y
-----------------+----------+----------+--------------------------+--------------------------+--------------------------
```

GH: https://github.com/lacework/go-sdk/issues/126

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>