### PR TITLE
refactor(cli): replace '--pdf-file' for '--pdf'

### DIFF
--- a/cli/cmd/compliance.go
+++ b/cli/cmd/compliance.go
@@ -36,7 +36,11 @@ var (
 		Type string
 
 		// download the report as PDF format with the provided filename
+		// (DEPRECATED)
 		PdfName string
+
+		// download report in PDF format
+		Pdf bool
 
 		// display extended details about a compliance report
 		Details bool
@@ -275,7 +279,7 @@ func buildComplianceReportTable(detailsTable, summaryTable, recommendationsTable
 		mainReport.WriteString(buildComplianceReportRecommandations(recommendationsTable))
 		mainReport.WriteString("\n")
 		mainReport.WriteString(
-			"Try using '--pdf-file <filename>' to download the report in PDF format.",
+			"Try using '--pdf' to download the report in PDF format.",
 		)
 		mainReport.WriteString("\n")
 	} else {

--- a/cli/cmd/compliance_aws.go
+++ b/cli/cmd/compliance_aws.go
@@ -69,15 +69,26 @@ To run an ad-hoc compliance assessment use the command:
 				Type:      compCmdState.Type,
 			}
 
-			if compCmdState.PdfName != "" {
+			if compCmdState.Pdf || compCmdState.PdfName != "" {
+				pdfName := fmt.Sprintf(
+					"%s_Report_%s_%s_%s.pdf",
+					config.Type,
+					config.AccountID,
+					cli.Account, time.Now().Format("20060102150405"),
+				)
+				if compCmdState.PdfName != "" {
+					cli.OutputHuman("(DEPRECATED) This flag has been replaced by '--pdf'\n\n")
+					pdfName = compCmdState.PdfName
+				}
+
 				cli.StartProgress(" Downloading compliance report...")
-				err := cli.LwApi.Compliance.DownloadAwsReportPDF(compCmdState.PdfName, config)
+				err := cli.LwApi.Compliance.DownloadAwsReportPDF(pdfName, config)
 				cli.StopProgress()
 				if err != nil {
 					return errors.Wrap(err, "unable to get aws pdf compliance report")
 				}
 
-				cli.OutputHuman("The AWS compliance report was downloaded at '%s'.\n", compCmdState.PdfName)
+				cli.OutputHuman("The AWS compliance report was downloaded at '%s'\n", pdfName)
 				return nil
 			}
 
@@ -146,7 +157,10 @@ func init() {
 		"increase details about the compliance report",
 	)
 	complianceAwsGetReportCmd.Flags().StringVar(&compCmdState.PdfName, "pdf-file", "",
-		"download the report as PDF format with the provided filename",
+		"(DEPRECATED) use --pdf",
+	)
+	complianceAwsGetReportCmd.Flags().BoolVar(&compCmdState.Pdf, "pdf", false,
+		"download report in PDF format",
 	)
 
 	// AWS report types: AWS_CIS_S3, NIST_800-53_Rev4, ISO_2700, HIPAA, SOC, or PCI

--- a/cli/cmd/compliance_azure.go
+++ b/cli/cmd/compliance_azure.go
@@ -93,15 +93,27 @@ To run an ad-hoc compliance assessment use the command:
 				Type:           compCmdState.Type,
 			}
 
-			if compCmdState.PdfName != "" {
+			if compCmdState.Pdf || compCmdState.PdfName != "" {
+				pdfName := fmt.Sprintf(
+					"%s_Report_%s_%s_%s_%s.pdf",
+					config.Type,
+					config.TenantID,
+					config.SubscriptionID,
+					cli.Account, time.Now().Format("20060102150405"),
+				)
+				if compCmdState.PdfName != "" {
+					cli.OutputHuman("(DEPRECATED) This flag has been replaced by '--pdf'\n\n")
+					pdfName = compCmdState.PdfName
+				}
+
 				cli.StartProgress(" Downloading compliance report...")
-				err := cli.LwApi.Compliance.DownloadAzureReportPDF(compCmdState.PdfName, config)
+				err := cli.LwApi.Compliance.DownloadAzureReportPDF(pdfName, config)
 				cli.StopProgress()
 				if err != nil {
 					return errors.Wrap(err, "unable to get azure pdf compliance report")
 				}
 
-				cli.OutputHuman("The Azure compliance report was downloaded at '%s'.\n", compCmdState.PdfName)
+				cli.OutputHuman("The Azure compliance report was downloaded at '%s'\n", pdfName)
 				return nil
 			}
 
@@ -168,7 +180,10 @@ func init() {
 		"increase details about the compliance report",
 	)
 	complianceAzureGetReportCmd.Flags().StringVar(&compCmdState.PdfName, "pdf-file", "",
-		"download the report as PDF format with the provided filename",
+		"(DEPRECATED) use --pdf",
+	)
+	complianceAzureGetReportCmd.Flags().BoolVar(&compCmdState.Pdf, "pdf", false,
+		"download report in PDF format",
 	)
 
 	// Azure report types: AZURE_CIS, AZURE_SOC, or AZURE_PCI

--- a/cli/cmd/compliance_gcp.go
+++ b/cli/cmd/compliance_gcp.go
@@ -93,15 +93,27 @@ To run an ad-hoc compliance assessment use the command:
 				Type:           compCmdState.Type,
 			}
 
-			if compCmdState.PdfName != "" {
+			if compCmdState.Pdf || compCmdState.PdfName != "" {
+				pdfName := fmt.Sprintf(
+					"%s_Report_%s_%s_%s_%s.pdf",
+					config.Type,
+					config.OrganizationID,
+					config.ProjectID,
+					cli.Account, time.Now().Format("20060102150405"),
+				)
+				if compCmdState.PdfName != "" {
+					cli.OutputHuman("(DEPRECATED) This flag has been replaced by '--pdf'\n\n")
+					pdfName = compCmdState.PdfName
+				}
+
 				cli.StartProgress(" Downloading compliance report...")
-				err := cli.LwApi.Compliance.DownloadGcpReportPDF(compCmdState.PdfName, config)
+				err := cli.LwApi.Compliance.DownloadGcpReportPDF(pdfName, config)
 				cli.StopProgress()
 				if err != nil {
 					return errors.Wrap(err, "unable to get gcp pdf compliance report")
 				}
 
-				cli.OutputHuman("The GCP compliance report was downloaded at '%s'.\n", compCmdState.PdfName)
+				cli.OutputHuman("The GCP compliance report was downloaded at '%s'\n", pdfName)
 				return nil
 			}
 
@@ -168,7 +180,10 @@ func init() {
 		"increase details about the compliance report",
 	)
 	complianceGcpGetReportCmd.Flags().StringVar(&compCmdState.PdfName, "pdf-file", "",
-		"download the report as PDF format with the provided filename",
+		"(DEPRECATED) use --pdf",
+	)
+	complianceGcpGetReportCmd.Flags().BoolVar(&compCmdState.Pdf, "pdf", false,
+		"download report in PDF format",
 	)
 
 	// GCP report types: GCP_CIS, GCP_SOC, or GCP_PCI.


### PR DESCRIPTION
This change deprecates `--pdf-file` in favor of `--pdf`, example:
```
$ lacework compliance aws get-report 123456789000 --pdf
The AWS compliance report was downloaded at 'AWS_CIS_S3_Report_123456789000_my-account_20200729134124.pdf'
```

Closes https://github.com/lacework/go-sdk/issues/122

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>