### PR TITLE
feat(cli): new access-tokens command

### DIFF
--- a/api/auth.go
+++ b/api/auth.go
@@ -24,7 +24,7 @@ import (
 	"go.uber.org/zap"
 )
 
-const defaultTokenExpiryTime = 3600
+const DefaultTokenExpiryTime = 3600
 
 // authConfig representing information like key_id, secret and token
 // used for authenticating requests
@@ -85,7 +85,7 @@ func WithExpirationTime(t int) Option {
 }
 
 // GenerateToken generates a new access token
-func (c *Client) GenerateToken() (response tokenResponse, err error) {
+func (c *Client) GenerateToken() (response TokenResponse, err error) {
 	if c.auth.keyID == "" || c.auth.secret == "" {
 		err = fmt.Errorf("unable to generate access token: auth keys missing")
 		return
@@ -113,7 +113,7 @@ func (c *Client) GenerateToken() (response tokenResponse, err error) {
 }
 
 // GenerateTokenWithKeys generates a new access token with the provided keys
-func (c *Client) GenerateTokenWithKeys(keyID, secretKey string) (tokenResponse, error) {
+func (c *Client) GenerateTokenWithKeys(keyID, secretKey string) (TokenResponse, error) {
 	c.log.Debug("setting up auth",
 		zap.String("key", keyID),
 		zap.String("secret", secretKey),
@@ -123,13 +123,13 @@ func (c *Client) GenerateTokenWithKeys(keyID, secretKey string) (tokenResponse, 
 	return c.GenerateToken()
 }
 
-type tokenResponse struct {
+type TokenResponse struct {
 	Data    []tokenData `json:"data"`
 	Ok      bool        `json:"ok"`
 	Message string      `json:"message"`
 }
 
-func (tr tokenResponse) Token() string {
+func (tr TokenResponse) Token() string {
 	if len(tr.Data) > 0 {
 		// @afiune how do we handle cases where there is more than one token
 		return tr.Data[0].Token

--- a/api/client.go
+++ b/api/client.go
@@ -86,7 +86,7 @@ func NewClient(account string, opts ...Option) (*Client, error) {
 			"User-Agent": fmt.Sprintf("Go Client/%s", Version),
 		},
 		auth: &authConfig{
-			expiration: defaultTokenExpiryTime,
+			expiration: DefaultTokenExpiryTime,
 		},
 		c: &http.Client{Timeout: defaultTimeout},
 	}

--- a/cli/cmd/access_token.go
+++ b/cli/cmd/access_token.go
@@ -1,0 +1,101 @@
+//
+// Author:: Salim Afiune Maya (<afiune@lacework.net>)
+// Copyright:: Copyright 2020, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/lacework/go-sdk/api"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+var (
+	// duration of the access token in seconds
+	durationSeconds int
+
+	// accessTokenCmd represents the access-token command
+	accessTokenCmd = &cobra.Command{
+		Use:   "access-token",
+		Short: "generate temporary access tokens",
+		Long: `Generates a temporary access token that can be used to access the
+Lacework API. The token will be valid for the duration that you specify.`,
+		Args: cobra.NoArgs,
+		RunE: generateAccessToken,
+	}
+)
+
+func init() {
+	// add the access-token command
+	rootCmd.AddCommand(accessTokenCmd)
+
+	accessTokenCmd.Flags().IntVarP(&durationSeconds,
+		"duration_seconds", "d", api.DefaultTokenExpiryTime,
+		"duration in seconds that the access token should remain valid",
+	)
+}
+
+func generateAccessToken(_ *cobra.Command, args []string) error {
+	var (
+		response api.TokenResponse
+		err      error
+	)
+
+	if durationSeconds == api.DefaultTokenExpiryTime {
+		response, err = cli.LwApi.GenerateToken()
+		if err != nil {
+			return errors.Wrap(err, "unable to generate access token")
+		}
+	} else {
+		// if the duration is different from the default,
+		// regenerate the lacework api client
+		client, err := api.NewClient(cli.Account,
+			api.WithLogLevel(cli.LogLevel),
+			api.WithExpirationTime(durationSeconds),
+			api.WithHeader("User-Agent", fmt.Sprintf("Command-Line/%s", Version)),
+		)
+		if err != nil {
+			return errors.Wrap(err, "unable to generate api client")
+		}
+
+		response, err = client.GenerateTokenWithKeys(cli.KeyID, cli.Secret)
+		if err != nil {
+			return errors.Wrap(err, "unable to generate access token")
+		}
+	}
+
+	if len(response.Data) == 0 {
+		return errors.New(`unable to generate access token
+
+The platform did not return any token in the response body, this is very
+unlikely to happen but, hey it happened. Please help us improve the
+Lacework CLI by reporting this issue at:
+
+  https://support.lacework.com/hc/en-us/requests/new
+`)
+	}
+
+	if cli.JSONOutput() {
+		return cli.OutputJSON(response.Data[0])
+	}
+
+	cli.OutputHuman(response.Token())
+	cli.OutputHuman("\n")
+	return nil
+}

--- a/integration/help_test.go
+++ b/integration/help_test.go
@@ -135,6 +135,7 @@ Usage:
   lacework [command]
 
 Available Commands:
+  access-token  generate temporary access tokens
   api           helper to call Lacework's RestfulAPI
   compliance    manage compliance reports
   configure     configure the Lacework CLI


### PR DESCRIPTION
This new command will allow users to generate access tokens:
```
$ lacework access-token --duration_seconds 7200
```

Closes https://github.com/lacework/go-sdk/issues/172

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>