### PR TITLE
refactor(api): remove automatic report trigger

### DIFF
--- a/api/integrations_aws_test.go
+++ b/api/integrations_aws_test.go
@@ -95,13 +95,6 @@ func TestIntegrationsCreateAws(t *testing.T) {
 		fakeServer = lacework.MockServer()
 	)
 
-	// WORKAROUND (@afiune) The backend is currently not triggering an initial
-	// report automatically after creation of Cloud Account (CFG) Integrations,
-	// we are implementing this trigger here until we implement it in the backend
-	// with RAIN-13422
-	fakeServer.MockAPI("external/runReport/integration/"+intgGUID, func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "POST", r.Method, "RunReport should be a POST method")
-	})
 	fakeServer.MockAPI("external/integrations", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "POST", r.Method, "CreateAws should be a POST method")
 

--- a/api/integrations_azure.go
+++ b/api/integrations_azure.go
@@ -18,8 +18,6 @@
 
 package api
 
-import "go.uber.org/zap"
-
 // NewAzureIntegration returns an instance of AzureIntegration with the provided
 // integration type, name and data. The type can only be AzureCfgIntegration or
 // AzureActivityLogIntegration
@@ -76,35 +74,6 @@ func (svc *IntegrationsService) CreateAzure(integration AzureIntegration) (
 	err error,
 ) {
 	err = svc.create(integration, &response)
-	if err != nil {
-		return
-	}
-
-	// WORKAROUND (@afiune) The backend is currently not triggering an initial
-	// report automatically after creation of Cloud Account (CFG) Integrations,
-	// we are implementing this trigger here until we implement it in the backend
-	// with RAIN-13422
-	if len(response.Data) == 0 {
-		return
-	}
-	if integration.Type != AzureCfgIntegration.String() {
-		return
-	}
-
-	intgGuid := response.Data[0].IntgGuid
-	svc.client.log.Info("triggering compliance report",
-		zap.String("cloud_integration", integration.Type),
-		zap.String("int_guid", intgGuid),
-	)
-	_, errComplianceReport := svc.client.Compliance.RunIntegrationReport(intgGuid)
-	if errComplianceReport != nil {
-		svc.client.log.Warn("unable to trigger compliance report",
-			zap.String("cloud_integration", integration.Type),
-			zap.String("int_guid", intgGuid),
-			zap.String("error", errComplianceReport.Error()),
-		)
-	}
-
 	return
 }
 

--- a/api/integrations_azure_test.go
+++ b/api/integrations_azure_test.go
@@ -36,13 +36,6 @@ func TestIntegrationsCreateAzure(t *testing.T) {
 		intgGUID   = intgguid.New()
 		fakeServer = lacework.MockServer()
 	)
-	// WORKAROUND (@afiune) The backend is currently not triggering an initial
-	// report automatically after creation of Cloud Account (CFG) Integrations,
-	// we are implementing this trigger here until we implement it in the backend
-	// with RAIN-13422
-	fakeServer.MockAPI("external/runReport/integration/"+intgGUID, func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "POST", r.Method, "RunReport should be a POST method")
-	})
 	fakeServer.MockAPI("external/integrations", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "POST", r.Method, "CreateAzure should be a POST method")
 

--- a/api/integrations_gcp.go
+++ b/api/integrations_gcp.go
@@ -18,8 +18,6 @@
 
 package api
 
-import "go.uber.org/zap"
-
 // gcpResourceLevel determines Project or Organization level integration
 type gcpResourceLevel int
 
@@ -96,35 +94,6 @@ func (svc *IntegrationsService) CreateGcp(data GcpIntegration) (
 	err error,
 ) {
 	err = svc.create(data, &response)
-	if err != nil {
-		return
-	}
-
-	// WORKAROUND (@afiune) The backend is currently not triggering an initial
-	// report automatically after creation of Cloud Account (CFG) Integrations,
-	// we are implementing this trigger here until we implement it in the backend
-	// with RAIN-13422
-	if len(response.Data) == 0 {
-		return
-	}
-	if data.Type != GcpCfgIntegration.String() {
-		return
-	}
-
-	intgGuid := response.Data[0].IntgGuid
-	svc.client.log.Info("triggering compliance report",
-		zap.String("cloud_integration", data.Type),
-		zap.String("int_guid", intgGuid),
-	)
-	_, errComplianceReport := svc.client.Compliance.RunIntegrationReport(intgGuid)
-	if errComplianceReport != nil {
-		svc.client.log.Warn("unable to trigger compliance report",
-			zap.String("cloud_integration", data.Type),
-			zap.String("int_guid", intgGuid),
-			zap.String("error", errComplianceReport.Error()),
-		)
-	}
-
 	return
 }
 

--- a/api/integrations_gcp_test.go
+++ b/api/integrations_gcp_test.go
@@ -36,13 +36,6 @@ func TestIntegrationsCreateGcp(t *testing.T) {
 		intgGUID   = intgguid.New()
 		fakeServer = lacework.MockServer()
 	)
-	// WORKAROUND (@afiune) The backend is currently not triggering an initial
-	// report automatically after creation of Cloud Account (CFG) Integrations,
-	// we are implementing this trigger here until we implement it in the backend
-	// with RAIN-13422
-	fakeServer.MockAPI("external/runReport/integration/"+intgGUID, func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "POST", r.Method, "RunReport should be a POST method")
-	})
 	fakeServer.MockAPI("external/integrations", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "POST", r.Method, "CreateGcp should be a POST method")
 


### PR DESCRIPTION
The automatic report triggering is now happening in the platform as part
of the creation of new compliance integrations. We are removing the
workaround we put in place while the platfom team was working on this.

JIRA: ALLY-257

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>