### PR TITLE
feat: Add telemetry to detect Homebrew installations

### DIFF
--- a/cli/cmd/cli_unix.go
+++ b/cli/cmd/cli_unix.go
@@ -25,6 +25,10 @@ import (
 	"github.com/AlecAivazis/survey/v2"
 )
 
+// HomebrewInstall is an environment variable that denotes the
+// install method was via homebrew package manager
+const HomebrewInstall = "LW_HOMEBREW_INSTALL"
+
 // used by configure.go
 var configureListCmdSetProfileEnv = `$ export LW_PROFILE="my-profile"`
 
@@ -36,7 +40,7 @@ var promptIconsFunc = func(icons *survey.IconSet) {
 // UpdateCommand returns the command that a user should run to update the cli
 // to the latest available version (unix specific command)
 func (c *cliState) UpdateCommand() string {
-	if os.Getenv("LW_HOMEBREW_INSTALL") != "" {
+	if os.Getenv(HomebrewInstall) != "" {
 		return `
   $ brew upgrade lacework-cli
 `

--- a/cli/cmd/cli_unix.go
+++ b/cli/cmd/cli_unix.go
@@ -25,10 +25,6 @@ import (
 	"github.com/AlecAivazis/survey/v2"
 )
 
-// HomebrewInstall is an environment variable that denotes the
-// install method was via homebrew package manager
-const HomebrewInstall = "LW_HOMEBREW_INSTALL"
-
 // used by configure.go
 var configureListCmdSetProfileEnv = `$ export LW_PROFILE="my-profile"`
 

--- a/cli/cmd/honeyvent.go
+++ b/cli/cmd/honeyvent.go
@@ -45,10 +45,6 @@ const (
 	// disable telemetry sent to Honeycomb
 	DisableTelemetry = "LW_TELEMETRY_DISABLE"
 
-	// HomebrewInstall is an environment variable that denotes the
-	// install method was via homebrew package manager
-	HomebrewInstall = "LW_HOMEBREW_INSTALL"
-
 	// List of Features
 	//
 	// A feature within the Lacework CLI is any functionality that

--- a/cli/cmd/honeyvent.go
+++ b/cli/cmd/honeyvent.go
@@ -45,6 +45,10 @@ const (
 	// disable telemetry sent to Honeycomb
 	DisableTelemetry = "LW_TELEMETRY_DISABLE"
 
+	// HomebrewInstall is an environment variable that denotes the
+	// install method was via homebrew package manager
+	HomebrewInstall = "LW_HOMEBREW_INSTALL"
+
 	// List of Features
 	//
 	// A feature within the Lacework CLI is any functionality that
@@ -196,7 +200,7 @@ func (e *Honeyvent) AddFeatureField(key string, value interface{}) {
 
 func installMethod() string {
 	if os.Getenv(HomebrewInstall) != "" {
-		return HomebrewInstall
+		return "HOMEBREW"
 	}
 	return ""
 }

--- a/cli/cmd/honeyvent.go
+++ b/cli/cmd/honeyvent.go
@@ -45,6 +45,10 @@ const (
 	// disable telemetry sent to Honeycomb
 	DisableTelemetry = "LW_TELEMETRY_DISABLE"
 
+	// HomebrewInstall is an environment variable that denotes the
+	// install method was via homebrew package manager
+	HomebrewInstall = "LW_HOMEBREW_INSTALL"
+
 	// List of Features
 	//
 	// A feature within the Lacework CLI is any functionality that
@@ -81,18 +85,19 @@ const (
 
 // Honeyvent defines what a Honeycomb event looks like for the Lacework CLI
 type Honeyvent struct {
-	Version     string      `json:"version"`
-	Os          string      `json:"os"`
-	Arch        string      `json:"arch"`
-	Command     string      `json:"command,omitempty"`
-	Args        []string    `json:"args,omitempty"`
-	Account     string      `json:"account,omitempty"`
-	Profile     string      `json:"profile,omitempty"`
-	ApiKey      string      `json:"api_key,omitempty"`
-	Feature     string      `json:"feature,omitempty"`
-	FeatureData interface{} `json:"feature.data,omitempty"`
-	DurationMs  int64       `json:"duration_ms,omitempty"`
-	Error       string      `json:"error,omitempty"`
+	Version       string      `json:"version"`
+	Os            string      `json:"os"`
+	Arch          string      `json:"arch"`
+	Command       string      `json:"command,omitempty"`
+	Args          []string    `json:"args,omitempty"`
+	Account       string      `json:"account,omitempty"`
+	Profile       string      `json:"profile,omitempty"`
+	ApiKey        string      `json:"api_key,omitempty"`
+	Feature       string      `json:"feature,omitempty"`
+	FeatureData   interface{} `json:"feature.data,omitempty"`
+	DurationMs    int64       `json:"duration_ms,omitempty"`
+	Error         string      `json:"error,omitempty"`
+	InstallMethod string      `json:"install_method,omitempty"`
 
 	// tracing data for multiple events, this is useful for specific features
 	// within the Lacework CLI such as daily version check, polling mechanism, etc.
@@ -112,13 +117,14 @@ func (c *cliState) InitHoneyvent() {
 	_ = libhoney.Init(hc)
 
 	c.Event = &Honeyvent{
-		Os:      runtime.GOOS,
-		Arch:    runtime.GOARCH,
-		Version: Version,
-		Profile: c.Profile,
-		Account: c.Account,
-		ApiKey:  c.KeyID,
-		TraceID: newID(),
+		Os:            runtime.GOOS,
+		Arch:          runtime.GOARCH,
+		Version:       Version,
+		Profile:       c.Profile,
+		Account:       c.Account,
+		ApiKey:        c.KeyID,
+		TraceID:       newID(),
+		InstallMethod: installMethod(),
 	}
 }
 
@@ -190,4 +196,11 @@ func (e *Honeyvent) AddFeatureField(key string, value interface{}) {
 		v[key] = value
 		e.FeatureData = v
 	}
+}
+
+func installMethod() string {
+	if os.Getenv(HomebrewInstall) != "" {
+		return HomebrewInstall
+	}
+	return ""
 }

--- a/cli/cmd/honeyvent_test.go
+++ b/cli/cmd/honeyvent_test.go
@@ -37,6 +37,7 @@ func TestHoneyventDefaultParameters(t *testing.T) {
 	assert.NotEmpty(t, cli.Event.TraceID)
 	assert.Empty(t, cli.Event.SpanID)
 	assert.Empty(t, cli.Event.ParentID)
+	assert.Empty(t, cli.Event.InstallMethod)
 }
 
 func TestSendHoneyventTracingFields(t *testing.T) {
@@ -104,4 +105,20 @@ func TestSendHoneyventDisableTelemetry(t *testing.T) {
 	assert.Equal(t, "test_feature", cli.Event.Feature)
 	// this validates that the environment variable is not sending
 	// events when it is set (disabled)
+}
+
+func TestSendHoneyventHomebrewInstall(t *testing.T) {
+	// testing that the install method will be "Homebrew"
+	// environment variable 'LW_HOMEBREW_INSTALL'  is set
+	os.Setenv(HomebrewInstall, "1")
+	defer os.Setenv(HomebrewInstall, "")
+
+	// init honeyvent as InstallMethod is set on init
+	cli.InitHoneyvent()
+
+	// mocking sending honeyvent
+	cli.SendHoneyvent()
+
+	assert.NotEmpty(t, cli.Event.InstallMethod)
+	assert.Equal(t, HomebrewInstall, cli.Event.InstallMethod)
 }

--- a/cli/cmd/honeyvent_test.go
+++ b/cli/cmd/honeyvent_test.go
@@ -120,5 +120,5 @@ func TestSendHoneyventHomebrewInstall(t *testing.T) {
 	cli.SendHoneyvent()
 
 	assert.NotEmpty(t, cli.Event.InstallMethod)
-	assert.Equal(t, HomebrewInstall, cli.Event.InstallMethod)
+	assert.Equal(t, "HOMEBREW", cli.Event.InstallMethod)
 }


### PR DESCRIPTION
Add telemetry to detect when customers are running the Lacework CLI that has been installed via Homebrew.

Signed-off-by: Darren Murray <darren.murray@lacework.net>