### PR TITLE
chore(cli): remove deprecated old config loading

### DIFF
--- a/cli/cmd/configure.go
+++ b/cli/cmd/configure.go
@@ -194,19 +194,9 @@ func promptConfigureSetup() error {
 			"path", confPath,
 		)
 	} else {
+		cli.Log.Debugw("decoding config", "path", confPath)
 		if _, err := toml.DecodeFile(confPath, &profiles); err != nil {
-			cli.Log.Debugw("unable to decode profiles from config, trying previous config",
-				"path", confPath, "error", err,
-			)
-
-			var oldcreds credsDetails
-			if _, err2 := toml.DecodeFile(confPath, &oldcreds); err2 != nil {
-				cli.Log.Debugw("unable to decode old config, no more options, exit",
-					"error", err2,
-				)
-				return err
-			}
-			profiles["default"] = oldcreds
+			return errors.Wrap(err, "unable to decode profiles from config")
 		}
 		cli.Log.Debugw("profiles loaded from config, updating", "profiles", profiles)
 	}


### PR DESCRIPTION
The first config we had in the Lacework CLI was a single account:
```toml
account = "dev"
api_key = "DEV_1234"
api_secret = "_abcd"
```

The new configuration file allows users to have multiple profiles, from
this commit, that is the only configuration file we support:
```toml
[default]
account = "prod"
api_key = "PROD_1234"
api_secret = "_abcd"

[dev]
account = "dev"
api_key = "DEV_1234"
api_secret = "_abcd"
```

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>