### PR TITLE
feat: add event flags --severity and --days

### DIFF
--- a/api/events.go
+++ b/api/events.go
@@ -31,6 +31,9 @@ type EventsService struct {
 	client *Client
 }
 
+// ValidEventSeverities is a list of all valid event severities
+var ValidEventSeverities = []string{"critical", "high", "medium", "low", "info"}
+
 // List leverages ListDateRange and returns a list of events from the last 7 days
 func (svc *EventsService) List() (EventsResponse, error) {
 	var (

--- a/cli/cmd/event.go
+++ b/cli/cmd/event.go
@@ -42,6 +42,9 @@ var (
 
 		// list events from an specific number of days
 		Days int
+
+		// list events with a specific severity
+		Severity string
 	}{}
 
 	// easily add or remove borders to all event details tables
@@ -58,10 +61,17 @@ var (
 	// eventListCmd represents the list sub-command inside the event command
 	eventListCmd = &cobra.Command{
 		Use:   "list",
-		Short: "list all events from a date range (default last 7 days)",
-		Long: `List all events from a time range, by default this command displays the
-events from the last 7 days, but it is possible to specify a different
-time range.`,
+		Short: "list all events (default last 7 days)",
+		Long: `List all events for the last 7 days by default, or pass --start and --end to
+specify a custom time period. You can also pass --serverity to filter by a
+severity threshold.
+
+Additionally, pass --days to list events for a specified number of days.
+
+For example, to list all events from the last day with severity medium and above
+(Critical, High and Medium) run:
+
+  $ lacework events list --severity medium --days 1`,
 		Args: cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
 
@@ -69,6 +79,15 @@ time range.`,
 				response api.EventsResponse
 				err      error
 			)
+
+			if eventsCmdState.Severity != "" {
+				if !array.ContainsStr(api.ValidEventSeverities, eventsCmdState.Severity) {
+					return errors.Errorf("the severity %s is not valid, use one of %s",
+						eventsCmdState.Severity, strings.Join(api.ValidEventSeverities, ", "),
+					)
+				}
+			}
+
 			if eventsCmdState.Start != "" || eventsCmdState.End != "" {
 				start, end, errT := parseStartAndEndTime(eventsCmdState.Start, eventsCmdState.End)
 				if errT != nil {
@@ -97,16 +116,30 @@ time range.`,
 			}
 
 			cli.Log.Debugw("events", "raw", response)
-			// Sort the events from the response by severity
-			sort.Slice(response.Events, func(i, j int) bool {
-				return response.Events[i].Severity < response.Events[j].Severity
+
+			// filter events by severity, if the user didn't specify a severity
+			// the funtion will return it back without modifications
+			events := filterEventsWithSeverity(response.Events)
+
+			// Sort the events by severity
+			sort.Slice(events, func(i, j int) bool {
+				return events[i].Severity < events[j].Severity
 			})
 
 			if cli.JSONOutput() {
-				return cli.OutputJSON(response.Events)
+				return cli.OutputJSON(events)
 			}
 
-			cli.OutputHuman(eventsToTableReport(response.Events))
+			if len(events) == 0 {
+				if eventsCmdState.Severity != "" {
+					cli.OutputHuman("There are no events with the specified severity.\n")
+				} else {
+					cli.OutputHuman("There are no events in your account in the specified time range.\n")
+				}
+				return nil
+			}
+
+			cli.OutputHuman(eventsToTableReport(events))
 			return nil
 		},
 	}
@@ -164,7 +197,15 @@ func init() {
 	)
 	// add days flag to events list command
 	eventListCmd.Flags().IntVar(&eventsCmdState.Days,
-		"days", 0, "list events from an specific number of days (max: 7 days)",
+		"days", 0, "list events for specified number of days (max: 7 days)",
+	)
+	// add severity flag to events list command
+	eventListCmd.Flags().StringVar(&eventsCmdState.Severity,
+		"severity", "",
+		fmt.Sprintf(
+			"filter events by severity threshold (%s)",
+			strings.Join(api.ValidEventSeverities, ", "),
+		),
 	)
 
 	eventCmd.AddCommand(eventShowCmd)
@@ -912,4 +953,41 @@ func eventMachineEntitiesTable(machines []api.EventMachineEntity) string {
 	t.Render()
 
 	return r.String()
+}
+
+func filterEventsWithSeverity(events []api.Event) []api.Event {
+	if eventsCmdState.Severity == "" {
+		return events
+	}
+
+	sevThreshold, sevString := eventSeverityToProperTypes(eventsCmdState.Severity)
+	cli.Log.Debugw("filtering events", "threshold", sevThreshold, "severity", sevString)
+	eFiltered := []api.Event{}
+	for _, event := range events {
+		eventSeverity, _ := eventSeverityToProperTypes(event.Severity)
+		if eventSeverity <= sevThreshold {
+			eFiltered = append(eFiltered, event)
+		}
+	}
+
+	cli.Log.Debugw("filtered events", "events", eFiltered)
+
+	return eFiltered
+}
+
+func eventSeverityToProperTypes(severity string) (int, string) {
+	switch strings.ToLower(severity) {
+	case "1", "critical":
+		return 1, "Critical"
+	case "2", "high":
+		return 2, "High"
+	case "3", "medium":
+		return 3, "Medium"
+	case "4", "low":
+		return 4, "Low"
+	case "5", "info":
+		return 5, "Info"
+	default:
+		return 6, "Unknown"
+	}
 }

--- a/cli/cmd/event.go
+++ b/cli/cmd/event.go
@@ -39,6 +39,9 @@ var (
 
 		// end time for listing events
 		End string
+
+		// list events from an specific number of days
+		Days int
 	}{}
 
 	// easily add or remove borders to all event details tables
@@ -56,8 +59,7 @@ var (
 	eventListCmd = &cobra.Command{
 		Use:   "list",
 		Short: "list all events from a date range (default last 7 days)",
-		Long: `
-List all events from a time range, by default this command displays the
+		Long: `List all events from a time range, by default this command displays the
 events from the last 7 days, but it is possible to specify a different
 time range.`,
 		Args: cobra.NoArgs,
@@ -75,6 +77,14 @@ time range.`,
 
 				cli.Log.Infow("requesting list of events from custom time range",
 					"start_time", start, "end_time", end,
+				)
+				response, err = cli.LwApi.Events.ListDateRange(start, end)
+			} else if eventsCmdState.Days != 0 {
+				end := time.Now()
+				start := end.Add(time.Hour * 24 * time.Duration(eventsCmdState.Days) * -1)
+
+				cli.Log.Infow("requesting list of events from specific days",
+					"days", eventsCmdState.Days, "start_time", start, "end_time", end,
 				)
 				response, err = cli.LwApi.Events.ListDateRange(start, end)
 			} else {
@@ -151,6 +161,10 @@ func init() {
 	// add end flag to events list command
 	eventListCmd.Flags().StringVar(&eventsCmdState.End,
 		"end", "", "end of the time range in UTC (format: yyyy-MM-ddTHH:mm:ssZ)",
+	)
+	// add days flag to events list command
+	eventListCmd.Flags().IntVar(&eventsCmdState.Days,
+		"days", 0, "list events from an specific number of days (max: 7 days)",
 	)
 
 	eventCmd.AddCommand(eventShowCmd)

--- a/cli/cmd/integration.go
+++ b/cli/cmd/integration.go
@@ -294,8 +294,8 @@ func buildIntDetailsTable(integrations []api.RawIntegration) string {
 	if len(integrations) != 0 {
 		integration := integrations[0]
 		t.AppendBulk(reflectIntegrationData(integration))
-		t.Append([]string{"UPDATE AT", integration.CreatedOrUpdatedTime})
-		t.Append([]string{"UPDATE BY", integration.CreatedOrUpdatedBy})
+		t.Append([]string{"UPDATED AT", integration.CreatedOrUpdatedTime})
+		t.Append([]string{"UPDATED BY", integration.CreatedOrUpdatedBy})
 		t.AppendBulk(buildIntegrationState(integration.State))
 	}
 	t.Render()

--- a/integration/event_test.go
+++ b/integration/event_test.go
@@ -58,6 +58,28 @@ func TestEventCommandList(t *testing.T) {
 		"EXITCODE is not the expected one")
 }
 
+func TestEventCommandListDays(t *testing.T) {
+	// @afiune could we find a way to generate a consistent event? but if we do
+	// wouldn't the ML learn it and then become a known behavior? uhmmm
+	// for now we will just check that we have the headers :wink:
+	out, err, exitcode := LaceworkCLIWithTOMLConfig("event", "list", "--days", "1")
+	assert.Contains(t, out.String(), "EVENT ID",
+		"STDOUT table headers changed, please check")
+	assert.Contains(t, out.String(), "TYPE",
+		"STDOUT table headers changed, please check")
+	assert.Contains(t, out.String(), "SEVERITY",
+		"STDOUT table headers changed, please check")
+	assert.Contains(t, out.String(), "START TIME",
+		"STDOUT table headers changed, please check")
+	assert.Contains(t, out.String(), "END TIME",
+		"STDOUT table headers changed, please check")
+	assert.Empty(t,
+		err.String(),
+		"STDERR should be empty")
+	assert.Equal(t, 0, exitcode,
+		"EXITCODE is not the expected one")
+}
+
 func TestEventCommandListTimeRange(t *testing.T) {
 	var (
 		now  = time.Now().UTC()

--- a/integration/event_test.go
+++ b/integration/event_test.go
@@ -80,6 +80,17 @@ func TestEventCommandListDays(t *testing.T) {
 		"EXITCODE is not the expected one")
 }
 
+func TestEventCommandListSeverityError(t *testing.T) {
+	out, err, exitcode := LaceworkCLIWithTOMLConfig("event", "list", "--severity", "foo")
+	assert.Contains(t, err.String(), "ERROR the severity foo is not valid, use one of critical, high, medium, low, info",
+		"STDERR the message to the user has changed, update please")
+	assert.Empty(t,
+		out.String(),
+		"STDOUT should be empty")
+	assert.Equal(t, 1, exitcode,
+		"EXITCODE is not the expected one")
+}
+
 func TestEventCommandListTimeRange(t *testing.T) {
 	var (
 		now  = time.Now().UTC()


### PR DESCRIPTION
## Use cases
Show me all the events from the past day:
``` 
$ lacework events list --days 1
```

Show me all the events from the past three days:
``` 
$ lacework events list --days 3
```

Show me all the events from the last 7 days that has severity high and above (Critical & High)
```
$ lacework events list --severity high
```

Show me all the events from the last day that has severity medium and above (Critical, High and Medium)
```
$ lacework events list --severity medium --days 1
```

Provide only the start time for the time range:
```
$ lacework events list --start 2020-08-18T00:00:00Z
```

Closes https://github.com/lacework/go-sdk/issues/195
Closes https://github.com/lacework/go-sdk/issues/192

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>