### PR TITLE
fix(cli): error showing non-existing integration

### DIFF
--- a/cli/cmd/integration.go
+++ b/cli/cmd/integration.go
@@ -95,6 +95,12 @@ var (
 				return cli.OutputJSON(integration.Data)
 			}
 
+			if len(integration.Data) == 0 {
+				msg := "the provided integration GUID was not found\n\n"
+				msg += "To list the available integrations in your account run 'lacework integrations list'"
+				return errors.New(msg)
+			}
+
 			cli.OutputHuman(buildIntegrationsTable(integration.Data))
 			cli.OutputHuman("\n")
 			cli.OutputHuman(buildIntDetailsTable(integration.Data))

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -92,3 +92,17 @@ func TestIntegrationCommandListWithTypeFlagErrorUnknownType(t *testing.T) {
 	assert.Equal(t, 1, exitcode,
 		"EXITCODE is not the expected one")
 }
+
+func TestIntegrationCommandShowNonExistingError(t *testing.T) {
+	out, err, exitcode := LaceworkCLIWithTOMLConfig("integration", "show", "EXXAMPLE_123")
+	assert.Emptyf(t, out.String(),
+		"STDOUT should be empty")
+	assert.Equal(t, 1, exitcode,
+		"EXITCODE is not the expected one")
+	assert.Contains(t, err.String(),
+		"ERROR the provided integration GUID was not found",
+		"STDERR should contain a helpful message")
+	assert.Contains(t, err.String(),
+		"To list the available integrations in your account run 'lacework integrations list'",
+		"STDERR should contain a helpful message")
+}


### PR DESCRIPTION
When trying to access an integration GUID that doesn't exist, the CLI
will return an error message like the following one:
```
$ lacework integrations show TECHALLY_1
Usage:
  lacework integration show <int_guid> [flags]

Flags:
  -h, --help   help for show

Global Flags:
  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
  -k, --api_key string      access key id
  -s, --api_secret string   secret access key
      --debug               turn on debug logging
      --json                switch commands output from human-readable to json format
      --nocolor             turn off colors
      --noninteractive      turn off interactive mode (disable spinners, prompts, etc.)
  -p, --profile string      switch between profiles configured at ~/.lacework.toml

ERROR the provided integration GUID was not found

To list the available integrations in your account run 'lacework integrations list'
```

Closes https://github.com/lacework/go-sdk/issues/176

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>