### PR TITLE
feat(api): add Jira alert channel integrations

### DIFF
--- a/api/integration_alert_channels_jira.go
+++ b/api/integration_alert_channels_jira.go
@@ -1,0 +1,132 @@
+//
+// Author:: Salim Afiune Maya (<afiune@lacework.net>)
+// Copyright:: Copyright 2020, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package api
+
+const (
+	JiraCloudAlertType  = "JIRA_CLOUD"
+	JiraServerAlertType = "JIRA_SERVER"
+)
+
+// NewJiraAlertChannel returns an instance of JiraAlertChannel
+// with the provided name and data.
+//
+// Basic usage: Initialize a new JiraAlertChannel struct, then
+//              use the new instance to do CRUD operations
+//
+//   client, err := api.NewClient("account")
+//   if err != nil {
+//     return err
+//   }
+//
+//   jiraAlert := api.NewJiraAlertChannel("foo",
+//     api.JiraAlertChannelData{
+//       MinAlertSeverity: api.CriticalAlertLevel,
+//       JiraType:         api.JiraCloudAlertType,
+//       JiraUrl:          "mycompany.atlassian.net",
+//       IssueType:        "Bug",
+//       ProjectID:        "EXAMPLE",
+//       Username:         "me",
+//       ApiToken:         "my-api-token",
+//       IssueGrouping:    "Resources",
+//     },
+//   )
+//
+//   client.Integrations.CreateJiraAlertChannel(jiraAlert)
+//
+func NewJiraAlertChannel(name string, data JiraAlertChannelData) JiraAlertChannel {
+	return JiraAlertChannel{
+		commonIntegrationData: commonIntegrationData{
+			Name:    name,
+			Type:    JiraIntegration.String(),
+			Enabled: 1,
+		},
+		Data: data,
+	}
+}
+
+// NewJiraCloudAlertChannel returns a JiraAlertChannel instance preconfigured as a JIRA_CLOUD type
+func NewJiraCloudAlertChannel(name string, data JiraAlertChannelData) JiraAlertChannel {
+	data.JiraType = JiraCloudAlertType
+	return NewJiraAlertChannel(name, data)
+}
+
+// NewJiraServerAlertChannel returns a JiraAlertChannel instance preconfigured as a JIRA_SERVER type
+func NewJiraServerAlertChannel(name string, data JiraAlertChannelData) JiraAlertChannel {
+	data.JiraType = JiraServerAlertType
+	return NewJiraAlertChannel(name, data)
+}
+
+// CreateJiraAlertChannel creates a jira alert channel integration on the Lacework Server
+func (svc *IntegrationsService) CreateJiraAlertChannel(integration JiraAlertChannel) (
+	response JiraAlertChannelResponse,
+	err error,
+) {
+	err = svc.create(integration, &response)
+	return
+}
+
+// GetJiraAlertChannel gets a jira alert channel integration that matches with
+// the provided integration guid on the Lacework Server
+func (svc *IntegrationsService) GetJiraAlertChannel(guid string) (
+	response JiraAlertChannelResponse,
+	err error,
+) {
+	err = svc.get(guid, &response)
+	return
+}
+
+// UpdateJiraAlertChannel updates a single jira alert channel integration
+func (svc *IntegrationsService) UpdateJiraAlertChannel(data JiraAlertChannel) (
+	response JiraAlertChannelResponse,
+	err error,
+) {
+	err = svc.update(data.IntgGuid, data, &response)
+	return
+}
+
+// ListJiraAlertChannel lists the JIRA external integrations available on the Lacework Server
+func (svc *IntegrationsService) ListJiraAlertChannel() (response JiraAlertChannelResponse, err error) {
+	err = svc.listByType(JiraIntegration, &response)
+	return
+}
+
+type JiraAlertChannelResponse struct {
+	Data    []JiraAlertChannel `json:"data"`
+	Ok      bool               `json:"ok"`
+	Message string             `json:"message"`
+}
+
+type JiraAlertChannel struct {
+	commonIntegrationData
+	Data JiraAlertChannelData `json:"DATA"`
+}
+
+type JiraAlertChannelData struct {
+	JiraType         string     `json:"JIRA_TYPE" mapstructure:"JIRA_TYPE"`
+	JiraUrl          string     `json:"JIRA_URL" mapstructure:"JIRA_URL"`
+	IssueType        string     `json:"ISSUE_TYPE" mapstructure:"ISSUE_TYPE"`
+	ProjectID        string     `json:"PROJECT_ID" mapstructure:"PROJECT_ID"`
+	Username         string     `json:"USERNAME" mapstructure:"USERNAME"`
+	ApiToken         string     `json:"API_TOKEN,omitempty" mapstructure:"API_TOKEN"` // Jira Cloud
+	Password         string     `json:"PASSWORD,omitempty" mapstructure:"PASSWORD"`   // Jira Server
+	IssueGrouping    string     `json:"ISSUE_GROUPING,omitempty" mapstructure:"ISSUE_GROUPING"`
+	MinAlertSeverity AlertLevel `json:"MIN_ALERT_SEVERITY,omitempty" mapstructure:"MIN_ALERT_SEVERITY"`
+
+	//CustomTemplateFile string `json:"CUSTOM_TEMPLATE_FILE,omitempty"`
+}

--- a/api/integration_alert_channels_jira_test.go
+++ b/api/integration_alert_channels_jira_test.go
@@ -1,0 +1,331 @@
+//
+// Author:: Salim Afiune Maya (<afiune@lacework.net>)
+// Copyright:: Copyright 2020, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package api_test
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/lacework/go-sdk/api"
+	"github.com/lacework/go-sdk/internal/intgguid"
+	"github.com/lacework/go-sdk/internal/lacework"
+)
+
+func TestIntegrationsJiraAlertChannelTypes(t *testing.T) {
+	assert.Equal(t, "JIRA_CLOUD", api.JiraCloudAlertType)
+	assert.Equal(t, "JIRA_SERVER", api.JiraServerAlertType)
+}
+
+func TestIntegrationsNewJiraAlertChannel(t *testing.T) {
+	subject := api.NewJiraAlertChannel("integration_name",
+		api.JiraAlertChannelData{
+			MinAlertSeverity: 1,
+			JiraType:         api.JiraCloudAlertType,
+			JiraUrl:          "mycompany.atlassian.net",
+			IssueType:        "Bug",
+			ProjectID:        "TEST",
+			Username:         "my@username.com",
+			ApiToken:         "my-api-token",
+			IssueGrouping:    "Resources",
+		},
+	)
+	assert.Equal(t, api.JiraIntegration.String(), subject.Type)
+	assert.Equal(t, api.CriticalAlertLevel, subject.Data.MinAlertSeverity)
+	assert.Equal(t, api.JiraCloudAlertType, subject.Data.JiraType)
+}
+
+func TestIntegrationsNewJiraCloudAlertChannel(t *testing.T) {
+	subject := api.NewJiraCloudAlertChannel("integration_name",
+		api.JiraAlertChannelData{
+			JiraUrl:       "mycompany.atlassian.net",
+			IssueType:     "Bug",
+			ProjectID:     "TEST",
+			Username:      "my@username.com",
+			ApiToken:      "my-api-token",
+			IssueGrouping: "Resources",
+		},
+	)
+	assert.Equal(t, api.JiraIntegration.String(), subject.Type)
+	assert.Equal(t, api.JiraCloudAlertType, subject.Data.JiraType)
+}
+
+func TestIntegrationsNewJiraServerAlertChannel(t *testing.T) {
+	subject := api.NewJiraServerAlertChannel("integration_name",
+		api.JiraAlertChannelData{
+			JiraUrl:       "mycompany.atlassian.net",
+			IssueType:     "Bug",
+			ProjectID:     "TEST",
+			Username:      "my@username.com",
+			Password:      "my-password",
+			IssueGrouping: "Resources",
+		},
+	)
+	assert.Equal(t, api.JiraIntegration.String(), subject.Type)
+	assert.Equal(t, api.JiraServerAlertType, subject.Data.JiraType)
+}
+
+func TestIntegrationsCreateJiraAlertChannel(t *testing.T) {
+	var (
+		intgGUID   = intgguid.New()
+		fakeServer = lacework.MockServer()
+	)
+	fakeServer.MockAPI("external/integrations", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method, "CreateJiraAlertChannel should be a POST method")
+
+		if assert.NotNil(t, r.Body) {
+			body := httpBodySniffer(r)
+			assert.Contains(t, body, "integration_name", "integration name is missing")
+			assert.Contains(t, body, "JIRA", "wrong integration type")
+			assert.Contains(t, body, "JIRA_CLOUD", "wrong jira type")
+			assert.Contains(t, body, "mycompany.atlassian.net", "wrong jira url")
+			assert.Contains(t, body, "Bug", "wrong issue type")
+			assert.Contains(t, body, "TEST", "wrong project_id")
+			assert.Contains(t, body, "my@username.com", "wrong username")
+			assert.Contains(t, body, "my-api-token", "wrong api token")
+			assert.Contains(t, body, "Resources", "wrong issue grouping")
+			assert.Contains(t, body, "MIN_ALERT_SEVERITY\":1", "wrong alert severity")
+			assert.Contains(t, body, "ENABLED\":1", "integration is not enabled")
+		}
+
+		fmt.Fprintf(w, jiraIntegrationJsonResponse(intgGUID))
+	})
+	defer fakeServer.Close()
+
+	c, err := api.NewClient("test",
+		api.WithToken("TOKEN"),
+		api.WithURL(fakeServer.URL()),
+	)
+	assert.Nil(t, err)
+
+	data := api.NewJiraAlertChannel("integration_name",
+		api.JiraAlertChannelData{
+			MinAlertSeverity: 1,
+			JiraType:         api.JiraCloudAlertType,
+			JiraUrl:          "mycompany.atlassian.net",
+			IssueType:        "Bug",
+			ProjectID:        "TEST",
+			Username:         "my@username.com",
+			ApiToken:         "my-api-token",
+			IssueGrouping:    "Resources",
+		},
+	)
+	assert.Equal(t, "integration_name", data.Name, "JIRA integration name mismatch")
+	assert.Equal(t, "JIRA", data.Type, "a new JIRA integration should match its type")
+	assert.Equal(t, 1, data.Enabled, "a new JIRA integration should be enabled")
+
+	response, err := c.Integrations.CreateJiraAlertChannel(data)
+	assert.Nil(t, err)
+	assert.NotNil(t, response)
+	assert.True(t, response.Ok)
+	if assert.Equal(t, 1, len(response.Data)) {
+		resData := response.Data[0]
+		assert.Equal(t, intgGUID, resData.IntgGuid)
+		assert.Equal(t, "integration_name", resData.Name)
+		assert.True(t, resData.State.Ok)
+		assert.Equal(t, "mycompany.atlassian.net", resData.Data.JiraUrl)
+		assert.Equal(t, "JIRA_CLOUD", resData.Data.JiraType)
+		assert.Equal(t, "Bug", resData.Data.IssueType)
+		assert.Equal(t, "TEST", resData.Data.ProjectID)
+		assert.Equal(t, "my@username.com", resData.Data.Username)
+		assert.Equal(t, "Resources", resData.Data.IssueGrouping)
+		assert.Equal(t, api.AlertLevel(1), resData.Data.MinAlertSeverity)
+	}
+}
+
+func TestIntegrationsGetJiraAlertChannel(t *testing.T) {
+	var (
+		intgGUID   = intgguid.New()
+		apiPath    = fmt.Sprintf("external/integrations/%s", intgGUID)
+		fakeServer = lacework.MockServer()
+	)
+	fakeServer.MockAPI(apiPath, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method, "GetJiraAlertChannel should be a GET method")
+		fmt.Fprintf(w, jiraIntegrationJsonResponse(intgGUID))
+	})
+	defer fakeServer.Close()
+
+	c, err := api.NewClient("test",
+		api.WithToken("TOKEN"),
+		api.WithURL(fakeServer.URL()),
+	)
+	assert.Nil(t, err)
+
+	response, err := c.Integrations.GetJiraAlertChannel(intgGUID)
+	assert.Nil(t, err)
+	assert.NotNil(t, response)
+	assert.True(t, response.Ok)
+	if assert.Equal(t, 1, len(response.Data)) {
+		resData := response.Data[0]
+		assert.Equal(t, intgGUID, resData.IntgGuid)
+		assert.Equal(t, "integration_name", resData.Name)
+		assert.True(t, resData.State.Ok)
+		assert.Equal(t, "mycompany.atlassian.net", resData.Data.JiraUrl)
+		assert.Equal(t, "JIRA_CLOUD", resData.Data.JiraType)
+		assert.Equal(t, "Bug", resData.Data.IssueType)
+		assert.Equal(t, "TEST", resData.Data.ProjectID)
+		assert.Equal(t, "my@username.com", resData.Data.Username)
+		assert.Equal(t, "Resources", resData.Data.IssueGrouping)
+		assert.Equal(t, api.AlertLevel(1), resData.Data.MinAlertSeverity)
+	}
+}
+
+func TestIntegrationsUpdateJiraAlertChannel(t *testing.T) {
+	var (
+		intgGUID   = intgguid.New()
+		apiPath    = fmt.Sprintf("external/integrations/%s", intgGUID)
+		fakeServer = lacework.MockServer()
+	)
+	fakeServer.MockAPI(apiPath, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "PATCH", r.Method, "UpdateJiraAlertChannel should be a PATCH method")
+
+		if assert.NotNil(t, r.Body) {
+			body := httpBodySniffer(r)
+			assert.Contains(t, body, intgGUID, "INTG_GUID missing")
+			assert.Contains(t, body, "integration_name", "integration name is missing")
+			assert.Contains(t, body, "JIRA", "wrong integration type")
+			assert.Contains(t, body, "JIRA_CLOUD", "wrong jira type")
+			assert.Contains(t, body, "mycompany.atlassian.net", "wrong jira url")
+			assert.Contains(t, body, "Bug", "wrong issue type")
+			assert.Contains(t, body, "TEST", "wrong project_id")
+			assert.Contains(t, body, "my@username.com", "wrong username")
+			assert.Contains(t, body, "my-api-token", "wrong api token")
+			assert.Contains(t, body, "Resources", "wrong issue grouping")
+			assert.Contains(t, body, "MIN_ALERT_SEVERITY\":1", "wrong alert severity")
+			assert.Contains(t, body, "ENABLED\":1", "integration is not enabled")
+		}
+
+		fmt.Fprintf(w, jiraIntegrationJsonResponse(intgGUID))
+	})
+	defer fakeServer.Close()
+
+	c, err := api.NewClient("test",
+		api.WithToken("TOKEN"),
+		api.WithURL(fakeServer.URL()),
+	)
+	assert.Nil(t, err)
+
+	data := api.NewJiraCloudAlertChannel("integration_name",
+		api.JiraAlertChannelData{
+			MinAlertSeverity: 1,
+			JiraUrl:          "mycompany.atlassian.net",
+			IssueType:        "Bug",
+			ProjectID:        "TEST",
+			Username:         "my@username.com",
+			ApiToken:         "my-api-token",
+			IssueGrouping:    "Resources",
+		},
+	)
+	assert.Equal(t, "integration_name", data.Name, "JIRA integration name mismatch")
+	assert.Equal(t, "JIRA", data.Type, "a new JIRA integration should match its type")
+	assert.Equal(t, 1, data.Enabled, "a new JIRA integration should be enabled")
+	data.IntgGuid = intgGUID
+
+	response, err := c.Integrations.UpdateJiraAlertChannel(data)
+	assert.Nil(t, err)
+	assert.NotNil(t, response)
+	assert.Equal(t, "SUCCESS", response.Message)
+	assert.Equal(t, 1, len(response.Data))
+	assert.Equal(t, intgGUID, response.Data[0].IntgGuid)
+}
+
+func TestIntegrationsListJiraAlertChannel(t *testing.T) {
+	var (
+		intgGUIDs  = []string{intgguid.New(), intgguid.New(), intgguid.New()}
+		fakeServer = lacework.MockServer()
+	)
+	fakeServer.MockAPI("external/integrations/type/JIRA",
+		func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "GET", r.Method, "ListJiraAlertChannel should be a GET method")
+			fmt.Fprintf(w, jiraMultiIntegrationJsonResponse(intgGUIDs))
+		},
+	)
+	defer fakeServer.Close()
+
+	c, err := api.NewClient("test",
+		api.WithToken("TOKEN"),
+		api.WithURL(fakeServer.URL()),
+	)
+	assert.Nil(t, err)
+
+	response, err := c.Integrations.ListJiraAlertChannel()
+	assert.Nil(t, err)
+	assert.NotNil(t, response)
+	assert.True(t, response.Ok)
+	assert.Equal(t, len(intgGUIDs), len(response.Data))
+	for _, d := range response.Data {
+		assert.Contains(t, intgGUIDs, d.IntgGuid)
+	}
+}
+
+func jiraIntegrationJsonResponse(intgGUID string) string {
+	return `
+{
+  "data": [` + singleJiraIntegration(intgGUID) + `],
+  "ok": true,
+  "message": "SUCCESS"
+}
+`
+}
+
+func jiraMultiIntegrationJsonResponse(guids []string) string {
+	integrations := []string{}
+	for _, guid := range guids {
+		integrations = append(integrations, singleJiraIntegration(guid))
+	}
+	return `
+{
+"data": [` + strings.Join(integrations, ", ") + `],
+"ok": true,
+"message": "SUCCESS"
+}
+`
+}
+
+func singleJiraIntegration(id string) string {
+	return `
+{
+  "INTG_GUID": "` + id + `",
+  "CREATED_OR_UPDATED_BY": "user@email.com",
+  "CREATED_OR_UPDATED_TIME": "2020-Jul-16 19:59:22 UTC",
+  "DATA": {
+    "ISSUE_GROUPING": "Resources",
+    "ISSUE_TYPE": "Bug",
+    "JIRA_TYPE": "JIRA_CLOUD",
+    "JIRA_URL": "mycompany.atlassian.net",
+    "MIN_ALERT_SEVERITY": 1,
+    "PROJECT_ID": "TEST",
+    "USERNAME": "my@username.com"
+  },
+  "ENABLED": 1,
+  "IS_ORG": 0,
+  "NAME": "integration_name",
+  "STATE": {
+    "lastSuccessfulTime": "2020-Jul-16 18:26:54 UTC",
+    "lastUpdatedTime": "2020-Jul-16 18:26:54 UTC",
+    "ok": true
+  },
+  "TYPE": "JIRA",
+  "TYPE_NAME": "JIRA"
+}
+`
+}

--- a/api/integrations.go
+++ b/api/integrations.go
@@ -63,6 +63,9 @@ const (
 
 	// Pager Duty integration type
 	PagerDutyIntegration
+
+	// Jira integration type
+	JiraIntegration
 )
 
 // IntegrationTypes is the list of available integration types
@@ -78,6 +81,7 @@ var IntegrationTypes = map[integrationType]string{
 	SlackChannelIntegration:      "SLACK_CHANNEL",
 	AwsCloudWatchIntegration:     "CLOUDWATCH_EB",
 	PagerDutyIntegration:         "PAGER_DUTY_API",
+	JiraIntegration:              "JIRA",
 }
 
 // String returns the string representation of an integration type

--- a/cli/cmd/integration.go
+++ b/cli/cmd/integration.go
@@ -193,6 +193,8 @@ func promptCreateIntegration() error {
 				"Slack Alert Channel",
 				"PagerDuty Alert Channel",
 				"AWS CloudWatch Alert Channel",
+				"Jira Cloud Alert Channel",
+				"Jira Server Alert Channel",
 				"Docker Hub",
 				"AWS Config",
 				"AWS CloudTrail",
@@ -219,6 +221,10 @@ func promptCreateIntegration() error {
 		return createPagerDutyAlertChannelIntegration()
 	case "AWS CloudWatch Alert Channel":
 		return createAwsCloudWatchAlertChannelIntegration()
+	case "Jira Cloud Alert Channel":
+		return createJiraCloudAlertChannelIntegration()
+	case "Jira Server Alert Channel":
+		return createJiraServerAlertChannelIntegration()
 	case "Docker Hub":
 		return createDockerHubIntegration()
 	case "AWS Config":
@@ -440,6 +446,30 @@ func reflectIntegrationData(raw api.RawIntegration) [][]string {
 		}
 		out := [][]string{
 			[]string{"INTEGRATION KEY", iData.IntegrationKey},
+			[]string{"ISSUE GROUPING", iData.IssueGrouping},
+			[]string{"ALERT ON SEVERITY", iData.MinAlertSeverity.String()},
+		}
+
+		return out
+
+	case api.JiraIntegration.String():
+
+		var iData api.JiraAlertChannelData
+		err := mapstructure.Decode(raw.Data, &iData)
+		if err != nil {
+			cli.Log.Debugw("unable to decode integration data",
+				"integration_type", raw.Type,
+				"raw_data", raw.Data,
+				"error", err,
+			)
+			break
+		}
+		out := [][]string{
+			[]string{"JIRA INTEGRATION TYPE", iData.JiraType},
+			[]string{"JIRA URL", iData.JiraUrl},
+			[]string{"PROJECT KEY", iData.ProjectID},
+			[]string{"USERNAME", iData.Username},
+			[]string{"ISSUE TYPE", iData.IssueType},
 			[]string{"ISSUE GROUPING", iData.IssueGrouping},
 			[]string{"ALERT ON SEVERITY", iData.MinAlertSeverity.String()},
 		}

--- a/cli/cmd/integration.go
+++ b/cli/cmd/integration.go
@@ -294,6 +294,8 @@ func buildIntDetailsTable(integrations []api.RawIntegration) string {
 	if len(integrations) != 0 {
 		integration := integrations[0]
 		t.AppendBulk(reflectIntegrationData(integration))
+		t.Append([]string{"UPDATE AT", integration.CreatedOrUpdatedTime})
+		t.Append([]string{"UPDATE BY", integration.CreatedOrUpdatedBy})
 		t.AppendBulk(buildIntegrationState(integration.State))
 	}
 	t.Render()
@@ -311,8 +313,8 @@ func buildIntDetailsTable(integrations []api.RawIntegration) string {
 func buildIntegrationState(state *api.IntegrationState) [][]string {
 	if state != nil {
 		return [][]string{
-			[]string{"LAST UPDATED TIME", state.LastUpdatedTime},
-			[]string{"LAST SUCCESSFUL TIME", state.LastSuccessfulTime},
+			[]string{"STATE UPDATED AT", state.LastUpdatedTime},
+			[]string{"LAST SUCCESSFUL STATE", state.LastSuccessfulTime},
 		}
 	}
 

--- a/cli/cmd/integration_jira.go
+++ b/cli/cmd/integration_jira.go
@@ -1,0 +1,182 @@
+//
+// Author:: Salim Afiune Maya (<afiune@lacework.net>)
+// Copyright:: Copyright 2020, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cmd
+
+import (
+	"github.com/AlecAivazis/survey/v2"
+
+	"github.com/lacework/go-sdk/api"
+)
+
+type jiraAlertChannelIntegrationSurvey struct {
+	Name          string
+	Url           string
+	Issue         string
+	Project       string
+	Username      string
+	Token         string
+	Password      string
+	AlertSeverity string `survey:"alert_severity_level"`
+}
+
+func createJiraCloudAlertChannelIntegration() error {
+	questions := []*survey.Question{
+		{
+			Name:     "name",
+			Prompt:   &survey.Input{Message: "Name: "},
+			Validate: survey.Required,
+		},
+		{
+			Name:     "url",
+			Prompt:   &survey.Input{Message: "Jira URL: "},
+			Validate: survey.Required,
+		},
+		{
+			Name:     "issue",
+			Prompt:   &survey.Input{Message: "Issue Type: "},
+			Validate: survey.Required,
+		},
+		{
+			Name:     "project",
+			Prompt:   &survey.Input{Message: "Project Key: "},
+			Validate: survey.Required,
+		},
+		{
+			Name:     "username",
+			Prompt:   &survey.Input{Message: "Username: "},
+			Validate: survey.Required,
+		},
+		{
+			Name:     "token",
+			Prompt:   &survey.Password{Message: "API Token: "},
+			Validate: survey.Required,
+		},
+		{
+			Name: "alert_severity_level",
+			Prompt: &survey.Select{
+				Message: "Alert Severity Level: ",
+				Options: []string{
+					"Critical",
+					"High and above",
+					"Medium and above",
+					"Low and above",
+					"All",
+				},
+			},
+			Validate: survey.Required,
+		},
+	}
+
+	var answers jiraAlertChannelIntegrationSurvey
+	err := survey.Ask(questions, &answers,
+		survey.WithIcons(promptIconsFunc),
+	)
+	if err != nil {
+		return err
+	}
+
+	jira := api.NewJiraCloudAlertChannel(answers.Name,
+		api.JiraAlertChannelData{
+			JiraUrl:          answers.Url,
+			IssueType:        answers.Issue,
+			ProjectID:        answers.Project,
+			Username:         answers.Username,
+			ApiToken:         answers.Token,
+			MinAlertSeverity: alertSeverityToEnum(answers.AlertSeverity),
+		},
+	)
+
+	return createJiraAlertChannelIntegration(jira)
+}
+
+func createJiraServerAlertChannelIntegration() error {
+	questions := []*survey.Question{
+		{
+			Name:     "name",
+			Prompt:   &survey.Input{Message: "Name: "},
+			Validate: survey.Required,
+		},
+		{
+			Name:     "url",
+			Prompt:   &survey.Input{Message: "Jira URL: "},
+			Validate: survey.Required,
+		},
+		{
+			Name:     "issue",
+			Prompt:   &survey.Input{Message: "Issue Type: "},
+			Validate: survey.Required,
+		},
+		{
+			Name:     "project",
+			Prompt:   &survey.Input{Message: "Project Key: "},
+			Validate: survey.Required,
+		},
+		{
+			Name:     "username",
+			Prompt:   &survey.Input{Message: "Username: "},
+			Validate: survey.Required,
+		},
+		{
+			Name:     "password",
+			Prompt:   &survey.Password{Message: "Password: "},
+			Validate: survey.Required,
+		},
+		{
+			Name: "alert_severity_level",
+			Prompt: &survey.Select{
+				Message: "Alert Severity Level: ",
+				Options: []string{
+					"Critical",
+					"High and above",
+					"Medium and above",
+					"Low and above",
+					"All",
+				},
+			},
+			Validate: survey.Required,
+		},
+	}
+
+	var answers jiraAlertChannelIntegrationSurvey
+	err := survey.Ask(questions, &answers,
+		survey.WithIcons(promptIconsFunc),
+	)
+	if err != nil {
+		return err
+	}
+
+	jira := api.NewJiraServerAlertChannel(answers.Name,
+		api.JiraAlertChannelData{
+			JiraUrl:          answers.Url,
+			IssueType:        answers.Issue,
+			ProjectID:        answers.Project,
+			Username:         answers.Username,
+			Password:         answers.Password,
+			MinAlertSeverity: alertSeverityToEnum(answers.AlertSeverity),
+		},
+	)
+	return createJiraAlertChannelIntegration(jira)
+}
+
+func createJiraAlertChannelIntegration(jira api.JiraAlertChannel) error {
+	cli.StartProgress(" Creating integration...")
+	_, err := cli.LwApi.Integrations.CreateJiraAlertChannel(jira)
+	cli.StopProgress()
+	return err
+}


### PR DESCRIPTION
With this change users can now do CRUD operations of Jira
Alert Channels (Integrations), here is a basic usage:

Initialize a new `JiraAlertChannel` struct, then use the new
instance to do CRUD operations.
```go
client, err := api.NewClient("account")
if err != nil {
  return err
}

jiraAlert := api.NewJiraAlertChannel("foo",
  api.JiraAlertChannelData{
    MinAlertSeverity: api.CriticalAlertLevel,
    JiraType:         api.JiraCloudType,
    JiraUrl:          "mycompany.atlassian.net",
    IssueType:        "Bug",
    ProjectID:        "EXAMPLE",
    Username:         "me",
    ApiToken:         "my-api-token",
    IssueGrouping:    "Resources",
  },
)

client.Integrations.CreateJiraAlertChannel(jiraAlert)
```

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>