### PR TITLE
ci: set container tag to debian-10 that has vulns

### DIFF
--- a/integration/container_vulnerability_test.go
+++ b/integration/container_vulnerability_test.go
@@ -34,7 +34,7 @@ const (
 	registry   = "index.docker.io"
 	repository = "lacework/lacework-cli"
 	tag1       = "ubuntu-1804"
-	tag2       = "amazonlinux-2"
+	tag2       = "debian-10"
 )
 
 func TestContainerVulnerabilityCommandAliases(t *testing.T) {


### PR DESCRIPTION
Since `amazonlinux-2` tag has no vulnerabilities:
```
➜  ~ lacework vuln ctr scan index.docker.io lacework/lacework-cli amazonlinux-2 --poll --html
A new vulnerability scan has been requested. (request_id: c60ae155-858c-4e76-8874-33010c081e8b)

Great news! This container image has no vulnerabilities... (time for 🌮 )
```

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>