### PR TITLE
fix(cli): propagate errors from install.sh

### DIFF
--- a/cli/install.sh
+++ b/cli/install.sh
@@ -245,4 +245,4 @@ exit_with() {
   exit "${2:-10}"
 }
 
-main "$@" || exit 99
+main "$@"


### PR DESCRIPTION
Before this change, any error trying to install the Lacework CLI
was ignored, this change is fixing that bug by propagating the
error to the end-user.

## Example: Running the installer without sufficient permissions
```
[ec2-user@ip-10-0-1-19 ~]$ curl https://raw.githubusercontent.com/lacework/go-sdk/2470b0480b753867a55484ea0a0156ac83d70201/cli/install.sh | bash
--> install: Installing the Lacework CLI
--> install: Downloading via curl: https://github.com/lacework/go-sdk/releases/latest/download/lacework-cli-linux-amd64.tar.gz
--> install: Downloading via curl: https://github.com/lacework/go-sdk/releases/latest/download/lacework-cli-linux-amd64.tar.gz.sha256sum
renamed '/var/tmp/tmp.hPKMHbT7oF/lacework-cli-latest.tar.gz' -> 'lacework-cli-linux-amd64.tar.gz'
renamed '/var/tmp/tmp.hPKMHbT7oF/lacework-cli-latest.tar.gz.sha256sum' -> 'lacework-cli-linux-amd64.tar.gz.sha256sum'
--> install: Verifying the shasum digest matches the downloaded archive
lacework-cli-linux-amd64.tar.gz: OK
--> install: Extracting lacework-cli-linux-amd64.tar.gz
--> install: Installing Lacework CLI into /usr/local/bin
install: cannot remove '/usr/local/bin/lacework': Permission denied
```

The user can use the option `-d /directory` to install the Lacework CLI
on a custom location. For example, inside the user's home directory:
```
[ec2-user@ip-10-0-1-19 ~]$ curl https://raw.githubusercontent.com/lacework/go-sdk/2470b0480b753867a55484ea0a0156ac83d70201/cli/install.sh | bash -s --  -d $HOME
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  5442  100  5442    0     0   118k      0 --:--:-- --:--:-- --:--:--  118k
--> install: Installing the Lacework CLI
--> install: Downloading via curl: https://github.com/lacework/go-sdk/releases/latest/download/lacework-cli-linux-amd64.tar.gz
--> install: Downloading via curl: https://github.com/lacework/go-sdk/releases/latest/download/lacework-cli-linux-amd64.tar.gz.sha256sum
renamed '/var/tmp/tmp.Gqo0rZxWJo/lacework-cli-latest.tar.gz' -> 'lacework-cli-linux-amd64.tar.gz'
renamed '/var/tmp/tmp.Gqo0rZxWJo/lacework-cli-latest.tar.gz.sha256sum' -> 'lacework-cli-linux-amd64.tar.gz.sha256sum'
--> install: Verifying the shasum digest matches the downloaded archive
lacework-cli-linux-amd64.tar.gz: OK
--> install: Extracting lacework-cli-linux-amd64.tar.gz
--> install: Installing Lacework CLI into /home/ec2-user
removed '/home/ec2-user/lacework'
'lacework-cli-linux-amd64/lacework' -> '/home/ec2-user/lacework'
--> install: Verifying installed Lacework CLI version
lacework v0.2.11 (sha:7505e50cb5ffd90e6594b7baf18a273b3ede88d2) (time:20201217124903)
--> install: The Lacework CLI has been successfully installed.
[ec2-user@ip-10-0-1-19 ~]$
```

Closes https://github.com/lacework/go-sdk/issues/275

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>