### PR TITLE
feat(cli): add account check to catch http(s)://

### DIFF
--- a/cli/cmd/configure.go
+++ b/cli/cmd/configure.go
@@ -231,16 +231,25 @@ func promptConfigureSetup() error {
 			Transform: func(ans interface{}) interface{} {
 				answer, ok := ans.(string)
 				if ok && strings.Contains(answer, ".lacework.net") {
-					// if the provided account is the full URL ACCOUNT.lacework.net
+					// if the provided account is the full URL https://ACCOUNT.lacework.net
+					// remove the prefix https:// or http://
+					rx, err := regexp.Compile(`(http://|https://)`)
+					if err == nil {
+						answer = rx.ReplaceAllString(answer, "")
+					}
+
+					// if the provided account is the full domain ACCOUNT.lacework.net
 					// subtract the account name and inform the user
-					rx, err := regexp.Compile(`\.lacework\.net.*`)
+					rx, err = regexp.Compile(`\.lacework\.net.*`)
 					if err == nil {
 						accountSplit := rx.Split(answer, -1)
 						if len(accountSplit) != 0 {
-							cli.OutputHuman("Passing '.lacework.net' domain not required. Using '%s'\n", accountSplit[0])
+							cli.OutputHuman("Passing full 'lacework.net' domain not required. Using '%s'\n", accountSplit[0])
 							return accountSplit[0]
 						}
 					}
+
+					return answer
 				}
 
 				return ans

--- a/integration/configure_unix_test.go
+++ b/integration/configure_unix_test.go
@@ -194,8 +194,8 @@ func TestConfigureCommandErrors(t *testing.T) {
 			c.ExpectString("Account:")
 			c.SendLine("")
 			c.ExpectString("The account subdomain of URL is required")
-			c.SendLine("my-account.lacework.net") // if the full URL was provided we transform it and inform the user
-			c.ExpectString("Passing '.lacework.net' domain not required. Using 'my-account'")
+			c.SendLine("https://my-account.lacework.net") // if the full URL was provided we transform it and inform the user
+			c.ExpectString("Passing full 'lacework.net' domain not required. Using 'my-account'")
 			c.ExpectString("Access Key ID:")
 			c.SendLine("")
 			c.ExpectString("The API access key id must have more than 55 characters")


### PR DESCRIPTION
We have found out that users are trying to pass the full URL as the
account setting when running the `configure` command:

```
$ lacework configure
▸ Account: http://my-account.lacework.net/
```

This change is adding a check to catch when users pass the prefix
`http://` or `https://`.

**JIRA: ALLY-280**

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>