### PR TITLE
fix(cli): add epoch to package manifest

### DIFF
--- a/cli/cmd/package_manifest.go
+++ b/cli/cmd/package_manifest.go
@@ -70,7 +70,7 @@ func (c *cliState) GeneratePackageManifest() (*PackageManifest, error) {
 	switch manager {
 	case "rpm":
 		managerQuery, err = exec.Command(
-			"rpm", "-qa", "--queryformat", "%{NAME},%{VERSION}-%{RELEASE}\n",
+			"rpm", "-qa", "--queryformat", "%{NAME},%|EPOCH?{%{EPOCH}}:{0}|:%{VERSION}-%{RELEASE}\n",
 		).Output()
 		if err != nil {
 			return manifest, errors.Wrap(err, "unable to query packages from package manager")

--- a/cli/cmd/vuln_host.go
+++ b/cli/cmd/vuln_host.go
@@ -807,7 +807,12 @@ func hostScanPackagesVulnToTable(scan *api.HostVulnScanPkgManifestResponse) stri
 		if vulCmdState.Fixable {
 			return "There are no fixable vulnerabilities.\n"
 		}
-		return "There are no matching vulnerabilities. Try adding '--json'.\n"
+		scannedVia := "package manifest"
+		if pkgManifestLocal {
+			scannedVia = "localhost"
+		}
+		return fmt.Sprintf("Great news! The %s has no vulnerabilities... (time for %s)\n",
+			scannedVia, randomEmoji())
 	}
 
 	t = tablewriter.NewWriter(summaryBuilder)

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -11,6 +11,7 @@
 set -eou pipefail
 
 readonly project_name=go-sdk
+readonly org_name=lacework
 readonly package_name=lacework-cli
 readonly binary_name=lacework
 readonly docker_org=lacework
@@ -82,7 +83,7 @@ trigger_release() {
       log ""
       log "removing release tag from version '${VERSION}'"
       remove_tag_version
-      log "commiting and pushing the vertion bump to github"
+      log "commiting and pushing the version bump to github"
       git config --global user.email "afiune@lacework.net"
       git config --global user.name "Salim Afiune Maya"
       git add VERSION
@@ -95,7 +96,7 @@ trigger_release() {
       log "No release needed. (VERSION=${VERSION})"
       log ""
       log "Read more about the release process at:"
-      log "  - https://github.com/lacework/${project_name}/wiki/Release-Process"
+      log "  - https://github.com/${org_name}/${project_name}/wiki/Release-Process"
   fi
 }
 
@@ -115,7 +116,7 @@ verify_release() {
       warn "$f needs to be updated"
       warn ""
       warn "Read more about the release process at:"
-      warn "  - https://github.com/lacework/${project_name}/wiki/Release-Process"
+      warn "  - https://github.com/${org_name}/${project_name}/wiki/Release-Process"
       exit 123
     fi
   done
@@ -126,7 +127,7 @@ verify_release() {
       warn "the 'VERSION' needs to be updated to have the 'x.y.z-release' tag"
       warn ""
       warn "Read more about the release process at:"
-      warn "  - https://github.com/lacework/${project_name}/wiki/Release-Process"
+      warn "  - https://github.com/${org_name}/${project_name}/wiki/Release-Process"
       exit 123
   fi
 }
@@ -169,7 +170,7 @@ update_changelog() {
 
 load_list_of_changes() {
   latest_version=$(find_latest_version)
-  local _list_of_changes=$(git log --no-merges --pretty="* %s (%an)([%h](https://github.com/lacework/${project_name}/commit/%H))" ${latest_version}..master)
+  local _list_of_changes=$(git log --no-merges --pretty="* %s (%an)([%h](https://github.com/${org_name}/${project_name}/commit/%H))" ${latest_version}..master)
   echo "## Features" > CHANGES.md
   echo "$_list_of_changes" | grep "\* feat[:(]" >> CHANGES.md
   echo "## Refactor" >> CHANGES.md
@@ -367,7 +368,7 @@ create_release() {
   log "generating GH release $_tag"
   generate_release_body "$_body"
   curl -XPOST -H "Authorization: token $GITHUB_TOKEN" --data  "@$_body" \
-        https://api.github.com/repos/lacework/${project_name}/releases > $_release
+        https://api.github.com/repos/${org_name}/${project_name}/releases > $_release
 
   local _content_type
   local _artifact
@@ -400,7 +401,7 @@ create_release() {
 
   log "the release has been completed!"
   log ""
-  log " -> https://github.com/lacework/${project_name}/releases/tag/${_tag}"
+  log " -> https://github.com/${org_name}/${project_name}/releases/tag/${_tag}"
 }
 
 generate_release_body() {


### PR DESCRIPTION
We have identified a bug in the Lacework CLI where we didn't add the
epoch for Centos/RHEL systems, this field would change drastically
the results of the package manifest scanner and therefore, we were
having inaccurate results.

This PR is adding the epoch and matching the output with the container
vulnerability scanner when there are no vulnerabilities via the package
manifest scanner.

```
[root@1f341170e7db /]# lacework vuln host scan-pkg-manifest --local
Great news! The localhost has no vulnerabilities... (time for 🌮 )
```

Jira: ALLY-215

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>