### PR TITLE
feat: add DockerV2, ECR and GCR container registries

### DIFF
--- a/api/integrations_ctr_reg_ecr.go
+++ b/api/integrations_ctr_reg_ecr.go
@@ -1,0 +1,86 @@
+//
+// Author:: Salim Afiune Maya (<afiune@lacework.net>)
+// Copyright:: Copyright 2020, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package api
+
+func NewAwsEcrRegistryIntegration(name string, data AwsEcrData) AwsEcrIntegration {
+	data.RegistryType = EcrRegistry.String()
+	return AwsEcrIntegration{
+		commonIntegrationData: commonIntegrationData{
+			Name:    name,
+			Type:    ContainerRegistryIntegration.String(),
+			Enabled: 1,
+		},
+		Data: data,
+	}
+}
+
+// CreateAwsEcrRegistry creates an AWS_ECR integration on the Lacework Server
+func (svc *IntegrationsService) CreateAwsEcrRegistry(integration AwsEcrIntegration) (
+	response AwsEcrResponse,
+	err error,
+) {
+	err = svc.create(integration, &response)
+	return
+}
+
+// GetAwsEcrRegistry gets an AWS_ECR integration that matches with
+// the provided integration guid on the Lacework Server
+func (svc *IntegrationsService) GetAwsEcrRegistry(guid string) (
+	response AwsEcrResponse,
+	err error,
+) {
+	err = svc.get(guid, &response)
+	return
+}
+
+// UpdateAwsEcrRegistry updates a single AWS_ECR integration
+func (svc *IntegrationsService) UpdateAwsEcrRegistry(integration AwsEcrIntegration) (
+	response AwsEcrResponse,
+	err error,
+) {
+	err = svc.update(integration.IntgGuid, integration, &response)
+	return
+}
+
+type AwsEcrResponse struct {
+	Data    []AwsEcrIntegration `json:"data"`
+	Ok      bool                `json:"ok"`
+	Message string              `json:"message"`
+}
+
+// For AWS_ECR registry
+type AwsEcrIntegration struct {
+	commonIntegrationData
+	Data AwsEcrData `json:"DATA"`
+}
+
+type AwsEcrData struct {
+	Credentials    AwsEcrCreds `json:"ACCESS_KEY_CREDENTIALS" mapstructure:"ACCESS_KEY_CREDENTIALS"`
+	RegistryType   string      `json:"REGISTRY_TYPE" mapstructure:"REGISTRY_TYPE"`
+	RegistryDomain string      `json:"REGISTRY_DOMAIN" mapstructure:"REGISTRY_DOMAIN"`
+	LimitByTag     string      `json:"LIMIT_BY_TAG" mapstructure:"LIMIT_BY_TAG"`
+	LimitByLabel   string      `json:"LIMIT_BY_LABEL" mapstructure:"LIMIT_BY_LABEL"`
+	LimitByRep     string      `json:"LIMIT_BY_REP,omitempty" mapstructure:"LIMIT_BY_REP"`
+	LimitNumImg    int         `json:"LIMIT_NUM_IMG,omitempty" mapstructure:"LIMIT_NUM_IMG"`
+}
+
+type AwsEcrCreds struct {
+	AccessKeyID     string `json:"ACCESS_KEY_ID" mapstructure:"ACCESS_KEY_ID"`
+	SecretAccessKey string `json:"SECRET_ACCESS_KEY" mapstructure:"SECRET_ACCESS_KEY"`
+}

--- a/api/integrations_ctr_reg_ecr_test.go
+++ b/api/integrations_ctr_reg_ecr_test.go
@@ -25,19 +25,15 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestIntegrationsNewContainerRegIntegration(t *testing.T) {
-	subject := api.NewContainerRegIntegration("integration_name",
-		api.ContainerRegData{
-			Credentials: api.ContainerRegCreds{
-				Username: "techally",
-				Password: "secret",
+func TestIntegrationsNewAwsEcrRegistryIntegration(t *testing.T) {
+	subject := api.NewAwsEcrRegistryIntegration("integration_name",
+		api.AwsEcrData{
+			Credentials: api.AwsEcrCreds{
+				AccessKeyID:     "id",
+				SecretAccessKey: "secret",
 			},
-			RegistryType:   api.DockerHubRegistry.String(),
-			RegistryDomain: "index.docker.io",
-			LimitByTag:     "*",
-			LimitByLabel:   "*",
-			LimitNumImg:    5,
 		},
 	)
 	assert.Equal(t, api.ContainerRegistryIntegration.String(), subject.Type)
+	assert.Equal(t, api.EcrRegistry.String(), subject.Data.RegistryType)
 }

--- a/api/integrations_ctr_reg_test.go
+++ b/api/integrations_ctr_reg_test.go
@@ -1,0 +1,86 @@
+//
+// Author:: Salim Afiune Maya (<afiune@lacework.net>)
+// Copyright:: Copyright 2020, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package api_test
+
+import (
+	"testing"
+
+	"github.com/lacework/go-sdk/api"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIntegrationsNewContainerRegIntegration(t *testing.T) {
+	subject := api.NewContainerRegIntegration("integration_name",
+		api.ContainerRegData{
+			Credentials: api.ContainerRegCreds{
+				Username: "techally",
+				Password: "secret",
+			},
+			RegistryType:   api.DockerHubRegistry.String(),
+			RegistryDomain: "index.docker.io",
+			LimitByTag:     "*",
+			LimitByLabel:   "*",
+			LimitNumImg:    5,
+		},
+	)
+	assert.Equal(t, api.ContainerRegistryIntegration.String(), subject.Type)
+}
+
+func TestIntegrationsNewDockerHubRegistryIntegration(t *testing.T) {
+	subject := api.NewDockerHubRegistryIntegration("integration_name",
+		api.ContainerRegData{
+			Credentials: api.ContainerRegCreds{
+				Username: "techally",
+				Password: "secret",
+			},
+		},
+	)
+	assert.Equal(t, api.ContainerRegistryIntegration.String(), subject.Type)
+	assert.Equal(t, api.DockerHubRegistry.String(), subject.Data.RegistryType)
+}
+
+func TestIntegrationsNewDockerV2RegistryIntegration(t *testing.T) {
+	subject := api.NewDockerV2RegistryIntegration("integration_name",
+		api.ContainerRegData{
+			Credentials: api.ContainerRegCreds{
+				Username: "techally",
+				Password: "secret",
+				SSL:      true,
+			},
+		},
+	)
+	assert.Equal(t, api.ContainerRegistryIntegration.String(), subject.Type)
+	assert.Equal(t, api.DockerV2Registry.String(), subject.Data.RegistryType)
+}
+
+func TestIntegrationsNewGcrRegistryIntegration(t *testing.T) {
+	subject := api.NewGcrRegistryIntegration("integration_name",
+		api.ContainerRegData{
+			Credentials: api.ContainerRegCreds{
+				ClientEmail:  "my@email.com",
+				ClientID:     "123abc-id",
+				PrivateKeyID: "aaa-key-id",
+				PrivateKey:   "key",
+			},
+			RegistryDomain: "gcr.io",
+		},
+	)
+	assert.Equal(t, api.ContainerRegistryIntegration.String(), subject.Type)
+	assert.Equal(t, api.GcrRegistry.String(), subject.Data.RegistryType)
+}

--- a/cli/cmd/integration_ecr.go
+++ b/cli/cmd/integration_ecr.go
@@ -26,7 +26,7 @@ import (
 	"github.com/lacework/go-sdk/api"
 )
 
-func createDockerHubIntegration() error {
+func createAwsEcrIntegration() error {
 	questions := []*survey.Question{
 		{
 			Name:     "name",
@@ -34,13 +34,18 @@ func createDockerHubIntegration() error {
 			Validate: survey.Required,
 		},
 		{
-			Name:     "username",
-			Prompt:   &survey.Input{Message: "Username: "},
+			Name:     "domain",
+			Prompt:   &survey.Input{Message: "Registry Domain: "},
 			Validate: survey.Required,
 		},
 		{
-			Name:     "password",
-			Prompt:   &survey.Password{Message: "Password: "},
+			Name:     "access_key_id",
+			Prompt:   &survey.Input{Message: "Access Key ID: "},
+			Validate: survey.Required,
+		},
+		{
+			Name:     "secret_access_key",
+			Prompt:   &survey.Password{Message: "Secret Access Key: "},
 			Validate: survey.Required,
 		},
 		{
@@ -72,13 +77,14 @@ func createDockerHubIntegration() error {
 	}
 
 	answers := struct {
-		Name           string
-		Username       string
-		Password       string
-		LimitTag       string `survey:"limit_tag"`
-		LimitLabel     string `survey:"limit_label"`
-		LimitRepos     string `survey:"limit_repos"`
-		LimitMaxImages string `survey:"limit_max_images"`
+		Name            string
+		Domain          string
+		AccessKeyID     string `survey:"access_key_id"`
+		SecretAccessKey string `survey:"secret_access_key"`
+		LimitTag        string `survey:"limit_tag"`
+		LimitLabel      string `survey:"limit_label"`
+		LimitRepos      string `survey:"limit_repos"`
+		LimitMaxImages  string `survey:"limit_max_images"`
 	}{}
 
 	err := survey.Ask(questions, &answers,
@@ -98,21 +104,22 @@ func createDockerHubIntegration() error {
 		limitMaxImages = 5
 	}
 
-	docker := api.NewDockerHubRegistryIntegration(answers.Name,
-		api.ContainerRegData{
-			Credentials: api.ContainerRegCreds{
-				Username: answers.Username,
-				Password: answers.Password,
+	ecr := api.NewAwsEcrRegistryIntegration(answers.Name,
+		api.AwsEcrData{
+			Credentials: api.AwsEcrCreds{
+				AccessKeyID:     answers.AccessKeyID,
+				SecretAccessKey: answers.SecretAccessKey,
 			},
-			LimitByTag:   answers.LimitTag,
-			LimitByLabel: answers.LimitLabel,
-			LimitByRep:   answers.LimitRepos,
-			LimitNumImg:  limitMaxImages,
+			RegistryDomain: answers.Domain,
+			LimitByTag:     answers.LimitTag,
+			LimitByLabel:   answers.LimitLabel,
+			LimitByRep:     answers.LimitRepos,
+			LimitNumImg:    limitMaxImages,
 		},
 	)
 
 	cli.StartProgress(" Creating integration...")
-	_, err = cli.LwApi.Integrations.CreateContainerRegistry(docker)
+	_, err = cli.LwApi.Integrations.CreateAwsEcrRegistry(ecr)
 	cli.StopProgress()
 	return err
 }

--- a/cli/cmd/integration_gcr.go
+++ b/cli/cmd/integration_gcr.go
@@ -26,7 +26,7 @@ import (
 	"github.com/lacework/go-sdk/api"
 )
 
-func createDockerHubIntegration() error {
+func createGcrIntegration() error {
 	questions := []*survey.Question{
 		{
 			Name:     "name",
@@ -34,13 +34,36 @@ func createDockerHubIntegration() error {
 			Validate: survey.Required,
 		},
 		{
-			Name:     "username",
-			Prompt:   &survey.Input{Message: "Username: "},
+			Name: "domain",
+			Prompt: &survey.Select{
+				Message: "Registry Domain:",
+				Options: []string{
+					"gcr.io",
+					"us.gcr.io",
+					"eu.gcr.io",
+					"asia.gcr.io",
+				},
+			},
 			Validate: survey.Required,
 		},
 		{
-			Name:     "password",
-			Prompt:   &survey.Password{Message: "Password: "},
+			Name:     "client_id",
+			Prompt:   &survey.Input{Message: "Client ID:"},
+			Validate: survey.Required,
+		},
+		{
+			Name:     "private_key_id",
+			Prompt:   &survey.Input{Message: "Private Key ID:"},
+			Validate: survey.Required,
+		},
+		{
+			Name:     "client_email",
+			Prompt:   &survey.Input{Message: "Client Email:"},
+			Validate: survey.Required,
+		},
+		{
+			Name:     "private_key",
+			Prompt:   &survey.Input{Message: "Private Key:"},
 			Validate: survey.Required,
 		},
 		{
@@ -73,8 +96,11 @@ func createDockerHubIntegration() error {
 
 	answers := struct {
 		Name           string
-		Username       string
-		Password       string
+		Domain         string
+		ClientID       string `survey:"client_id"`
+		PrivateKeyID   string `survey:"private_key_id"`
+		ClientEmail    string `survey:"client_email"`
+		PrivateKey     string `survey:"private_key"`
 		LimitTag       string `survey:"limit_tag"`
 		LimitLabel     string `survey:"limit_label"`
 		LimitRepos     string `survey:"limit_repos"`
@@ -98,21 +124,24 @@ func createDockerHubIntegration() error {
 		limitMaxImages = 5
 	}
 
-	docker := api.NewDockerHubRegistryIntegration(answers.Name,
+	gcr := api.NewGcrRegistryIntegration(answers.Name,
 		api.ContainerRegData{
 			Credentials: api.ContainerRegCreds{
-				Username: answers.Username,
-				Password: answers.Password,
+				ClientEmail:  answers.ClientEmail,
+				ClientID:     answers.ClientID,
+				PrivateKey:   answers.PrivateKey,
+				PrivateKeyID: answers.PrivateKeyID,
 			},
-			LimitByTag:   answers.LimitTag,
-			LimitByLabel: answers.LimitLabel,
-			LimitByRep:   answers.LimitRepos,
-			LimitNumImg:  limitMaxImages,
+			RegistryDomain: answers.Domain,
+			LimitByTag:     answers.LimitTag,
+			LimitByLabel:   answers.LimitLabel,
+			LimitByRep:     answers.LimitRepos,
+			LimitNumImg:    limitMaxImages,
 		},
 	)
 
 	cli.StartProgress(" Creating integration...")
-	_, err = cli.LwApi.Integrations.CreateContainerRegistry(docker)
+	_, err = cli.LwApi.Integrations.CreateContainerRegistry(gcr)
 	cli.StopProgress()
 	return err
 }


### PR DESCRIPTION
## Docker Hub Registry:
```go
api.NewDockerHubRegistryIntegration(integrationName, api.ContainerRegData{})
```

## Docker V2 Registry:
```go
api.NewDockerV2RegistryIntegration(integrationName, api.ContainerRegData{})
```

## ECR Registry:
```go
api.NewAwsEcrRegistryIntegration(integrationName, api.AwsEcrData{})
```

## GCR Registry:
```go
api.NewGcrRegistryIntegration(integrationName, api.ContainerRegData{})
```

# Lacework CLI
<img width="585" alt="Screen Shot 2020-09-09 at 8 15 04 PM" src="https://user-images.githubusercontent.com/5712253/92638283-45028d00-f297-11ea-8669-dd1c3982d4e3.png">

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>