### PR TITLE
feat(cli): gen-pkg-manifest detect running kernel

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 parameters:
   slack-mentions:
     type: string
-    default: 'allies'
+    default: 'S01JP5A3ACQ'
   only_for_branches:
     type: string
     default: 'master'

--- a/cli/cmd/honeyvent.go
+++ b/cli/cmd/honeyvent.go
@@ -71,6 +71,9 @@ const (
 
 	// Daily version check feature
 	featDailyVerCheck = "daily_check"
+
+	// Generate package manifest feature
+	featGenPkgManifest = "gen_pkg_manifest"
 )
 
 // Honeyvent defines what a Honeycomb event looks like for the Lacework CLI
@@ -172,4 +175,16 @@ func (c *cliState) SendHoneyvent() {
 	c.Event.Error = ""
 	c.Event.Feature = ""
 	c.Event.FeatureData = nil
+}
+
+func (e *Honeyvent) AddFeatureField(key string, value interface{}) {
+	if e.FeatureData == nil {
+		e.FeatureData = map[string]interface{}{key: value}
+		return
+	}
+
+	if v, ok := e.FeatureData.(map[string]interface{}); ok {
+		v[key] = value
+		e.FeatureData = v
+	}
 }

--- a/cli/cmd/package_manifest.go
+++ b/cli/cmd/package_manifest.go
@@ -56,6 +56,10 @@ func (c *cliState) GeneratePackageManifest() (*api.PackageManifest, error) {
 	defer func() {
 		c.Event.DurationMs = time.Since(start).Milliseconds()
 		if err == nil {
+			// if this function returns an error, most likely,
+			// the command will send a honeyvent with that error,
+			// therefore we should duplicate events and only send
+			// one here if there is NO error
 			c.SendHoneyvent()
 		}
 	}()

--- a/cli/cmd/package_manifest.go
+++ b/cli/cmd/package_manifest.go
@@ -340,13 +340,11 @@ func (c *cliState) checkPackageManagerWithNativeCommand(manager string) bool {
 }
 
 func removeEpochFromPkgVersion(pkgVer string) string {
-	if !strings.Contains(pkgVer, ":") {
-		return pkgVer
-	}
-
-	pkgVerSplit := strings.Split(pkgVer, ":")
-	if len(pkgVerSplit) == 2 {
-		return pkgVerSplit[1]
+	if strings.Contains(pkgVer, ":") {
+		pkgVerSplit := strings.Split(pkgVer, ":")
+		if len(pkgVerSplit) == 2 {
+			return pkgVerSplit[1]
+		}
 	}
 
 	return pkgVer

--- a/cli/cmd/package_manifest_test.go
+++ b/cli/cmd/package_manifest_test.go
@@ -1,0 +1,93 @@
+//
+// Author:: Salim Afiune Maya (<afiune@lacework.net>)
+// Copyright:: Copyright 2020, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/lacework/go-sdk/api"
+)
+
+func TestRemoveInactivePackagesFromManifest(t *testing.T) {
+	manifest := new(api.PackageManifest)
+	subject := cli.removeInactivePackagesFromManifest(manifest, "rpm")
+	assert.Equal(t, manifest, subject)
+}
+
+func TestRemoveInactivePackagesFromManifestRemoveKernelRPM(t *testing.T) {
+	manifest := &api.PackageManifest{
+		OsPkgInfoList: []api.OsPkgInfo{
+			api.OsPkgInfo{
+				Os: "amzn", OsVer: "2",
+				Pkg: "kernel", PkgVer: "0:4.14.209-160.339.amzn2", // with EPOCH
+			},
+			api.OsPkgInfo{
+				Os: "amzn", OsVer: "2",
+				Pkg: "kernel", PkgVer: "4.14.203-156.332.amzn2", // without EPOCH
+			},
+		},
+	}
+	subject := cli.removeInactivePackagesFromManifest(manifest, "rpm")
+	assert.Empty(t, subject)
+}
+
+func TestRemoveInactivePackagesFromManifestRemoveKernelDPKG(t *testing.T) {
+	manifest := &api.PackageManifest{
+		OsPkgInfoList: []api.OsPkgInfo{
+			api.OsPkgInfo{
+				Os: "ubuntu", OsVer: "18.04",
+				Pkg: "linux-image-5.3.0-1035-aws", PkgVer: "5.3.0-1035.37",
+			},
+			api.OsPkgInfo{
+				Os: "ubuntu", OsVer: "18.04",
+				Pkg: "sudo", PkgVer: "1.8.21p2-3ubuntu1.2", // not a kernel pkg
+			},
+		},
+	}
+	subject := cli.removeInactivePackagesFromManifest(manifest, "dpkg-query")
+	assert.NotEmpty(t, subject)
+	assert.Equal(t, &api.PackageManifest{
+		OsPkgInfoList: []api.OsPkgInfo{
+			api.OsPkgInfo{
+				Os: "ubuntu", OsVer: "18.04",
+				Pkg: "sudo", PkgVer: "1.8.21p2-3ubuntu1.2", // this pkg should persist
+			},
+		},
+	}, subject)
+}
+
+func TestRemoveInactivePackagesFromManifestUnknownManager(t *testing.T) {
+	manifest := new(api.PackageManifest)
+	subject := cli.removeInactivePackagesFromManifest(manifest, "apk")
+	assert.Equal(t, manifest, subject)
+}
+
+func TestRemoveEpochFromPkgVersion(t *testing.T) {
+	assert.Equal(t,
+		"4.14.209-160.339.amzn2",
+		removeEpochFromPkgVersion("4.14.209-160.339.amzn2"))
+	assert.Equal(t,
+		"4.14.209-160.339.amzn2",
+		removeEpochFromPkgVersion("0:4.14.209-160.339.amzn2"))
+	assert.Equal(t,
+		"version",
+		removeEpochFromPkgVersion("epoch:version"))
+}


### PR DESCRIPTION
The default behavior of most Linux distros is to keep the last `N` kernel
packages installed for users that need to fall back in case the new
kernel does not boot.  However, the presence of the package does not mean
that kernel is active.  We must continue to allow the standard kernel
package preservation behavior without providing false-positives of
vulnerabilities that are not active.

This feature detects the active kernel and removes any other
installed-and-inactive kernel from the generated package manifest.

Additionally, we are adding instrumentation to trace the CLI feature
`gen_pkg_manifest` and understand how often is it used and find out
if there are problems with it.

### gen_pkg_manifest feature event

![Screen Shot 2021-01-06 at 1 00 29 PM](https://user-images.githubusercontent.com/5712253/103766881-d59a7100-4fdc-11eb-879e-139be2671f30.png)

With feature data:
```json
{
  "active_kernel": "4.14.209-160.339.amzn2.x86_64",
  "kernel_suppressed_158": "kernel-0:4.14.203-156.332.amzn2",
  "os": "amzn",
  "os_ver": "2",
  "pkg_manager": "rpm",
  "total_manifest_pkgs": 441
}
```

**JIRA: ALLY-264**

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>