### PR TITLE
feat(cli): configure in non-interactive mode

### DIFF
--- a/cli/cmd/configure.go
+++ b/cli/cmd/configure.go
@@ -54,6 +54,19 @@ type credsDetails struct {
 	ApiSecret string `toml:"api_secret" json:"api_secret" survey:"api_secret"`
 }
 
+func (c *credsDetails) Verify() error {
+	if c.Account == "" {
+		return errors.New("account missing")
+	}
+	if c.ApiKey == "" {
+		return errors.New("api_key missing")
+	}
+	if c.ApiSecret == "" {
+		return errors.New("api_secret missing")
+	}
+	return nil
+}
+
 // apiKeyDetails represents the details of an API key, we use this struct
 // internally to unmarshal the JSON file provided by the Lacework WebUI
 type apiKeyDetails struct {
@@ -105,6 +118,9 @@ func init() {
 
 func promptConfigureSetup() error {
 	cli.Log.Debugw("configuring cli", "profile", cli.Profile)
+
+	// make sure that the state is loaded to use during configuration
+	cli.loadStateFromViper()
 
 	// if the Lacework account is empty, and the profile that is being configured is
 	// not the 'default' profile, auto-populate the account with the provided profile
@@ -167,15 +183,26 @@ func promptConfigureSetup() error {
 	}
 
 	newCreds := credsDetails{}
-	err := survey.Ask(append(questions, secretQuest), &newCreds,
-		survey.WithIcons(promptIconsFunc),
-	)
-	if err != nil {
-		return err
+	if cli.InteractiveMode() {
+		err := survey.Ask(append(questions, secretQuest), &newCreds,
+			survey.WithIcons(promptIconsFunc),
+		)
+		if err != nil {
+			return err
+		}
+
+		if len(newCreds.ApiSecret) == 0 {
+			newCreds.ApiSecret = cli.Secret
+		}
+		cli.OutputHuman("\n")
+	} else {
+		newCreds.Account = cli.Account
+		newCreds.ApiKey = cli.KeyID
+		newCreds.ApiSecret = cli.Secret
 	}
 
-	if len(newCreds.ApiSecret) == 0 {
-		newCreds.ApiSecret = cli.Secret
+	if err := newCreds.Verify(); err != nil {
+		return errors.Wrap(err, "unable to configure the command-line")
 	}
 
 	var (
@@ -217,12 +244,12 @@ func promptConfigureSetup() error {
 		return err
 	}
 
-	err = ioutil.WriteFile(confPath, buf.Bytes(), 0600)
+	err := ioutil.WriteFile(confPath, buf.Bytes(), 0600)
 	if err != nil {
 		return err
 	}
 
-	cli.OutputHuman("\nYou are all set!\n")
+	cli.OutputHuman("You are all set!\n")
 	return nil
 }
 

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -83,7 +83,7 @@ func init() {
 		"turn off colors",
 	)
 	rootCmd.PersistentFlags().Bool("noninteractive", false,
-		"disable interactive progress bars (i.e. 'spinners')",
+		"turn off interactive mode (disable spinners, prompts, etc.)",
 	)
 	rootCmd.PersistentFlags().Bool("json", false,
 		"switch commands output from human-readable to json format",

--- a/integration/compliance_test.go
+++ b/integration/compliance_test.go
@@ -65,7 +65,7 @@ Global Flags:
       --debug               turn on debug logging
       --json                switch commands output from human-readable to json format
       --nocolor             turn off colors
-      --noninteractive      disable interactive progress bars (i.e. 'spinners')
+      --noninteractive      turn off interactive mode (disable spinners, prompts, etc.)
   -p, --profile string      switch between profiles configured at ~/.lacework.toml
 
 Use "lacework compliance [command] --help" for more information about a command.

--- a/integration/configure_test.go
+++ b/integration/configure_test.go
@@ -51,6 +51,41 @@ func TestConfigureCommand(t *testing.T) {
 `, laceworkTOML, "there is a problem with the generated config")
 }
 
+func TestConfigureCommandNonInteractive(t *testing.T) {
+	// create a temporal directory where we will check that the
+	// configuration file is deployed (.lacework.toml)
+	home, err := ioutil.TempDir("", "lacework-cli")
+	if err != nil {
+		panic(err)
+	}
+
+	defer os.RemoveAll(home)
+	out, errB, exitcode := LaceworkCLIWithHome(home, "configure",
+		"--noninteractive",
+		"-a", "my-account",
+		"-k", "my-key",
+		"-s", "my-secret",
+	)
+
+	assert.Empty(t, errB.String())
+	assert.Equal(t, 0, exitcode)
+	assert.Equal(t, "You are all set!\n", out.String(),
+		"you are not all set, check configure cmd")
+
+	configPath := path.Join(home, ".lacework.toml")
+	assert.FileExists(t, configPath, "the configuration file is missing")
+	laceworkTOML, err := ioutil.ReadFile(configPath)
+	if err != nil {
+		panic(err)
+	}
+
+	assert.Equal(t, `[default]
+  account = "my-account"
+  api_key = "my-key"
+  api_secret = "my-secret"
+`, string(laceworkTOML), "there is a problem with the generated config")
+}
+
 func TestConfigureCommandWithProfileFlag(t *testing.T) {
 	_, laceworkTOML := runConfigureTest(t,
 		func(c *expect.Console) {

--- a/integration/help_test.go
+++ b/integration/help_test.go
@@ -74,7 +74,7 @@ Global Flags:
       --debug               turn on debug logging
       --json                switch commands output from human-readable to json format
       --nocolor             turn off colors
-      --noninteractive      disable interactive progress bars (i.e. 'spinners')
+      --noninteractive      turn off interactive mode (disable spinners, prompts, etc.)
   -p, --profile string      switch between profiles configured at ~/.lacework.toml
 `,
 		out.String(),
@@ -150,7 +150,7 @@ Flags:
       --debug               turn on debug logging
       --json                switch commands output from human-readable to json format
       --nocolor             turn off colors
-      --noninteractive      disable interactive progress bars (i.e. 'spinners')
+      --noninteractive      turn off interactive mode (disable spinners, prompts, etc.)
   -p, --profile string      switch between profiles configured at ~/.lacework.toml
 
 Use "lacework [command] --help" for more information about a command.


### PR DESCRIPTION
>As a Lacework CLI user that uses the tool in CI/CD Pipelines,
>I want to have a non-interactive way to configure the Lacework CLI,
>So I don't have to manually create the config file `~/.lacework.toml` inside my pipeline.

When a user runs:
```
$ lacework configure -a foo -k bar -s bubu --noninteractive
```
The result is the creation of the `~/.lacework.toml` without asking the user
to validate the inputs. (non-interactive mode)

The command loads these settings from all sources, as usual, environment
variables, parameters (including `--json_file`), and the actual config file.

Closes https://github.com/lacework/go-sdk/issues/112

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>