### PR TITLE
fix(cli): install.sh should respect target override

### DIFF
--- a/cli/install.sh
+++ b/cli/install.sh
@@ -89,6 +89,10 @@ create_workdir() {
 }
 
 check_target() {
+  if [[ ! $target =~ "-" ]]; then
+    exit_with "malformed target '${target}' (format: system-arch)" 5
+  fi
+
   sys=$(echo "$target" | cut -d- -f1)
   if [ -z "${sys}" ]; then
     exit_with "malformed target '${target}' (format: system-arch)" 5
@@ -232,7 +236,7 @@ download_file() {
     if [ $_code -eq 0 ]; then
       return 0
     else
-      warn "wget failed to download file, trying to download with curl"
+      warn "wget failed to download file, trying to download with curl (exitcode: ${_code})"
     fi
   fi
 
@@ -248,7 +252,7 @@ download_file() {
     if [ $_code -eq 0 ]; then
       return 0
     else
-      warn "curl failed to download file"
+      warn "curl failed to download file (exitcode: ${_code})"
     fi
   fi
 


### PR DESCRIPTION
If the user provides a target, the `install.sh` script should honor that option
and try to install it without verifying the running system.

Example: Running on a macOS ARM arch, we get the following error.
```
$ curl https://raw.githubusercontent.com/lacework/go-sdk/master/cli/install.sh | bash -s -- -t darwin-amd64
--> install: Installing the Lacework CLI
xxx install: architecture not supported: arm64
```

This change is fixing the script to respect the provided target, the expected behavior of running the above
command on the same ARM system should be:
```
$ curl https://raw.githubusercontent.com/lacework/go-sdk/master/cli/install.sh | bash -s -- -t darwin-amd64
--> install: Installing the Lacework CLI
--> install: Downloading via wget: https://github.com/lacework/go-sdk/releases/latest/download/lacework-cli-darwin-amd64.zip
--> install: Downloading via wget: https://github.com/lacework/go-sdk/releases/latest/download/lacework-cli-darwin-amd64.zip.sha256sum
...
```

## Test this PR
To test this PR you can run the following command on a macOS ARM system:
```
$ curl https://raw.githubusercontent.com/lacework/go-sdk/5e66c11264f0b9ba012be20370b0b65cc114fe4c/cli/install.sh | bash -s -- -t darwin-amd64
```

Verify malformed targets:
```
$ curl https://raw.githubusercontent.com/lacework/go-sdk/5e66c11264f0b9ba012be20370b0b65cc114fe4c/cli/install.sh | bash -s -- -t foo
xxx install: malformed target 'foo' (format: system-arch)
```

Verify non-existing packages:
```
$ curl https://raw.githubusercontent.com/lacework/go-sdk/5e66c11264f0b9ba012be20370b0b65cc114fe4c/cli/install.sh | bash -s -- -t darwin-arm
--> install: Installing the Lacework CLI
--> install: Downloading via wget: https://github.com/lacework/go-sdk/releases/latest/download/lacework-cli-darwin-arm.zip
xxx install: wget failed to download file, trying to download with curl (exitcode: 8)
--> install: Downloading via curl: https://github.com/lacework/go-sdk/releases/latest/download/lacework-cli-darwin-arm.zip
curl: (22) The requested URL returned error: 404
xxx install: curl failed to download file (exitcode: 22)
xxx install: Required: SSL-enabled 'curl' or 'wget' on PATH
```

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>