### PR TITLE
refactor(cli): exponential retries polling scans

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,9 @@ jobs:
       - checkout
       - attach_workspace:
           at: bin
-      - run: make integration-only
+      - run:
+          command: make integration-only
+          no_output_timeout: 30m
       - store_artifacts:
           path: circleci-artifacts
       - slack/status:
@@ -80,7 +82,8 @@ jobs:
       - run:
           command: |
             $env:LW_CLI_BIN = Join-Path (Get-Location).Path "bin\\lacework-cli-windows-amd64.exe"
-            go test -v github.com/lacework/go-sdk/integration
+            go test -v github.com/lacework/go-sdk/integration -timeout 30m
+          no_output_timeout: 30m
       - store_artifacts:
           path: circleci-artifacts
   verify-release:

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ test:
 integration: build-cli-cross-platform integration-only
 
 integration-only:
-	PATH=$(PWD)/bin:${PATH} go test -v github.com/lacework/go-sdk/integration
+	PATH=$(PWD)/bin:${PATH} go test -v github.com/lacework/go-sdk/integration -timeout 30m
 
 coverage: test
 	go tool cover -func=$(COVERAGEOUT)

--- a/cli/cmd/vulnerability.go
+++ b/cli/cmd/vulnerability.go
@@ -36,9 +36,6 @@ var (
 		// enable poll mechanism for scans status
 		Poll bool
 
-		// pollInterval is the time is seconds to wait between polls
-		PollInterval time.Duration
-
 		// store the vulnerability assessment in HTML format on disk
 		Html bool
 
@@ -72,7 +69,7 @@ var (
 
 		// filter assessments for specific repositories
 		Repositories []string
-	}{PollInterval: time.Second * 5}
+	}{}
 
 	// vulnerability represents the vulnerability command that holds both, the host
 	// and container sub-commands
@@ -225,10 +222,7 @@ func init() {
 func setPollFlag(cmds ...*flag.FlagSet) {
 	for _, cmd := range cmds {
 		if cmd != nil {
-			cmd.BoolVar(&vulCmdState.Poll, "poll", false,
-				fmt.Sprintf("poll until the vulnerability scan completes (%vs intervals)",
-					vulCmdState.PollInterval.Seconds()),
-			)
+			cmd.BoolVar(&vulCmdState.Poll, "poll", false, "poll until the vulnerability scan completes")
 		}
 	}
 }
@@ -290,6 +284,7 @@ func pollScanStatus(requestID string) error {
 		retries      = 0
 		start        = time.Now()
 		durationTime = start
+		expPollTime  = time.Second
 		params       = map[string]interface{}{"request_id": requestID}
 	)
 
@@ -318,9 +313,10 @@ func pollScanStatus(requestID string) error {
 		}
 
 		if retry {
-			cli.Log.Debugw("waiting for a retry", "request_id", requestID, "sleep", vulCmdState.PollInterval)
+			cli.Log.Debugw("waiting for a retry", "request_id", requestID, "sleep", expPollTime)
 			cli.SendHoneyvent()
-			time.Sleep(vulCmdState.PollInterval)
+			time.Sleep(expPollTime)
+			expPollTime = time.Duration(retries*retries) * time.Second
 			continue
 		}
 
@@ -333,7 +329,9 @@ func pollScanStatus(requestID string) error {
 		if bugRetry {
 			bugRetry = false
 			cli.SendHoneyvent()
-			time.Sleep(vulCmdState.PollInterval)
+			// we do NOT use the exponential polling time here since this is just a
+			// workaround and therefore waiting for 5s or so is enough time
+			time.Sleep(time.Second * 5)
 			continue
 		}
 

--- a/integration/container_vulnerability_test.go
+++ b/integration/container_vulnerability_test.go
@@ -34,7 +34,7 @@ const (
 	registry   = "index.docker.io"
 	repository = "lacework/lacework-cli"
 	tag1       = "ubuntu-1804"
-	tag2       = "debian-10"
+	tag2       = "amazonlinux-2"
 )
 
 func TestContainerVulnerabilityCommandAliases(t *testing.T) {


### PR DESCRIPTION
We are improving the retry mechanism to be exponential instead
of a fixed time. The times now will start with 5s, then wait for
10s, 16s, 25s, and so forth.

Closes RAIN-15292

# Before This Change

We did 5s intervals

<img width="1691" alt="Screen Shot 2021-02-12 at 8 49 27 PM" src="https://user-images.githubusercontent.com/5712253/107839813-8e399a00-6d6b-11eb-93f8-1c44e48836ef.png">


# After This Change

We are doing exponential wait times; 5s, 10s, 16s, 25s, and so forth.

<img width="1688" alt="Screen Shot 2021-02-13 at 11 48 21 AM" src="https://user-images.githubusercontent.com/5712253/107857016-0db97e80-6de9-11eb-894b-887b204cd6c8.png">

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>