### PR TITLE
fix(cli): render account mapping file correctly

### DIFF
--- a/cli/cmd/integration.go
+++ b/cli/cmd/integration.go
@@ -286,15 +286,18 @@ func buildIntDetailsTable(integrations []api.RawIntegration) string {
 	details = append(details, buildIntegrationState(integration.State)...)
 
 	return renderOneLineCustomTable("INTEGRATION DETAILS",
-		renderSimpleTable([]string{}, details),
+		renderCustomTable([]string{}, details,
+			tableFunc(func(t *tablewriter.Table) {
+				t.SetBorder(false)
+				t.SetColumnSeparator(" ")
+				t.SetAutoWrapText(false)
+			}),
+		),
 		tableFunc(func(t *tablewriter.Table) {
 			t.SetBorder(false)
 			t.SetAutoWrapText(false)
 		}),
 	)
-	//t.SetBorder(false)
-	//t.SetAutoWrapText(false)
-	//t.SetAlignment(tablewriter.ALIGN_LEFT)
 }
 
 func buildIntegrationState(state *api.IntegrationState) [][]string {


### PR DESCRIPTION
The account mapping file is not rendering correctly:
```
    ACCOUNT MAPPING FILE    {
                            "defaultLaceworkAccountAws":
                            "customerdemo",
                            "integration_mappings": {
                                "mini-ally": {
                            "aws_accounts": [
                            "123456789012"       ]
                            },     "tech-ally": {
                             "aws_accounts": [
                            "123456789012"       ]     }
                              } }
```

After this change this field will look correctly:
```
    ACCOUNT MAPPING FILE    {
                              "defaultLaceworkAccountAws": "customerdemo",
                              "integration_mappings": {
                                "mini-ally": {
                                  "aws_accounts": [
                                    "123456789012"
                                  ]
                                },
                                "tech-ally": {
                                  "aws_accounts": [
                                    "123456789012"
                                  ]
                                }
                              }
                            }
```

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>