### PR TITLE
feat(cli): better ux in account validation

### DIFF
--- a/integration/configure_test.go
+++ b/integration/configure_test.go
@@ -242,7 +242,8 @@ func TestConfigureCommandErrors(t *testing.T) {
 			c.ExpectString("Account:")
 			c.SendLine("")
 			c.ExpectString("The account subdomain of URL is required")
-			c.SendLine("my-account")
+			c.SendLine("my-account.lacework.net") // if the full URL was provided we transform it and inform the user
+			c.ExpectString("Passing '.lacework.net' domain not required. Using 'my-account'")
 			c.ExpectString("Access Key ID:")
 			c.SendLine("")
 			c.ExpectString("The API access key id must have more than 55 characters")


### PR DESCRIPTION
This change will add a better user-experience to the `lacework configure`
command so that if the user provides the complete URL as the account
name we will subtract the account and notify the end-user:

```
$ lacework configure
Passing '.lacework.net' domain not required. Using 'tech-ally'
▸ Account: tech-ally
▸ Access Key ID: TECHALLY_1234567890
▸ Secret Access Key: (*****************************91f3)

You are all set!
```

Closes https://github.com/lacework/go-sdk/issues/86

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>