### PR TITLE
feat(cli): add scan-pkg-manifest summary 📈

### DIFF
--- a/integration/host_vulnerability_test.go
+++ b/integration/host_vulnerability_test.go
@@ -198,6 +198,12 @@ func TestHostVulnerabilityCommandScanPkgManifest(t *testing.T) {
 			"PACKAGE",
 			"VERSION",
 			"FIX VERSION",
+
+			// summary headers
+			"VULNERABILITIES",
+			"SEVERITY",
+			"COUNT",
+			"FIXABLE",
 		}
 		t.Run("verifying table headers", func(t *testing.T) {
 			for _, str := range expectedOutput {


### PR DESCRIPTION
Since all our other commands always provide a nice summary table, we are
adding one to the `scan-pkg-manifest` command! :100:

New output looks like:
```
$ lacework vuln host scan-pkg-manifest --local --fixable
          VULNERABILITIES
------------------------------------
     SEVERITY    COUNT   FIXABLE
  -------------+-------+----------
    Critical         0         0
    High            16         0
    Medium           6         1
    Low              8         1
    Negligible       0         0

       CVE       | SEVERITY | SCORE | PACKAGE |   VERSION    |  FIX VERSION
-----------------+----------+-------+---------+--------------+-----------------
  CVE-2019-3817  | Medium   | 8.8   | librepo | 1.11.0-2.el8 | 0:1.10.3-3.el8
  CVE-2018-20534 | Low      | 6.5   | librepo | 1.11.0-2.el8 | 0:1.10.3-3.el8
```

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>