### PR TITLE
ci: fix mv on non exisitent directory

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,7 +123,9 @@ jobs:
       - run:
           command: |
             mkdir  circleci-artifacts/
-            mv lacework-lacework-cli* circleci-artifacts/
+            if [ `ls -1 lacework-lacework-cli* 2>/dev/null | wc -l ` -gt 0 ]; then
+                mv lacework-lacework-cli* circleci-artifacts/
+            fi
       - store_artifacts:
           path: circleci-artifacts
       - slack/status:


### PR DESCRIPTION
Add condition before mv command to prevent "No such file or directory" error 

Signed-off-by: Darren Murray <darren.murray@lacework.net>