### PR TITLE
feat(ux): generate package-manifest automatically

### DIFF
--- a/cli/cmd/package_manifest.go
+++ b/cli/cmd/package_manifest.go
@@ -1,0 +1,247 @@
+//
+// Author:: Salim Afiune Maya (<afiune@lacework.net>)
+// Copyright:: Copyright 2020, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cmd
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"os/exec"
+	"regexp"
+	"runtime"
+	"strings"
+	"syscall"
+
+	"github.com/pkg/errors"
+)
+
+var SupportedPackageManagers = []string{"dpkg-query", "rpm", "apk"} // @afiune can we support ym and apk?
+
+type PackageManifest struct {
+	OsPkgInfoList []OsPkgInfo `json:"os_pkg_info_list"`
+}
+
+type OsPkgInfo struct {
+	Os     string `json:"os"`
+	OsVer  string `json:"os_ver"`
+	Pkg    string `json:"pkg"`
+	PkgVer string `json:"pkg_ver"`
+}
+
+type OS struct {
+	Name    string
+	Version string
+}
+
+var (
+	osReleaseFile = "/etc/os-release"
+	rexNameFromID = regexp.MustCompile(`^ID=(.*)$`)
+	rexVersionID  = regexp.MustCompile(`^VERSION_ID=(.*)$`)
+)
+
+func (c *cliState) GeneratePackageManifest() (*PackageManifest, error) {
+	manifest := new(PackageManifest)
+	osInfo, err := cli.GetOSInfo()
+	if err != nil {
+		return manifest, err
+	}
+	manager, err := cli.DetectPackageManager()
+	if err != nil {
+		return manifest, err
+	}
+
+	var managerQuery []byte
+	switch manager {
+	case "rpm":
+		managerQuery, err = exec.Command(
+			"rpm", "-qa", "--queryformat", "%{NAME},%{VERSION}-%{RELEASE}\n",
+		).Output()
+		if err != nil {
+			return manifest, errors.Wrap(err, "unable to query packages from package manager")
+		}
+	case "dpkg-query":
+		managerQuery, err = exec.Command(
+			"dpkg-query", "--show", "--showformat", "${Package},${Version}\n",
+		).Output()
+		if err != nil {
+			return manifest, errors.Wrap(err, "unable to query packages from package manager")
+		}
+	case "yum":
+		return manifest, errors.New("yum not yet supported")
+	case "apk":
+		apkInfo, err := exec.Command("apk", "info").Output()
+		if err != nil {
+			return manifest, errors.Wrap(err, "unable to query packages from package manager")
+		}
+		apkInfoT := strings.TrimSuffix(string(apkInfo), "\n")
+		apkInfoArray := strings.Split(apkInfoT, "\n")
+
+		apkInfoWithVersion, err := exec.Command("apk", "info", "-v").Output()
+		if err != nil {
+			return manifest, errors.Wrap(err, "unable to query packages from package manager")
+		}
+		apkInfoWithVersionT := strings.TrimSuffix(string(apkInfoWithVersion), "\n")
+		apkInfoWithVersionArray := strings.Split(apkInfoWithVersionT, "\n")
+
+		mq := []string{}
+		for i, pkg := range apkInfoWithVersionArray {
+			mq = append(mq,
+				fmt.Sprintf("%s,%s",
+					apkInfoArray[i],
+					strings.Trim(
+						strings.Replace(pkg, apkInfoArray[i], "", 1),
+						"-",
+					),
+				),
+			)
+		}
+		managerQuery = []byte(strings.Join(mq, "\n"))
+	default:
+		return manifest, errors.New(
+			"this is most likely a mistake on us, please report it to support.lacework.com.",
+		)
+	}
+
+	c.Log.Debugw("package-manager query", "raw", string(managerQuery))
+
+	// @afiune this is an example of the output from the query we
+	// send to the local package-manager:
+	//
+	// {PkgName},{PkgVersion}\n
+	// ...
+	// {PkgName},{PkgVersion}\n
+	//
+	// first, trim the last carriage return
+	managerQueryOut := strings.TrimSuffix(string(managerQuery), "\n")
+	// then, split by carriage return
+	for _, pkg := range strings.Split(managerQueryOut, "\n") {
+		// finally, split by comma to get PackageName and PackageVersion
+		pkgDetail := strings.Split(pkg, ",")
+
+		// the splitted package detail must be size of 2 elements
+		if len(pkgDetail) != 2 {
+			c.Log.Warnw("unable to parse package, expected length=2, skipping",
+				"raw_pkg_details", pkg,
+				"split_pkg_details", pkgDetail,
+			)
+			continue
+		}
+
+		manifest.OsPkgInfoList = append(manifest.OsPkgInfoList,
+			OsPkgInfo{
+				Os:     osInfo.Name,
+				OsVer:  osInfo.Version,
+				Pkg:    pkgDetail[0],
+				PkgVer: pkgDetail[1],
+			},
+		)
+	}
+
+	c.Log.Debugw("package-manifest", "raw", manifest)
+	return manifest, nil
+}
+
+func (c *cliState) GetOSInfo() (*OS, error) {
+	osInfo := new(OS)
+
+	c.Log.Debugw("detecting operating system information",
+		"os", runtime.GOOS,
+		"arch", runtime.GOARCH,
+	)
+
+	f, err := os.Open(osReleaseFile)
+	if err != nil {
+		msg := `unsupported platform
+
+For more information about supported platforms, visit:
+    https://support.lacework.com/hc/en-us/articles/360049666194-Host-Vulnerability-Assessment-Overview`
+		return osInfo, errors.New(msg)
+	}
+	defer f.Close()
+
+	c.Log.Debugw("parsing os release file", "file", osReleaseFile)
+	s := bufio.NewScanner(f)
+	for s.Scan() {
+		if m := rexNameFromID.FindStringSubmatch(s.Text()); m != nil {
+			osInfo.Name = strings.Trim(m[1], `"`)
+		} else if m := rexVersionID.FindStringSubmatch(s.Text()); m != nil {
+			osInfo.Version = strings.Trim(m[1], `"`)
+		}
+	}
+
+	return osInfo, nil
+}
+
+func (c *cliState) DetectPackageManager() (string, error) {
+	c.Log.Debugw("detecting package-manager")
+
+	for _, manager := range SupportedPackageManagers {
+		if cli.checkPackageManager(manager) {
+			c.Log.Debugw("detected", "package-manager", manager)
+			return manager, nil
+		}
+	}
+	msg := "unable to find supported package managers."
+	msg = fmt.Sprintf("%s Supported package managers are %s.",
+		msg, strings.Join(SupportedPackageManagers, ", "))
+	return "", errors.New(msg)
+}
+
+func (c *cliState) checkPackageManager(manager string) bool {
+	var (
+		cmd    = exec.Command("which", manager)
+		_, err = cmd.CombinedOutput()
+	)
+	if err != nil {
+		c.Log.Debugw("error trying to check package-manager",
+			"cmd", "which",
+			"package-manager", manager,
+			"error", err,
+		)
+		if exitError, ok := err.(*exec.ExitError); ok {
+			waitStatus := exitError.Sys().(syscall.WaitStatus)
+			return waitStatus.ExitStatus() == 0
+		}
+		c.Log.Warnw("something went wrong with 'which', trying native command")
+		return cli.checkPackageManagerWithNativeCommand(manager)
+	}
+	waitStatus := cmd.ProcessState.Sys().(syscall.WaitStatus)
+	return waitStatus.ExitStatus() == 0
+}
+
+func (c *cliState) checkPackageManagerWithNativeCommand(manager string) bool {
+	var (
+		cmd    = exec.Command("command", "-v", manager)
+		_, err = cmd.CombinedOutput()
+	)
+	if err != nil {
+		c.Log.Debugw("error trying to check package-manager",
+			"cmd", "command",
+			"package-manager", manager,
+			"error", err,
+		)
+		if exitError, ok := err.(*exec.ExitError); ok {
+			waitStatus := exitError.Sys().(syscall.WaitStatus)
+			return waitStatus.ExitStatus() == 0
+		}
+		return false
+	}
+	waitStatus := cmd.ProcessState.Sys().(syscall.WaitStatus)
+	return waitStatus.ExitStatus() == 0
+}

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -51,7 +51,7 @@ Start by configuring the Lacework CLI with the command:
 This will prompt you for your Lacework account and a set of API access keys.`,
 		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
 			switch cmd.Use {
-			case "help [command]", "configure", "version":
+			case "help [command]", "configure", "version", "generate-pkg-manifest":
 				return nil
 			default:
 				return cli.NewClient()

--- a/integration/host_vulnerability_test.go
+++ b/integration/host_vulnerability_test.go
@@ -22,6 +22,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"runtime"
 	"testing"
 
 	"github.com/lacework/go-sdk/api"
@@ -159,4 +160,64 @@ func TestHostVulnerabilityCommandShowAssessment(t *testing.T) {
 		"STDERR should be empty")
 	assert.Equal(t, 0, exitcode,
 		"EXITCODE is not the expected one")
+}
+
+func TestHostVulnerabilityCommandGeneratePkgManifest(t *testing.T) {
+	out, err, exitcode := LaceworkCLIWithTOMLConfig(
+		"vulnerability", "host", "generate-pkg-manifest")
+
+	if runtime.GOOS == "linux" {
+		assert.Contains(t, out.String(), "os_pkg_info_list",
+			"STDOUT does not contain the os_pkg_info_list output")
+		assert.Empty(t,
+			err.String(),
+			"STDERR should be empty")
+		assert.Equal(t, 0, exitcode,
+			"EXITCODE is not the expected one")
+	} else {
+		assert.Contains(t, err.String(), "unable to generate package manifest: unsupported platform",
+			"STDERR doesn't match")
+		assert.Empty(t,
+			out.String(),
+			"STDOUT should be empty")
+		assert.Equal(t, 1, exitcode,
+			"EXITCODE is not the expected one")
+	}
+}
+
+func TestHostVulnerabilityCommandScanPkgManifest(t *testing.T) {
+	out, err, exitcode := LaceworkCLIWithTOMLConfig(
+		"vulnerability", "host", "scan-pkg-manifest", "--local")
+
+	if runtime.GOOS == "linux" {
+		expectedOutput := []string{
+			// headers
+			"CVE",
+			"SEVERITY",
+			"SCORE",
+			"PACKAGE",
+			"VERSION",
+			"FIX VERSION",
+		}
+		t.Run("verifying table headers", func(t *testing.T) {
+			for _, str := range expectedOutput {
+				assert.Contains(t, out.String(), str,
+					"STDOUT table does not contain the '"+str+"' output")
+			}
+		})
+		assert.Empty(t,
+			err.String(),
+			"STDERR should be empty")
+		assert.Equal(t, 0, exitcode,
+			"EXITCODE is not the expected one")
+	} else {
+		assert.Contains(t, err.String(), "unable to generate package manifest: unsupported platform",
+			"STDERR doesn't match")
+		assert.Empty(t,
+			out.String(),
+			"STDOUT should be empty")
+		assert.Equal(t, 1, exitcode,
+			"EXITCODE is not the expected one")
+
+	}
 }


### PR DESCRIPTION
This Pull Request is improving the way we scan package-manifests, this is all
about User Experience (UX).

We want to help our users to adopt our CI/CD story and make it easy for them
to scan their package manifests, with that mentality we are introducing a couple
new feature to the Lacework CLI.

## Generation of Package Manifest
Generating a package manifest could be confusing for some users, if you are an
expert you will probably have your own Python scripts ready to be piped to our
APIs, but if you are not, we have a new command for you: 
```
root@7c42aed31953:/# lacework vulnerability host generate-pkg-manifest
{
  "os_pkg_info_list": [
    {
      "os": "ubuntu",
      "os_ver": "18.04",
      "pkg": "adduser",
      "pkg_ver": "3.116ubuntu1"
    },
    {
      "os": "ubuntu",
      "os_ver": "18.04",
      "pkg": "zlib1g",
      "pkg_ver": "1:1.2.11.dfsg-0ubuntu2"
    }
  ]
}
```
This command will automatically detect any supported package manager and generate
the package manifest for you!

![tenor-111571833](https://user-images.githubusercontent.com/5712253/93834021-af241600-fc37-11ea-9a76-71f168ddd79c.gif)

## Scan Local Host
Let us take it one step further! Since we now have a way to generate a package manifest
for you, we have also added a new flag `--local` that you can use to automatically generate
the package manifest on a running host and submit a scan, all at once!

```
root@7c42aed31953:/# lacework vulnerability host scan-pkg-manifest --local
        CVE        |  SEVERITY  | SCORE |   PACKAGE   |       VERSION       |    FIX VERSION
-------------------+------------+-------+-------------+---------------------+---------------------
  CVE-2016-6313    | High       |   5.3 | libgcrypt20 | 1.8.1-4ubuntu1.2    | 0:1.7.2-2ubuntu1
  CVE-2019-13627   | Medium     |   6.3 | libgcrypt20 | 1.8.1-4ubuntu1.2    | 0:1.8.1-4ubuntu1.2
  CVE-2018-0495    | Low        |   4.7 | libgcrypt20 | 1.8.1-4ubuntu1.2    | 0:1.8.1-4ubuntu1.1
  CVE-2016-2781    | Low        |   6.5 | coreutils   | 8.28-1ubuntu1       |
  CVE-2019-12904   | Low        |   5.9 | libgcrypt20 | 1.8.1-4ubuntu1.2    |
  CVE-2019-9923    | Low        |   7.5 | tar         | 1.29b-2ubuntu0.1    |
  CVE-2018-20482   | Low        |   4.7 | tar         | 1.29b-2ubuntu0.1    |
  CVE-2019-18276   | Low        |   7.8 | bash        | 4.4.18-2ubuntu1.2   |
  CVE-2017-8283    | Negligible |   9.8 | dpkg        | 1.19.0.5ubuntu2.3   |
  CVE-2018-1000654 | Negligible |   5.5 | libtasn1-6  | 4.13-2              |
  CVE-2016-9401    | Negligible |   5.5 | bash        | 4.4.18-2ubuntu1.2   | 0:4.4-5ubuntu1
  CVE-2018-7738    | Negligible |   7.8 | util-linux  | 2.31.1-0.4ubuntu3.6 |
```

![tenor-263751943](https://user-images.githubusercontent.com/5712253/93834123-f7dbcf00-fc37-11ea-9c16-3dcafec14f05.gif)


Signed-off-by: Salim Afiune Maya <afiune@lacework.net>