### PR TITLE
feat: add decoder for jira custom_template_file

### DIFF
--- a/api/integration_alert_channels_jira.go
+++ b/api/integration_alert_channels_jira.go
@@ -21,6 +21,7 @@ package api
 import (
 	"encoding/base64"
 	"fmt"
+	"strings"
 )
 
 const (
@@ -136,10 +137,26 @@ type JiraAlertChannelData struct {
 	// "data:application/json;name=i.json;base64,[ENCODING]"
 	//
 	// [ENCODING] is the the base64 encode, use EncodeCustomTemplateFile() to encode a JSON template
-	CustomTemplateFile string `json:"CUSTOM_TEMPLATE_FILE,omitempty"`
+	CustomTemplateFile string `json:"CUSTOM_TEMPLATE_FILE,omitempty" mapstructure:"CUSTOM_TEMPLATE_FILE"`
 }
 
 func (jira *JiraAlertChannelData) EncodeCustomTemplateFile(template string) {
 	encodedTemplate := base64.StdEncoding.EncodeToString([]byte(template))
 	jira.CustomTemplateFile = fmt.Sprintf("data:application/json;name=i.json;base64,%s", encodedTemplate)
+}
+
+func (jira *JiraAlertChannelData) DecodeCustomTemplateFile() (string, error) {
+	if len(jira.CustomTemplateFile) == 0 {
+		return "", nil
+	}
+
+	var (
+		b64      = strings.Split(jira.CustomTemplateFile, ",")
+		raw, err = base64.StdEncoding.DecodeString(b64[1])
+	)
+	if err != nil {
+		return "", err
+	}
+
+	return string(raw), nil
 }

--- a/api/integration_alert_channels_jira_test.go
+++ b/api/integration_alert_channels_jira_test.go
@@ -83,6 +83,17 @@ func TestIntegrationsNewJiraAlertChannelWithCustomTemplateFile(t *testing.T) {
 		"data:application/json;name=i.json;base64,",
 		"check the custom_template_file encoder",
 	)
+	templateString, err := subject.Data.DecodeCustomTemplateFile()
+	assert.Nil(t, err)
+	assert.Equal(t, templateJSON, templateString)
+
+	// When there is no custom template file, this function should
+	// return an empty string to match the pattern
+	subject.Data.CustomTemplateFile = ""
+	templateString, err = subject.Data.DecodeCustomTemplateFile()
+	assert.Nil(t, err)
+	assert.Equal(t, "", templateString)
+
 }
 
 func TestIntegrationsNewJiraCloudAlertChannel(t *testing.T) {

--- a/cli/cmd/integration.go
+++ b/cli/cmd/integration.go
@@ -290,6 +290,7 @@ func buildIntDetailsTable(integrations []api.RawIntegration) string {
 	)
 
 	t.SetBorder(false)
+	t.SetAutoWrapText(false)
 	t.SetAlignment(tablewriter.ALIGN_LEFT)
 	if len(integrations) != 0 {
 		integration := integrations[0]
@@ -463,6 +464,15 @@ func reflectIntegrationData(raw api.RawIntegration) [][]string {
 			)
 			break
 		}
+
+		templateString, err := iData.DecodeCustomTemplateFile()
+		if err != nil {
+			cli.Log.Debugw("unable to decode custom template file",
+				"integration_type", raw.Type,
+				"raw_data", iData.CustomTemplateFile,
+				"error", err,
+			)
+		}
 		out := [][]string{
 			[]string{"JIRA INTEGRATION TYPE", iData.JiraType},
 			[]string{"JIRA URL", iData.JiraUrl},
@@ -470,6 +480,7 @@ func reflectIntegrationData(raw api.RawIntegration) [][]string {
 			[]string{"USERNAME", iData.Username},
 			[]string{"ISSUE TYPE", iData.IssueType},
 			[]string{"ISSUE GROUPING", iData.IssueGrouping},
+			[]string{"CUSTOM TEMPLATE FILE", templateString},
 		}
 
 		return out


### PR DESCRIPTION
This will help the CLI and Terraform provider to decode the Custom Template File that the API returns:
```
$ lacework int show TECHALLY_9D32C5DB324FEB13B9D24988E6216B5EC448A3B8B2631DF
                      INTEGRATION GUID                     |              NAME              | TYPE | STATUS  | STATE
-----------------------------------------------------------+--------------------------------+------+---------+--------
  TECHALLY_9D32C5DB324FEB13B9D24988E6216B5EC448A3B8B2631DF | My Jira Cloud Alert Channel    | JIRA | Enabled | Check

                     INTEGRATION DETAILS
-------------------------------------------------------------
    JIRA INTEGRATION TYPE | JIRA_CLOUD
    JIRA URL              | mycompany.atlassian.net
    PROJECT KEY           | EXAMPLE
    USERNAME              | my@username.com
    ISSUE TYPE            | Bug
    ISSUE GROUPING        | Events
    CUSTOM TEMPLATE FILE  | {
                          |     "fields": {
                          |         "labels": [
                          |             "myLabel"
                          |         ],
                          |         "priority":
                          |         {
                          |             "id": "1"
                          |         }
                          |     }
                          | }
                          |
    UPDATED AT            | 2020-Aug-27 17:45:17 UTC
    UPDATED BY            | salim.afiunemaya@lacework.net

```

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>