### PR TITLE
build: upgrade Go version to 1.15

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ orbs:
 executors:
   go-executor:
     docker:
-      - image: circleci/golang:1.14
+      - image: circleci/golang:1.15
     working_directory: /go/src/github.com/lacework/go-sdk
   alpine:
     docker:

--- a/Makefile
+++ b/Makefile
@@ -49,9 +49,9 @@ imports-check:
 
 build-cli-cross-platform:
 	gox -output="bin/$(PACKAGENAME)-{{.OS}}-{{.Arch}}" \
-            -os="darwin linux windows" \
+            -os="linux windows" \
             -arch="amd64 386" \
-            -osarch="linux/arm linux/arm64" \
+            -osarch="darwin/amd64 linux/arm linux/arm64" \
             -ldflags=$(GO_LDFLAGS) \
             github.com/lacework/go-sdk/cli
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/lacework/go-sdk
 
-go 1.14
+go 1.15
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.0.7

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -30,7 +30,6 @@ readonly docker_tags=(
 
 VERSION=$(cat VERSION)
 TARGETS=(
-  ${package_name}-darwin-386
   ${package_name}-darwin-amd64
   ${package_name}-windows-386.exe
   ${package_name}-windows-amd64.exe


### PR DESCRIPTION
From community contribution: https://github.com/lacework/go-sdk/pull/235

We are upgrading the Go version to 1.15. On this version the **macOS arch 386 is
unsupported** and therefore, we are roving the building and releasing that binary.
```
$ make install-cli
1 errors occurred:
--> darwin/386 error: exit status 2
Stderr: cmd/go: unsupported GOOS/GOARCH pair darwin/386
```

![tenor-73907008](https://user-images.githubusercontent.com/5712253/102090068-3c5fac80-3dda-11eb-9176-28bdf0cfeb7a.gif)
