### PR TITLE
fix(cli): match API client timeout with NGINX

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -117,6 +117,15 @@ func NewClient(account string, opts ...Option) (*Client, error) {
 	return c, nil
 }
 
+// WithTimeout changes the default client timeout
+func WithTimeout(timeout time.Duration) Option {
+	return clientFunc(func(c *Client) error {
+		c.log.Debug("setting up client", zap.Reflect("timeout", timeout))
+		c.c.Timeout = timeout
+		return nil
+	})
+}
+
 // WithURL sets the base URL, this options is only available for test purposes
 func WithURL(baseURL string) Option {
 	return clientFunc(func(c *Client) error {

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -20,6 +20,7 @@ package api_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -53,6 +54,7 @@ func TestNewClientWithOptions(t *testing.T) {
 		api.WithURL(fakeServer.URL()),
 		api.WithExpirationTime(1800),
 		api.WithApiV2(),
+		api.WithTimeout(time.Minute*5),
 		api.WithLogLevel("DEBUG"),
 		api.WithHeader("User-Agent", "test-agent"),
 		api.WithTokenFromKeys("KEY", "SECRET"), // this option has to be the last one

--- a/cli/cmd/cli_state.go
+++ b/cli/cmd/cli_state.go
@@ -183,6 +183,7 @@ func (c *cliState) NewClient() error {
 	client, err := api.NewClient(c.Account,
 		api.WithLogLevel(c.LogLevel),
 		api.WithApiKeys(c.KeyID, c.Secret),
+		api.WithTimeout(time.Second*125),
 		api.WithHeader("User-Agent", fmt.Sprintf("Command-Line/%s", Version)),
 	)
 	if err != nil {


### PR DESCRIPTION
Currently, the Lacework CLI has a timeout of 60 seconds and users
are experiencing the following errors:
```
context deadline exceeded (Client.Timeout exceeded while awaiting headers)
```

We are increasing the timeout to match what we have on NGINX which
is 120 seconds, we add 5 more seconds to let NGINX close the connection
instead of the Lacework CLI.

Closes RAIN-15291

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>