### PR TITLE
fix(api): avoid updating AgentTokenResponse.Props

### DIFF
--- a/api/agent.go
+++ b/api/agent.go
@@ -47,7 +47,7 @@ func (svc *AgentsService) CreateToken(name, desc string) (response AgentTokensRe
 		AgentTokenRequest{
 			TokenAlias: name,
 			Enabled:    1,
-			Props: AgentTokenProps{
+			Props: &AgentTokenProps{
 				Description: desc,
 			},
 		},
@@ -122,9 +122,9 @@ func (t AgentToken) EnabledInt() int {
 }
 
 type AgentTokenRequest struct {
-	TokenAlias string          `json:"TOKEN_ALIAS,omitempty"`
-	Enabled    int             `json:"TOKEN_ENABLED"`
-	Props      AgentTokenProps `json:"PROPS,omitempty"`
+	TokenAlias string           `json:"TOKEN_ALIAS,omitempty"`
+	Enabled    int              `json:"TOKEN_ENABLED"`
+	Props      *AgentTokenProps `json:"PROPS,omitempty"`
 }
 
 type AgentTokenProps struct {

--- a/cli/cmd/agent.go
+++ b/cli/cmd/agent.go
@@ -242,7 +242,7 @@ func updateAgentToken(_ *cobra.Command, args []string) error {
 	updated := api.AgentTokenRequest{
 		TokenAlias: actual.TokenAlias,
 		Enabled:    actual.EnabledInt(),
-		Props: api.AgentTokenProps{
+		Props: &api.AgentTokenProps{
 			CreatedTime: actual.Props.CreatedTime,
 		},
 	}


### PR DESCRIPTION
This change is making the `api.AgentTokenResponse` to have the field
`Props` to be a pointer of `AgentTokenProps`, this way we are not
sending an empty description and updating it.

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>