### PR TITLE
feature: AWS CloudWatch Alert Channel Integrations

### DIFF
--- a/api/_examples/aws-cloudwatch-alert-channel/main.go
+++ b/api/_examples/aws-cloudwatch-alert-channel/main.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/lacework/go-sdk/api"
+)
+
+func main() {
+	lacework, err := api.NewClient("account", api.WithApiKeys("KEY", "SECRET"))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	alert := api.NewAwsCloudWatchAlertChannel("aws-cloudwatch-alert-from-golang",
+		api.AwsCloudWatchData{
+			EventBusArn:      "arn:aws:events:us-west-2:1234567890:event-bus/default",
+			MinAlertSeverity: 1,
+		},
+	)
+
+	response, err := lacework.Integrations.CreateAwsCloudWatchAlertChannel(alert)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Output: Aws CloudWatch alert channel created: THE-INTEGRATION-GUID
+	fmt.Printf("Aws CloudWatch alert channel created: %s", response.Data[0].IntgGuid)
+}

--- a/api/_examples/slack-alert-channel/main.go
+++ b/api/_examples/slack-alert-channel/main.go
@@ -13,18 +13,18 @@ func main() {
 		log.Fatal(err)
 	}
 
-	mySlackChannel := api.NewSlackChannelIntegration("slack-alert-from-golang",
+	mySlackChannel := api.NewSlackAlertChannel("slack-alert-from-golang",
 		api.SlackChannelData{
 			SlackUrl:         "https://hooks.slack.com/services/ABCD/12345/abcd1234",
 			MinAlertSeverity: 3,
 		},
 	)
 
-	response, err := lacework.Integrations.CreateSlackChannel(mySlackChannel)
+	response, err := lacework.Integrations.CreateSlackAlertChannel(mySlackChannel)
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	// Output: Slack Channel alert created: THE-INTEGRATION-GUID
-	fmt.Printf("Slack Channel alert created: %s", response.Data[0].IntgGuid)
+	// Output: Slack alert channel created: THE-INTEGRATION-GUID
+	fmt.Printf("Slack alert channel created: %s", response.Data[0].IntgGuid)
 }

--- a/api/integration_alert_channels.go
+++ b/api/integration_alert_channels.go
@@ -1,0 +1,55 @@
+//
+// Author:: Salim Afiune Maya (<afiune@lacework.net>)
+// Copyright:: Copyright 2020, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package api
+
+// Enum for Alert Severity Levels
+type AlertLevel int
+
+const (
+	CriticalAlertLevel AlertLevel = 1 // Critical only
+	HighAlertLevel     AlertLevel = 2 // High and above
+	MediumAlertLevel   AlertLevel = 3 // Medium and above
+	LowAlertLevel      AlertLevel = 4 // Low and above
+	AllAlertLevel      AlertLevel = 5 // Info and above (which is All of them)
+)
+
+// AlertLevels is the list of available alert levels
+var AlertLevels = map[AlertLevel]string{
+	CriticalAlertLevel: "Critical",
+	HighAlertLevel:     "High",
+	MediumAlertLevel:   "Medium",
+	LowAlertLevel:      "Low",
+	AllAlertLevel:      "All",
+}
+
+// String returns the string representation of an alert level
+func (i AlertLevel) String() string {
+	return AlertLevels[i]
+}
+
+// Int returns the int representation of an alert level
+func (i AlertLevel) Int() int {
+	return int(i)
+}
+
+// Valid returns whether the AlertLevel is valid or not
+func (i AlertLevel) Valid() bool {
+	_, ok := AlertLevels[i]
+	return ok
+}

--- a/api/integration_alert_channels_aws_cloudwatch.go
+++ b/api/integration_alert_channels_aws_cloudwatch.go
@@ -18,10 +18,10 @@
 
 package api
 
-// NewAwsCloudWatchIntegration returns an instance of AwsCloudWatchInt
+// NewAwsCloudWatchAlertChannel returns an instance of AwsCloudWatchAlertChannel
 // with the provided name and data.
 //
-// Basic usage: Initialize a new AwsCloudWatchInt struct, then
+// Basic usage: Initialize a new AwsCloudWatchAlertChannel struct, then
 //              use the new instance to do CRUD operations
 //
 //   client, err := api.NewClient("account")
@@ -29,17 +29,17 @@ package api
 //     return err
 //   }
 //
-//   awsCloudWatch := api.NewAwsCloudWatchIntegration("foo",
+//   awsCloudWatch := api.NewAwsCloudWatchAlertChannel("foo",
 //     api.AwsCloudWatchData{
 //       EventBusArn: "arn:aws:events:us-west-2:1234567890:event-bus/default",
 //       MinAlertSeverity: api.MediumAlertLevel,
 //     },
 //   )
 //
-//   client.Integrations.CreateAwsCloudWatch(awsCloudWatch)
+//   client.Integrations.CreateAwsCloudWatchAlertChannel(awsCloudWatch)
 //
-func NewAwsCloudWatchIntegration(name string, data AwsCloudWatchData) AwsCloudWatchInt {
-	return AwsCloudWatchInt{
+func NewAwsCloudWatchAlertChannel(name string, data AwsCloudWatchData) AwsCloudWatchAlertChannel {
+	return AwsCloudWatchAlertChannel{
 		commonIntegrationData: commonIntegrationData{
 			Name:    name,
 			Type:    AwsCloudWatchIntegration.String(),
@@ -49,47 +49,47 @@ func NewAwsCloudWatchIntegration(name string, data AwsCloudWatchData) AwsCloudWa
 	}
 }
 
-// CreateAwsCloudWatch creates a AWS CloudWatch alert integration on the Lacework Server
-func (svc *IntegrationsService) CreateAwsCloudWatch(integration AwsCloudWatchInt) (
-	response AwsCloudWatchIntResponse,
+// CreateAwsCloudWatchAlertChannel creates a AWS CloudWatch alert channel on the Lacework Server
+func (svc *IntegrationsService) CreateAwsCloudWatchAlertChannel(integration AwsCloudWatchAlertChannel) (
+	response AwsCloudWatchResponse,
 	err error,
 ) {
 	err = svc.create(integration, &response)
 	return
 }
 
-// GetAwsCloudWatch gets a AWS CloudWatch alert integration that matches with
+// GetAwsCloudWatchAlertChannel gets a AWS CloudWatch alert channel that matches with
 // the provided integration guid on the Lacework Server
-func (svc *IntegrationsService) GetAwsCloudWatch(guid string) (
-	response AwsCloudWatchIntResponse,
+func (svc *IntegrationsService) GetAwsCloudWatchAlertChannel(guid string) (
+	response AwsCloudWatchResponse,
 	err error,
 ) {
 	err = svc.get(guid, &response)
 	return
 }
 
-// UpdateAwsCloudWatch updates a single AWS CloudWatch alert integration
-func (svc *IntegrationsService) UpdateAwsCloudWatch(data AwsCloudWatchInt) (
-	response AwsCloudWatchIntResponse,
+// UpdateAwsCloudWatchAlertChannel updates a single AWS CloudWatch alert channel
+func (svc *IntegrationsService) UpdateAwsCloudWatchAlertChannel(data AwsCloudWatchAlertChannel) (
+	response AwsCloudWatchResponse,
 	err error,
 ) {
 	err = svc.update(data.IntgGuid, data, &response)
 	return
 }
 
-// ListAwsCloudWatch lists the CLOUDWATCH_EB external integrations available on the Lacework Server
-func (svc *IntegrationsService) ListAwsCloudWatch() (response AwsCloudWatchIntResponse, err error) {
+// ListAwsCloudWatchAlertChannel lists the CLOUDWATCH_EB external integrations available on the Lacework Server
+func (svc *IntegrationsService) ListAwsCloudWatchAlertChannel() (response AwsCloudWatchResponse, err error) {
 	err = svc.listByType(AwsCloudWatchIntegration, &response)
 	return
 }
 
-type AwsCloudWatchIntResponse struct {
-	Data    []AwsCloudWatchInt `json:"data"`
-	Ok      bool               `json:"ok"`
-	Message string             `json:"message"`
+type AwsCloudWatchResponse struct {
+	Data    []AwsCloudWatchAlertChannel `json:"data"`
+	Ok      bool                        `json:"ok"`
+	Message string                      `json:"message"`
 }
 
-type AwsCloudWatchInt struct {
+type AwsCloudWatchAlertChannel struct {
 	commonIntegrationData
 	Data AwsCloudWatchData `json:"DATA"`
 }

--- a/api/integration_alert_channels_aws_cloudwatch.go
+++ b/api/integration_alert_channels_aws_cloudwatch.go
@@ -1,0 +1,101 @@
+//
+// Author:: Salim Afiune Maya (<afiune@lacework.net>)
+// Copyright:: Copyright 2020, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package api
+
+// NewAwsCloudWatchIntegration returns an instance of AwsCloudWatchInt
+// with the provided name and data.
+//
+// Basic usage: Initialize a new AwsCloudWatchInt struct, then
+//              use the new instance to do CRUD operations
+//
+//   client, err := api.NewClient("account")
+//   if err != nil {
+//     return err
+//   }
+//
+//   awsCloudWatch := api.NewAwsCloudWatchIntegration("foo",
+//     api.AwsCloudWatchData{
+//       EventBusArn: "arn:aws:events:us-west-2:1234567890:event-bus/default",
+//       MinAlertSeverity: api.MediumAlertLevel,
+//     },
+//   )
+//
+//   client.Integrations.CreateAwsCloudWatch(awsCloudWatch)
+//
+func NewAwsCloudWatchIntegration(name string, data AwsCloudWatchData) AwsCloudWatchInt {
+	return AwsCloudWatchInt{
+		commonIntegrationData: commonIntegrationData{
+			Name:    name,
+			Type:    AwsCloudWatchIntegration.String(),
+			Enabled: 1,
+		},
+		Data: data,
+	}
+}
+
+// CreateAwsCloudWatch creates a AWS CloudWatch alert integration on the Lacework Server
+func (svc *IntegrationsService) CreateAwsCloudWatch(integration AwsCloudWatchInt) (
+	response AwsCloudWatchIntResponse,
+	err error,
+) {
+	err = svc.create(integration, &response)
+	return
+}
+
+// GetAwsCloudWatch gets a AWS CloudWatch alert integration that matches with
+// the provided integration guid on the Lacework Server
+func (svc *IntegrationsService) GetAwsCloudWatch(guid string) (
+	response AwsCloudWatchIntResponse,
+	err error,
+) {
+	err = svc.get(guid, &response)
+	return
+}
+
+// UpdateAwsCloudWatch updates a single AWS CloudWatch alert integration
+func (svc *IntegrationsService) UpdateAwsCloudWatch(data AwsCloudWatchInt) (
+	response AwsCloudWatchIntResponse,
+	err error,
+) {
+	err = svc.update(data.IntgGuid, data, &response)
+	return
+}
+
+// ListAwsCloudWatch lists the CLOUDWATCH_EB external integrations available on the Lacework Server
+func (svc *IntegrationsService) ListAwsCloudWatch() (response AwsCloudWatchIntResponse, err error) {
+	err = svc.listByType(AwsCloudWatchIntegration, &response)
+	return
+}
+
+type AwsCloudWatchIntResponse struct {
+	Data    []AwsCloudWatchInt `json:"data"`
+	Ok      bool               `json:"ok"`
+	Message string             `json:"message"`
+}
+
+type AwsCloudWatchInt struct {
+	commonIntegrationData
+	Data AwsCloudWatchData `json:"DATA"`
+}
+
+type AwsCloudWatchData struct {
+	IssueGrouping    string     `json:"ISSUE_GROUPING,omitempty" mapstructure:"ISSUE_GROUPING"`
+	EventBusArn      string     `json:"EVENT_BUS_ARN" mapstructure:"EVENT_BUS_ARN"`
+	MinAlertSeverity AlertLevel `json:"MIN_ALERT_SEVERITY,omitempty" mapstructure:"MIN_ALERT_SEVERITY"`
+}

--- a/api/integration_alert_channels_aws_cloudwatch_test.go
+++ b/api/integration_alert_channels_aws_cloudwatch_test.go
@@ -1,0 +1,252 @@
+//
+// Author:: Salim Afiune Maya (<afiune@lacework.net>)
+// Copyright:: Copyright 2020, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package api_test
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/lacework/go-sdk/api"
+	"github.com/lacework/go-sdk/internal/intgguid"
+	"github.com/lacework/go-sdk/internal/lacework"
+)
+
+func TestIntegrationsNewAwsCloudWatchIntegration(t *testing.T) {
+	subject := api.NewAwsCloudWatchIntegration("integration_name",
+		api.AwsCloudWatchData{
+			EventBusArn:      "arn:aws:events:us-west-2:1234567890:event-bus/default",
+			MinAlertSeverity: 1,
+		},
+	)
+	assert.Equal(t, api.AwsCloudWatchIntegration.String(), subject.Type)
+	assert.Equal(t, api.CriticalAlertLevel, subject.Data.MinAlertSeverity)
+}
+
+func TestIntegrationsCreateAwsCloudWatch(t *testing.T) {
+	var (
+		intgGUID   = intgguid.New()
+		fakeServer = lacework.MockServer()
+	)
+	fakeServer.MockAPI("external/integrations", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method, "CreateAwsCloudWatch should be a POST method")
+
+		if assert.NotNil(t, r.Body) {
+			body := httpBodySniffer(r)
+			assert.Contains(t, body, "integration_name", "integration name is missing")
+			assert.Contains(t, body, "CLOUDWATCH_EB", "wrong integration type")
+			assert.Contains(t, body, "arn:aws:events:us-west-2:1234567890:event-bus/default", "wrong event bus arn")
+			assert.Contains(t, body, "MIN_ALERT_SEVERITY\":3", "wrong alert severity")
+			assert.Contains(t, body, "ENABLED\":1", "integration is not enabled")
+		}
+
+		fmt.Fprintf(w, awsCloudWatchIntegrationJsonResponse(intgGUID))
+	})
+	defer fakeServer.Close()
+
+	c, err := api.NewClient("test",
+		api.WithToken("TOKEN"),
+		api.WithURL(fakeServer.URL()),
+	)
+	assert.Nil(t, err)
+
+	data := api.NewAwsCloudWatchIntegration("integration_name",
+		api.AwsCloudWatchData{
+			EventBusArn:      "arn:aws:events:us-west-2:1234567890:event-bus/default",
+			MinAlertSeverity: 3,
+		},
+	)
+	assert.Equal(t, "integration_name", data.Name, "AwsCloudWatch integration name mismatch")
+	assert.Equal(t, "CLOUDWATCH_EB", data.Type, "a new AwsCloudWatch integration should match its type")
+	assert.Equal(t, 1, data.Enabled, "a new AwsCloudWatch integration should be enabled")
+
+	response, err := c.Integrations.CreateAwsCloudWatch(data)
+	assert.Nil(t, err)
+	assert.NotNil(t, response)
+	assert.True(t, response.Ok)
+	if assert.Equal(t, 1, len(response.Data)) {
+		resData := response.Data[0]
+		assert.Equal(t, intgGUID, resData.IntgGuid)
+		assert.Equal(t, "integration_name", resData.Name)
+		assert.True(t, resData.State.Ok)
+		assert.Equal(t, "arn:aws:events:us-west-2:1234567890:event-bus/default", resData.Data.EventBusArn)
+		assert.Equal(t, api.AlertLevel(3), resData.Data.MinAlertSeverity)
+	}
+}
+
+func TestIntegrationsGetAwsCloudWatch(t *testing.T) {
+	var (
+		intgGUID   = intgguid.New()
+		apiPath    = fmt.Sprintf("external/integrations/%s", intgGUID)
+		fakeServer = lacework.MockServer()
+	)
+	fakeServer.MockAPI(apiPath, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method, "GetAwsCloudWatch should be a GET method")
+		fmt.Fprintf(w, awsCloudWatchIntegrationJsonResponse(intgGUID))
+	})
+	defer fakeServer.Close()
+
+	c, err := api.NewClient("test",
+		api.WithToken("TOKEN"),
+		api.WithURL(fakeServer.URL()),
+	)
+	assert.Nil(t, err)
+
+	response, err := c.Integrations.GetAwsCloudWatch(intgGUID)
+	assert.Nil(t, err)
+	assert.NotNil(t, response)
+	assert.True(t, response.Ok)
+	if assert.Equal(t, 1, len(response.Data)) {
+		resData := response.Data[0]
+		assert.Equal(t, intgGUID, resData.IntgGuid)
+		assert.Equal(t, "integration_name", resData.Name)
+		assert.True(t, resData.State.Ok)
+		assert.Equal(t, "arn:aws:events:us-west-2:1234567890:event-bus/default", resData.Data.EventBusArn)
+		assert.Equal(t, api.AlertLevel(3), resData.Data.MinAlertSeverity)
+	}
+}
+
+func TestIntegrationsUpdateAwsCloudWatch(t *testing.T) {
+	var (
+		intgGUID   = intgguid.New()
+		apiPath    = fmt.Sprintf("external/integrations/%s", intgGUID)
+		fakeServer = lacework.MockServer()
+	)
+	fakeServer.MockAPI(apiPath, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "PATCH", r.Method, "UpdateAwsCloudWatch should be a PATCH method")
+
+		if assert.NotNil(t, r.Body) {
+			body := httpBodySniffer(r)
+			assert.Contains(t, body, intgGUID, "INTG_GUID missing")
+			assert.Contains(t, body, "integration_name", "integration name is missing")
+			assert.Contains(t, body, "CLOUDWATCH_EB", "wrong integration type")
+			assert.Contains(t, body, "arn:aws:events:us-west-2:1234567890:event-bus/default", "wrong event bus arn")
+			assert.Contains(t, body, "MIN_ALERT_SEVERITY\":3", "wrong alert severity")
+			assert.Contains(t, body, "ENABLED\":1", "integration is not enabled")
+		}
+
+		fmt.Fprintf(w, awsCloudWatchIntegrationJsonResponse(intgGUID))
+	})
+	defer fakeServer.Close()
+
+	c, err := api.NewClient("test",
+		api.WithToken("TOKEN"),
+		api.WithURL(fakeServer.URL()),
+	)
+	assert.Nil(t, err)
+
+	data := api.NewAwsCloudWatchIntegration("integration_name",
+		api.AwsCloudWatchData{
+			EventBusArn:      "arn:aws:events:us-west-2:1234567890:event-bus/default",
+			MinAlertSeverity: 3,
+		},
+	)
+	assert.Equal(t, "integration_name", data.Name, "AwsCloudWatch integration name mismatch")
+	assert.Equal(t, "CLOUDWATCH_EB", data.Type, "a new AwsCloudWatch integration should match its type")
+	assert.Equal(t, 1, data.Enabled, "a new AwsCloudWatch integration should be enabled")
+	data.IntgGuid = intgGUID
+
+	response, err := c.Integrations.UpdateAwsCloudWatch(data)
+	assert.Nil(t, err)
+	assert.NotNil(t, response)
+	assert.Equal(t, "SUCCESS", response.Message)
+	assert.Equal(t, 1, len(response.Data))
+	assert.Equal(t, intgGUID, response.Data[0].IntgGuid)
+}
+
+func TestIntegrationsListAwsCloudWatch(t *testing.T) {
+	var (
+		intgGUIDs  = []string{intgguid.New(), intgguid.New(), intgguid.New()}
+		fakeServer = lacework.MockServer()
+	)
+	fakeServer.MockAPI("external/integrations/type/CLOUDWATCH_EB",
+		func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "GET", r.Method, "ListAwsCloudWatch should be a GET method")
+			fmt.Fprintf(w, awsCloudWatchMultiIntegrationJsonResponse(intgGUIDs))
+		},
+	)
+	defer fakeServer.Close()
+
+	c, err := api.NewClient("test",
+		api.WithToken("TOKEN"),
+		api.WithURL(fakeServer.URL()),
+	)
+	assert.Nil(t, err)
+
+	response, err := c.Integrations.ListAwsCloudWatch()
+	assert.Nil(t, err)
+	assert.NotNil(t, response)
+	assert.True(t, response.Ok)
+	assert.Equal(t, len(intgGUIDs), len(response.Data))
+	for _, d := range response.Data {
+		assert.Contains(t, intgGUIDs, d.IntgGuid)
+	}
+}
+
+func awsCloudWatchIntegrationJsonResponse(intgGUID string) string {
+	return `
+{
+  "data": [` + singleAwsCloudWatchIntegration(intgGUID) + `],
+  "ok": true,
+  "message": "SUCCESS"
+}
+`
+}
+
+func awsCloudWatchMultiIntegrationJsonResponse(guids []string) string {
+	integrations := []string{}
+	for _, guid := range guids {
+		integrations = append(integrations, singleAwsCloudWatchIntegration(guid))
+	}
+	return `
+{
+"data": [` + strings.Join(integrations, ", ") + `],
+"ok": true,
+"message": "SUCCESS"
+}
+`
+}
+
+func singleAwsCloudWatchIntegration(id string) string {
+	return `
+{
+  "INTG_GUID": "` + id + `",
+  "CREATED_OR_UPDATED_BY": "user@email.com",
+  "CREATED_OR_UPDATED_TIME": "2020-Jul-16 19:59:22 UTC",
+  "DATA": {
+    "ISSUE_GROUPING": "Events",
+    "MIN_ALERT_SEVERITY": 3,
+    "EVENT_BUS_ARN": "arn:aws:events:us-west-2:1234567890:event-bus/default"
+  },
+  "ENABLED": 1,
+  "IS_ORG": 0,
+  "NAME": "integration_name",
+  "STATE": {
+    "lastSuccessfulTime": "2020-Jul-16 18:26:54 UTC",
+    "lastUpdatedTime": "2020-Jul-16 18:26:54 UTC",
+    "ok": true
+  },
+  "TYPE": "CLOUDWATCH_EB",
+  "TYPE_NAME": "CLOUDWATCH_EB"
+}
+`
+}

--- a/api/integration_alert_channels_aws_cloudwatch_test.go
+++ b/api/integration_alert_channels_aws_cloudwatch_test.go
@@ -31,8 +31,8 @@ import (
 	"github.com/lacework/go-sdk/internal/lacework"
 )
 
-func TestIntegrationsNewAwsCloudWatchIntegration(t *testing.T) {
-	subject := api.NewAwsCloudWatchIntegration("integration_name",
+func TestIntegrationsNewAwsCloudWatchAlertChannel(t *testing.T) {
+	subject := api.NewAwsCloudWatchAlertChannel("integration_name",
 		api.AwsCloudWatchData{
 			EventBusArn:      "arn:aws:events:us-west-2:1234567890:event-bus/default",
 			MinAlertSeverity: 1,
@@ -42,13 +42,13 @@ func TestIntegrationsNewAwsCloudWatchIntegration(t *testing.T) {
 	assert.Equal(t, api.CriticalAlertLevel, subject.Data.MinAlertSeverity)
 }
 
-func TestIntegrationsCreateAwsCloudWatch(t *testing.T) {
+func TestIntegrationsCreateAwsCloudWatchAlertChannel(t *testing.T) {
 	var (
 		intgGUID   = intgguid.New()
 		fakeServer = lacework.MockServer()
 	)
 	fakeServer.MockAPI("external/integrations", func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "POST", r.Method, "CreateAwsCloudWatch should be a POST method")
+		assert.Equal(t, "POST", r.Method, "CreateAwsCloudWatchAlertChannel should be a POST method")
 
 		if assert.NotNil(t, r.Body) {
 			body := httpBodySniffer(r)
@@ -69,7 +69,7 @@ func TestIntegrationsCreateAwsCloudWatch(t *testing.T) {
 	)
 	assert.Nil(t, err)
 
-	data := api.NewAwsCloudWatchIntegration("integration_name",
+	data := api.NewAwsCloudWatchAlertChannel("integration_name",
 		api.AwsCloudWatchData{
 			EventBusArn:      "arn:aws:events:us-west-2:1234567890:event-bus/default",
 			MinAlertSeverity: 3,
@@ -79,7 +79,7 @@ func TestIntegrationsCreateAwsCloudWatch(t *testing.T) {
 	assert.Equal(t, "CLOUDWATCH_EB", data.Type, "a new AwsCloudWatch integration should match its type")
 	assert.Equal(t, 1, data.Enabled, "a new AwsCloudWatch integration should be enabled")
 
-	response, err := c.Integrations.CreateAwsCloudWatch(data)
+	response, err := c.Integrations.CreateAwsCloudWatchAlertChannel(data)
 	assert.Nil(t, err)
 	assert.NotNil(t, response)
 	assert.True(t, response.Ok)
@@ -93,14 +93,14 @@ func TestIntegrationsCreateAwsCloudWatch(t *testing.T) {
 	}
 }
 
-func TestIntegrationsGetAwsCloudWatch(t *testing.T) {
+func TestIntegrationsGetAwsCloudWatchAlertChannel(t *testing.T) {
 	var (
 		intgGUID   = intgguid.New()
 		apiPath    = fmt.Sprintf("external/integrations/%s", intgGUID)
 		fakeServer = lacework.MockServer()
 	)
 	fakeServer.MockAPI(apiPath, func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "GET", r.Method, "GetAwsCloudWatch should be a GET method")
+		assert.Equal(t, "GET", r.Method, "GetAwsCloudWatchAlertChannel should be a GET method")
 		fmt.Fprintf(w, awsCloudWatchIntegrationJsonResponse(intgGUID))
 	})
 	defer fakeServer.Close()
@@ -111,7 +111,7 @@ func TestIntegrationsGetAwsCloudWatch(t *testing.T) {
 	)
 	assert.Nil(t, err)
 
-	response, err := c.Integrations.GetAwsCloudWatch(intgGUID)
+	response, err := c.Integrations.GetAwsCloudWatchAlertChannel(intgGUID)
 	assert.Nil(t, err)
 	assert.NotNil(t, response)
 	assert.True(t, response.Ok)
@@ -125,14 +125,14 @@ func TestIntegrationsGetAwsCloudWatch(t *testing.T) {
 	}
 }
 
-func TestIntegrationsUpdateAwsCloudWatch(t *testing.T) {
+func TestIntegrationsUpdateAwsCloudWatchAlertChannel(t *testing.T) {
 	var (
 		intgGUID   = intgguid.New()
 		apiPath    = fmt.Sprintf("external/integrations/%s", intgGUID)
 		fakeServer = lacework.MockServer()
 	)
 	fakeServer.MockAPI(apiPath, func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "PATCH", r.Method, "UpdateAwsCloudWatch should be a PATCH method")
+		assert.Equal(t, "PATCH", r.Method, "UpdateAwsCloudWatchAlertChannel should be a PATCH method")
 
 		if assert.NotNil(t, r.Body) {
 			body := httpBodySniffer(r)
@@ -154,7 +154,7 @@ func TestIntegrationsUpdateAwsCloudWatch(t *testing.T) {
 	)
 	assert.Nil(t, err)
 
-	data := api.NewAwsCloudWatchIntegration("integration_name",
+	data := api.NewAwsCloudWatchAlertChannel("integration_name",
 		api.AwsCloudWatchData{
 			EventBusArn:      "arn:aws:events:us-west-2:1234567890:event-bus/default",
 			MinAlertSeverity: 3,
@@ -165,7 +165,7 @@ func TestIntegrationsUpdateAwsCloudWatch(t *testing.T) {
 	assert.Equal(t, 1, data.Enabled, "a new AwsCloudWatch integration should be enabled")
 	data.IntgGuid = intgGUID
 
-	response, err := c.Integrations.UpdateAwsCloudWatch(data)
+	response, err := c.Integrations.UpdateAwsCloudWatchAlertChannel(data)
 	assert.Nil(t, err)
 	assert.NotNil(t, response)
 	assert.Equal(t, "SUCCESS", response.Message)
@@ -173,14 +173,14 @@ func TestIntegrationsUpdateAwsCloudWatch(t *testing.T) {
 	assert.Equal(t, intgGUID, response.Data[0].IntgGuid)
 }
 
-func TestIntegrationsListAwsCloudWatch(t *testing.T) {
+func TestIntegrationsListAwsCloudWatchAlertChannel(t *testing.T) {
 	var (
 		intgGUIDs  = []string{intgguid.New(), intgguid.New(), intgguid.New()}
 		fakeServer = lacework.MockServer()
 	)
 	fakeServer.MockAPI("external/integrations/type/CLOUDWATCH_EB",
 		func(w http.ResponseWriter, r *http.Request) {
-			assert.Equal(t, "GET", r.Method, "ListAwsCloudWatch should be a GET method")
+			assert.Equal(t, "GET", r.Method, "ListAwsCloudWatchAlertChannel should be a GET method")
 			fmt.Fprintf(w, awsCloudWatchMultiIntegrationJsonResponse(intgGUIDs))
 		},
 	)
@@ -192,7 +192,7 @@ func TestIntegrationsListAwsCloudWatch(t *testing.T) {
 	)
 	assert.Nil(t, err)
 
-	response, err := c.Integrations.ListAwsCloudWatch()
+	response, err := c.Integrations.ListAwsCloudWatchAlertChannel()
 	assert.Nil(t, err)
 	assert.NotNil(t, response)
 	assert.True(t, response.Ok)

--- a/api/integration_alert_channels_slack.go
+++ b/api/integration_alert_channels_slack.go
@@ -32,7 +32,7 @@ package api
 //   slackChannel := api.NewSlackChannelIntegration("foo",
 //     api.SlackChannelData{
 //       SlackUrl: "https://hooks.slack.com/services/ABCD/12345/abcd1234",
-//       MinAlertSeverity: 3,
+//       MinAlertSeverity: api.CriticalAlertLevel,
 //     },
 //   )
 //
@@ -47,35 +47,6 @@ func NewSlackChannelIntegration(name string, data SlackChannelData) SlackChanInt
 		},
 		Data: data,
 	}
-}
-
-type SlackAlertLevel int
-
-const (
-	CriticalSlackAlertLevel SlackAlertLevel = 1
-	HighSlackAlertLevel     SlackAlertLevel = 2
-	MediumSlackAlertLevel   SlackAlertLevel = 3
-	LowSlackAlertLevel      SlackAlertLevel = 4
-	AllSlackAlertLevel      SlackAlertLevel = 5
-)
-
-// SlackAlertLevels is the list of available slack alert levels
-var SlackAlertLevels = map[SlackAlertLevel]string{
-	CriticalSlackAlertLevel: "Critical",
-	HighSlackAlertLevel:     "High",
-	MediumSlackAlertLevel:   "Medium",
-	LowSlackAlertLevel:      "Low",
-	AllSlackAlertLevel:      "All",
-}
-
-// String returns the string representation of a slack alert level
-func (i SlackAlertLevel) String() string {
-	return SlackAlertLevels[i]
-}
-
-// Int returns the int representation of a slack alert level
-func (i SlackAlertLevel) Int() int {
-	return int(i)
 }
 
 // CreateSlackChannel creates a slack channel alert integration on the Lacework Server
@@ -124,7 +95,7 @@ type SlackChanIntegration struct {
 }
 
 type SlackChannelData struct {
-	IssueGrouping    string          `json:"ISSUE_GROUPING,omitempty" mapstructure:"ISSUE_GROUPING"`
-	SlackUrl         string          `json:"SLACK_URL" mapstructure:"SLACK_URL"`
-	MinAlertSeverity SlackAlertLevel `json:"MIN_ALERT_SEVERITY" mapstructure:"MIN_ALERT_SEVERITY"`
+	IssueGrouping    string     `json:"ISSUE_GROUPING,omitempty" mapstructure:"ISSUE_GROUPING"`
+	SlackUrl         string     `json:"SLACK_URL" mapstructure:"SLACK_URL"`
+	MinAlertSeverity AlertLevel `json:"MIN_ALERT_SEVERITY,omitempty" mapstructure:"MIN_ALERT_SEVERITY"`
 }

--- a/api/integration_alert_channels_slack.go
+++ b/api/integration_alert_channels_slack.go
@@ -18,10 +18,10 @@
 
 package api
 
-// NewSlackChannelIntegration returns an instance of SlackChanIntegration
+// NewSlackAlertChannel returns an instance of SlackAlertChannel
 // with the provided name and data.
 //
-// Basic usage: Initialize a new SlackChanIntegration struct, then
+// Basic usage: Initialize a new SlackAlertChannel struct, then
 //              use the new instance to do CRUD operations
 //
 //   client, err := api.NewClient("account")
@@ -29,17 +29,17 @@ package api
 //     return err
 //   }
 //
-//   slackChannel := api.NewSlackChannelIntegration("foo",
+//   slackChannel := api.NewSlackAlertChannel("foo",
 //     api.SlackChannelData{
 //       SlackUrl: "https://hooks.slack.com/services/ABCD/12345/abcd1234",
 //       MinAlertSeverity: api.CriticalAlertLevel,
 //     },
 //   )
 //
-//   client.Integrations.CreateSlackChannel(slackChannel)
+//   client.Integrations.CreateSlackAlertChannel(slackChannel)
 //
-func NewSlackChannelIntegration(name string, data SlackChannelData) SlackChanIntegration {
-	return SlackChanIntegration{
+func NewSlackAlertChannel(name string, data SlackChannelData) SlackAlertChannel {
+	return SlackAlertChannel{
 		commonIntegrationData: commonIntegrationData{
 			Name:    name,
 			Type:    SlackChannelIntegration.String(),
@@ -49,47 +49,47 @@ func NewSlackChannelIntegration(name string, data SlackChannelData) SlackChanInt
 	}
 }
 
-// CreateSlackChannel creates a slack channel alert integration on the Lacework Server
-func (svc *IntegrationsService) CreateSlackChannel(integration SlackChanIntegration) (
-	response SlackChanIntResponse,
+// CreateSlackAlertChannel creates a slack alert channel integration on the Lacework Server
+func (svc *IntegrationsService) CreateSlackAlertChannel(integration SlackAlertChannel) (
+	response SlackAlertChannelResponse,
 	err error,
 ) {
 	err = svc.create(integration, &response)
 	return
 }
 
-// GetSlackChannel gets a slack channel alert integration that matches with
+// GetSlackAlertChannel gets a slack alert channel integration that matches with
 // the provided integration guid on the Lacework Server
-func (svc *IntegrationsService) GetSlackChannel(guid string) (
-	response SlackChanIntResponse,
+func (svc *IntegrationsService) GetSlackAlertChannel(guid string) (
+	response SlackAlertChannelResponse,
 	err error,
 ) {
 	err = svc.get(guid, &response)
 	return
 }
 
-// UpdateSlackChannel updates a single slack channel alert integration
-func (svc *IntegrationsService) UpdateSlackChannel(data SlackChanIntegration) (
-	response SlackChanIntResponse,
+// UpdateSlackAlertChannel updates a single slack alert channel integration
+func (svc *IntegrationsService) UpdateSlackAlertChannel(data SlackAlertChannel) (
+	response SlackAlertChannelResponse,
 	err error,
 ) {
 	err = svc.update(data.IntgGuid, data, &response)
 	return
 }
 
-// ListSlackChannel lists the SLACK_CHANNEL external integrations available on the Lacework Server
-func (svc *IntegrationsService) ListSlackChannel() (response SlackChanIntResponse, err error) {
+// ListSlackAlertChannel lists the SLACK_CHANNEL external integrations available on the Lacework Server
+func (svc *IntegrationsService) ListSlackAlertChannel() (response SlackAlertChannelResponse, err error) {
 	err = svc.listByType(SlackChannelIntegration, &response)
 	return
 }
 
-type SlackChanIntResponse struct {
-	Data    []SlackChanIntegration `json:"data"`
-	Ok      bool                   `json:"ok"`
-	Message string                 `json:"message"`
+type SlackAlertChannelResponse struct {
+	Data    []SlackAlertChannel `json:"data"`
+	Ok      bool                `json:"ok"`
+	Message string              `json:"message"`
 }
 
-type SlackChanIntegration struct {
+type SlackAlertChannel struct {
 	commonIntegrationData
 	Data SlackChannelData `json:"DATA"`
 }

--- a/api/integration_alert_channels_slack_test.go
+++ b/api/integration_alert_channels_slack_test.go
@@ -31,8 +31,8 @@ import (
 	"github.com/lacework/go-sdk/internal/lacework"
 )
 
-func TestIntegrationsNewSlackChannelIntegration(t *testing.T) {
-	subject := api.NewSlackChannelIntegration("integration_name",
+func TestIntegrationsNewSlackAlertChannel(t *testing.T) {
+	subject := api.NewSlackAlertChannel("integration_name",
 		api.SlackChannelData{
 			SlackUrl:         "https://hooks.slack.com/services/ABCD/12345/abcd1234",
 			MinAlertSeverity: 3,
@@ -42,13 +42,13 @@ func TestIntegrationsNewSlackChannelIntegration(t *testing.T) {
 	assert.Equal(t, api.MediumAlertLevel, subject.Data.MinAlertSeverity)
 }
 
-func TestIntegrationsCreateSlackChannel(t *testing.T) {
+func TestIntegrationsCreateSlackAlertChannel(t *testing.T) {
 	var (
 		intgGUID   = intgguid.New()
 		fakeServer = lacework.MockServer()
 	)
 	fakeServer.MockAPI("external/integrations", func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "POST", r.Method, "CreateSlackChannel should be a POST method")
+		assert.Equal(t, "POST", r.Method, "CreateSlackAlertChannel should be a POST method")
 
 		if assert.NotNil(t, r.Body) {
 			body := httpBodySniffer(r)
@@ -69,7 +69,7 @@ func TestIntegrationsCreateSlackChannel(t *testing.T) {
 	)
 	assert.Nil(t, err)
 
-	data := api.NewSlackChannelIntegration("integration_name",
+	data := api.NewSlackAlertChannel("integration_name",
 		api.SlackChannelData{
 			SlackUrl:         "https://hooks.slack.com/services/ABCD/12345/abcd1234",
 			MinAlertSeverity: 3,
@@ -79,7 +79,7 @@ func TestIntegrationsCreateSlackChannel(t *testing.T) {
 	assert.Equal(t, "SLACK_CHANNEL", data.Type, "a new SlackChannel integration should match its type")
 	assert.Equal(t, 1, data.Enabled, "a new SlackChannel integration should be enabled")
 
-	response, err := c.Integrations.CreateSlackChannel(data)
+	response, err := c.Integrations.CreateSlackAlertChannel(data)
 	assert.Nil(t, err)
 	assert.NotNil(t, response)
 	assert.True(t, response.Ok)
@@ -93,14 +93,14 @@ func TestIntegrationsCreateSlackChannel(t *testing.T) {
 	}
 }
 
-func TestIntegrationsGetSlackChannel(t *testing.T) {
+func TestIntegrationsGetSlackAlertChannel(t *testing.T) {
 	var (
 		intgGUID   = intgguid.New()
 		apiPath    = fmt.Sprintf("external/integrations/%s", intgGUID)
 		fakeServer = lacework.MockServer()
 	)
 	fakeServer.MockAPI(apiPath, func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "GET", r.Method, "GetSlackChannel should be a GET method")
+		assert.Equal(t, "GET", r.Method, "GetSlackAlertChannel should be a GET method")
 		fmt.Fprintf(w, slackChannelIntegrationJsonResponse(intgGUID))
 	})
 	defer fakeServer.Close()
@@ -111,7 +111,7 @@ func TestIntegrationsGetSlackChannel(t *testing.T) {
 	)
 	assert.Nil(t, err)
 
-	response, err := c.Integrations.GetSlackChannel(intgGUID)
+	response, err := c.Integrations.GetSlackAlertChannel(intgGUID)
 	assert.Nil(t, err)
 	assert.NotNil(t, response)
 	assert.True(t, response.Ok)
@@ -125,14 +125,14 @@ func TestIntegrationsGetSlackChannel(t *testing.T) {
 	}
 }
 
-func TestIntegrationsUpdateSlackChannel(t *testing.T) {
+func TestIntegrationsUpdateSlackAlertChannel(t *testing.T) {
 	var (
 		intgGUID   = intgguid.New()
 		apiPath    = fmt.Sprintf("external/integrations/%s", intgGUID)
 		fakeServer = lacework.MockServer()
 	)
 	fakeServer.MockAPI(apiPath, func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "PATCH", r.Method, "UpdateSlackChannel should be a PATCH method")
+		assert.Equal(t, "PATCH", r.Method, "UpdateSlackAlertChannel should be a PATCH method")
 
 		if assert.NotNil(t, r.Body) {
 			body := httpBodySniffer(r)
@@ -154,7 +154,7 @@ func TestIntegrationsUpdateSlackChannel(t *testing.T) {
 	)
 	assert.Nil(t, err)
 
-	data := api.NewSlackChannelIntegration("integration_name",
+	data := api.NewSlackAlertChannel("integration_name",
 		api.SlackChannelData{
 			SlackUrl:         "https://hooks.slack.com/services/ABCD/12345/abcd1234",
 			MinAlertSeverity: 3,
@@ -165,7 +165,7 @@ func TestIntegrationsUpdateSlackChannel(t *testing.T) {
 	assert.Equal(t, 1, data.Enabled, "a new SlackChannel integration should be enabled")
 	data.IntgGuid = intgGUID
 
-	response, err := c.Integrations.UpdateSlackChannel(data)
+	response, err := c.Integrations.UpdateSlackAlertChannel(data)
 	assert.Nil(t, err)
 	assert.NotNil(t, response)
 	assert.Equal(t, "SUCCESS", response.Message)
@@ -173,14 +173,14 @@ func TestIntegrationsUpdateSlackChannel(t *testing.T) {
 	assert.Equal(t, intgGUID, response.Data[0].IntgGuid)
 }
 
-func TestIntegrationsListSlackChannel(t *testing.T) {
+func TestIntegrationsListSlackAlertChannel(t *testing.T) {
 	var (
 		intgGUIDs  = []string{intgguid.New(), intgguid.New(), intgguid.New()}
 		fakeServer = lacework.MockServer()
 	)
 	fakeServer.MockAPI("external/integrations/type/SLACK_CHANNEL",
 		func(w http.ResponseWriter, r *http.Request) {
-			assert.Equal(t, "GET", r.Method, "ListSlackChannel should be a GET method")
+			assert.Equal(t, "GET", r.Method, "ListSlackAlertChannel should be a GET method")
 			fmt.Fprintf(w, slackChanMultiIntegrationJsonResponse(intgGUIDs))
 		},
 	)
@@ -192,7 +192,7 @@ func TestIntegrationsListSlackChannel(t *testing.T) {
 	)
 	assert.Nil(t, err)
 
-	response, err := c.Integrations.ListSlackChannel()
+	response, err := c.Integrations.ListSlackAlertChannel()
 	assert.Nil(t, err)
 	assert.NotNil(t, response)
 	assert.True(t, response.Ok)

--- a/api/integration_alert_channels_slack_test.go
+++ b/api/integration_alert_channels_slack_test.go
@@ -39,6 +39,7 @@ func TestIntegrationsNewSlackChannelIntegration(t *testing.T) {
 		},
 	)
 	assert.Equal(t, api.SlackChannelIntegration.String(), subject.Type)
+	assert.Equal(t, api.MediumAlertLevel, subject.Data.MinAlertSeverity)
 }
 
 func TestIntegrationsCreateSlackChannel(t *testing.T) {
@@ -88,7 +89,7 @@ func TestIntegrationsCreateSlackChannel(t *testing.T) {
 		assert.Equal(t, "integration_name", resData.Name)
 		assert.True(t, resData.State.Ok)
 		assert.Equal(t, "https://hooks.slack.com/services/ABCD/12345/abcd1234", resData.Data.SlackUrl)
-		assert.Equal(t, api.SlackAlertLevel(3), resData.Data.MinAlertSeverity)
+		assert.Equal(t, api.AlertLevel(3), resData.Data.MinAlertSeverity)
 	}
 }
 
@@ -120,7 +121,7 @@ func TestIntegrationsGetSlackChannel(t *testing.T) {
 		assert.Equal(t, "integration_name", resData.Name)
 		assert.True(t, resData.State.Ok)
 		assert.Equal(t, "https://hooks.slack.com/services/ABCD/12345/abcd1234", resData.Data.SlackUrl)
-		assert.Equal(t, api.SlackAlertLevel(3), resData.Data.MinAlertSeverity)
+		assert.Equal(t, api.AlertLevel(3), resData.Data.MinAlertSeverity)
 	}
 }
 

--- a/api/integration_alert_channels_test.go
+++ b/api/integration_alert_channels_test.go
@@ -1,0 +1,53 @@
+//
+// Author:: Salim Afiune Maya (<afiune@lacework.net>)
+// Copyright:: Copyright 2020, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package api_test
+
+import (
+	"testing"
+
+	"github.com/lacework/go-sdk/api"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAlertLevelValid(t *testing.T) {
+	assert.True(t, api.AlertLevel(1).Valid())
+	assert.True(t, api.AlertLevel(2).Valid())
+	assert.True(t, api.AlertLevel(3).Valid())
+	assert.True(t, api.AlertLevel(4).Valid())
+	assert.True(t, api.AlertLevel(5).Valid())
+
+	assert.False(t, api.AlertLevel(6).Valid())
+	assert.False(t, api.AlertLevel(123).Valid())
+}
+
+func TestAlertLevelStrings(t *testing.T) {
+	assert.Equal(t, "Critical", api.CriticalAlertLevel.String())
+	assert.Equal(t, "High", api.HighAlertLevel.String())
+	assert.Equal(t, "Medium", api.MediumAlertLevel.String())
+	assert.Equal(t, "Low", api.LowAlertLevel.String())
+	assert.Equal(t, "All", api.AllAlertLevel.String())
+}
+
+func TestAlertLevelInts(t *testing.T) {
+	assert.Equal(t, 1, api.CriticalAlertLevel.Int())
+	assert.Equal(t, 2, api.HighAlertLevel.Int())
+	assert.Equal(t, 3, api.MediumAlertLevel.Int())
+	assert.Equal(t, 4, api.LowAlertLevel.Int())
+	assert.Equal(t, 5, api.AllAlertLevel.Int())
+}

--- a/api/integrations.go
+++ b/api/integrations.go
@@ -55,8 +55,11 @@ const (
 	// Container registry integration type
 	ContainerRegistryIntegration
 
-	//Slack channel integration type
+	// Slack channel integration type
 	SlackChannelIntegration
+
+	// AWS CloudWatch integration type
+	AwsCloudWatchIntegration
 )
 
 // IntegrationTypes is the list of available integration types
@@ -70,6 +73,7 @@ var IntegrationTypes = map[integrationType]string{
 	AzureActivityLogIntegration:  "AZURE_AL_SEQ",
 	ContainerRegistryIntegration: "CONT_VULN_CFG",
 	SlackChannelIntegration:      "SLACK_CHANNEL",
+	AwsCloudWatchIntegration:     "CLOUDWATCH_EB",
 }
 
 // String returns the string representation of an integration type

--- a/cli/cmd/integration.go
+++ b/cli/cmd/integration.go
@@ -183,7 +183,8 @@ func promptCreateIntegration() error {
 		prompt      = &survey.Select{
 			Message: "Choose an integration type to create: ",
 			Options: []string{
-				"Slack Channel Alert",
+				"Slack Alert Channel",
+				"AWS CloudWatch Alert Channel",
 				"Docker Hub",
 				"AWS Config",
 				"AWS CloudTrail",
@@ -204,8 +205,10 @@ func promptCreateIntegration() error {
 	}
 
 	switch integration {
-	case "Slack Channel Alert":
-		return createSlackChannelIntegration()
+	case "Slack Alert Channel":
+		return createSlackAlertChannelIntegration()
+	case "AWS CloudWatch Alert Channel":
+		return createAwsCloudWatchAlertChannelIntegration()
 	case "Docker Hub":
 		return createDockerHubIntegration()
 	case "AWS Config":
@@ -387,6 +390,26 @@ func reflectIntegrationData(raw api.RawIntegration) [][]string {
 		}
 		out := [][]string{
 			[]string{"SLACK URL", iData.SlackUrl},
+			[]string{"ISSUE GROUPING", iData.IssueGrouping},
+			[]string{"ALERT ON SEVERITY", iData.MinAlertSeverity.String()},
+		}
+
+		return out
+
+	case api.AwsCloudWatchIntegration.String():
+
+		var iData api.AwsCloudWatchData
+		err := mapstructure.Decode(raw.Data, &iData)
+		if err != nil {
+			cli.Log.Debugw("unable to decode integration data",
+				"integration_type", raw.Type,
+				"raw_data", raw.Data,
+				"error", err,
+			)
+			break
+		}
+		out := [][]string{
+			[]string{"EVENT BUS ARN", iData.EventBusArn},
 			[]string{"ISSUE GROUPING", iData.IssueGrouping},
 			[]string{"ALERT ON SEVERITY", iData.MinAlertSeverity.String()},
 		}

--- a/cli/cmd/integration_aws_cloudwatch.go
+++ b/cli/cmd/integration_aws_cloudwatch.go
@@ -24,7 +24,7 @@ import (
 	"github.com/lacework/go-sdk/api"
 )
 
-func createSlackAlertChannelIntegration() error {
+func createAwsCloudWatchAlertChannelIntegration() error {
 	questions := []*survey.Question{
 		{
 			Name:     "name",
@@ -32,8 +32,8 @@ func createSlackAlertChannelIntegration() error {
 			Validate: survey.Required,
 		},
 		{
-			Name:     "url",
-			Prompt:   &survey.Input{Message: "Slack URL: "},
+			Name:     "arn",
+			Prompt:   &survey.Input{Message: "Event Bus ARN: "},
 			Validate: survey.Required,
 		},
 		{
@@ -54,7 +54,7 @@ func createSlackAlertChannelIntegration() error {
 
 	answers := struct {
 		Name          string
-		Url           string
+		Arn           string
 		AlertSeverity string `survey:"alert_severity_level"`
 	}{}
 
@@ -65,32 +65,15 @@ func createSlackAlertChannelIntegration() error {
 		return err
 	}
 
-	slack := api.NewSlackAlertChannel(answers.Name,
-		api.SlackChannelData{
-			SlackUrl:         answers.Url,
+	slack := api.NewAwsCloudWatchAlertChannel(answers.Name,
+		api.AwsCloudWatchData{
+			EventBusArn:      answers.Arn,
 			MinAlertSeverity: alertSeverityToEnum(answers.AlertSeverity),
 		},
 	)
 
 	cli.StartProgress(" Creating integration...")
-	_, err = cli.LwApi.Integrations.CreateSlackAlertChannel(slack)
+	_, err = cli.LwApi.Integrations.CreateAwsCloudWatchAlertChannel(slack)
 	cli.StopProgress()
 	return err
-}
-
-func alertSeverityToEnum(level string) api.AlertLevel {
-	switch level {
-	case "Critical":
-		return api.CriticalAlertLevel
-	case "High and above":
-		return api.HighAlertLevel
-	case "Medium and above":
-		return api.MediumAlertLevel
-	case "Low and above":
-		return api.LowAlertLevel
-	case "All":
-		return api.AllAlertLevel
-	default:
-		return api.MediumAlertLevel
-	}
 }

--- a/cli/cmd/integration_slack_channel.go
+++ b/cli/cmd/integration_slack_channel.go
@@ -65,7 +65,7 @@ func createSlackChannelIntegration() error {
 		return err
 	}
 
-	slack := api.NewSlackChannelIntegration(answers.Name,
+	slack := api.NewSlackAlertChannel(answers.Name,
 		api.SlackChannelData{
 			SlackUrl:         answers.Url,
 			MinAlertSeverity: alertSeverityToEnum(answers.AlertSeverity),
@@ -73,7 +73,7 @@ func createSlackChannelIntegration() error {
 	)
 
 	cli.StartProgress(" Creating integration...")
-	_, err = cli.LwApi.Integrations.CreateSlackChannel(slack)
+	_, err = cli.LwApi.Integrations.CreateSlackAlertChannel(slack)
 	cli.StopProgress()
 	return err
 }

--- a/cli/cmd/integration_slack_channel.go
+++ b/cli/cmd/integration_slack_channel.go
@@ -78,19 +78,19 @@ func createSlackChannelIntegration() error {
 	return err
 }
 
-func alertSeverityToEnum(level string) api.SlackAlertLevel {
+func alertSeverityToEnum(level string) api.AlertLevel {
 	switch level {
 	case "Critical":
-		return api.CriticalSlackAlertLevel
+		return api.CriticalAlertLevel
 	case "High and above":
-		return api.HighSlackAlertLevel
+		return api.HighAlertLevel
 	case "Medium and above":
-		return api.MediumSlackAlertLevel
+		return api.MediumAlertLevel
 	case "Low and above":
-		return api.LowSlackAlertLevel
+		return api.LowAlertLevel
 	case "All":
-		return api.AllSlackAlertLevel
+		return api.AllAlertLevel
 	default:
-		return api.MediumSlackAlertLevel
+		return api.MediumAlertLevel
 	}
 }


### PR DESCRIPTION
# feat(cli): Create AWS CloudWatch Alert Channels 🚨

Users now can create AWS CloudWatch Alert Channel Integrations via the CLI:

    $ lacework integration create
    ? Choose an integration type to create:  AWS CloudWatch Alert Channel
    ▸ Name:  cloud-watch-test
    ▸ Event Bus ARN:  arn:aws:events:us-west-2:1234567890:event-bus/default
    ▸ Alert Severity Level:  All
    The integration was created.


# feat(api): add AWS CloudWatch Alert Channels Int

With this change users can now do CRUD operations of AWS CloudWatch
Alert Channels (Integrations), here is a basic usage:

Initialize a new `AwsCloudWatchAlertChannel` struct, then use the new
instance to do CRUD operations.

```go
client, err := api.NewClient("account")
if err != nil {
  return err
}

awsCloudWatch := api.NewAwsCloudWatchAlertChannel("foo",
  api.AwsCloudWatchData{
    EventBusArn: "arn:aws:events:us-west-2:1234567890:event-bus/default",
    MinAlertSeverity: api.MediumAlertLevel,
  },
)

client.Integrations.CreateAwsCloudWatchAlertChannel(awsCloudWatch)
```

# refactor(api): use AlertLevel enum for Slack Alerts
A refactor was made to use the new `AlertLevel` and naming convention for Alerts:

```go
client, err := api.NewClient("account")
  if err != nil {
    return err
}

slackChannel := api.NewSlackAlertChannel("foo",
  api.SlackChannelData{
    SlackUrl: "https://hooks.slack.com/services/ABCD/12345/abcd1234",
    MinAlertSeverity: api.CriticalAlertLevel,
  },
)

client.Integrations.CreateSlackAlertChannel(slackChannel)
```

Additional Changes:
* refactor(api): AlertChannel prefix in funcs/structs
* feat(api): enum AlertLevel for alert severity levels

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>