### PR TITLE
alpha+feat: run LQL queries

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -49,6 +49,9 @@ const (
 
 	apiEventsDetails   = "external/events/GetEventDetails"
 	apiEventsDateRange = "external/events/GetEventsForDateRange"
+
+	// Alpha
+	apiLQLQuery = "external/lql/query"
 )
 
 // WithApiV2 configures the client to use the API version 2 (/api/v2)

--- a/api/client.go
+++ b/api/client.go
@@ -43,6 +43,7 @@ type Client struct {
 	log        *zap.Logger
 	headers    map[string]string
 
+	LQL             *LQLService
 	Events          *EventsService
 	Compliance      *ComplianceService
 	Integrations    *IntegrationsService
@@ -90,6 +91,7 @@ func NewClient(account string, opts ...Option) (*Client, error) {
 		},
 		c: &http.Client{Timeout: defaultTimeout},
 	}
+	c.LQL = &LQLService{c}
 	c.Events = &EventsService{c}
 	c.Compliance = &ComplianceService{c}
 	c.Integrations = &IntegrationsService{c}

--- a/api/lql.go
+++ b/api/lql.go
@@ -1,0 +1,57 @@
+//
+// Author:: Salim Afiune Maya (<afiune@lacework.net>)
+// Copyright:: Copyright 2020, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package api
+
+import (
+	"bytes"
+
+	"go.uber.org/zap"
+)
+
+// LQLService is a service that interacts with the LQL
+// endpoints from the Lacework Server
+type LQLService struct {
+	client *Client
+}
+
+func (svc *LQLService) Query(query string) (
+	response map[string]interface{},
+	err error,
+) {
+	request, err := svc.client.NewRequest(
+		"POST",
+		apiLQLQuery,
+		bytes.NewReader([]byte(query)),
+	)
+	if err != nil {
+		return
+	}
+
+	// LQL requires the Content-Type to be 'text/plain'
+	svc.client.log.Debug("setting custom header for LQL", zap.String("Content-Type", "text/plain"))
+	request.Header.Set("Content-Type", "text/plain")
+
+	res, err := svc.client.DoDecoder(request, &response)
+	if err != nil {
+		return
+	}
+	defer res.Body.Close()
+
+	return
+}

--- a/cli/cmd/lql.go
+++ b/cli/cmd/lql.go
@@ -1,0 +1,65 @@
+//
+// Author:: Salim Afiune Maya (<afiune@lacework.net>)
+// Copyright:: Copyright 2020, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cmd
+
+import (
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+var (
+	// lqlCmd represents the lql command
+	lqlCmd = &cobra.Command{
+		Use:    "lql <query>",
+		Hidden: true,
+		Short:  "run an LQL query",
+		Long: `Run an LQL query.
+
+A simple example of an LQL query:
+
+  $ lacework lql 'SimpleLQL_3(RecentComplianceReports Data) {SELECT Data.*}'
+
+NOTE: This feature is not yet available!`,
+		Args: cobra.ExactArgs(1),
+		RunE: runLQLQuery,
+	}
+)
+
+func init() {
+	// add the lql command
+	rootCmd.AddCommand(lqlCmd)
+}
+
+func runLQLQuery(_ *cobra.Command, args []string) error {
+	cli.Log.Debugw("running LQL query", "query", args[0])
+	response, err := cli.LwApi.LQL.Query(args[0])
+	if err != nil {
+		return errors.Wrap(err, "unable to run LQL query")
+	}
+
+	if data, ok := response["data"]; ok {
+		err := cli.OutputJSON(data)
+		return err
+	}
+
+	if err := cli.OutputJSON(response); err != nil {
+		return errors.Wrap(err, "unable to format json response")
+	}
+	return nil
+}


### PR DESCRIPTION
This feature is NOT yet released but we want to start experimenting and
using LQL inside the Lacework CLI, the feature is hidden and the endpoit
is not enabled on any Lacework account in production.

To run a simple LQL query, run:
```
$ lacework lql 'SimpleLQL_3(RecentComplianceReports Data) {SELECT Data.*}'
```

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>