### PR TITLE
feat(cli): Create PagerDuty Alert Channels 🚨

### DIFF
--- a/cli/cmd/integration.go
+++ b/cli/cmd/integration.go
@@ -184,6 +184,7 @@ func promptCreateIntegration() error {
 			Message: "Choose an integration type to create: ",
 			Options: []string{
 				"Slack Alert Channel",
+				"PagerDuty Alert Channel",
 				"AWS CloudWatch Alert Channel",
 				"Docker Hub",
 				"AWS Config",
@@ -207,6 +208,8 @@ func promptCreateIntegration() error {
 	switch integration {
 	case "Slack Alert Channel":
 		return createSlackAlertChannelIntegration()
+	case "PagerDuty Alert Channel":
+		return createPagerDutyAlertChannelIntegration()
 	case "AWS CloudWatch Alert Channel":
 		return createAwsCloudWatchAlertChannelIntegration()
 	case "Docker Hub":
@@ -416,6 +419,25 @@ func reflectIntegrationData(raw api.RawIntegration) [][]string {
 
 		return out
 
+	case api.PagerDutyIntegration.String():
+
+		var iData api.PagerDutyData
+		err := mapstructure.Decode(raw.Data, &iData)
+		if err != nil {
+			cli.Log.Debugw("unable to decode integration data",
+				"integration_type", raw.Type,
+				"raw_data", raw.Data,
+				"error", err,
+			)
+			break
+		}
+		out := [][]string{
+			[]string{"INTEGRATION KEY", iData.IntegrationKey},
+			[]string{"ISSUE GROUPING", iData.IssueGrouping},
+			[]string{"ALERT ON SEVERITY", iData.MinAlertSeverity.String()},
+		}
+
+		return out
 	default:
 		out := [][]string{}
 		for key, value := range deepKeyValueExtract(raw.Data) {

--- a/cli/cmd/integration_pagerduty.go
+++ b/cli/cmd/integration_pagerduty.go
@@ -1,0 +1,79 @@
+//
+// Author:: Salim Afiune Maya (<afiune@lacework.net>)
+// Copyright:: Copyright 2020, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cmd
+
+import (
+	"github.com/AlecAivazis/survey/v2"
+
+	"github.com/lacework/go-sdk/api"
+)
+
+func createPagerDutyAlertChannelIntegration() error {
+	questions := []*survey.Question{
+		{
+			Name:     "name",
+			Prompt:   &survey.Input{Message: "Name: "},
+			Validate: survey.Required,
+		},
+		{
+			Name:     "key",
+			Prompt:   &survey.Input{Message: "Integration Key: "},
+			Validate: survey.Required,
+		},
+		{
+			Name: "alert_severity_level",
+			Prompt: &survey.Select{
+				Message: "Alert Severity Level: ",
+				Options: []string{
+					"Critical",
+					"High and above",
+					"Medium and above",
+					"Low and above",
+					"All",
+				},
+			},
+			Validate: survey.Required,
+		},
+	}
+
+	answers := struct {
+		Name          string
+		Key           string
+		AlertSeverity string `survey:"alert_severity_level"`
+	}{}
+
+	err := survey.Ask(questions, &answers,
+		survey.WithIcons(promptIconsFunc),
+	)
+	if err != nil {
+		return err
+	}
+
+	alert := api.NewPagerDutyAlertChannel(answers.Name,
+		api.PagerDutyData{
+			IntegrationKey:   answers.Key,
+			MinAlertSeverity: alertSeverityToEnum(answers.AlertSeverity),
+		},
+	)
+
+	cli.StartProgress(" Creating integration...")
+	_, err = cli.LwApi.Integrations.CreatePagerDutyAlertChannel(alert)
+	cli.StopProgress()
+	return err
+}


### PR DESCRIPTION
Users now can create PagerDuty Alert Channel Integrations via the CLI:
```
$ lacework integration create
? Choose an integration type to create:  PagerDuty Alert Channel
▸ Name:  pagerduty-test
▸ Integration Key:  1234abc8901abc567abc123abc78e012
▸ Alert Severity Level:  All
The integration was created.
```

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>