### PR TITLE
feat(cli): add time range flags to events list cmd

### DIFF
--- a/integration/event_test.go
+++ b/integration/event_test.go
@@ -20,6 +20,7 @@ package integration
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -40,6 +41,30 @@ func TestEventCommandAliases(t *testing.T) {
 
 func TestEventCommandList(t *testing.T) {
 	out, err, exitcode := LaceworkCLIWithTOMLConfig("event", "list")
+	assert.Contains(t, out.String(), "EVENT ID",
+		"STDOUT table headers changed, please check")
+	assert.Contains(t, out.String(), "TYPE",
+		"STDOUT table headers changed, please check")
+	assert.Contains(t, out.String(), "SEVERITY",
+		"STDOUT table headers changed, please check")
+	assert.Contains(t, out.String(), "START TIME",
+		"STDOUT table headers changed, please check")
+	assert.Contains(t, out.String(), "END TIME",
+		"STDOUT table headers changed, please check")
+	assert.Empty(t,
+		err.String(),
+		"STDERR should be empty")
+	assert.Equal(t, 0, exitcode,
+		"EXITCODE is not the expected one")
+}
+
+func TestEventCommandListTimeRange(t *testing.T) {
+	var (
+		now  = time.Now().UTC()
+		from = now.AddDate(0, 0, -1) // 1 days from now
+	)
+
+	out, err, exitcode := LaceworkCLIWithTOMLConfig("event", "list", "--start", from.Format(time.RFC3339), "--end", now.Format(time.RFC3339))
 	assert.Contains(t, out.String(), "EVENT ID",
 		"STDOUT table headers changed, please check")
 	assert.Contains(t, out.String(), "TYPE",


### PR DESCRIPTION
We are adding two flags to the `events list` command to provide a custom
time range:
```
$ lacework event list --end "2020-06-19T00:00:00Z" --start "2020-06-13T00:00:00Z"
```

If either a start or an end time is provided, both flags are required.

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>