### PR TITLE
feat(cli): add --packages flag to vulnerability cmd

### DIFF
--- a/cli/cmd/vulnerability.go
+++ b/cli/cmd/vulnerability.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -49,6 +50,9 @@ var (
 
 		// display only fixable vulnerabilities
 		Fixable bool
+
+		// show a list of packages by number of CVEs
+		Packages bool
 	}{PollInterval: time.Second * 5}
 
 	// vulnerability represents the vulnerability command
@@ -283,6 +287,12 @@ func init() {
 		vulReportCmd.Flags(),
 	)
 
+	setPackagesFlag(
+		vulScanRunCmd.Flags(),
+		vulScanShowCmd.Flags(),
+		vulReportCmd.Flags(),
+	)
+
 	vulReportCmd.Flags().BoolVar(
 		&vulCmdState.ImageID, "image_id", false,
 		"tread the provided sha256 hash as image id",
@@ -295,6 +305,16 @@ func setPollFlag(cmds ...*flag.FlagSet) {
 			cmd.BoolVar(&vulCmdState.Poll, "poll", false,
 				fmt.Sprintf("poll until the vulnerability scan completes (%vs intervals)",
 					vulCmdState.PollInterval.Seconds()),
+			)
+		}
+	}
+}
+
+func setPackagesFlag(cmds ...*flag.FlagSet) {
+	for _, cmd := range cmds {
+		if cmd != nil {
+			cmd.BoolVar(&vulCmdState.Packages, "packages", false,
+				"show a list of packages by number of CVEs",
 			)
 		}
 	}
@@ -423,8 +443,12 @@ func buildVulnerabilityReport(report *api.VulContainerReport) string {
 	})
 	t.Render()
 
-	if vulCmdState.Details || vulCmdState.Fixable {
-		mainReport.WriteString(buildVulnerabilityReportDetails(report))
+	if vulCmdState.Details || vulCmdState.Fixable || vulCmdState.Packages {
+		if vulCmdState.Packages {
+			mainReport.WriteString(buildVulnerabilityPackageSummary(report))
+		} else {
+			mainReport.WriteString(buildVulnerabilityReportDetails(report))
+		}
 		mainReport.WriteString("\n")
 	} else {
 		mainReport.WriteString(
@@ -433,6 +457,29 @@ func buildVulnerabilityReport(report *api.VulContainerReport) string {
 	}
 
 	return mainReport.String()
+}
+
+func buildVulnerabilityPackageSummary(report *api.VulContainerReport) string {
+	var (
+		detailsTable = &strings.Builder{}
+		t            = tablewriter.NewWriter(detailsTable)
+	)
+
+	t.SetRowLine(false)
+	t.SetBorder(false)
+	t.SetColumnSeparator(" ")
+	t.SetAlignment(tablewriter.ALIGN_LEFT)
+	t.SetHeader([]string{
+		"CVE Count",
+		"Severity",
+		"Package",
+		"Current Version",
+		"Fix Version",
+	})
+	t.AppendBulk(vulContainerImagePackagesToTable(report.Image))
+	t.Render()
+
+	return detailsTable.String()
 }
 
 func buildVulnerabilityReportDetails(report *api.VulContainerReport) string {
@@ -461,6 +508,57 @@ func buildVulnerabilityReportDetails(report *api.VulContainerReport) string {
 	t.Render()
 
 	return detailsTable.String()
+}
+
+func vulContainerImagePackagesToTable(image *api.VulContainerImage) [][]string {
+	if image == nil {
+		return [][]string{}
+	}
+
+	out := [][]string{}
+	for _, layer := range image.ImageLayers {
+		for _, pkg := range layer.Packages {
+			for _, vul := range pkg.Vulnerabilities {
+				if vulCmdState.Fixable && vul.FixVersion == "" {
+					continue
+				}
+
+				added := false
+				for i := range out {
+					if out[i][1] == strings.Title(vul.Severity) &&
+						out[i][2] == pkg.Name &&
+						out[i][3] == pkg.Version &&
+						out[i][4] == vul.FixVersion {
+
+						if count, err := strconv.Atoi(out[i][0]); err == nil {
+							out[i][0] = fmt.Sprintf("%d", (count + 1))
+							added = true
+						}
+
+					}
+				}
+
+				if added {
+					continue
+				}
+
+				out = append(out, []string{
+					"1",
+					strings.Title(vul.Severity),
+					pkg.Name,
+					pkg.Version,
+					vul.FixVersion,
+				})
+			}
+		}
+	}
+
+	// order by severity
+	sort.Slice(out, func(i, j int) bool {
+		return severityOrder(out[i][1]) < severityOrder(out[j][1])
+	})
+
+	return out
 }
 
 func vulContainerImageLayersToTable(image *api.VulContainerImage) [][]string {

--- a/cli/cmd/vulnerability.go
+++ b/cli/cmd/vulnerability.go
@@ -314,7 +314,7 @@ func setPackagesFlag(cmds ...*flag.FlagSet) {
 	for _, cmd := range cmds {
 		if cmd != nil {
 			cmd.BoolVar(&vulCmdState.Packages, "packages", false,
-				"show a list of packages by number of CVEs",
+				"show a list of packages with CVE count",
 			)
 		}
 	}
@@ -446,10 +446,12 @@ func buildVulnerabilityReport(report *api.VulContainerReport) string {
 	if vulCmdState.Details || vulCmdState.Fixable || vulCmdState.Packages {
 		if vulCmdState.Packages {
 			mainReport.WriteString(buildVulnerabilityPackageSummary(report))
+			mainReport.WriteString("\n")
 		} else {
 			mainReport.WriteString(buildVulnerabilityReportDetails(report))
+			mainReport.WriteString("\n")
+			mainReport.WriteString("Try using '--packages' to show a list of packages with CVE count.\n")
 		}
-		mainReport.WriteString("\n")
 	} else {
 		mainReport.WriteString(
 			"Try using '--details' to increase details shown about the vulnerability report.\n",


### PR DESCRIPTION
## User Story
As an Engineer fixing container vulnerabilities,
I would like to have a report that lists all the packages that contain vulnerabilities,
so that I can easily understand the total number of CVEs (vulnerabilities) of individual packages and
detect which packages introduce the most number of vulnerabilities.

The output of this new `--packages` flag looks like this:
```
lacework vulnerability report sha256:167ec3ad6d0368acc9d64b1d857c0208ac641da83209498d1f3da9f38c9ae9ec --packages
                                  CONTAINER IMAGE DETAILS                                 |        VULNERABILITIES
------------------------------------------------------------------------------------------+---------------------------------
    ID          sha256:32d9a0f8b7169d837120339f930117eeccbd7fb65f65415cf0a1a4970ff38ee9   |   SEVERITY   COUNT   FIXABLE
    Digest      sha256:167ec3ad6d0368acc9d64b1d857c0208ac641da83209498d1f3da9f38c9ae9ec   | -----------+-------+----------
    Registry    index.docker.io                                                           |   Critical       0         0
    Repository  techallylw/lacework-cli                                                   |   High          13        13
    Size        102.6 MB                                                                  |   Medium        48        48
    Created At  2020-06-25T21:00:00+0000                                                  |   Low           14        14
    Tags        centos-8-patch-8                                                          |   Info           0         0
                                                                                          |
  CVE COUNT   SEVERITY          PACKAGE             CURRENT VERSION        FIX VERSION
------------+----------+------------------------+---------------------+---------------------
  1           High       sqlite                   3.26.0-3.el8          0:3.26.0-4.el8_1
  2           High       bind                     32:9.11.4-26.P2.el8   32:9.11.13-5.el8_2
  2           High       bind-export-libs         32:9.11.4-26.P2.el8   32:9.11.13-5.el8_2
  1           High       systemd-libs             239-18.el8_1.1        0:239-18.el8_1.4
  1           High       systemd-udev             239-18.el8_1.1        0:239-18.el8_1.4
  1           High       systemd                  239-18.el8_1.1        0:239-18.el8_1.4
  1           High       systemd-pam              239-18.el8_1.1        0:239-18.el8_1.4
  1           High       sqlite                   3.26.0-3.el8          0:3.26.0-4.el8_0
  1           High       sqlite-libs              3.26.0-3.el8          0:3.26.0-4.el8_1
  1           High       sqlite-libs              3.26.0-3.el8          0:3.26.0-4.el8_0
  1           High       libarchive               3.3.2-7.el8           0:3.3.2-8.el8_1
  1           Medium     openssl                  1:1.1.1c-2.el8        1:1.1.1c-15.el8
  7           Medium     sqlite-libs              3.26.0-3.el8          0:3.26.0-6.el8
  1           Medium     libstdc++                8.3.1-4.5.el8         0:8.3.1-5.el8
  1           Medium     glib2                    2.56.4-7.el8          0:2.56.4-8.el8
  2           Medium     systemd-pam              239-18.el8_1.1        0:239-29.el8
  3           Medium     python3-pip-wheel        9.0.3-15.el8          0:9.0.3-16.el8
  1           Medium     gcc                      8.3.1-4.5.el8         0:8.3.1-5.el8
  2           Medium     curl                     7.61.1-11.el8         0:7.61.1-12.el8
  2           Medium     systemd-udev             239-18.el8_1.1        0:239-29.el8
  1           Medium     libxml2                  2.9.7-5.el8           0:2.9.7-7.el8
  1           Medium     gnutls                   3.6.8-8.el8           0:3.6.8-10.el8_2
  2           Medium     systemd-libs             239-18.el8_1.1        0:239-29.el8
  1           Medium     libcom_err               1.44.6-3.el8          0:1.45.4-3.el8
  2           Medium     platform-python          3.6.8-15.1.el8        0:3.6.8-23.el8
  1           Medium     libgcc                   8.3.1-4.5.el8         0:8.3.1-5.el8
  1           Medium     bind-export-libs         32:9.11.4-26.P2.el8   32:9.11.13-3.el8
  2           Medium     systemd                  239-18.el8_1.1        0:239-29.el8
  1           Medium     bind                     32:9.11.4-26.P2.el8   32:9.11.13-3.el8
  2           Medium     python3-libs             3.6.8-15.1.el8        0:3.6.8-23.el8
  1           Medium     e2fsprogs                1.44.6-3.el8          0:1.45.4-3.el8
  3           Medium     platform-python-pip      9.0.3-15.el8          0:9.0.3-16.el8
  2           Medium     libcurl-minimal          7.61.1-11.el8         0:7.61.1-12.el8
  1           Medium     openssl-libs             1:1.1.1c-2.el8        1:1.1.1c-15.el8
  7           Medium     sqlite                   3.26.0-3.el8          0:3.26.0-6.el8
  1           Low        glibc                    2.28-72.el8           0:2.28-101.el8
  2           Low        openssl-libs             1:1.1.1c-2.el8        1:1.1.1c-15.el8
  2           Low        openssl                  1:1.1.1c-2.el8        1:1.1.1c-15.el8
  1           Low        glibc-minimal-langpack   2.28-72.el8           0:2.28-101.el8
  1           Low        platform-python-pip      9.0.3-15.el8          0:9.0.3-16.el8
  1           Low        libxml2                  2.9.7-5.el8           0:2.9.7-7.el8
  1           Low        glibc-common             2.28-72.el8           0:2.28-101.el8
  1           Low        curl                     7.61.1-11.el8         0:7.61.1-12.el8
  2           Low        binutils                 2.30-58.el8.0.1       0:2.30-73.el8
  1           Low        python3-pip-wheel        9.0.3-15.el8          0:9.0.3-16.el8
  1           Low        libcurl-minimal          7.61.1-11.el8         0:7.61.1-12.el8

```

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>