### PR TITLE
doc(cli): update scan-pkg-manifest help to 10k pkgs

### DIFF
--- a/cli/cmd/vuln_host.go
+++ b/cli/cmd/vuln_host.go
@@ -92,8 +92,7 @@ To generate a package-manifest from the local host and scan it automatically:
 (*) NOTE:
  - Only packages managed by a package manager for supported OS's are reported.
  - Calls to this operation are rate limited to 10 calls per hour, per access key.
- - This operation is limited to 1k of packages per payload. If you require a payload
-   larger than 1k, you must make multiple requests.`,
+ - This operation is limited to 10k packages per command execution.`,
 		RunE: func(_ *cobra.Command, args []string) error {
 			var (
 				pkgManifest      = new(api.PackageManifest)


### PR DESCRIPTION
This update is to reflect the new limit of packages that the
Lacework CLI supports.

The Wiki has been updated already: https://github.com/lacework/go-sdk/wiki/CLI-Documentation#host-vulnerability-assessments

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>