### PR TITLE
feat(api): add Webhook integration

### DIFF
--- a/api/_examples/webhook-alert-channel/main.go
+++ b/api/_examples/webhook-alert-channel/main.go
@@ -19,7 +19,7 @@ func main() {
 		},
 	)
 
-	response, err := lacework.Integrations.CreateWebhookAlertChannel(mySlackChannel)
+	response, err := lacework.Integrations.CreateWebhookAlertChannel(myWebhookChannel)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/api/_examples/webhook-alert-channel/main.go
+++ b/api/_examples/webhook-alert-channel/main.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/lacework/go-sdk/api"
+)
+
+func main() {
+	lacework, err := api.NewClient("account", api.WithApiKeys("KEY", "SECRET"))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	myWebhookChannel := api.NewWebhookAlertChannel("webhook-alert-from-golang",
+		api.WebhookChannelData{
+			WebhookUrl: "https://mywebhook.com/?api-token=123",
+		},
+	)
+
+	response, err := lacework.Integrations.CreateWebhookAlertChannel(mySlackChannel)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Output: Webhook alert channel created: THE-INTEGRATION-GUID
+	fmt.Printf("Webhook alert channel created: %s", response.Data[0].IntgGuid)
+}

--- a/api/integration_alert_channels_slack.go
+++ b/api/integration_alert_channels_slack.go
@@ -94,6 +94,5 @@ type SlackAlertChannel struct {
 }
 
 type SlackChannelData struct {
-	IssueGrouping string `json:"ISSUE_GROUPING,omitempty" mapstructure:"ISSUE_GROUPING"`
-	SlackUrl      string `json:"SLACK_URL" mapstructure:"SLACK_URL"`
+	SlackUrl string `json:"SLACK_URL" mapstructure:"SLACK_URL"`
 }

--- a/api/integration_alert_channels_webhook.go
+++ b/api/integration_alert_channels_webhook.go
@@ -1,0 +1,73 @@
+//
+// Author:: Darren Murray(<darren.murray@lacework.net>)
+// Copyright:: Copyright 2020, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package api
+
+func NewWebhookAlertChannel(name string, data WebhookChannelData) WebhookAlertChannel {
+	return WebhookAlertChannel{
+		commonIntegrationData: commonIntegrationData{
+			Name:    name,
+			Type:    WebhookIntegration.String(),
+			Enabled: 1,
+		},
+		Data: data,
+	}
+}
+
+func (svc *IntegrationsService) CreateWebhookAlertChannel(integration WebhookAlertChannel) (
+	response WebhookAlertChannelResponse,
+	err error,
+) {
+	err = svc.create(integration, &response)
+	return
+}
+
+func (svc *IntegrationsService) GetWebhookAlertChannel(guid string) (response WebhookAlertChannelResponse,
+	err error) {
+	err = svc.get(guid, &response)
+	return
+}
+
+func (svc *IntegrationsService) UpdateWebhookAlertChannel(data WebhookAlertChannel) (
+	response WebhookAlertChannelResponse,
+	err error,
+) {
+	err = svc.update(data.IntgGuid, data, &response)
+	return
+}
+
+func (svc *IntegrationsService) ListWebhookAlertChannel() (response WebhookAlertChannelResponse, err error) {
+	err = svc.listByType(WebhookIntegration, &response)
+	return
+}
+
+type WebhookAlertChannelResponse struct {
+	Data    []WebhookAlertChannel `json:"data"`
+	Ok      bool                  `json:"ok"`
+	Message string                `json:"message"`
+}
+
+type WebhookAlertChannel struct {
+	commonIntegrationData
+	Data WebhookChannelData `json:"DATA"`
+}
+
+type WebhookChannelData struct {
+	IssueGrouping string `json:"ISSUE_GROUPING,omitempty" mapstructure:"ISSUE_GROUPING"`
+	WebhookUrl    string `json:"WEBHOOK_URL" mapstructure:"WEBHOOK_URL"`
+}

--- a/api/integration_alert_channels_webhook.go
+++ b/api/integration_alert_channels_webhook.go
@@ -68,6 +68,5 @@ type WebhookAlertChannel struct {
 }
 
 type WebhookChannelData struct {
-	IssueGrouping string `json:"ISSUE_GROUPING,omitempty" mapstructure:"ISSUE_GROUPING"`
-	WebhookUrl    string `json:"WEBHOOK_URL" mapstructure:"WEBHOOK_URL"`
+	WebhookUrl string `json:"WEBHOOK_URL" mapstructure:"WEBHOOK_URL"`
 }

--- a/api/integration_alert_channels_webhook.go
+++ b/api/integration_alert_channels_webhook.go
@@ -18,6 +18,25 @@
 
 package api
 
+// NewWebhookAlertChannel returns an instance of WebhookAlertChannel
+// with the provided name and data.
+//
+// Basic usage: Initialize a new WebhookAlertChannel struct, then
+//              use the new instance to do CRUD operations
+//
+//   client, err := api.NewClient("account")
+//   if err != nil {
+//     return err
+//   }
+//
+//   webhookChannel := api.NewWebhookAlertChannel("foo",
+//     api.WebhookChannelData{
+//       WebhookUrl: "https://mywebhook.com/?api-token=123",
+//     },
+//   )
+//
+//   client.Integrations.CreateWebhookAlertChannel(webhookChannel)
+//
 func NewWebhookAlertChannel(name string, data WebhookChannelData) WebhookAlertChannel {
 	return WebhookAlertChannel{
 		commonIntegrationData: commonIntegrationData{
@@ -29,6 +48,7 @@ func NewWebhookAlertChannel(name string, data WebhookChannelData) WebhookAlertCh
 	}
 }
 
+// CreateWebhookAlertChannel creates a webhook alert channel integration on the Lacework Server
 func (svc *IntegrationsService) CreateWebhookAlertChannel(integration WebhookAlertChannel) (
 	response WebhookAlertChannelResponse,
 	err error,
@@ -37,12 +57,15 @@ func (svc *IntegrationsService) CreateWebhookAlertChannel(integration WebhookAle
 	return
 }
 
+// GetWebhookAlertChannel gets a webhook alert channel integration that matches with
+// the provided integration guid on the Lacework Server
 func (svc *IntegrationsService) GetWebhookAlertChannel(guid string) (response WebhookAlertChannelResponse,
 	err error) {
 	err = svc.get(guid, &response)
 	return
 }
 
+// UpdateWebhookAlertChannel updates a single webhook alert channel integration
 func (svc *IntegrationsService) UpdateWebhookAlertChannel(data WebhookAlertChannel) (
 	response WebhookAlertChannelResponse,
 	err error,
@@ -51,6 +74,7 @@ func (svc *IntegrationsService) UpdateWebhookAlertChannel(data WebhookAlertChann
 	return
 }
 
+// ListWebhookAlertChannel lists the WEBHOOK external integrationS available on the Lacework Server
 func (svc *IntegrationsService) ListWebhookAlertChannel() (response WebhookAlertChannelResponse, err error) {
 	err = svc.listByType(WebhookIntegration, &response)
 	return

--- a/api/integration_alert_channels_webhook_test.go
+++ b/api/integration_alert_channels_webhook_test.go
@@ -1,0 +1,243 @@
+//
+// Author:: Darren Murray (<darren.murray@lacework.net>)
+// Copyright:: Copyright 2020, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package api_test
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/lacework/go-sdk/api"
+	"github.com/lacework/go-sdk/internal/intgguid"
+	"github.com/lacework/go-sdk/internal/lacework"
+)
+
+func TestIntegrationsNewWebhookAlertChannel(t *testing.T) {
+	subject := api.NewWebhookAlertChannel("integration_name",
+		api.WebhookChannelData{
+			WebhookUrl: "https://hooks.webhook.com/?api-token=12345",
+		},
+	)
+	assert.Equal(t, api.WebhookIntegration.String(), subject.Type)
+}
+
+func TestIntegrationsCreateWebhookAlertChannel(t *testing.T) {
+	var (
+		intgGUID   = intgguid.New()
+		fakeServer = lacework.MockServer()
+	)
+	fakeServer.MockAPI("external/integrations", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method, "CreateWebhookAlertChannel should be a POST method")
+
+		if assert.NotNil(t, r.Body) {
+			body := httpBodySniffer(r)
+			assert.Contains(t, body, "integration_name", "integration name is missing")
+			assert.Contains(t, body, "WEBHOOK", "wrong integration type")
+			assert.Contains(t, body, "https://hooks.webhook.com/?api-token=12345", "wrong webhook url")
+			assert.Contains(t, body, "ENABLED\":1", "integration is not enabled")
+		}
+
+		fmt.Fprintf(w, webhookChannelIntegrationJsonResponse(intgGUID))
+	})
+	defer fakeServer.Close()
+
+	c, err := api.NewClient("test",
+		api.WithToken("TOKEN"),
+		api.WithURL(fakeServer.URL()),
+	)
+	assert.Nil(t, err)
+
+	data := api.NewWebhookAlertChannel("integration_name",
+		api.WebhookChannelData{
+			WebhookUrl: "https://hooks.webhook.com/?api-token=12345",
+		},
+	)
+	assert.Equal(t, "integration_name", data.Name, "Webhook integration name mismatch")
+	assert.Equal(t, "WEBHOOK", data.Type, "a new Webhook integration should match its type")
+	assert.Equal(t, 1, data.Enabled, "a new Webhook integration should be enabled")
+
+	response, err := c.Integrations.CreateWebhookAlertChannel(data)
+	assert.Nil(t, err)
+	assert.NotNil(t, response)
+	assert.True(t, response.Ok)
+	if assert.Equal(t, 1, len(response.Data)) {
+		resData := response.Data[0]
+		assert.Equal(t, intgGUID, resData.IntgGuid)
+		assert.Equal(t, "integration_name", resData.Name)
+		assert.True(t, resData.State.Ok)
+		assert.Equal(t, "https://hooks.webhook.com/?api-token=12345", resData.Data.WebhookUrl)
+	}
+}
+
+func TestIntegrationsGetWebhookAlertChannel(t *testing.T) {
+	var (
+		intgGUID   = intgguid.New()
+		apiPath    = fmt.Sprintf("external/integrations/%s", intgGUID)
+		fakeServer = lacework.MockServer()
+	)
+	fakeServer.MockAPI(apiPath, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method, "GetWebhookAlertChannel should be a GET method")
+		fmt.Fprintf(w, webhookChannelIntegrationJsonResponse(intgGUID))
+	})
+	defer fakeServer.Close()
+
+	c, err := api.NewClient("test",
+		api.WithToken("TOKEN"),
+		api.WithURL(fakeServer.URL()),
+	)
+	assert.Nil(t, err)
+
+	response, err := c.Integrations.GetWebhookAlertChannel(intgGUID)
+	assert.Nil(t, err)
+	assert.NotNil(t, response)
+	assert.True(t, response.Ok)
+	if assert.Equal(t, 1, len(response.Data)) {
+		resData := response.Data[0]
+		assert.Equal(t, intgGUID, resData.IntgGuid)
+		assert.Equal(t, "integration_name", resData.Name)
+		assert.True(t, resData.State.Ok)
+		assert.Equal(t, "https://hooks.webhook.com/?api-token=12345", resData.Data.WebhookUrl)
+	}
+}
+
+func TestIntegrationsUpdateWebhookAlertChannel(t *testing.T) {
+	var (
+		intgGUID   = intgguid.New()
+		apiPath    = fmt.Sprintf("external/integrations/%s", intgGUID)
+		fakeServer = lacework.MockServer()
+	)
+	fakeServer.MockAPI(apiPath, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "PATCH", r.Method, "UpdateWebhookAlertChannel should be a PATCH method")
+
+		if assert.NotNil(t, r.Body) {
+			body := httpBodySniffer(r)
+			assert.Contains(t, body, intgGUID, "INTG_GUID missing")
+			assert.Contains(t, body, "integration_name", "integration name is missing")
+			assert.Contains(t, body, "WEBHOOK", "wrong integration type")
+			assert.Contains(t, body, "https://hooks.webhook.com/?api-token=12345", "wrong webhook url")
+			assert.Contains(t, body, "ENABLED\":1", "integration is not enabled")
+		}
+
+		fmt.Fprintf(w, webhookChannelIntegrationJsonResponse(intgGUID))
+	})
+	defer fakeServer.Close()
+
+	c, err := api.NewClient("test",
+		api.WithToken("TOKEN"),
+		api.WithURL(fakeServer.URL()),
+	)
+	assert.Nil(t, err)
+
+	data := api.NewWebhookAlertChannel("integration_name",
+		api.WebhookChannelData{
+			WebhookUrl: "https://hooks.webhook.com/?api-token=12345",
+		},
+	)
+	assert.Equal(t, "integration_name", data.Name, "Webhook integration name mismatch")
+	assert.Equal(t, "WEBHOOK", data.Type, "a new Webhook integration should match its type")
+	assert.Equal(t, 1, data.Enabled, "a new Webhook integration should be enabled")
+	data.IntgGuid = intgGUID
+
+	response, err := c.Integrations.UpdateWebhookAlertChannel(data)
+	assert.Nil(t, err)
+	assert.NotNil(t, response)
+	assert.Equal(t, "SUCCESS", response.Message)
+	assert.Equal(t, 1, len(response.Data))
+	assert.Equal(t, intgGUID, response.Data[0].IntgGuid)
+}
+
+func TestIntegrationsListWebhookAlertChannel(t *testing.T) {
+	var (
+		intgGUIDs  = []string{intgguid.New(), intgguid.New(), intgguid.New()}
+		fakeServer = lacework.MockServer()
+	)
+	fakeServer.MockAPI("external/integrations/type/WEBHOOK",
+		func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "GET", r.Method, "ListWebhookAlertChannel should be a GET method")
+			fmt.Fprintf(w, webhookChanMultiIntegrationJsonResponse(intgGUIDs))
+		},
+	)
+	defer fakeServer.Close()
+
+	c, err := api.NewClient("test",
+		api.WithToken("TOKEN"),
+		api.WithURL(fakeServer.URL()),
+	)
+	assert.Nil(t, err)
+
+	response, err := c.Integrations.ListWebhookAlertChannel()
+	assert.Nil(t, err)
+	assert.NotNil(t, response)
+	assert.True(t, response.Ok)
+	assert.Equal(t, len(intgGUIDs), len(response.Data))
+	for _, d := range response.Data {
+		assert.Contains(t, intgGUIDs, d.IntgGuid)
+	}
+}
+
+func webhookChannelIntegrationJsonResponse(intgGUID string) string {
+	return `
+{
+  "data": [` + singleWebhookChanIntegration(intgGUID) + `],
+  "ok": true,
+  "message": "SUCCESS"
+}
+`
+}
+
+func webhookChanMultiIntegrationJsonResponse(guids []string) string {
+	integrations := []string{}
+	for _, guid := range guids {
+		integrations = append(integrations, singleWebhookChanIntegration(guid))
+	}
+	return `
+{
+"data": [` + strings.Join(integrations, ", ") + `],
+"ok": true,
+"message": "SUCCESS"
+}
+`
+}
+
+func singleWebhookChanIntegration(id string) string {
+	return `
+{
+  "INTG_GUID": "` + id + `",
+  "CREATED_OR_UPDATED_BY": "user@email.com",
+  "CREATED_OR_UPDATED_TIME": "2020-Jul-16 19:59:22 UTC",
+  "DATA": {
+    "ISSUE_GROUPING": "Events",
+    "WEBHOOK_URL": "https://hooks.webhook.com/?api-token=12345"
+  },
+  "ENABLED": 1,
+  "IS_ORG": 0,
+  "NAME": "integration_name",
+  "STATE": {
+    "lastSuccessfulTime": "2020-Jul-16 18:26:54 UTC",
+    "lastUpdatedTime": "2020-Jul-16 18:26:54 UTC",
+    "ok": true
+  },
+  "TYPE": "WEBHOOK",
+  "TYPE_NAME": "WEBHOOK"
+}
+`
+}

--- a/api/integrations.go
+++ b/api/integrations.go
@@ -66,6 +66,9 @@ const (
 
 	// Jira integration type
 	JiraIntegration
+
+	// Webhook channel integration type
+	WebhookIntegration
 )
 
 // IntegrationTypes is the list of available integration types
@@ -82,6 +85,7 @@ var IntegrationTypes = map[integrationType]string{
 	AwsCloudWatchIntegration:     "CLOUDWATCH_EB",
 	PagerDutyIntegration:         "PAGER_DUTY_API",
 	JiraIntegration:              "JIRA",
+	WebhookIntegration:           "WEBHOOK",
 }
 
 // String returns the string representation of an integration type

--- a/cli/cmd/integration_webhook.go
+++ b/cli/cmd/integration_webhook.go
@@ -1,0 +1,63 @@
+//
+// Author:: Darren Murray(<darren.murray@lacework.net>)
+// Copyright:: Copyright 2020, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cmd
+
+import (
+	"github.com/AlecAivazis/survey/v2"
+
+	"github.com/lacework/go-sdk/api"
+)
+
+func createWebhookIntegration() error {
+	questions := []*survey.Question{
+		{
+			Name:     "name",
+			Prompt:   &survey.Input{Message: "Name: "},
+			Validate: survey.Required,
+		},
+		{
+			Name:     "url",
+			Prompt:   &survey.Input{Message: "Webhook URL: "},
+			Validate: survey.Required,
+		},
+	}
+
+	answers := struct {
+		Name string
+		Url  string
+	}{}
+
+	err := survey.Ask(questions, &answers,
+		survey.WithIcons(promptIconsFunc),
+	)
+	if err != nil {
+		return err
+	}
+
+	webhook := api.NewWebhookAlertChannel(answers.Name,
+		api.WebhookChannelData{
+			WebhookUrl: answers.Url,
+		},
+	)
+
+	cli.StartProgress(" Creating integration...")
+	_, err = cli.LwApi.Integrations.CreateWebhookAlertChannel(webhook)
+	cli.StopProgress()
+	return err
+}


### PR DESCRIPTION
Users can do CRUD operations of Webhook Channel Alerts
+
Users can create Webhook Channel Alert Integrations via the CLI

Signed-off-by: Darren Murray darren.murray@lacework.net