### PR TITLE
ci: generate code coverage in HTML format

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,9 @@ jobs:
       - checkout
       - run: make prepare
       - run: make lint
-      - run: make test
+      - run: make coverage-ci
+      - store_artifacts:
+          path: circleci-artifacts
       - run: make fmt-check
       - run: make imports-check
       - slack/status:
@@ -69,6 +71,8 @@ jobs:
           only_for_branches: <<pipeline.parameters.only_for_branches>>
   integration-test-windows:
     executor: win/default
+    environment:
+      GOFLAGS: -mod=vendor
     steps:
       - checkout
       - attach_workspace:

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 
 # Go test coverage
 coverage.out
+coverage.html
 circleci-artifacts/
 
 # for building binary files

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,9 @@ default: ci
 ci: lint test fmt-check imports-check integration
 
 GOLANGCILINTVERSION?=1.23.8
+CIARTIFACTS?=circleci-artifacts
 COVERAGEOUT?=coverage.out
+COVERAGEHTML?=coverage.html
 PACKAGENAME?=lacework-cli
 CLINAME?=lacework
 # Honeycomb variables
@@ -35,6 +37,10 @@ coverage: test
 
 coverage-html: test
 	go tool cover -html=$(COVERAGEOUT)
+
+coverage-ci: test
+	mkdir -p $(CIARTIFACTS)
+	go tool cover -html=$(COVERAGEOUT) -o "$(CIARTIFACTS)/$(COVERAGEHTML)"
 
 go-vendor:
 	go mod tidy

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -175,6 +175,7 @@ load_list_of_changes() {
   _fix=$(echo "$_list_of_changes" | grep "\* fix[:(]")
   _doc=$(echo "$_list_of_changes" | grep "\* doc[:(]")
   _docs=$(echo "$_list_of_changes" | grep "\* docs[:(]")
+  _metric=$(echo "$_list_of_changes" | grep "\* metric[:(]")
   _style=$(echo "$_list_of_changes" | grep "\* style[:(]")
   _chore=$(echo "$_list_of_changes" | grep "\* chore[:(]")
   _build=$(echo "$_list_of_changes" | grep "\* build[:(]")
@@ -213,6 +214,7 @@ load_list_of_changes() {
     if [ "$_chore" != "" ]; then echo "$_chore" >> CHANGES.md; fi
     if [ "$_build" != "" ]; then echo "$_build" >> CHANGES.md; fi
     if [ "$_ci" != "" ]; then echo "$_ci" >> CHANGES.md; fi
+    if [ "$_metric" != "" ]; then echo "$_metric" >> CHANGES.md; fi
     if [ "$_test" != "" ]; then echo "$_test" >> CHANGES.md; fi
   fi
 }


### PR DESCRIPTION
Enabling generating and storing code coverage in HTML format! 🙌🏽

Now every commit/pull-request will generate an HTML artifact that can be found inside Circle CI:

Job Example: https://app.circleci.com/pipelines/github/lacework/go-sdk/896/workflows/60a38854-ed2f-48e7-8907-35eb774a1f00/jobs/3217/artifacts

![image](https://user-images.githubusercontent.com/5712253/103795435-33da4a80-5003-11eb-85a7-9d339f6af980.png)


![image](https://user-images.githubusercontent.com/5712253/103795360-1d33f380-5003-11eb-8144-aa074f127965.png)
