### PR TITLE
feat(api): get/update container registry integrations

### DIFF
--- a/api/integrations_cont_reg.go
+++ b/api/integrations_cont_reg.go
@@ -86,6 +86,27 @@ func (svc *IntegrationsService) CreateContainerRegistry(integration ContainerReg
 	return
 }
 
+// GetContainerRegistry gets a container registry integration that matches with
+// the provided integration guid on the Lacework Server
+func (svc *IntegrationsService) GetContainerRegistry(guid string) (
+	response map[string]interface{},
+	//response ContainerRegIntResponse, // @afiune we can't use this :(
+	err error,
+) {
+	err = svc.get(guid, &response)
+	return
+}
+
+// UpdateContainerRegistry updates a single container registry integration
+func (svc *IntegrationsService) UpdateContainerRegistry(integration ContainerRegIntegration) (
+	response map[string]interface{},
+	//response ContainerRegIntResponse, // @afiune we can't use this :(
+	err error,
+) {
+	err = svc.update(integration.IntgGuid, integration, &response)
+	return
+}
+
 type ContainerRegIntegration struct {
 	commonIntegrationData
 	Data ContainerRegData `json:"DATA"`

--- a/api/integrations_cont_reg_test.go
+++ b/api/integrations_cont_reg_test.go
@@ -1,0 +1,43 @@
+//
+// Author:: Salim Afiune Maya (<afiune@lacework.net>)
+// Copyright:: Copyright 2020, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package api_test
+
+import (
+	"testing"
+
+	"github.com/lacework/go-sdk/api"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIntegrationsNewContainerRegIntegration(t *testing.T) {
+	subject := api.NewContainerRegIntegration("integration_name",
+		api.ContainerRegData{
+			Credentials: api.ContainerRegCreds{
+				Username: "techally",
+				Password: "secret",
+			},
+			RegistryType:   api.DockerHubRegistry.String(),
+			RegistryDomain: "index.docker.io",
+			LimitByTag:     "*",
+			LimitByLabel:   "*",
+			LimitNumImg:    5,
+		},
+	)
+	assert.Equal(t, api.ContainerRegistryIntegration.String(), subject.Type)
+}


### PR DESCRIPTION
This change adds the Get and Update functions for the Container Registry
integrations.

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>