### PR TITLE
feat(api): encode custom_template_file for Jira int

### DIFF
--- a/api/_examples/aws-cloudwatch-alert-channel/main.go
+++ b/api/_examples/aws-cloudwatch-alert-channel/main.go
@@ -15,8 +15,7 @@ func main() {
 
 	alert := api.NewAwsCloudWatchAlertChannel("aws-cloudwatch-alert-from-golang",
 		api.AwsCloudWatchData{
-			EventBusArn:      "arn:aws:events:us-west-2:1234567890:event-bus/default",
-			MinAlertSeverity: 1,
+			EventBusArn: "arn:aws:events:us-west-2:1234567890:event-bus/default",
 		},
 	)
 

--- a/api/_examples/jira-cloud-with-custom-template-alert-channel/main.go
+++ b/api/_examples/jira-cloud-with-custom-template-alert-channel/main.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"log"
+
+	"github.com/lacework/go-sdk/api"
+)
+
+func main() {
+	lacework, err := api.NewClient("account", api.WithApiKeys("KEY", "SECRET"))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	jiraTemplateJSON := `{
+      "fields": {
+          "labels": [
+              "myLabel"
+          ],
+          "priority":
+          {
+              "id": "1"
+          }
+      }
+  }`
+	jira := api.JiraAlertChannelData{
+		JiraType:      api.JiraCloudAlertType,
+		JiraUrl:       "mycompany.atlassian.net",
+		IssueType:     "Bug",
+		ProjectID:     "TEST",
+		Username:      "my@username.com",
+		ApiToken:      "my-api-token",
+		IssueGrouping: "Resources",
+	}
+	jira.EncodeCustomTemplateFile(jiraTemplateJSON)
+	jiraAlert := api.NewJiraAlertChannel("integration_name", jira)
+	client.Integrations.CreateJiraAlertChannel(jiraAlert)
+}

--- a/api/_examples/slack-alert-channel/main.go
+++ b/api/_examples/slack-alert-channel/main.go
@@ -15,8 +15,7 @@ func main() {
 
 	mySlackChannel := api.NewSlackAlertChannel("slack-alert-from-golang",
 		api.SlackChannelData{
-			SlackUrl:         "https://hooks.slack.com/services/ABCD/12345/abcd1234",
-			MinAlertSeverity: 3,
+			SlackUrl: "https://hooks.slack.com/services/ABCD/12345/abcd1234",
 		},
 	)
 

--- a/api/integration_alert_channels_jira.go
+++ b/api/integration_alert_channels_jira.go
@@ -18,6 +18,11 @@
 
 package api
 
+import (
+	"encoding/base64"
+	"fmt"
+)
+
 const (
 	JiraCloudAlertType  = "JIRA_CLOUD"
 	JiraServerAlertType = "JIRA_SERVER"
@@ -126,5 +131,15 @@ type JiraAlertChannelData struct {
 	Password      string `json:"PASSWORD,omitempty" mapstructure:"PASSWORD"`   // Jira Server
 	IssueGrouping string `json:"ISSUE_GROUPING,omitempty" mapstructure:"ISSUE_GROUPING"`
 
-	//CustomTemplateFile string `json:"CUSTOM_TEMPLATE_FILE,omitempty"`
+	// This field must be a base64 encode with the following format:
+	//
+	// "data:application/json;name=i.json;base64,[ENCODING]"
+	//
+	// [ENCODING] is the the base64 encode, use EncodeCustomTemplateFile() to encode a JSON template
+	CustomTemplateFile string `json:"CUSTOM_TEMPLATE_FILE,omitempty"`
+}
+
+func (jira *JiraAlertChannelData) EncodeCustomTemplateFile(template string) {
+	encodedTemplate := base64.StdEncoding.EncodeToString([]byte(template))
+	jira.CustomTemplateFile = fmt.Sprintf("data:application/json;name=i.json;base64,%s", encodedTemplate)
 }

--- a/api/integration_alert_channels_jira_test.go
+++ b/api/integration_alert_channels_jira_test.go
@@ -52,6 +52,39 @@ func TestIntegrationsNewJiraAlertChannel(t *testing.T) {
 	assert.Equal(t, api.JiraCloudAlertType, subject.Data.JiraType)
 }
 
+func TestIntegrationsNewJiraAlertChannelWithCustomTemplateFile(t *testing.T) {
+	templateJSON := `{
+      "fields": {
+          "labels": [
+              "myLabel"
+          ],
+          "priority": 
+          {
+              "id": "1"
+          }
+      }
+  }`
+	jira := api.JiraAlertChannelData{
+		JiraType:      api.JiraCloudAlertType,
+		JiraUrl:       "mycompany.atlassian.net",
+		IssueType:     "Bug",
+		ProjectID:     "TEST",
+		Username:      "my@username.com",
+		ApiToken:      "my-api-token",
+		IssueGrouping: "Resources",
+	}
+	jira.EncodeCustomTemplateFile(templateJSON)
+
+	subject := api.NewJiraAlertChannel("integration_name", jira)
+	assert.Equal(t, api.JiraIntegration.String(), subject.Type)
+	assert.Equal(t, api.JiraCloudAlertType, subject.Data.JiraType)
+	assert.Contains(t,
+		subject.Data.CustomTemplateFile,
+		"data:application/json;name=i.json;base64,",
+		"check the custom_template_file encoder",
+	)
+}
+
 func TestIntegrationsNewJiraCloudAlertChannel(t *testing.T) {
 	subject := api.NewJiraCloudAlertChannel("integration_name",
 		api.JiraAlertChannelData{

--- a/cli/cmd/integration_jira.go
+++ b/cli/cmd/integration_jira.go
@@ -76,17 +76,41 @@ func createJiraCloudAlertChannelIntegration() error {
 		return err
 	}
 
-	jira := api.NewJiraCloudAlertChannel(answers.Name,
-		api.JiraAlertChannelData{
-			JiraUrl:   answers.Url,
-			IssueType: answers.Issue,
-			ProjectID: answers.Project,
-			Username:  answers.Username,
-			ApiToken:  answers.Token,
-		},
-	)
+	jira := api.JiraAlertChannelData{
+		JiraUrl:   answers.Url,
+		IssueType: answers.Issue,
+		ProjectID: answers.Project,
+		Username:  answers.Username,
+		ApiToken:  answers.Token,
+	}
 
-	return createJiraAlertChannelIntegration(jira)
+	// ask the user if they would like to configure a Custom Template
+	custom := false
+	err = survey.AskOne(&survey.Confirm{
+		Message: "Configure a Custom Template File?",
+	}, &custom)
+
+	if err != nil {
+		return err
+	}
+
+	if custom {
+		var content string
+
+		err = survey.AskOne(&survey.Editor{
+			Message:  "Provide the Custom Template File in JSON format",
+			FileName: "*.json",
+		}, &content)
+
+		if err != nil {
+			return err
+		}
+
+		jira.EncodeCustomTemplateFile(content)
+	}
+
+	jiraAlert := api.NewJiraCloudAlertChannel(answers.Name, jira)
+	return createJiraAlertChannelIntegration(jiraAlert)
 }
 
 func createJiraServerAlertChannelIntegration() error {
@@ -131,16 +155,43 @@ func createJiraServerAlertChannelIntegration() error {
 		return err
 	}
 
-	jira := api.NewJiraServerAlertChannel(answers.Name,
-		api.JiraAlertChannelData{
-			JiraUrl:   answers.Url,
-			IssueType: answers.Issue,
-			ProjectID: answers.Project,
-			Username:  answers.Username,
-			Password:  answers.Password,
-		},
-	)
-	return createJiraAlertChannelIntegration(jira)
+	jira := api.JiraAlertChannelData{
+		JiraUrl:   answers.Url,
+		IssueType: answers.Issue,
+		ProjectID: answers.Project,
+		Username:  answers.Username,
+		Password:  answers.Password,
+	}
+
+	// ask the user if they would like to configure a Custom Template
+	custom := false
+	err = survey.AskOne(&survey.Confirm{
+		Message: "Configure a Custom Template File?",
+	}, &custom)
+
+	if err != nil {
+		return err
+	}
+
+	if custom {
+		var content string
+
+		err = survey.AskOne(&survey.Editor{
+			Message:  "Provide the Custom Template File in JSON format",
+			FileName: "*.json",
+		}, &content)
+
+		if err != nil {
+			return err
+		}
+
+		if len(content) != 0 {
+			jira.EncodeCustomTemplateFile(content)
+		}
+	}
+
+	jiraAlert := api.NewJiraServerAlertChannel(answers.Name, jira)
+	return createJiraAlertChannelIntegration(jiraAlert)
 }
 
 func createJiraAlertChannelIntegration(jira api.JiraAlertChannel) error {

--- a/integration/event_test.go
+++ b/integration/event_test.go
@@ -94,7 +94,7 @@ func TestEventCommandListSeverityError(t *testing.T) {
 func TestEventCommandListTimeRange(t *testing.T) {
 	var (
 		now  = time.Now().UTC()
-		from = now.AddDate(0, 0, -2) // 2 days from now
+		from = now.AddDate(0, 0, -4) // 4 days from now
 	)
 
 	out, err, exitcode := LaceworkCLIWithTOMLConfig("event", "list", "--start", from.Format(time.RFC3339), "--end", now.Format(time.RFC3339))


### PR DESCRIPTION
This change allows users to use the `CustomTemplateFile` field inside
the `JiraAlertChannelData` struct to pass a Custom Jira Template.

An example:
```go
func main() {
	lacework, err := api.NewClient("account", api.WithApiKeys("KEY", "SECRET"))
	if err != nil {
		log.Fatal(err)
	}

	jiraTemplateJSON := `{
      "fields": {
          "labels": [
              "myLabel"
          ],
          "priority":
          {
              "id": "1"
          }
      }
  }`
	jira := api.JiraAlertChannelData{
		JiraType:      api.JiraCloudAlertType,
		JiraUrl:       "mycompany.atlassian.net",
		IssueType:     "Bug",
		ProjectID:     "TEST",
		Username:      "my@username.com",
		ApiToken:      "my-api-token",
		IssueGrouping: "Resources",
	}
	jira.EncodeCustomTemplateFile(jiraTemplateJSON)
	jiraAlert := api.NewJiraAlertChannel("integration_name", jira)
	client.Integrations.CreateJiraAlertChannel(jiraAlert)
}
```

Additionally, we are adding this functionality to the Lacework CLI:

    $ lacework integration create
    ? Choose an integration type to create:  Jira Cloud Alert Channel
    ▸ Name:  cli jira cloud
    ▸ Jira URL:  mycompany.atlassian.net
    ▸ Issue Type:  Bug
    ▸ Project Key:  EXAMPLE
    ▸ Username:  my@username.com
    ▸ API Token:  ********
    ? Configure a Custom Template File? Yes
    ? Provide the Custom Template File in JSON format <Received>
    The integration was created.

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>