### PR TITLE
fix(cli): skip daily version check for version cmd

### DIFF
--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -67,7 +67,12 @@ This will prompt you for your Lacework account and a set of API access keys.`,
 				return cli.NewClient()
 			}
 		},
-		PersistentPostRunE: func(_ *cobra.Command, _ []string) error {
+		PersistentPostRunE: func(cmd *cobra.Command, _ []string) error {
+			// skip daily version check if the user is running the version command
+			if cmd.Use == "version" {
+				return nil
+			}
+
 			// run the daily version check but do not fail if we couldn't check
 			// this is not a critical part of the CLI and we do not want to impact
 			// cusomters workflows or CI systems


### PR DESCRIPTION
If the user is running the command `lacework version` we don't need to
run a daily version check, so we are skipping it for that command.

Closes https://github.com/lacework/go-sdk/issues/287

JIRA: ALLY-285

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>