### PR TITLE
test(cli): disable failing tests (RAIN-15300)

### DIFF
--- a/integration/container_vulnerability_test.go
+++ b/integration/container_vulnerability_test.go
@@ -87,7 +87,9 @@ func TestContainerVulnerabilityCommandListAssessments(t *testing.T) {
 	})
 }
 
-func TestContainerVulnerabilityCommandScanHumanReadablePollGenerateHtml(t *testing.T) {
+// Disabling this test since it has been failing for over a week,
+// we will enable it once RAIN-15300 is solved
+func _TestContainerVulnerabilityCommandScanHumanReadablePollGenerateHtml(t *testing.T) {
 	// create a temporal directory to check that the HTML file is deployed
 	home := createTOMLConfigFromCIvars()
 	defer os.RemoveAll(home)
@@ -122,7 +124,9 @@ type containerVulnerabilityScan struct {
 	Status    string `json:"status"`
 }
 
-func TestContainerVulnerabilityCommandsEndToEnd(t *testing.T) {
+// Disabling this test since it has been failing for over a week,
+// we will enable it once RAIN-15300 is solved
+func _TestContainerVulnerabilityCommandsEndToEnd(t *testing.T) {
 	var (
 		out      bytes.Buffer
 		err      bytes.Buffer


### PR DESCRIPTION
The team have decided to disable these integration tests that have been failing
constantly, we will enable them once RAIN-15300 is resolved.

<img width="887" alt="Screen Shot 2021-02-16 at 11 40 06 AM" src="https://user-images.githubusercontent.com/5712253/108101146-135ed080-7044-11eb-8a3c-204b2c8b08b1.png">

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>