### PR TITLE
feat(cli): daily version check

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ func main() {
 	} else {
 		// Output: The latest release of the go-sdk project is v0.1.7
 		fmt.Printf("The latest release of the %s project is %s\n",
-			project, sdk.Latest,
+			project, sdk.LatestVersion,
 		)
 	}
 }

--- a/cli/README.md
+++ b/cli/README.md
@@ -100,6 +100,7 @@ operation of the Lacework CLI.
 |`LW_NOCOLOR=1`|turn off colors|
 |`LW_DEBUG=1`|turn on debug logging|
 |`LW_JSON=1`|switch commands output from human-readable to JSON format|
+|`LW_UPDATES_DISABLE=1`|disable daily version checks|
 |`LW_NONINTERACTIVE=1`|disable interactive progress bars (i.e. spinners)|
 |`LW_PROFILE="<name>"`|switch between profiles configured at `~/.lacework.toml`|
 |`LW_ACCOUNT="<account>"`|account subdomain of URL (i.e. `<ACCOUNT>.lacework.net`)|

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -61,6 +61,15 @@ This will prompt you for your Lacework account and a set of API access keys.`,
 				return cli.NewClient()
 			}
 		},
+		PersistentPostRunE: func(cmd *cobra.Command, _ []string) error {
+			// run the daily version check but do not fail if we couldn't check
+			// this is not a critical part of the CLI and we do not want to impact
+			// cusomters workflows or CI systems
+			if err := dailyVersionCheck(); err != nil {
+				cli.Log.Debugw("unable to run daily version check", "error", err)
+			}
+			return nil
+		},
 	}
 )
 

--- a/cli/cmd/version.go
+++ b/cli/cmd/version.go
@@ -83,6 +83,14 @@ func init() {
 	rootCmd.AddCommand(versionCmd)
 }
 
+// VersionCache is the representation of the file named 'version_cache' stored
+// at the directory ~/.config/lacework
+type VersionCache struct {
+	Project        string    `json:"project"`
+	CurrentVersion string    `json:"current_version"`
+	LastCheckTime  time.Time `json:"last_check_time"`
+}
+
 // versionCheck checks if the user is running the latest version of the cli,
 // if not, displays a friendly message about the new version available
 func versionCheck() error {
@@ -102,14 +110,9 @@ func versionCheck() error {
 	return nil
 }
 
-type VersionCache struct {
-	Project        string    `json:"project"`
-	CurrentVersion string    `json:"current_version"`
-	LastCheckTime  time.Time `json:"last_check_time"`
-}
-
+// dailyVersionCheck will execute a version check on a daily basis, the function uses
+// the file ~/.config/lacework/version_cache to track the time of last check
 func dailyVersionCheck() error {
-	// find home directory
 	home, err := homedir.Dir()
 	if err != nil {
 		return err

--- a/integration/framework_test.go
+++ b/integration/framework_test.go
@@ -28,6 +28,8 @@ import (
 	"path"
 	"path/filepath"
 	"runtime"
+
+	"github.com/lacework/go-sdk/lwupdater"
 )
 
 // Use this function to execute a real lacework CLI command, under the hood the function
@@ -85,6 +87,7 @@ func NewLaceworkCLI(workingDir string, args ...string) *exec.Cmd {
 		cmd.Dir = workingDir
 		cmd.Env = append(os.Environ(),
 			fmt.Sprintf("HOME=%s", workingDir),
+			fmt.Sprintf("%s=1", lwupdater.DisableEnv),
 		)
 	}
 	return cmd
@@ -128,7 +131,6 @@ func createTOMLConfigFromCIvars() string {
 	if os.Getenv("CI_ACCOUNT") == "" ||
 		os.Getenv("CI_API_KEY") == "" ||
 		os.Getenv("CI_API_SECRET") == "" {
-		// @afiune add instructions
 		log.Fatal(missingCIEnvironmentVariables())
 	}
 

--- a/integration/framework_test.go
+++ b/integration/framework_test.go
@@ -85,12 +85,37 @@ func NewLaceworkCLI(workingDir string, args ...string) *exec.Cmd {
 	cmd.Env = os.Environ()
 	if len(workingDir) != 0 {
 		cmd.Dir = workingDir
-		cmd.Env = append(os.Environ(),
-			fmt.Sprintf("HOME=%s", workingDir),
-			fmt.Sprintf("%s=1", lwupdater.DisableEnv),
-		)
+		env := append(os.Environ(), fmt.Sprintf("HOME=%s", workingDir))
+
+		// by default, we disable all lwupdater requests, unless we are testing it
+		// to test it, set the environment variable CI_TEST_LWUPDATER
+		if os.Getenv(ciTestingUpdaterEnv) == "" {
+			env = append(env, fmt.Sprintf("%s=1", lwupdater.DisableEnv))
+		}
+		cmd.Env = env
 	}
 	return cmd
+}
+
+// By default, we disable all lwupdater requests, unless we are testing it
+// to test it, set the environment variable CI_TEST_LWUPDATER=1
+//
+// Example:
+//
+// func TestUpdaterExample(t *testing.T) {
+//   enableTestingUpdaterEnv()
+//   defer disableTestingUpdaterEnv()
+//
+//   // exacute an updater test
+// }
+var ciTestingUpdaterEnv = "CI_TEST_LWUPDATER"
+
+func enableTestingUpdaterEnv() {
+	os.Setenv(ciTestingUpdaterEnv, "1")
+}
+
+func disableTestingUpdaterEnv() {
+	os.Setenv(ciTestingUpdaterEnv, "")
 }
 
 func runLaceworkCLI(workingDir string, args ...string) (stdout bytes.Buffer, stderr bytes.Buffer, exitcode int) {

--- a/integration/version_test.go
+++ b/integration/version_test.go
@@ -1,0 +1,128 @@
+//
+// Author:: Salim Afiune Maya (<afiune@lacework.net>)
+// Copyright:: Copyright 2020, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package integration
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"path"
+	"testing"
+	"time"
+
+	"github.com/lacework/go-sdk/lwupdater"
+	"github.com/stretchr/testify/assert"
+)
+
+// To test the daily version check we need to set the environment
+// variable CI_TEST_LWUPDATER=1 so that the framework does not disable it
+func TestDailyVersionCheckEndToEnd(t *testing.T) {
+	enableTestingUpdaterEnv()
+	defer disableTestingUpdaterEnv()
+
+	// create a temporal directory to use it as our home directory to test
+	// the version_cache mechanism
+	home := createTOMLConfigFromCIvars()
+	defer os.RemoveAll(home)
+
+	out, errB, exitcode := LaceworkCLIWithHome(home, "configure", "list")
+	assert.Empty(t, errB.String())
+	assert.Equal(t, 0, exitcode)
+	assert.Contains(t, out.String(),
+		"A newer version of the Lacework CLI is available! The latest version is v",
+		"version check message changed?",
+	)
+
+	versionCacheFile := path.Join(home, ".config", "lacework", "version_cache")
+	assert.FileExists(t, versionCacheFile, "the version_cache file is missing")
+
+	var actualCache lwupdater.Version
+	cacheJSON, err := ioutil.ReadFile(versionCacheFile)
+	if assert.Nil(t, err) {
+		err := json.Unmarshal(cacheJSON, &actualCache)
+		if assert.Nil(t, err) {
+			assert.Equal(t, actualCache.Project, "go-sdk")
+			assert.True(t, time.Now().After(actualCache.LastCheckTime))
+			assert.True(t, time.Now().AddDate(0, 0, -1).Before(actualCache.LastCheckTime))
+		}
+	}
+
+	// re-running the same command should not check and display the version update
+	out, errB, exitcode = LaceworkCLIWithHome(home, "configure", "list")
+	assert.Empty(t, errB.String())
+	assert.Equal(t, 0, exitcode)
+	assert.NotContains(t, out.String(),
+		"A newer version of the Lacework CLI is available! The latest version is v",
+		"version update message should not be displayed",
+	)
+
+	// version cache file should continue to exist
+	assert.FileExists(t, versionCacheFile, "the version_cache file is missing")
+
+	var nextCache lwupdater.Version
+	cacheJSON, err = ioutil.ReadFile(versionCacheFile)
+	if assert.Nil(t, err) {
+		err := json.Unmarshal(cacheJSON, &nextCache)
+		if assert.Nil(t, err) {
+			assert.Equal(t, actualCache.Project, nextCache.Project)
+			assert.Equal(t, actualCache.LastCheckTime, nextCache.LastCheckTime)
+			assert.Equal(t, actualCache.CurrentVersion, nextCache.CurrentVersion)
+		}
+	}
+
+	// manipulate the version cache file, set the last check to two days ago
+	actualCache.LastCheckTime = time.Now().AddDate(0, 0, -2)
+
+	err = actualCache.StoreCache(versionCacheFile)
+	assert.Nil(t, err)
+
+	out, errB, exitcode = LaceworkCLIWithHome(home, "configure", "list")
+	assert.Empty(t, errB.String())
+	assert.Equal(t, 0, exitcode)
+	assert.Contains(t, out.String(),
+		"A newer version of the Lacework CLI is available! The latest version is v",
+		"version check message should be there",
+	)
+
+	assert.FileExists(t, versionCacheFile, "the version_cache file is missing")
+
+	var lastCache lwupdater.Version
+	cacheJSON, err = ioutil.ReadFile(versionCacheFile)
+	if assert.Nil(t, err) {
+		err := json.Unmarshal(cacheJSON, &lastCache)
+		if assert.Nil(t, err) {
+			assert.Equal(t, lastCache.Project, "go-sdk")
+			assert.True(t, time.Now().After(lastCache.LastCheckTime))
+			assert.True(t, time.Now().AddDate(0, 0, -1).Before(lastCache.LastCheckTime))
+		}
+	}
+}
+
+func TestVersionCommand(t *testing.T) {
+	enableTestingUpdaterEnv()
+	defer disableTestingUpdaterEnv()
+
+	out, errB, exitcode := LaceworkCLIWithTOMLConfig("version")
+	assert.Empty(t, errB.String())
+	assert.Equal(t, 0, exitcode)
+	assert.Contains(t, out.String(),
+		"A newer version of the Lacework CLI is available! The latest version is v",
+		"version update message should be displayed",
+	)
+}

--- a/lwupdater/README.md
+++ b/lwupdater/README.md
@@ -40,7 +40,7 @@ func main() {
 
 	// Output: The latest release of the go-sdk project is v0.1.7
 	fmt.Printf("The latest release of the %s project is %s\n",
-		project, sdk.Latest,
+		project, sdk.LatestVersion,
 	)
 }
 ```

--- a/lwupdater/_examples/main.go
+++ b/lwupdater/_examples/main.go
@@ -17,7 +17,7 @@ func main() {
 	} else {
 		// Output: The latest release of the go-sdk project is v0.1.7
 		fmt.Printf("The latest release of the %s project is %s\n",
-			project, sdk.Latest,
+			project, sdk.LatestVersion,
 		)
 	}
 }


### PR DESCRIPTION
## User Story
As a Lacework user that leverages the Command-line Interface,
I would like to have a daily reminder that there is a new version I can upgrade to,
So that I know about the new features and functionalities released and I can easily upgrade and use them.

## Description
This change is adding a post function that will verify the version of the Lacework CLI daily,
this function will run (only once a day) on every command.

New users will have the following experience:
```
$ lacework integrations list
                      INTEGRATION GUID                             NAME              TYPE        STATUS    STATE
-----------------------------------------------------------+-------------------+---------------+---------+--------
  TECHALLY_82043CC9554F32F8CE80317B54C486926B56A25CC9E0977   #tech-ally-notify   SLACK_CHANNEL   Enabled   Check

A newer version of the Lacework CLI is available! The latest version is v0.2.11,
to update execute the following command:

  $ curl https://raw.githubusercontent.com/lacework/go-sdk/master/cli/install.sh | bash

$
```

JIRA: ALLY-230

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>