### PR TITLE
fix: false positive results in pkg-manifest scan

### DIFF
--- a/cli/cmd/package_manifest.go
+++ b/cli/cmd/package_manifest.go
@@ -29,20 +29,11 @@ import (
 	"syscall"
 
 	"github.com/pkg/errors"
+
+	"github.com/lacework/go-sdk/api"
 )
 
 var SupportedPackageManagers = []string{"dpkg-query", "rpm"} // @afiune can we support ym and apk?
-
-type PackageManifest struct {
-	OsPkgInfoList []OsPkgInfo `json:"os_pkg_info_list"`
-}
-
-type OsPkgInfo struct {
-	Os     string `json:"os"`
-	OsVer  string `json:"os_ver"`
-	Pkg    string `json:"pkg"`
-	PkgVer string `json:"pkg_ver"`
-}
 
 type OS struct {
 	Name    string
@@ -55,8 +46,8 @@ var (
 	rexVersionID  = regexp.MustCompile(`^VERSION_ID=(.*)$`)
 )
 
-func (c *cliState) GeneratePackageManifest() (*PackageManifest, error) {
-	manifest := new(PackageManifest)
+func (c *cliState) GeneratePackageManifest() (*api.PackageManifest, error) {
+	manifest := new(api.PackageManifest)
 	osInfo, err := cli.GetOSInfo()
 	if err != nil {
 		return manifest, err
@@ -144,7 +135,7 @@ func (c *cliState) GeneratePackageManifest() (*PackageManifest, error) {
 		}
 
 		manifest.OsPkgInfoList = append(manifest.OsPkgInfoList,
-			OsPkgInfo{
+			api.OsPkgInfo{
 				Os:     osInfo.Name,
 				OsVer:  osInfo.Version,
 				Pkg:    pkgDetail[0],

--- a/cli/cmd/vuln_html.go
+++ b/cli/cmd/vuln_html.go
@@ -28,9 +28,10 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/lacework/go-sdk/api"
 	"github.com/lacework/go-sdk/internal/databox"
 	"github.com/pkg/errors"
+
+	"github.com/lacework/go-sdk/api"
 )
 
 const (


### PR DESCRIPTION
The API response coming from the Lacework server contains too much
information that could confuse our users, this change is cleaning the
response by removing all vulnerabilities that don't match, that is, those
vulnerabilities that have the evaluation status equal to `VULNERABLE`.

This fix is modifying both, the human-readable and JSON outputs.

With these changes, the CLI results match what the UI shows on the daily scan:

## UI Dashboard
![Screen Shot 2020-12-07 at 12 18 56 PM](https://user-images.githubusercontent.com/5712253/101345191-ede36880-3843-11eb-8b68-63c6775c3c06.png)

## Local CLI scan
![Screen Shot 2020-12-07 at 12 18 43 PM](https://user-images.githubusercontent.com/5712253/101345256-0784b000-3844-11eb-87e0-742fc79ad3c9.png)

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>