### PR TITLE
fix(cli): avoid daily update check during install

### DIFF
--- a/cli/cmd/version.go
+++ b/cli/cmd/version.go
@@ -114,6 +114,10 @@ func versionCacheDir() (string, error) {
 // dailyVersionCheck will execute a version check on a daily basis, the function uses
 // the file ~/.config/lacework/version_cache to track the last check time
 func dailyVersionCheck() error {
+	if disabled := os.Getenv(lwupdater.DisableEnv); disabled != "" {
+		return nil
+	}
+
 	cacheDir, err := versionCacheDir()
 	if err != nil {
 		return err

--- a/cli/install.sh
+++ b/cli/install.sh
@@ -214,7 +214,7 @@ install_cli() {
 
 print_cli_version() {
   log "Verifying installed Lacework CLI version"
-  "${installation_dir}/${binary_name}" version
+  LW_TELEMETRY_DISABLE=1 LW_UPDATES_DISABLE=1 "${installation_dir}/${binary_name}" version
 }
 
 download_file() {

--- a/integration/event_test.go
+++ b/integration/event_test.go
@@ -19,6 +19,7 @@
 package integration
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -58,26 +59,30 @@ func TestEventCommandList(t *testing.T) {
 		"EXITCODE is not the expected one")
 }
 
-func TestEventCommandList3Days(t *testing.T) {
+func TestEventCommandList4Days(t *testing.T) {
 	// @afiune could we find a way to generate a consistent event? but if we do
 	// wouldn't the ML learn it and then become a known behavior? uhmmm
 	// for now we will just check that we have the headers :wink:
-	out, err, exitcode := LaceworkCLIWithTOMLConfig("event", "list", "--days", "3")
-	assert.Contains(t, out.String(), "EVENT ID",
-		"STDOUT table headers changed, please check")
-	assert.Contains(t, out.String(), "TYPE",
-		"STDOUT table headers changed, please check")
-	assert.Contains(t, out.String(), "SEVERITY",
-		"STDOUT table headers changed, please check")
-	assert.Contains(t, out.String(), "START TIME",
-		"STDOUT table headers changed, please check")
-	assert.Contains(t, out.String(), "END TIME",
-		"STDOUT table headers changed, please check")
+	out, err, exitcode := LaceworkCLIWithTOMLConfig("event", "list", "--days", "4")
 	assert.Empty(t,
 		err.String(),
 		"STDERR should be empty")
 	assert.Equal(t, 0, exitcode,
 		"EXITCODE is not the expected one")
+
+	// only verify the table headers if there are events
+	if !strings.Contains(out.String(), "There are no events in your account in the specified time range.") {
+		assert.Contains(t, out.String(), "EVENT ID",
+			"STDOUT table headers changed, please check")
+		assert.Contains(t, out.String(), "TYPE",
+			"STDOUT table headers changed, please check")
+		assert.Contains(t, out.String(), "SEVERITY",
+			"STDOUT table headers changed, please check")
+		assert.Contains(t, out.String(), "START TIME",
+			"STDOUT table headers changed, please check")
+		assert.Contains(t, out.String(), "END TIME",
+			"STDOUT table headers changed, please check")
+	}
 }
 
 func TestEventCommandListSeverityError(t *testing.T) {


### PR DESCRIPTION
When users install the CLI we should not run the daily update check
since it could create files on the home directory of a mortal user.

Additionally, we are turning off telemetry so that we don't have
multiple events being reported on install.

JIRA: ALLY-305

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>