### PR TITLE
feat(cli): support Homebrew upgrade command

### DIFF
--- a/cli/cmd/cli_unix.go
+++ b/cli/cmd/cli_unix.go
@@ -19,7 +19,11 @@
 
 package cmd
 
-import "github.com/AlecAivazis/survey/v2"
+import (
+	"os"
+
+	"github.com/AlecAivazis/survey/v2"
+)
 
 // used by configure.go
 var configureListCmdSetProfileEnv = `$ export LW_PROFILE="my-profile"`
@@ -32,7 +36,12 @@ var promptIconsFunc = func(icons *survey.IconSet) {
 // UpdateCommand returns the command that a user should run to update the cli
 // to the latest available version (unix specific command)
 func (c *cliState) UpdateCommand() string {
+	if os.Getenv("LW_HOMEBREW_INSTALL") != "" {
+		return `
+	 $ brew upgrade lacework-cli
+	`
+	}
 	return `
-  $ curl https://raw.githubusercontent.com/lacework/go-sdk/master/cli/install.sh | bash
-`
+	   $ curl https://raw.githubusercontent.com/lacework/go-sdk/master/cli/install.sh | bash
+	 `
 }

--- a/cli/cmd/cli_unix.go
+++ b/cli/cmd/cli_unix.go
@@ -38,10 +38,10 @@ var promptIconsFunc = func(icons *survey.IconSet) {
 func (c *cliState) UpdateCommand() string {
 	if os.Getenv("LW_HOMEBREW_INSTALL") != "" {
 		return `
-	 $ brew upgrade lacework-cli
-	`
+  $ brew upgrade lacework-cli
+`
 	}
 	return `
-	   $ curl https://raw.githubusercontent.com/lacework/go-sdk/master/cli/install.sh | bash
-	 `
+  $ curl https://raw.githubusercontent.com/lacework/go-sdk/master/cli/install.sh | bash
+`
 }

--- a/cli/cmd/cli_unix_test.go
+++ b/cli/cmd/cli_unix_test.go
@@ -1,0 +1,40 @@
+// +build !windows
+//
+// Author:: Salim Afiune Maya (<afiune@lacework.net>)
+// Copyright:: Copyright 2020, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cmd
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCliStateUpdateCommand(t *testing.T) {
+	assert.Contains(t,
+		cli.UpdateCommand(),
+		"curl https://raw.githubusercontent.com/lacework/go-sdk/master/cli/install.sh | bash",
+	)
+
+	t.Run("Homebrew installation", func(t *testing.T) {
+		os.Setenv("LW_HOMEBREW_INSTALL", "1")
+		defer os.Setenv("LW_HOMEBREW_INSTALL", "")
+		assert.Contains(t, cli.UpdateCommand(), "brew upgrade lacework-cli")
+	})
+}


### PR DESCRIPTION
Update the display message from UpdateCommand() function to check for homebrew managed Lacework CLI users. Displays `brew upgrade lacework-cli` command instead of the default curl command.

Signed-off-by: Darren Murray <darren.murray@lacework.net>