### PR TITLE
refactor: remove legacy field min_alert_severity

### DIFF
--- a/api/integration_alert_channels_aws_cloudwatch.go
+++ b/api/integration_alert_channels_aws_cloudwatch.go
@@ -32,7 +32,6 @@ package api
 //   awsCloudWatch := api.NewAwsCloudWatchAlertChannel("foo",
 //     api.AwsCloudWatchData{
 //       EventBusArn: "arn:aws:events:us-west-2:1234567890:event-bus/default",
-//       MinAlertSeverity: api.MediumAlertLevel,
 //     },
 //   )
 //
@@ -95,7 +94,6 @@ type AwsCloudWatchAlertChannel struct {
 }
 
 type AwsCloudWatchData struct {
-	IssueGrouping    string     `json:"ISSUE_GROUPING,omitempty" mapstructure:"ISSUE_GROUPING"`
-	EventBusArn      string     `json:"EVENT_BUS_ARN" mapstructure:"EVENT_BUS_ARN"`
-	MinAlertSeverity AlertLevel `json:"MIN_ALERT_SEVERITY,omitempty" mapstructure:"MIN_ALERT_SEVERITY"`
+	IssueGrouping string `json:"ISSUE_GROUPING,omitempty" mapstructure:"ISSUE_GROUPING"`
+	EventBusArn   string `json:"EVENT_BUS_ARN" mapstructure:"EVENT_BUS_ARN"`
 }

--- a/api/integration_alert_channels_aws_cloudwatch_test.go
+++ b/api/integration_alert_channels_aws_cloudwatch_test.go
@@ -34,12 +34,10 @@ import (
 func TestIntegrationsNewAwsCloudWatchAlertChannel(t *testing.T) {
 	subject := api.NewAwsCloudWatchAlertChannel("integration_name",
 		api.AwsCloudWatchData{
-			EventBusArn:      "arn:aws:events:us-west-2:1234567890:event-bus/default",
-			MinAlertSeverity: 1,
+			EventBusArn: "arn:aws:events:us-west-2:1234567890:event-bus/default",
 		},
 	)
 	assert.Equal(t, api.AwsCloudWatchIntegration.String(), subject.Type)
-	assert.Equal(t, api.CriticalAlertLevel, subject.Data.MinAlertSeverity)
 }
 
 func TestIntegrationsCreateAwsCloudWatchAlertChannel(t *testing.T) {
@@ -55,7 +53,6 @@ func TestIntegrationsCreateAwsCloudWatchAlertChannel(t *testing.T) {
 			assert.Contains(t, body, "integration_name", "integration name is missing")
 			assert.Contains(t, body, "CLOUDWATCH_EB", "wrong integration type")
 			assert.Contains(t, body, "arn:aws:events:us-west-2:1234567890:event-bus/default", "wrong event bus arn")
-			assert.Contains(t, body, "MIN_ALERT_SEVERITY\":3", "wrong alert severity")
 			assert.Contains(t, body, "ENABLED\":1", "integration is not enabled")
 		}
 
@@ -71,8 +68,7 @@ func TestIntegrationsCreateAwsCloudWatchAlertChannel(t *testing.T) {
 
 	data := api.NewAwsCloudWatchAlertChannel("integration_name",
 		api.AwsCloudWatchData{
-			EventBusArn:      "arn:aws:events:us-west-2:1234567890:event-bus/default",
-			MinAlertSeverity: 3,
+			EventBusArn: "arn:aws:events:us-west-2:1234567890:event-bus/default",
 		},
 	)
 	assert.Equal(t, "integration_name", data.Name, "AwsCloudWatch integration name mismatch")
@@ -89,7 +85,6 @@ func TestIntegrationsCreateAwsCloudWatchAlertChannel(t *testing.T) {
 		assert.Equal(t, "integration_name", resData.Name)
 		assert.True(t, resData.State.Ok)
 		assert.Equal(t, "arn:aws:events:us-west-2:1234567890:event-bus/default", resData.Data.EventBusArn)
-		assert.Equal(t, api.AlertLevel(3), resData.Data.MinAlertSeverity)
 	}
 }
 
@@ -121,7 +116,6 @@ func TestIntegrationsGetAwsCloudWatchAlertChannel(t *testing.T) {
 		assert.Equal(t, "integration_name", resData.Name)
 		assert.True(t, resData.State.Ok)
 		assert.Equal(t, "arn:aws:events:us-west-2:1234567890:event-bus/default", resData.Data.EventBusArn)
-		assert.Equal(t, api.AlertLevel(3), resData.Data.MinAlertSeverity)
 	}
 }
 
@@ -140,7 +134,6 @@ func TestIntegrationsUpdateAwsCloudWatchAlertChannel(t *testing.T) {
 			assert.Contains(t, body, "integration_name", "integration name is missing")
 			assert.Contains(t, body, "CLOUDWATCH_EB", "wrong integration type")
 			assert.Contains(t, body, "arn:aws:events:us-west-2:1234567890:event-bus/default", "wrong event bus arn")
-			assert.Contains(t, body, "MIN_ALERT_SEVERITY\":3", "wrong alert severity")
 			assert.Contains(t, body, "ENABLED\":1", "integration is not enabled")
 		}
 
@@ -156,8 +149,7 @@ func TestIntegrationsUpdateAwsCloudWatchAlertChannel(t *testing.T) {
 
 	data := api.NewAwsCloudWatchAlertChannel("integration_name",
 		api.AwsCloudWatchData{
-			EventBusArn:      "arn:aws:events:us-west-2:1234567890:event-bus/default",
-			MinAlertSeverity: 3,
+			EventBusArn: "arn:aws:events:us-west-2:1234567890:event-bus/default",
 		},
 	)
 	assert.Equal(t, "integration_name", data.Name, "AwsCloudWatch integration name mismatch")
@@ -226,6 +218,7 @@ func awsCloudWatchMultiIntegrationJsonResponse(guids []string) string {
 `
 }
 
+// @afiune heads-up: MIN_ALERT_SEVERITY is a legacy field
 func singleAwsCloudWatchIntegration(id string) string {
 	return `
 {

--- a/api/integration_alert_channels_jira.go
+++ b/api/integration_alert_channels_jira.go
@@ -36,7 +36,6 @@ const (
 //
 //   jiraAlert := api.NewJiraAlertChannel("foo",
 //     api.JiraAlertChannelData{
-//       MinAlertSeverity: api.CriticalAlertLevel,
 //       JiraType:         api.JiraCloudAlertType,
 //       JiraUrl:          "mycompany.atlassian.net",
 //       IssueType:        "Bug",
@@ -118,15 +117,14 @@ type JiraAlertChannel struct {
 }
 
 type JiraAlertChannelData struct {
-	JiraType         string     `json:"JIRA_TYPE" mapstructure:"JIRA_TYPE"`
-	JiraUrl          string     `json:"JIRA_URL" mapstructure:"JIRA_URL"`
-	IssueType        string     `json:"ISSUE_TYPE" mapstructure:"ISSUE_TYPE"`
-	ProjectID        string     `json:"PROJECT_ID" mapstructure:"PROJECT_ID"`
-	Username         string     `json:"USERNAME" mapstructure:"USERNAME"`
-	ApiToken         string     `json:"API_TOKEN,omitempty" mapstructure:"API_TOKEN"` // Jira Cloud
-	Password         string     `json:"PASSWORD,omitempty" mapstructure:"PASSWORD"`   // Jira Server
-	IssueGrouping    string     `json:"ISSUE_GROUPING,omitempty" mapstructure:"ISSUE_GROUPING"`
-	MinAlertSeverity AlertLevel `json:"MIN_ALERT_SEVERITY,omitempty" mapstructure:"MIN_ALERT_SEVERITY"`
+	JiraType      string `json:"JIRA_TYPE" mapstructure:"JIRA_TYPE"`
+	JiraUrl       string `json:"JIRA_URL" mapstructure:"JIRA_URL"`
+	IssueType     string `json:"ISSUE_TYPE" mapstructure:"ISSUE_TYPE"`
+	ProjectID     string `json:"PROJECT_ID" mapstructure:"PROJECT_ID"`
+	Username      string `json:"USERNAME" mapstructure:"USERNAME"`
+	ApiToken      string `json:"API_TOKEN,omitempty" mapstructure:"API_TOKEN"` // Jira Cloud
+	Password      string `json:"PASSWORD,omitempty" mapstructure:"PASSWORD"`   // Jira Server
+	IssueGrouping string `json:"ISSUE_GROUPING,omitempty" mapstructure:"ISSUE_GROUPING"`
 
 	//CustomTemplateFile string `json:"CUSTOM_TEMPLATE_FILE,omitempty"`
 }

--- a/api/integration_alert_channels_jira_test.go
+++ b/api/integration_alert_channels_jira_test.go
@@ -39,18 +39,16 @@ func TestIntegrationsJiraAlertChannelTypes(t *testing.T) {
 func TestIntegrationsNewJiraAlertChannel(t *testing.T) {
 	subject := api.NewJiraAlertChannel("integration_name",
 		api.JiraAlertChannelData{
-			MinAlertSeverity: 1,
-			JiraType:         api.JiraCloudAlertType,
-			JiraUrl:          "mycompany.atlassian.net",
-			IssueType:        "Bug",
-			ProjectID:        "TEST",
-			Username:         "my@username.com",
-			ApiToken:         "my-api-token",
-			IssueGrouping:    "Resources",
+			JiraType:      api.JiraCloudAlertType,
+			JiraUrl:       "mycompany.atlassian.net",
+			IssueType:     "Bug",
+			ProjectID:     "TEST",
+			Username:      "my@username.com",
+			ApiToken:      "my-api-token",
+			IssueGrouping: "Resources",
 		},
 	)
 	assert.Equal(t, api.JiraIntegration.String(), subject.Type)
-	assert.Equal(t, api.CriticalAlertLevel, subject.Data.MinAlertSeverity)
 	assert.Equal(t, api.JiraCloudAlertType, subject.Data.JiraType)
 }
 
@@ -103,7 +101,6 @@ func TestIntegrationsCreateJiraAlertChannel(t *testing.T) {
 			assert.Contains(t, body, "my@username.com", "wrong username")
 			assert.Contains(t, body, "my-api-token", "wrong api token")
 			assert.Contains(t, body, "Resources", "wrong issue grouping")
-			assert.Contains(t, body, "MIN_ALERT_SEVERITY\":1", "wrong alert severity")
 			assert.Contains(t, body, "ENABLED\":1", "integration is not enabled")
 		}
 
@@ -119,14 +116,13 @@ func TestIntegrationsCreateJiraAlertChannel(t *testing.T) {
 
 	data := api.NewJiraAlertChannel("integration_name",
 		api.JiraAlertChannelData{
-			MinAlertSeverity: 1,
-			JiraType:         api.JiraCloudAlertType,
-			JiraUrl:          "mycompany.atlassian.net",
-			IssueType:        "Bug",
-			ProjectID:        "TEST",
-			Username:         "my@username.com",
-			ApiToken:         "my-api-token",
-			IssueGrouping:    "Resources",
+			JiraType:      api.JiraCloudAlertType,
+			JiraUrl:       "mycompany.atlassian.net",
+			IssueType:     "Bug",
+			ProjectID:     "TEST",
+			Username:      "my@username.com",
+			ApiToken:      "my-api-token",
+			IssueGrouping: "Resources",
 		},
 	)
 	assert.Equal(t, "integration_name", data.Name, "JIRA integration name mismatch")
@@ -148,7 +144,6 @@ func TestIntegrationsCreateJiraAlertChannel(t *testing.T) {
 		assert.Equal(t, "TEST", resData.Data.ProjectID)
 		assert.Equal(t, "my@username.com", resData.Data.Username)
 		assert.Equal(t, "Resources", resData.Data.IssueGrouping)
-		assert.Equal(t, api.AlertLevel(1), resData.Data.MinAlertSeverity)
 	}
 }
 
@@ -185,7 +180,6 @@ func TestIntegrationsGetJiraAlertChannel(t *testing.T) {
 		assert.Equal(t, "TEST", resData.Data.ProjectID)
 		assert.Equal(t, "my@username.com", resData.Data.Username)
 		assert.Equal(t, "Resources", resData.Data.IssueGrouping)
-		assert.Equal(t, api.AlertLevel(1), resData.Data.MinAlertSeverity)
 	}
 }
 
@@ -210,7 +204,6 @@ func TestIntegrationsUpdateJiraAlertChannel(t *testing.T) {
 			assert.Contains(t, body, "my@username.com", "wrong username")
 			assert.Contains(t, body, "my-api-token", "wrong api token")
 			assert.Contains(t, body, "Resources", "wrong issue grouping")
-			assert.Contains(t, body, "MIN_ALERT_SEVERITY\":1", "wrong alert severity")
 			assert.Contains(t, body, "ENABLED\":1", "integration is not enabled")
 		}
 
@@ -226,13 +219,12 @@ func TestIntegrationsUpdateJiraAlertChannel(t *testing.T) {
 
 	data := api.NewJiraCloudAlertChannel("integration_name",
 		api.JiraAlertChannelData{
-			MinAlertSeverity: 1,
-			JiraUrl:          "mycompany.atlassian.net",
-			IssueType:        "Bug",
-			ProjectID:        "TEST",
-			Username:         "my@username.com",
-			ApiToken:         "my-api-token",
-			IssueGrouping:    "Resources",
+			JiraUrl:       "mycompany.atlassian.net",
+			IssueType:     "Bug",
+			ProjectID:     "TEST",
+			Username:      "my@username.com",
+			ApiToken:      "my-api-token",
+			IssueGrouping: "Resources",
 		},
 	)
 	assert.Equal(t, "integration_name", data.Name, "JIRA integration name mismatch")
@@ -301,6 +293,7 @@ func jiraMultiIntegrationJsonResponse(guids []string) string {
 `
 }
 
+// @afiune heads-up: MIN_ALERT_SEVERITY is a legacy field
 func singleJiraIntegration(id string) string {
 	return `
 {

--- a/api/integration_alert_channels_pagerduty.go
+++ b/api/integration_alert_channels_pagerduty.go
@@ -32,7 +32,6 @@ package api
 //   pagerduty := api.NewPagerDutyAlertChannel("foo",
 //     api.PagerDutyData{
 //       IntegrationKey:   "1234abc8901abc567abc123abc78e012",
-//       MinAlertSeverity: api.AllAlertLevel,
 //     },
 //   )
 //
@@ -95,7 +94,6 @@ type PagerDutyAlertChannel struct {
 }
 
 type PagerDutyData struct {
-	IssueGrouping    string     `json:"ISSUE_GROUPING,omitempty" mapstructure:"ISSUE_GROUPING"`
-	IntegrationKey   string     `json:"API_INTG_KEY" mapstructure:"API_INTG_KEY"`
-	MinAlertSeverity AlertLevel `json:"MIN_ALERT_SEVERITY,omitempty" mapstructure:"MIN_ALERT_SEVERITY"`
+	IssueGrouping  string `json:"ISSUE_GROUPING,omitempty" mapstructure:"ISSUE_GROUPING"`
+	IntegrationKey string `json:"API_INTG_KEY" mapstructure:"API_INTG_KEY"`
 }

--- a/api/integration_alert_channels_pagerduty_test.go
+++ b/api/integration_alert_channels_pagerduty_test.go
@@ -34,12 +34,10 @@ import (
 func TestIntegrationsNewPagerDutyAlertChannel(t *testing.T) {
 	subject := api.NewPagerDutyAlertChannel("integration_name",
 		api.PagerDutyData{
-			IntegrationKey:   "1234567890abcd1234567890",
-			MinAlertSeverity: 3,
+			IntegrationKey: "1234567890abcd1234567890",
 		},
 	)
 	assert.Equal(t, api.PagerDutyIntegration.String(), subject.Type)
-	assert.Equal(t, api.MediumAlertLevel, subject.Data.MinAlertSeverity)
 }
 
 func TestIntegrationsCreatePagerDutyAlertChannel(t *testing.T) {
@@ -55,7 +53,6 @@ func TestIntegrationsCreatePagerDutyAlertChannel(t *testing.T) {
 			assert.Contains(t, body, "integration_name", "integration name is missing")
 			assert.Contains(t, body, "PAGER_DUTY_API", "wrong integration type")
 			assert.Contains(t, body, "1234567890abcd1234567890", "wrong integration_key")
-			assert.Contains(t, body, "MIN_ALERT_SEVERITY\":3", "wrong alert severity")
 			assert.Contains(t, body, "ENABLED\":1", "integration is not enabled")
 		}
 
@@ -71,8 +68,7 @@ func TestIntegrationsCreatePagerDutyAlertChannel(t *testing.T) {
 
 	data := api.NewPagerDutyAlertChannel("integration_name",
 		api.PagerDutyData{
-			IntegrationKey:   "1234567890abcd1234567890",
-			MinAlertSeverity: 3,
+			IntegrationKey: "1234567890abcd1234567890",
 		},
 	)
 	assert.Equal(t, "integration_name", data.Name, "PagerDuty integration name mismatch")
@@ -89,7 +85,6 @@ func TestIntegrationsCreatePagerDutyAlertChannel(t *testing.T) {
 		assert.Equal(t, "integration_name", resData.Name)
 		assert.True(t, resData.State.Ok)
 		assert.Equal(t, "1234567890abcd1234567890", resData.Data.IntegrationKey)
-		assert.Equal(t, api.AlertLevel(3), resData.Data.MinAlertSeverity)
 	}
 }
 
@@ -121,7 +116,6 @@ func TestIntegrationsGetPagerDutyAlertChannel(t *testing.T) {
 		assert.Equal(t, "integration_name", resData.Name)
 		assert.True(t, resData.State.Ok)
 		assert.Equal(t, "1234567890abcd1234567890", resData.Data.IntegrationKey)
-		assert.Equal(t, api.AlertLevel(3), resData.Data.MinAlertSeverity)
 	}
 }
 
@@ -140,7 +134,6 @@ func TestIntegrationsUpdatePagerDutyAlertChannel(t *testing.T) {
 			assert.Contains(t, body, "integration_name", "integration name is missing")
 			assert.Contains(t, body, "PAGER_DUTY_API", "wrong integration type")
 			assert.Contains(t, body, "1234567890abcd1234567890", "wrong integration_key")
-			assert.Contains(t, body, "MIN_ALERT_SEVERITY\":3", "wrong alert severity")
 			assert.Contains(t, body, "ENABLED\":1", "integration is not enabled")
 		}
 
@@ -156,8 +149,7 @@ func TestIntegrationsUpdatePagerDutyAlertChannel(t *testing.T) {
 
 	data := api.NewPagerDutyAlertChannel("integration_name",
 		api.PagerDutyData{
-			IntegrationKey:   "1234567890abcd1234567890",
-			MinAlertSeverity: 3,
+			IntegrationKey: "1234567890abcd1234567890",
 		},
 	)
 	assert.Equal(t, "integration_name", data.Name, "PagerDuty integration name mismatch")
@@ -226,6 +218,7 @@ func pagerDutyMultiIntegrationJsonResponse(guids []string) string {
 `
 }
 
+// @afiune heads-up: MIN_ALERT_SEVERITY is a legacy field
 func singlePagerDutyIntegration(id string) string {
 	return `
 {

--- a/api/integration_alert_channels_slack.go
+++ b/api/integration_alert_channels_slack.go
@@ -32,7 +32,6 @@ package api
 //   slackChannel := api.NewSlackAlertChannel("foo",
 //     api.SlackChannelData{
 //       SlackUrl: "https://hooks.slack.com/services/ABCD/12345/abcd1234",
-//       MinAlertSeverity: api.CriticalAlertLevel,
 //     },
 //   )
 //
@@ -95,7 +94,6 @@ type SlackAlertChannel struct {
 }
 
 type SlackChannelData struct {
-	IssueGrouping    string     `json:"ISSUE_GROUPING,omitempty" mapstructure:"ISSUE_GROUPING"`
-	SlackUrl         string     `json:"SLACK_URL" mapstructure:"SLACK_URL"`
-	MinAlertSeverity AlertLevel `json:"MIN_ALERT_SEVERITY,omitempty" mapstructure:"MIN_ALERT_SEVERITY"`
+	IssueGrouping string `json:"ISSUE_GROUPING,omitempty" mapstructure:"ISSUE_GROUPING"`
+	SlackUrl      string `json:"SLACK_URL" mapstructure:"SLACK_URL"`
 }

--- a/api/integration_alert_channels_slack_test.go
+++ b/api/integration_alert_channels_slack_test.go
@@ -34,12 +34,10 @@ import (
 func TestIntegrationsNewSlackAlertChannel(t *testing.T) {
 	subject := api.NewSlackAlertChannel("integration_name",
 		api.SlackChannelData{
-			SlackUrl:         "https://hooks.slack.com/services/ABCD/12345/abcd1234",
-			MinAlertSeverity: 3,
+			SlackUrl: "https://hooks.slack.com/services/ABCD/12345/abcd1234",
 		},
 	)
 	assert.Equal(t, api.SlackChannelIntegration.String(), subject.Type)
-	assert.Equal(t, api.MediumAlertLevel, subject.Data.MinAlertSeverity)
 }
 
 func TestIntegrationsCreateSlackAlertChannel(t *testing.T) {
@@ -55,7 +53,6 @@ func TestIntegrationsCreateSlackAlertChannel(t *testing.T) {
 			assert.Contains(t, body, "integration_name", "integration name is missing")
 			assert.Contains(t, body, "SLACK_CHANNEL", "wrong integration type")
 			assert.Contains(t, body, "https://hooks.slack.com/services/ABCD/12345/abcd1234", "wrong slack url")
-			assert.Contains(t, body, "MIN_ALERT_SEVERITY\":3", "wrong alert severity")
 			assert.Contains(t, body, "ENABLED\":1", "integration is not enabled")
 		}
 
@@ -71,8 +68,7 @@ func TestIntegrationsCreateSlackAlertChannel(t *testing.T) {
 
 	data := api.NewSlackAlertChannel("integration_name",
 		api.SlackChannelData{
-			SlackUrl:         "https://hooks.slack.com/services/ABCD/12345/abcd1234",
-			MinAlertSeverity: 3,
+			SlackUrl: "https://hooks.slack.com/services/ABCD/12345/abcd1234",
 		},
 	)
 	assert.Equal(t, "integration_name", data.Name, "SlackChannel integration name mismatch")
@@ -89,7 +85,6 @@ func TestIntegrationsCreateSlackAlertChannel(t *testing.T) {
 		assert.Equal(t, "integration_name", resData.Name)
 		assert.True(t, resData.State.Ok)
 		assert.Equal(t, "https://hooks.slack.com/services/ABCD/12345/abcd1234", resData.Data.SlackUrl)
-		assert.Equal(t, api.AlertLevel(3), resData.Data.MinAlertSeverity)
 	}
 }
 
@@ -121,7 +116,6 @@ func TestIntegrationsGetSlackAlertChannel(t *testing.T) {
 		assert.Equal(t, "integration_name", resData.Name)
 		assert.True(t, resData.State.Ok)
 		assert.Equal(t, "https://hooks.slack.com/services/ABCD/12345/abcd1234", resData.Data.SlackUrl)
-		assert.Equal(t, api.AlertLevel(3), resData.Data.MinAlertSeverity)
 	}
 }
 
@@ -140,7 +134,6 @@ func TestIntegrationsUpdateSlackAlertChannel(t *testing.T) {
 			assert.Contains(t, body, "integration_name", "integration name is missing")
 			assert.Contains(t, body, "SLACK_CHANNEL", "wrong integration type")
 			assert.Contains(t, body, "https://hooks.slack.com/services/ABCD/12345/abcd1234", "wrong slack url")
-			assert.Contains(t, body, "MIN_ALERT_SEVERITY\":3", "wrong alert severity")
 			assert.Contains(t, body, "ENABLED\":1", "integration is not enabled")
 		}
 
@@ -156,8 +149,7 @@ func TestIntegrationsUpdateSlackAlertChannel(t *testing.T) {
 
 	data := api.NewSlackAlertChannel("integration_name",
 		api.SlackChannelData{
-			SlackUrl:         "https://hooks.slack.com/services/ABCD/12345/abcd1234",
-			MinAlertSeverity: 3,
+			SlackUrl: "https://hooks.slack.com/services/ABCD/12345/abcd1234",
 		},
 	)
 	assert.Equal(t, "integration_name", data.Name, "SlackChannel integration name mismatch")
@@ -226,6 +218,7 @@ func slackChanMultiIntegrationJsonResponse(guids []string) string {
 `
 }
 
+// @afiune heads-up: MIN_ALERT_SEVERITY is a legacy field
 func singleSlackChanIntegration(id string) string {
 	return `
 {

--- a/cli/cmd/integration.go
+++ b/cli/cmd/integration.go
@@ -409,7 +409,6 @@ func reflectIntegrationData(raw api.RawIntegration) [][]string {
 		out := [][]string{
 			[]string{"SLACK URL", iData.SlackUrl},
 			[]string{"ISSUE GROUPING", iData.IssueGrouping},
-			[]string{"ALERT ON SEVERITY", iData.MinAlertSeverity.String()},
 		}
 
 		return out
@@ -429,7 +428,6 @@ func reflectIntegrationData(raw api.RawIntegration) [][]string {
 		out := [][]string{
 			[]string{"EVENT BUS ARN", iData.EventBusArn},
 			[]string{"ISSUE GROUPING", iData.IssueGrouping},
-			[]string{"ALERT ON SEVERITY", iData.MinAlertSeverity.String()},
 		}
 
 		return out
@@ -449,7 +447,6 @@ func reflectIntegrationData(raw api.RawIntegration) [][]string {
 		out := [][]string{
 			[]string{"INTEGRATION KEY", iData.IntegrationKey},
 			[]string{"ISSUE GROUPING", iData.IssueGrouping},
-			[]string{"ALERT ON SEVERITY", iData.MinAlertSeverity.String()},
 		}
 
 		return out
@@ -473,7 +470,6 @@ func reflectIntegrationData(raw api.RawIntegration) [][]string {
 			[]string{"USERNAME", iData.Username},
 			[]string{"ISSUE TYPE", iData.IssueType},
 			[]string{"ISSUE GROUPING", iData.IssueGrouping},
-			[]string{"ALERT ON SEVERITY", iData.MinAlertSeverity.String()},
 		}
 
 		return out

--- a/cli/cmd/integration_aws_cloudwatch.go
+++ b/cli/cmd/integration_aws_cloudwatch.go
@@ -36,26 +36,11 @@ func createAwsCloudWatchAlertChannelIntegration() error {
 			Prompt:   &survey.Input{Message: "Event Bus ARN: "},
 			Validate: survey.Required,
 		},
-		{
-			Name: "alert_severity_level",
-			Prompt: &survey.Select{
-				Message: "Alert Severity Level: ",
-				Options: []string{
-					"Critical",
-					"High and above",
-					"Medium and above",
-					"Low and above",
-					"All",
-				},
-			},
-			Validate: survey.Required,
-		},
 	}
 
 	answers := struct {
-		Name          string
-		Arn           string
-		AlertSeverity string `survey:"alert_severity_level"`
+		Name string
+		Arn  string
 	}{}
 
 	err := survey.Ask(questions, &answers,
@@ -67,8 +52,7 @@ func createAwsCloudWatchAlertChannelIntegration() error {
 
 	slack := api.NewAwsCloudWatchAlertChannel(answers.Name,
 		api.AwsCloudWatchData{
-			EventBusArn:      answers.Arn,
-			MinAlertSeverity: alertSeverityToEnum(answers.AlertSeverity),
+			EventBusArn: answers.Arn,
 		},
 	)
 

--- a/cli/cmd/integration_jira.go
+++ b/cli/cmd/integration_jira.go
@@ -25,14 +25,13 @@ import (
 )
 
 type jiraAlertChannelIntegrationSurvey struct {
-	Name          string
-	Url           string
-	Issue         string
-	Project       string
-	Username      string
-	Token         string
-	Password      string
-	AlertSeverity string `survey:"alert_severity_level"`
+	Name     string
+	Url      string
+	Issue    string
+	Project  string
+	Username string
+	Token    string
+	Password string
 }
 
 func createJiraCloudAlertChannelIntegration() error {
@@ -67,20 +66,6 @@ func createJiraCloudAlertChannelIntegration() error {
 			Prompt:   &survey.Password{Message: "API Token: "},
 			Validate: survey.Required,
 		},
-		{
-			Name: "alert_severity_level",
-			Prompt: &survey.Select{
-				Message: "Alert Severity Level: ",
-				Options: []string{
-					"Critical",
-					"High and above",
-					"Medium and above",
-					"Low and above",
-					"All",
-				},
-			},
-			Validate: survey.Required,
-		},
 	}
 
 	var answers jiraAlertChannelIntegrationSurvey
@@ -93,12 +78,11 @@ func createJiraCloudAlertChannelIntegration() error {
 
 	jira := api.NewJiraCloudAlertChannel(answers.Name,
 		api.JiraAlertChannelData{
-			JiraUrl:          answers.Url,
-			IssueType:        answers.Issue,
-			ProjectID:        answers.Project,
-			Username:         answers.Username,
-			ApiToken:         answers.Token,
-			MinAlertSeverity: alertSeverityToEnum(answers.AlertSeverity),
+			JiraUrl:   answers.Url,
+			IssueType: answers.Issue,
+			ProjectID: answers.Project,
+			Username:  answers.Username,
+			ApiToken:  answers.Token,
 		},
 	)
 
@@ -137,20 +121,6 @@ func createJiraServerAlertChannelIntegration() error {
 			Prompt:   &survey.Password{Message: "Password: "},
 			Validate: survey.Required,
 		},
-		{
-			Name: "alert_severity_level",
-			Prompt: &survey.Select{
-				Message: "Alert Severity Level: ",
-				Options: []string{
-					"Critical",
-					"High and above",
-					"Medium and above",
-					"Low and above",
-					"All",
-				},
-			},
-			Validate: survey.Required,
-		},
 	}
 
 	var answers jiraAlertChannelIntegrationSurvey
@@ -163,12 +133,11 @@ func createJiraServerAlertChannelIntegration() error {
 
 	jira := api.NewJiraServerAlertChannel(answers.Name,
 		api.JiraAlertChannelData{
-			JiraUrl:          answers.Url,
-			IssueType:        answers.Issue,
-			ProjectID:        answers.Project,
-			Username:         answers.Username,
-			Password:         answers.Password,
-			MinAlertSeverity: alertSeverityToEnum(answers.AlertSeverity),
+			JiraUrl:   answers.Url,
+			IssueType: answers.Issue,
+			ProjectID: answers.Project,
+			Username:  answers.Username,
+			Password:  answers.Password,
 		},
 	)
 	return createJiraAlertChannelIntegration(jira)

--- a/cli/cmd/integration_pagerduty.go
+++ b/cli/cmd/integration_pagerduty.go
@@ -36,26 +36,11 @@ func createPagerDutyAlertChannelIntegration() error {
 			Prompt:   &survey.Input{Message: "Integration Key: "},
 			Validate: survey.Required,
 		},
-		{
-			Name: "alert_severity_level",
-			Prompt: &survey.Select{
-				Message: "Alert Severity Level: ",
-				Options: []string{
-					"Critical",
-					"High and above",
-					"Medium and above",
-					"Low and above",
-					"All",
-				},
-			},
-			Validate: survey.Required,
-		},
 	}
 
 	answers := struct {
-		Name          string
-		Key           string
-		AlertSeverity string `survey:"alert_severity_level"`
+		Name string
+		Key  string
 	}{}
 
 	err := survey.Ask(questions, &answers,
@@ -67,8 +52,7 @@ func createPagerDutyAlertChannelIntegration() error {
 
 	alert := api.NewPagerDutyAlertChannel(answers.Name,
 		api.PagerDutyData{
-			IntegrationKey:   answers.Key,
-			MinAlertSeverity: alertSeverityToEnum(answers.AlertSeverity),
+			IntegrationKey: answers.Key,
 		},
 	)
 

--- a/cli/cmd/integration_slack_channel.go
+++ b/cli/cmd/integration_slack_channel.go
@@ -36,26 +36,11 @@ func createSlackAlertChannelIntegration() error {
 			Prompt:   &survey.Input{Message: "Slack URL: "},
 			Validate: survey.Required,
 		},
-		{
-			Name: "alert_severity_level",
-			Prompt: &survey.Select{
-				Message: "Alert Severity Level: ",
-				Options: []string{
-					"Critical",
-					"High and above",
-					"Medium and above",
-					"Low and above",
-					"All",
-				},
-			},
-			Validate: survey.Required,
-		},
 	}
 
 	answers := struct {
-		Name          string
-		Url           string
-		AlertSeverity string `survey:"alert_severity_level"`
+		Name string
+		Url  string
 	}{}
 
 	err := survey.Ask(questions, &answers,
@@ -67,8 +52,7 @@ func createSlackAlertChannelIntegration() error {
 
 	slack := api.NewSlackAlertChannel(answers.Name,
 		api.SlackChannelData{
-			SlackUrl:         answers.Url,
-			MinAlertSeverity: alertSeverityToEnum(answers.AlertSeverity),
+			SlackUrl: answers.Url,
 		},
 	)
 
@@ -76,21 +60,4 @@ func createSlackAlertChannelIntegration() error {
 	_, err = cli.LwApi.Integrations.CreateSlackAlertChannel(slack)
 	cli.StopProgress()
 	return err
-}
-
-func alertSeverityToEnum(level string) api.AlertLevel {
-	switch level {
-	case "Critical":
-		return api.CriticalAlertLevel
-	case "High and above":
-		return api.HighAlertLevel
-	case "Medium and above":
-		return api.MediumAlertLevel
-	case "Low and above":
-		return api.LowAlertLevel
-	case "All":
-		return api.AllAlertLevel
-	default:
-		return api.MediumAlertLevel
-	}
 }


### PR DESCRIPTION
The team was not aware of the fact that that the `min_alert_severity`
field is a legacy field that is no longer in use by the platform, it was
deprecated in favor of Alert Rules.

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>