### PR TITLE
refactor: account mapping file for consolidated CT

### DIFF
--- a/api/integrations_aws.go
+++ b/api/integrations_aws.go
@@ -176,14 +176,14 @@ type AwsIntegrationData struct {
 	AccountMappingFile string `json:"ACCOUNT_MAPPING_FILE,omitempty" mapstructure:"ACCOUNT_MAPPING_FILE"`
 }
 
-func (aws *AwsIntegrationData) EncodeAccountMappingFile(mapping string) {
-	encodedMappings := base64.StdEncoding.EncodeToString([]byte(mapping))
+func (aws *AwsIntegrationData) EncodeAccountMappingFile(mapping []byte) {
+	encodedMappings := base64.StdEncoding.EncodeToString(mapping)
 	aws.AccountMappingFile = fmt.Sprintf("data:application/json;name=i.json;base64,%s", encodedMappings)
 }
 
-func (aws *AwsIntegrationData) DecodeAccountMappingFile() (string, error) {
+func (aws *AwsIntegrationData) DecodeAccountMappingFile() ([]byte, error) {
 	if len(aws.AccountMappingFile) == 0 {
-		return "", nil
+		return []byte{}, nil
 	}
 
 	var (
@@ -191,10 +191,10 @@ func (aws *AwsIntegrationData) DecodeAccountMappingFile() (string, error) {
 		raw, err = base64.StdEncoding.DecodeString(b64[1])
 	)
 	if err != nil {
-		return "", err
+		return []byte{}, err
 	}
 
-	return string(raw), nil
+	return raw, nil
 }
 
 type AwsIntegrationCreds struct {

--- a/api/integrations_aws_test.go
+++ b/api/integrations_aws_test.go
@@ -44,7 +44,7 @@ func TestIntegrationsNewAwsCfgIntegration(t *testing.T) {
 }
 
 func TestIntegrationsNewAwsCfgIntegrationWithCustomTemplateFile(t *testing.T) {
-	accountMappingJSON := `{
+	accountMappingJSON := []byte(`{
     "defaultLaceworkAccountAws": "lw_account_1",
     "integration_mappings": {
       "lw_account_2": {
@@ -60,7 +60,7 @@ func TestIntegrationsNewAwsCfgIntegrationWithCustomTemplateFile(t *testing.T) {
         ]
       }
     }
-  }`
+  }`)
 	awsData := api.AwsIntegrationData{
 		Credentials: api.AwsIntegrationCreds{
 			RoleArn:    "arn:foo:bar",
@@ -76,16 +76,16 @@ func TestIntegrationsNewAwsCfgIntegrationWithCustomTemplateFile(t *testing.T) {
 		"data:application/json;name=i.json;base64,",
 		"check the custom_template_file encoder",
 	)
-	accountMappingString, err := subject.Data.DecodeAccountMappingFile()
+	accountMapping, err := subject.Data.DecodeAccountMappingFile()
 	assert.Nil(t, err)
-	assert.Equal(t, accountMappingJSON, accountMappingString)
+	assert.Equal(t, accountMappingJSON, accountMapping)
 
 	// When there is no custom account mapping file, this function should
 	// return an empty string to match the pattern
 	subject.Data.AccountMappingFile = ""
-	accountMappingString, err = subject.Data.DecodeAccountMappingFile()
+	accountMapping, err = subject.Data.DecodeAccountMappingFile()
 	assert.Nil(t, err)
-	assert.Equal(t, "", accountMappingString)
+	assert.Empty(t, accountMapping)
 
 }
 

--- a/cli/cmd/integration.go
+++ b/cli/cmd/integration.go
@@ -371,7 +371,25 @@ func reflectIntegrationData(raw api.RawIntegration) [][]string {
 			[]string{"EXTERNAL ID", iData.Credentials.ExternalID},
 		}
 		if iData.QueueUrl != "" {
-			return append(out, []string{"QUEUE URL", iData.QueueUrl})
+			out = append(out, []string{"QUEUE URL", iData.QueueUrl})
+		}
+
+		accountMapping, err := iData.DecodeAccountMappingFile()
+		if err != nil {
+			cli.Log.Debugw("unable to decode account mapping file",
+				"integration_type", raw.Type,
+				"raw_data", iData.AccountMappingFile,
+				"error", err,
+			)
+		}
+
+		if len(accountMapping) != 0 {
+			// @afiune should we disable the colors here?
+			accountMappingJSON, err := cli.FormatJSONString(string(accountMapping))
+			if err != nil {
+				accountMappingJSON = string(accountMapping)
+			}
+			out = append(out, []string{"ACCOUNT MAPPING FILE", accountMappingJSON})
 		}
 		return out
 
@@ -530,6 +548,12 @@ func reflectIntegrationData(raw api.RawIntegration) [][]string {
 				"error", err,
 			)
 		}
+
+		// @afiune should we disable the colors here?
+		tmplStrPretty, err := cli.FormatJSONString(templateString)
+		if err != nil {
+			tmplStrPretty = templateString
+		}
 		out := [][]string{
 			[]string{"JIRA INTEGRATION TYPE", iData.JiraType},
 			[]string{"JIRA URL", iData.JiraUrl},
@@ -537,7 +561,7 @@ func reflectIntegrationData(raw api.RawIntegration) [][]string {
 			[]string{"USERNAME", iData.Username},
 			[]string{"ISSUE TYPE", iData.IssueType},
 			[]string{"ISSUE GROUPING", iData.IssueGrouping},
-			[]string{"CUSTOM TEMPLATE FILE", templateString},
+			[]string{"CUSTOM TEMPLATE FILE", tmplStrPretty},
 		}
 
 		return out

--- a/cli/cmd/integration_aws.go
+++ b/cli/cmd/integration_aws.go
@@ -137,7 +137,7 @@ func createAwsCloudTrailIntegration() error {
 			return err
 		}
 
-		aws.EncodeAccountMappingFile(content)
+		aws.EncodeAccountMappingFile([]byte(content))
 	}
 
 	awsCT := api.NewAwsCloudTrailIntegration(answers.Name, aws)


### PR DESCRIPTION
This refactor is modifying the behavior of the Encode and Decode
functions to use `[]byte` instead of `string`, this way we won't be
casting its content back and forth like this example:

https://github.com/lacework/terraform-provider-lacework/pull/43

Additionally, I have made the `lacework integration show` command to
display the account mapping content.

```
$ lacework int show TECHALLY_53DFFB3E788A30BD84AD1822B06473018B2B4CBA0C1AD4C
                      INTEGRATION GUID                     |              NAME              |    TYPE    | STATUS  | STATE
-----------------------------------------------------------+--------------------------------+------------+---------+--------
  TECHALLY_53DFFB3E788A30BD84AD1822B06473018B2B4CBA0C1AD4C | A consolidated CloudTrail      | AWS_CT_SQS | Enabled | Ok

                                           INTEGRATION DETAILS
----------------------------------------------------------------------------------------------------------
    ROLE ARN              | arn:aws:iam::123483698038:role/lacework_iam_role
    EXTERNAL ID           | bubulubu
    QUEUE URL             | https://sqs.us-west-2.amazonaws.com/123483698038/lacework-ct-sqs-tech-ally
    ACCOUNT MAPPING FILE  | {
                          |   "defaultLaceworkAccountAws": "mini-ally",
                          |   "integration_mappings": {
                          |     "customerdemo": {
                          |       "aws_accounts": [
                          |         "934534535",
                          |         "553453453"
                          |       ]
                          |     },
                          |     "tech-ally": {
                          |       "aws_accounts": [
                          |         "774564564",
                          |         "234556677"
                          |       ]
                          |     }
                          |   }
                          | }
    UPDATED AT            | 2020-Nov-24 14:05:58 UTC
    UPDATED BY            | salim.afiunemaya@lacework.net
    STATE UPDATED AT      | 2020-Nov-24 14:06:02 UTC
    LAST SUCCESSFUL STATE | 2020-Nov-24 14:06:02 UTC

```

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>