### PR TITLE
refactor(api): better error check handler

### DIFF
--- a/api/errors.go
+++ b/api/errors.go
@@ -32,24 +32,33 @@ type errorResponse struct {
 }
 
 type apiErrorResponse struct {
-	Ok   bool
+	Ok   bool `json:"ok"`
 	Data struct {
-		Message       string
-		StatusMessage string
-	}
+		Message       string `json:"message"`
+		StatusMessage string `json:"statusMessage"`
+		ErrorMsg      string `json:"ErrorMsg"`
+	} `json:"data"`
 }
 
 // Message extracts the message from an api error response
 func (r *apiErrorResponse) Message() string {
 	if r != nil {
-		return r.Data.Message
+		if r.Data.Message != "" {
+			return r.Data.Message
+		}
+		if r.Data.ErrorMsg != "" {
+			return r.Data.ErrorMsg
+		}
+		if r.Data.StatusMessage != "" {
+			return r.Data.StatusMessage
+		}
 	}
 	return ""
 }
 
 // Error fulfills the built-in error interface function
 func (r *errorResponse) Error() string {
-	return fmt.Sprintf("[%v] %v: %d %s",
+	return fmt.Sprintf("\n  [%v] %v\n  [%d] %s",
 		r.Response.Request.Method,
 		r.Response.Request.URL,
 		r.Response.StatusCode,
@@ -70,11 +79,30 @@ func checkErrorInResponse(r *http.Response) error {
 	if err == nil && len(data) > 0 {
 		// try to unmarshal the api error response
 		apiErrRes := &apiErrorResponse{}
-		if err := json.Unmarshal(data, apiErrRes); err == nil {
-			errRes.Message = apiErrRes.Message()
-		} else {
+		if err := json.Unmarshal(data, apiErrRes); err != nil {
 			errRes.Message = string(data)
+			return errRes
 		}
+
+		var (
+			apiErrResMessage = apiErrRes.Message()
+			statusText       = http.StatusText(r.StatusCode)
+		)
+
+		// try our best to parse the error message
+		if apiErrResMessage != "" {
+			errRes.Message = apiErrResMessage
+			return errRes
+		}
+
+		// if it is empty, try to display the Status Code in pretty Text
+		if statusText != "" {
+			errRes.Message = statusText
+			return errRes
+		}
+
+		// if we couldn't even decode the StatusCode... well, lets just be transparent
+		errRes.Message = "Unknown"
 	}
 
 	return errRes

--- a/api/errors_test.go
+++ b/api/errors_test.go
@@ -1,0 +1,222 @@
+//
+// Author:: Salim Afiune Maya (<afiune@lacework.net>)
+// Copyright:: Copyright 2020, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package api_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/lacework/go-sdk/api"
+	"github.com/lacework/go-sdk/internal/lacework"
+)
+
+func TestErrorWithDataMessage(t *testing.T) {
+	fakeServer := lacework.MockServer()
+	fakeServer.MockAPI(
+		"external/any/endpoint",
+		func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, `
+{
+  "data": {
+    "statusMessage": "We may receive error messages from here. Catch it!"
+  },
+  "ok": true,
+  "message": "SUCCESS"
+}
+`, http.StatusInternalServerError)
+		},
+	)
+	defer fakeServer.Close()
+
+	c, err := api.NewClient("test",
+		api.WithToken("TOKEN"),
+		api.WithURL(fakeServer.URL()),
+	)
+	assert.Nil(t, err)
+
+	var v interface{}
+	err = c.RequestDecoder("GET", "external/any/endpoint", nil, v)
+	assert.Nil(t, v)
+	if assert.NotNil(t, err) {
+		assert.Contains(t, err.Error(), "[GET] http://")
+		assert.Contains(t, err.Error(), "/external/any/endpoint")
+		assert.Contains(t,
+			err.Error(),
+			"[500] We may receive error messages from here. Catch it!",
+		)
+	}
+}
+
+func TestErrorWithDataStatusMessage(t *testing.T) {
+	fakeServer := lacework.MockServer()
+	fakeServer.MockAPI(
+		"external/any/endpoint",
+		func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, `
+{
+  "data": {
+    "Status": "NotFound",
+    "Message": "We should catch this error message!"
+  },
+  "ok": true,
+  "message": "SUCCESS"
+}
+`, http.StatusBadRequest)
+		},
+	)
+	defer fakeServer.Close()
+
+	c, err := api.NewClient("test",
+		api.WithToken("TOKEN"),
+		api.WithURL(fakeServer.URL()),
+	)
+	assert.Nil(t, err)
+
+	var v interface{}
+	err = c.RequestDecoder("GET", "external/any/endpoint", nil, v)
+	assert.Nil(t, v)
+	if assert.NotNil(t, err) {
+		assert.Contains(t, err.Error(), "[GET] http://")
+		assert.Contains(t, err.Error(), "/external/any/endpoint")
+		assert.Contains(t,
+			err.Error(), "[400] We should catch this error message!",
+		)
+	}
+}
+
+func TestErrorWithDataErrorMsg(t *testing.T) {
+	fakeServer := lacework.MockServer()
+	fakeServer.MockAPI(
+		"external/any/endpoint",
+		func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, `
+{
+  "data": {
+    "ErrorMsg": "This is an error message we should display!"
+  },
+  "ok": true,
+  "message": "SUCCESS"
+}
+`, http.StatusTooManyRequests)
+		},
+	)
+	defer fakeServer.Close()
+
+	c, err := api.NewClient("test",
+		api.WithToken("TOKEN"),
+		api.WithURL(fakeServer.URL()),
+	)
+	assert.Nil(t, err)
+
+	var v interface{}
+	err = c.RequestDecoder("GET", "external/any/endpoint", nil, v)
+	assert.Nil(t, v)
+	if assert.NotNil(t, err) {
+		assert.Contains(t, err.Error(), "[GET] http://")
+		assert.Contains(t, err.Error(), "/external/any/endpoint")
+		assert.Contains(t,
+			err.Error(),
+			"[429] This is an error message we should display!",
+		)
+	}
+}
+
+func TestErrorWithoutValidErrorMessageInDataField(t *testing.T) {
+	fakeServer := lacework.MockServer()
+	fakeServer.MockAPI(
+		"external/any/endpoint",
+		func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, `
+{
+  "data": {
+    "MessageError": "We would never catch this error!"
+  },
+  "ok": true,
+  "message": "SUCCESS"
+}
+`, http.StatusTooManyRequests)
+		},
+	)
+	defer fakeServer.Close()
+
+	c, err := api.NewClient("test",
+		api.WithToken("TOKEN"),
+		api.WithURL(fakeServer.URL()),
+	)
+	assert.Nil(t, err)
+
+	var v interface{}
+	err = c.RequestDecoder("GET", "external/any/endpoint", nil, v)
+	assert.Nil(t, v)
+	if assert.NotNil(t, err) {
+		assert.Contains(t, err.Error(), "[GET] http://")
+		assert.Contains(t, err.Error(), "/external/any/endpoint")
+		assert.Contains(t,
+			err.Error(),
+			"[429] Too Many Requests", // This is better than nothing
+		)
+		assert.NotContains(t,
+			err.Error(),
+			"We would never catch this error!",
+		)
+	}
+}
+
+func TestErrorInvalidStatusCode(t *testing.T) {
+	fakeServer := lacework.MockServer()
+	fakeServer.MockAPI(
+		"external/any/endpoint",
+		func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, `
+{
+  "data": {
+    "YetAnotherErrorField": "We would never catch this error!"
+  },
+  "ok": true,
+  "message": "SUCCESS"
+}
+`, 432) // Note that this status code is not valid
+		},
+	)
+	defer fakeServer.Close()
+
+	c, err := api.NewClient("test",
+		api.WithToken("TOKEN"),
+		api.WithURL(fakeServer.URL()),
+	)
+	assert.Nil(t, err)
+
+	var v interface{}
+	err = c.RequestDecoder("GET", "external/any/endpoint", nil, v)
+	assert.Nil(t, v)
+	if assert.NotNil(t, err) {
+		assert.Contains(t, err.Error(), "[GET] http://")
+		assert.Contains(t, err.Error(), "/external/any/endpoint")
+		assert.Contains(t,
+			err.Error(),
+			"[432] Unknown", // This is better than nothing, I guess
+		)
+		assert.NotContains(t,
+			err.Error(),
+			"We would never catch this error!",
+		)
+	}
+}

--- a/api/integrations_test.go
+++ b/api/integrations_test.go
@@ -169,7 +169,7 @@ func TestIntegrationsGet(t *testing.T) {
 		assert.Empty(t, response)
 		if assert.NotNil(t, err) {
 			assert.Contains(t, err.Error(), "api/v1/external/integrations/UNKNOWN_INTG_GUID")
-			assert.Contains(t, err.Error(), "404 Not Found")
+			assert.Contains(t, err.Error(), "[404] Not Found")
 		}
 	})
 }


### PR DESCRIPTION
This change is making the error check handler to understand better the
error messages sent from the Lacework API, it also formats them a bit
better so that human can read them.

## Before
```
[POST] https://tech-ally.lacework.net/api/v1/external/vulnerabilities/container/repository/images/scan: 400
```

## After:
```
  [POST] https://tech-ally.lacework.net/api/v1/external/vulnerabilities/container/repository/images/scan
  [400] Could not find integraion matching the registry provided
```

This will also improve the error messages from the Lacework CLI:
## Before
```
$ lacework vuln ctr scan foo bar tag

ERROR unable to request on-demand vulnerability scan: [POST] https://tech-ally.lacework.net/api/v1/external/vulnerabilities/container/repository/images/scan: 400
```

## After
```
$ lacework vuln ctr scan foo bar tag

ERROR unable to request on-demand vulnerability scan:
  [POST] https://tech-ally.lacework.net/api/v1/external/vulnerabilities/container/repository/images/scan
  [400] Could not find integraion matching the registry provided
```

**JIRA:** https://lacework.atlassian.net/browse/ALLY-40
Closes https://github.com/lacework/go-sdk/issues/26

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>