### PR TITLE
feat(cli): filtering flags for compliance report recommendations

### DIFF
--- a/api/compliance.go
+++ b/api/compliance.go
@@ -108,4 +108,4 @@ type ComplianceViolation struct {
 }
 
 // ValidComplianceStatuses is a list of all valid compliance statuses
-var ValidComplianceStatuses = []string{"non-compliant", "requires-manual-assessment", "suppressed", "compliant"}
+var ValidComplianceStatuses = []string{"non-compliant", "requires-manual-assessment", "suppressed", "compliant", "could-not-assess"}

--- a/api/compliance.go
+++ b/api/compliance.go
@@ -106,3 +106,6 @@ type ComplianceViolation struct {
 	Resource string   `json:"resource"`
 	Reasons  []string `json:"reasons"`
 }
+
+// ValidComplianceStatuses is a list of all valid compliance statuses
+var ValidComplianceStatuses = []string{"non-compliant", "requires-manual-assessment", "suppressed", "compliant"}

--- a/api/compliance.go
+++ b/api/compliance.go
@@ -107,5 +107,5 @@ type ComplianceViolation struct {
 	Reasons  []string `json:"reasons"`
 }
 
-// ValidComplianceStatuses is a list of all valid compliance statuses
-var ValidComplianceStatuses = []string{"non-compliant", "requires-manual-assessment", "suppressed", "compliant", "could-not-assess"}
+// ValidComplianceStatus is a list of all valid compliance status
+var ValidComplianceStatus = []string{"non-compliant", "requires-manual-assessment", "suppressed", "compliant", "could-not-assess"}

--- a/cli/README.md
+++ b/cli/README.md
@@ -107,6 +107,7 @@ operation of the Lacework CLI.
 |`LW_ACCOUNT="<account>"`|account subdomain of URL (i.e. `<ACCOUNT>.lacework.net`)|
 |`LW_API_KEY="<key>"`|API access key id|
 |`LW_API_SECRET="<secret>"`|API secret access key|
+|`LW_INT_TEST_AWS_ACC="<secret>"`|AWS Account for integration tests|
 
 ## Basic Usage
 A few basic commands are:

--- a/cli/README.md
+++ b/cli/README.md
@@ -154,7 +154,7 @@ Server, for that reason, it requires a set of Lacework API keys. To run these te
 locally you need to setup the following environment variables and use the directive
 `make integration`, an example of the command you can use is:
 ```
-$ CI_ACCOUNT="<YOUR_ACCOUNT>" CI_API_KEY="<YOUR_API_KEY>" CI_API_SECRET="<YOUR_API_SECRET>" make integration
+$ CI_ACCOUNT="<YOUR_ACCOUNT>" CI_API_KEY="<YOUR_API_KEY>" CI_API_SECRET="<YOUR_API_SECRET>" LW_INT_TEST_AWS_ACC="<YOUR_AWS_ACCOUNT>" make integration
 ```
 This is a list of all environment variables used in the running the integration tests.
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -107,7 +107,6 @@ operation of the Lacework CLI.
 |`LW_ACCOUNT="<account>"`|account subdomain of URL (i.e. `<ACCOUNT>.lacework.net`)|
 |`LW_API_KEY="<key>"`|API access key id|
 |`LW_API_SECRET="<secret>"`|API secret access key|
-|`LW_INT_TEST_AWS_ACC="<secret>"`|AWS Account for integration tests|
 
 ## Basic Usage
 A few basic commands are:
@@ -157,6 +156,11 @@ locally you need to setup the following environment variables and use the direct
 ```
 $ CI_ACCOUNT="<YOUR_ACCOUNT>" CI_API_KEY="<YOUR_API_KEY>" CI_API_SECRET="<YOUR_API_SECRET>" make integration
 ```
+This is a list of all environment variables used in the running the integration tests.
+
+| Environment Variable | Description |
+|----------------------|-------------|
+|`LW_INT_TEST_AWS_ACC="<secret>"`|AWS Account for integration tests|
 
 ### Telemetry via Honeycomb
 

--- a/cli/cmd/compliance.go
+++ b/cli/cmd/compliance.go
@@ -305,8 +305,8 @@ func matchRecommendationsFilters(r api.ComplianceRecommendation) bool {
 	// severity returns specified threshold and above
 	if compCmdState.Severity != "" {
 		sevThreshold, _ := eventSeverityToProperTypes(compCmdState.Severity)
-				results = append(results, r.Severity <= sevThreshold)
-		}
+		results = append(results, r.Severity <= sevThreshold)
+	}
 
 	if compCmdState.Category != "" {
 		category := strings.ReplaceAll(compCmdState.Category, "-", " ")

--- a/cli/cmd/compliance.go
+++ b/cli/cmd/compliance.go
@@ -199,12 +199,6 @@ func complianceReportSummaryTable(summaries []api.ComplianceSummary) [][]string 
 	}
 }
 
-// And or for mulitple filters
-// integration test for headers
-// statuses to status
-// implicit --details
-// move env var to string above
-
 func complianceReportRecommendationsTable(recommendations []api.ComplianceRecommendation) ([][]string, string) {
 	out := [][]string{}
 	var filteredOutput string

--- a/cli/cmd/compliance.go
+++ b/cli/cmd/compliance.go
@@ -292,7 +292,7 @@ func filterRecommendations(recommendations []api.ComplianceRecommendation) ([]ap
 		}
 	}
 	if len(filtered) == 0 {
-		return filtered, "There are no recommendations with the specified filters.\n"
+		return filtered, "There are no recommendations with the specified filter(s).\n"
 	}
 
 	cli.Log.Debugw("filtered recommendations", "recommendations", filtered)

--- a/cli/cmd/compliance.go
+++ b/cli/cmd/compliance.go
@@ -255,7 +255,7 @@ func buildComplianceReportTable(detailsTable, summaryTable, recommendationsTable
 		),
 	)
 
-	if compCmdState.Details {
+	if compCmdState.Details || filtersEnabled() {
 		mainReport.WriteString(
 			renderCustomTable(
 				[]string{"ID", "Recommendation", "Status", "Severity",

--- a/cli/cmd/compliance.go
+++ b/cli/cmd/compliance.go
@@ -305,9 +305,7 @@ func matchRecommendationsFilters(r api.ComplianceRecommendation) bool {
 	// severity returns specified threshold and above
 	if compCmdState.Severity != "" {
 		sevThreshold, _ := eventSeverityToProperTypes(compCmdState.Severity)
-			if r.Severity <= sevThreshold {
-				results = append(results, true)
-			}
+				results = append(results, r.Severity <= sevThreshold)
 		}
 
 	if compCmdState.Category != "" {

--- a/cli/cmd/compliance.go
+++ b/cli/cmd/compliance.go
@@ -334,7 +334,7 @@ func statusToProperTypes(status string) string {
 		return "NonCompliant"
 	case "compliant":
 		return "Compliant"
-	case "could-not-assess":
+	case "could-not-assess", "couldnotassess":
 		return "CouldNotAssess"
 	case "suppressed":
 		return "Suppressed"

--- a/cli/cmd/compliance.go
+++ b/cli/cmd/compliance.go
@@ -334,6 +334,8 @@ func statusToProperTypes(status string) string {
 		return "NonCompliant"
 	case "compliant":
 		return "Compliant"
+	case "could-not-assess":
+		return "CouldNotAssess"
 	case "suppressed":
 		return "Suppressed"
 	case "requires-manual-assessment", "requiresmanualassessment":

--- a/cli/cmd/compliance_aws.go
+++ b/cli/cmd/compliance_aws.go
@@ -20,6 +20,7 @@ package cmd
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -151,12 +152,14 @@ To run an ad-hoc compliance assessment of an AWS account:
 			}
 
 			report := response.Data[0]
+			recommendations, filteredOutput := complianceReportRecommendationsTable(report.Recommendations)
 			cli.OutputHuman("\n")
 			cli.OutputHuman(
 				buildComplianceReportTable(
 					complianceAwsReportDetailsTable(&report),
 					complianceReportSummaryTable(report.Summary),
-					complianceReportRecommendationsTable(report.Recommendations),
+					recommendations,
+					filteredOutput,
 				),
 			)
 			return nil
@@ -215,6 +218,24 @@ func init() {
 	// AWS report types: AWS_CIS_S3, NIST_800-53_Rev4, ISO_2700, HIPAA, SOC, or PCI
 	complianceAwsGetReportCmd.Flags().StringVar(&compCmdState.Type, "type", "CIS",
 		"report type to display, supported types: CIS, NIST_800-53_Rev4, ISO_2700, HIPAA, SOC, or PCI",
+	)
+
+	complianceAwsGetReportCmd.Flags().StringVar(&compCmdState.Category, "category", "",
+		"filter the compliance report details view by category (identity-and-access-management, s3, logging...)",
+	)
+
+	complianceAwsGetReportCmd.Flags().StringVar(&compCmdState.Service, "service", "",
+		"filter the compliance report details view by service (aws:s3, aws:iam, aws:cloudtrail ...)",
+	)
+
+	complianceAwsGetReportCmd.Flags().StringVar(&compCmdState.Severity, "severity", "",
+		fmt.Sprintf("filter compliance report details view by severity threshold (%s)",
+			strings.Join(api.ValidEventSeverities, ", ")),
+	)
+
+	complianceAwsGetReportCmd.Flags().StringVar(&compCmdState.Status, "status", "",
+		fmt.Sprintf("filter compliance report details view by status (%s)",
+			strings.Join(api.ValidComplianceStatuses, ", ")),
 	)
 }
 

--- a/cli/cmd/compliance_aws.go
+++ b/cli/cmd/compliance_aws.go
@@ -237,20 +237,20 @@ func init() {
 	)
 
 	complianceAwsGetReportCmd.Flags().StringVar(&compCmdState.Category, "category", "",
-		"filter the compliance report details view by category (identity-and-access-management, s3, logging...)",
+		"filter report details by category (identity-and-access-management, s3, logging...)",
 	)
 
 	complianceAwsGetReportCmd.Flags().StringVar(&compCmdState.Service, "service", "",
-		"filter the compliance report details view by service (aws:s3, aws:iam, aws:cloudtrail ...)",
+		"filter report details by service (aws:s3, aws:iam, aws:cloudtrail, ...)",
 	)
 
 	complianceAwsGetReportCmd.Flags().StringVar(&compCmdState.Severity, "severity", "",
-		fmt.Sprintf("filter compliance report details view by severity threshold (%s)",
+		fmt.Sprintf("filter report details by severity threshold (%s)",
 			strings.Join(api.ValidEventSeverities, ", ")),
 	)
 
 	complianceAwsGetReportCmd.Flags().StringVar(&compCmdState.Status, "status", "",
-		fmt.Sprintf("filter compliance report details view by status (%s)",
+		fmt.Sprintf("filter report details by status (%s)",
 			strings.Join(api.ValidComplianceStatuses, ", ")),
 	)
 }

--- a/cli/cmd/compliance_aws.go
+++ b/cli/cmd/compliance_aws.go
@@ -27,6 +27,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/lacework/go-sdk/api"
+	"github.com/lacework/go-sdk/internal/array"
 )
 
 var (
@@ -134,6 +135,21 @@ To run an ad-hoc compliance assessment of an AWS account:
 
 				cli.OutputHuman("The AWS compliance report was downloaded at '%s'\n", pdfName)
 				return nil
+			}
+
+			if compCmdState.Severity != "" {
+				if !array.ContainsStr(api.ValidEventSeverities, compCmdState.Severity) {
+					return errors.Errorf("the severity %s is not valid, use one of %s",
+						compCmdState.Severity, strings.Join(api.ValidEventSeverities, ", "),
+					)
+				}
+			}
+			if compCmdState.Status != "" {
+				if !array.ContainsStr(api.ValidComplianceStatuses, compCmdState.Status) {
+					return errors.Errorf("the status %s is not valid, use one of %s",
+						compCmdState.Status, strings.Join(api.ValidComplianceStatuses, ", "),
+					)
+				}
 			}
 
 			cli.StartProgress(" Getting compliance report...")

--- a/cli/cmd/compliance_aws.go
+++ b/cli/cmd/compliance_aws.go
@@ -145,9 +145,9 @@ To run an ad-hoc compliance assessment of an AWS account:
 				}
 			}
 			if compCmdState.Status != "" {
-				if !array.ContainsStr(api.ValidComplianceStatuses, compCmdState.Status) {
+				if !array.ContainsStr(api.ValidComplianceStatus, compCmdState.Status) {
 					return errors.Errorf("the status %s is not valid, use one of %s",
-						compCmdState.Status, strings.Join(api.ValidComplianceStatuses, ", "),
+						compCmdState.Status, strings.Join(api.ValidComplianceStatus, ", "),
 					)
 				}
 			}
@@ -251,7 +251,7 @@ func init() {
 
 	complianceAwsGetReportCmd.Flags().StringVar(&compCmdState.Status, "status", "",
 		fmt.Sprintf("filter report details by status (%s)",
-			strings.Join(api.ValidComplianceStatuses, ", ")),
+			strings.Join(api.ValidComplianceStatus, ", ")),
 	)
 }
 

--- a/cli/cmd/compliance_aws.go
+++ b/cli/cmd/compliance_aws.go
@@ -236,11 +236,11 @@ func init() {
 		"report type to display, supported types: CIS, NIST_800-53_Rev4, ISO_2700, HIPAA, SOC, or PCI",
 	)
 
-	complianceAwsGetReportCmd.Flags().StringVar(&compCmdState.Category, "category", "",
+	complianceAwsGetReportCmd.Flags().StringSliceVar(&compCmdState.Category, "category", []string{},
 		"filter report details by category (identity-and-access-management, s3, logging...)",
 	)
 
-	complianceAwsGetReportCmd.Flags().StringVar(&compCmdState.Service, "service", "",
+	complianceAwsGetReportCmd.Flags().StringSliceVar(&compCmdState.Service, "service", []string{},
 		"filter report details by service (aws:s3, aws:iam, aws:cloudtrail, ...)",
 	)
 

--- a/cli/cmd/compliance_azure.go
+++ b/cli/cmd/compliance_azure.go
@@ -219,11 +219,11 @@ func init() {
 		"report type to display, supported types: CIS, SOC, or PCI",
 	)
 
-	complianceAzureGetReportCmd.Flags().StringVar(&compCmdState.Category, "category", "",
+	complianceAzureGetReportCmd.Flags().StringSliceVar(&compCmdState.Category, "category", []string{},
 		"filter the compliance report details view by category (identity-and-access-management, s3, logging...)",
 	)
 
-	complianceAzureGetReportCmd.Flags().StringVar(&compCmdState.Service, "service", "",
+	complianceAzureGetReportCmd.Flags().StringSliceVar(&compCmdState.Service, "service", []string{},
 		"filter the compliance report details view by service (aws:s3, aws:iam, aws:cloudtrail ...)",
 	)
 

--- a/cli/cmd/compliance_azure.go
+++ b/cli/cmd/compliance_azure.go
@@ -131,9 +131,9 @@ To run an ad-hoc compliance assessment use the command:
 				}
 			}
 			if compCmdState.Status != "" {
-				if !array.ContainsStr(api.ValidComplianceStatuses, compCmdState.Status) {
+				if !array.ContainsStr(api.ValidComplianceStatus, compCmdState.Status) {
 					return errors.Errorf("the status %s is not valid, use one of %s",
-						compCmdState.Status, strings.Join(api.ValidComplianceStatuses, ", "),
+						compCmdState.Status, strings.Join(api.ValidComplianceStatus, ", "),
 					)
 				}
 			}
@@ -234,7 +234,7 @@ func init() {
 
 	complianceAzureGetReportCmd.Flags().StringVar(&compCmdState.Status, "status", "",
 		fmt.Sprintf("filter compliance report details view by status (%s)",
-			strings.Join(api.ValidComplianceStatuses, ", ")),
+			strings.Join(api.ValidComplianceStatus, ", ")),
 	)
 }
 

--- a/cli/cmd/compliance_azure.go
+++ b/cli/cmd/compliance_azure.go
@@ -220,20 +220,20 @@ func init() {
 	)
 
 	complianceAzureGetReportCmd.Flags().StringSliceVar(&compCmdState.Category, "category", []string{},
-		"filter the compliance report details view by category (identity-and-access-management, s3, logging...)",
+		"filter report details by category (networking, storage, ...)",
 	)
 
 	complianceAzureGetReportCmd.Flags().StringSliceVar(&compCmdState.Service, "service", []string{},
-		"filter the compliance report details view by service (aws:s3, aws:iam, aws:cloudtrail ...)",
+		"filter report details by service (azure:ms:storage, azure:ms:sql, azure:ms:network, ...)",
 	)
 
 	complianceAzureGetReportCmd.Flags().StringVar(&compCmdState.Severity, "severity", "",
-		fmt.Sprintf("filter compliance report details view by severity threshold (%s)",
+		fmt.Sprintf("filter report details by severity threshold (%s)",
 			strings.Join(api.ValidEventSeverities, ", ")),
 	)
 
 	complianceAzureGetReportCmd.Flags().StringVar(&compCmdState.Status, "status", "",
-		fmt.Sprintf("filter compliance report details view by status (%s)",
+		fmt.Sprintf("filter report details by status (%s)",
 			strings.Join(api.ValidComplianceStatus, ", ")),
 	)
 }

--- a/cli/cmd/compliance_azure.go
+++ b/cli/cmd/compliance_azure.go
@@ -20,6 +20,7 @@ package cmd
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -137,12 +138,14 @@ To run an ad-hoc compliance assessment use the command:
 			}
 
 			report := response.Data[0]
+			recommendations, filteredOutput := complianceReportRecommendationsTable(report.Recommendations)
 			cli.OutputHuman("\n")
 			cli.OutputHuman(
 				buildComplianceReportTable(
 					complianceAzureReportDetailsTable(&report),
 					complianceReportSummaryTable(report.Summary),
-					complianceReportRecommendationsTable(report.Recommendations),
+					recommendations,
+					filteredOutput,
 				),
 			)
 			return nil
@@ -198,6 +201,24 @@ func init() {
 	// Azure report types: AZURE_CIS, AZURE_SOC, or AZURE_PCI
 	complianceAzureGetReportCmd.Flags().StringVar(&compCmdState.Type, "type", "CIS",
 		"report type to display, supported types: CIS, SOC, or PCI",
+	)
+
+	complianceAzureGetReportCmd.Flags().StringVar(&compCmdState.Category, "category", "",
+		"filter the compliance report details view by category (identity-and-access-management, s3, logging...)",
+	)
+
+	complianceAzureGetReportCmd.Flags().StringVar(&compCmdState.Service, "service", "",
+		"filter the compliance report details view by service (aws:s3, aws:iam, aws:cloudtrail ...)",
+	)
+
+	complianceAzureGetReportCmd.Flags().StringVar(&compCmdState.Severity, "severity", "",
+		fmt.Sprintf("filter compliance report details view by severity threshold (%s)",
+			strings.Join(api.ValidEventSeverities, ", ")),
+	)
+
+	complianceAzureGetReportCmd.Flags().StringVar(&compCmdState.Status, "status", "",
+		fmt.Sprintf("filter compliance report details view by status (%s)",
+			strings.Join(api.ValidComplianceStatuses, ", ")),
 	)
 }
 

--- a/cli/cmd/compliance_azure.go
+++ b/cli/cmd/compliance_azure.go
@@ -27,6 +27,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/lacework/go-sdk/api"
+	"github.com/lacework/go-sdk/internal/array"
 )
 
 var (
@@ -120,6 +121,21 @@ To run an ad-hoc compliance assessment use the command:
 
 				cli.OutputHuman("The Azure compliance report was downloaded at '%s'\n", pdfName)
 				return nil
+			}
+
+			if compCmdState.Severity != "" {
+				if !array.ContainsStr(api.ValidEventSeverities, compCmdState.Severity) {
+					return errors.Errorf("the severity %s is not valid, use one of %s",
+						compCmdState.Severity, strings.Join(api.ValidEventSeverities, ", "),
+					)
+				}
+			}
+			if compCmdState.Status != "" {
+				if !array.ContainsStr(api.ValidComplianceStatuses, compCmdState.Status) {
+					return errors.Errorf("the status %s is not valid, use one of %s",
+						compCmdState.Status, strings.Join(api.ValidComplianceStatuses, ", "),
+					)
+				}
 			}
 
 			cli.StartProgress(" Getting compliance report...")

--- a/cli/cmd/compliance_gcp.go
+++ b/cli/cmd/compliance_gcp.go
@@ -27,6 +27,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/lacework/go-sdk/api"
+	"github.com/lacework/go-sdk/internal/array"
 )
 
 var (
@@ -120,6 +121,21 @@ To run an ad-hoc compliance assessment use the command:
 
 				cli.OutputHuman("The GCP compliance report was downloaded at '%s'\n", pdfName)
 				return nil
+			}
+
+			if compCmdState.Severity != "" {
+				if !array.ContainsStr(api.ValidEventSeverities, compCmdState.Severity) {
+					return errors.Errorf("the severity %s is not valid, use one of %s",
+						compCmdState.Severity, strings.Join(api.ValidEventSeverities, ", "),
+					)
+				}
+			}
+			if compCmdState.Status != "" {
+				if !array.ContainsStr(api.ValidComplianceStatuses, compCmdState.Status) {
+					return errors.Errorf("the status %s is not valid, use one of %s",
+						compCmdState.Status, strings.Join(api.ValidComplianceStatuses, ", "),
+					)
+				}
 			}
 
 			cli.StartProgress(" Getting compliance report...")

--- a/cli/cmd/compliance_gcp.go
+++ b/cli/cmd/compliance_gcp.go
@@ -219,11 +219,11 @@ func init() {
 		"report type to display, supported types: CIS, SOC, or PCI",
 	)
 
-	complianceGcpGetReportCmd.Flags().StringVar(&compCmdState.Category, "category", "",
+	complianceGcpGetReportCmd.Flags().StringSliceVar(&compCmdState.Category, "category", []string{},
 		"filter the compliance report details view by category (identity-and-access-management, s3, logging...)",
 	)
 
-	complianceGcpGetReportCmd.Flags().StringVar(&compCmdState.Service, "service", "",
+	complianceGcpGetReportCmd.Flags().StringSliceVar(&compCmdState.Service, "service", []string{},
 		"filter the compliance report details view by service (aws:s3, aws:iam, aws:cloudtrail ...)",
 	)
 

--- a/cli/cmd/compliance_gcp.go
+++ b/cli/cmd/compliance_gcp.go
@@ -131,9 +131,9 @@ To run an ad-hoc compliance assessment use the command:
 				}
 			}
 			if compCmdState.Status != "" {
-				if !array.ContainsStr(api.ValidComplianceStatuses, compCmdState.Status) {
+				if !array.ContainsStr(api.ValidComplianceStatus, compCmdState.Status) {
 					return errors.Errorf("the status %s is not valid, use one of %s",
-						compCmdState.Status, strings.Join(api.ValidComplianceStatuses, ", "),
+						compCmdState.Status, strings.Join(api.ValidComplianceStatus, ", "),
 					)
 				}
 			}
@@ -234,7 +234,7 @@ func init() {
 
 	complianceGcpGetReportCmd.Flags().StringVar(&compCmdState.Status, "status", "",
 		fmt.Sprintf("filter compliance report details view by status (%s)",
-			strings.Join(api.ValidComplianceStatuses, ", ")),
+			strings.Join(api.ValidComplianceStatus, ", ")),
 	)
 }
 

--- a/cli/cmd/compliance_gcp.go
+++ b/cli/cmd/compliance_gcp.go
@@ -220,20 +220,20 @@ func init() {
 	)
 
 	complianceGcpGetReportCmd.Flags().StringSliceVar(&compCmdState.Category, "category", []string{},
-		"filter the compliance report details view by category (identity-and-access-management, s3, logging...)",
+		"filter report details by category (storage, networking, identity-and-access-management, ...)",
 	)
 
 	complianceGcpGetReportCmd.Flags().StringSliceVar(&compCmdState.Service, "service", []string{},
-		"filter the compliance report details view by service (aws:s3, aws:iam, aws:cloudtrail ...)",
+		"filter report details by service (gcp:storage:bucket, gcp:kms:cryptoKey, gcp:project, ...)",
 	)
 
 	complianceGcpGetReportCmd.Flags().StringVar(&compCmdState.Severity, "severity", "",
-		fmt.Sprintf("filter compliance report details view by severity threshold (%s)",
+		fmt.Sprintf("filter report details by severity threshold (%s)",
 			strings.Join(api.ValidEventSeverities, ", ")),
 	)
 
 	complianceGcpGetReportCmd.Flags().StringVar(&compCmdState.Status, "status", "",
-		fmt.Sprintf("filter compliance report details view by status (%s)",
+		fmt.Sprintf("filter report details by status (%s)",
 			strings.Join(api.ValidComplianceStatus, ", ")),
 	)
 }

--- a/cli/cmd/compliance_gcp.go
+++ b/cli/cmd/compliance_gcp.go
@@ -20,6 +20,7 @@ package cmd
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -138,11 +139,13 @@ To run an ad-hoc compliance assessment use the command:
 
 			report := response.Data[0]
 			cli.OutputHuman("\n")
+			recommendations, filteredOutput := complianceReportRecommendationsTable(report.Recommendations)
 			cli.OutputHuman(
 				buildComplianceReportTable(
 					complianceGcpReportDetailsTable(&report),
 					complianceReportSummaryTable(report.Summary),
-					complianceReportRecommendationsTable(report.Recommendations),
+					recommendations,
+					filteredOutput,
 				),
 			)
 			return nil
@@ -198,6 +201,24 @@ func init() {
 	// GCP report types: GCP_CIS, GCP_SOC, or GCP_PCI.
 	complianceGcpGetReportCmd.Flags().StringVar(&compCmdState.Type, "type", "CIS",
 		"report type to display, supported types: CIS, SOC, or PCI",
+	)
+
+	complianceGcpGetReportCmd.Flags().StringVar(&compCmdState.Category, "category", "",
+		"filter the compliance report details view by category (identity-and-access-management, s3, logging...)",
+	)
+
+	complianceGcpGetReportCmd.Flags().StringVar(&compCmdState.Service, "service", "",
+		"filter the compliance report details view by service (aws:s3, aws:iam, aws:cloudtrail ...)",
+	)
+
+	complianceGcpGetReportCmd.Flags().StringVar(&compCmdState.Severity, "severity", "",
+		fmt.Sprintf("filter compliance report details view by severity threshold (%s)",
+			strings.Join(api.ValidEventSeverities, ", ")),
+	)
+
+	complianceGcpGetReportCmd.Flags().StringVar(&compCmdState.Status, "status", "",
+		fmt.Sprintf("filter compliance report details view by status (%s)",
+			strings.Join(api.ValidComplianceStatuses, ", ")),
 	)
 }
 

--- a/cli/cmd/compliance_test.go
+++ b/cli/cmd/compliance_test.go
@@ -73,11 +73,11 @@ func TestComplianceRecommendationsFilterOnSeverityLow(t *testing.T) {
 func TestComplianceRecommendationsFilterOnSeverityCritical(t *testing.T) {
 	mockRecommendations := []api.ComplianceRecommendation{mockRecommendationOne, mockRecommendationTwo,
 		mockRecommendationThree, mockRecommendationFour}
-	compCmdState.Severity = "low"
+	compCmdState.Severity = "critical"
 	result, output := filterRecommendations(mockRecommendations)
 
-	assert.Equal(t, len(result), 4)
-	assert.Equal(t, output, "4 of 4 recommendations showing \n")
+	assert.Equal(t, len(result), 1)
+	assert.Equal(t, output, "1 of 4 recommendations showing \n")
 	clearFilters()
 }
 
@@ -105,7 +105,7 @@ func TestComplianceRecommendationsFilterMultiple(t *testing.T) {
 	clearFilters()
 }
 
-func clearFilters(){
+func clearFilters() {
 	compCmdState.Category = ""
 	compCmdState.Severity = ""
 	compCmdState.Service = ""

--- a/cli/cmd/compliance_test.go
+++ b/cli/cmd/compliance_test.go
@@ -116,6 +116,40 @@ func TestComplianceRecommendationsFilterMultiple(t *testing.T) {
 	clearFilters()
 }
 
+func TestStatusInputToProperTransform(t *testing.T) {
+	status := statusToProperTypes("non-compliant")
+	assert.Equal(t, status, "NonCompliant")
+
+	status = statusToProperTypes("compliant")
+	assert.Equal(t, status, "Compliant")
+
+	status = statusToProperTypes("suppressed")
+	assert.Equal(t, status, "Suppressed")
+
+	status = statusToProperTypes("requires-manual-assessment")
+	assert.Equal(t, status, "RequiresManualAssessment")
+}
+
+func TestFiltersEnabled(t *testing.T) {
+	NoneEnabled := filtersEnabled()
+	assert.Equal(t, NoneEnabled, false)
+
+	compCmdState.Category = "s3"
+	compCmdState.Status = "non-compliant"
+	compCmdState.Severity = "high"
+	compCmdState.Service = "aws:s3"
+	AllEnabled := filtersEnabled()
+	assert.Equal(t, AllEnabled, true)
+
+	compCmdState.Severity = ""
+	compCmdState.Service = ""
+
+	SomeEnabled := filtersEnabled()
+	assert.Equal(t, SomeEnabled, true)
+
+	clearFilters()
+}
+
 func clearFilters() {
 	compCmdState.Category = ""
 	compCmdState.Severity = ""

--- a/cli/cmd/compliance_test.go
+++ b/cli/cmd/compliance_test.go
@@ -32,7 +32,7 @@ func TestComplianceRecommendationsFilterNoResults(t *testing.T) {
 	result, output := filterRecommendations(mockRecommendations)
 
 	assert.Equal(t, len(result), 0)
-	assert.Equal(t, output, "There are no recommendations with the specified filters.\n")
+	assert.Equal(t, output, "There are no recommendations with the specified filter(s).\n")
 	clearFilters()
 }
 

--- a/cli/cmd/compliance_test.go
+++ b/cli/cmd/compliance_test.go
@@ -70,6 +70,17 @@ func TestComplianceRecommendationsFilterOnSeverityLow(t *testing.T) {
 	clearFilters()
 }
 
+func TestComplianceRecommendationsFilterOnSeverityMedium(t *testing.T) {
+	mockRecommendations := []api.ComplianceRecommendation{mockRecommendationOne, mockRecommendationTwo,
+		mockRecommendationThree, mockRecommendationFour}
+	compCmdState.Severity = "medium"
+	result, output := filterRecommendations(mockRecommendations)
+
+	assert.Equal(t, len(result), 3)
+	assert.Equal(t, output, "3 of 4 recommendations showing \n")
+	clearFilters()
+}
+
 func TestComplianceRecommendationsFilterOnSeverityCritical(t *testing.T) {
 	mockRecommendations := []api.ComplianceRecommendation{mockRecommendationOne, mockRecommendationTwo,
 		mockRecommendationThree, mockRecommendationFour}

--- a/cli/cmd/compliance_test.go
+++ b/cli/cmd/compliance_test.go
@@ -28,7 +28,7 @@ import (
 func TestComplianceRecommendationsFilterNoResults(t *testing.T) {
 	mockRecommendations := []api.ComplianceRecommendation{mockRecommendationOne, mockRecommendationTwo,
 		mockRecommendationThree, mockRecommendationFour}
-	compCmdState.Category = "monitoring"
+	compCmdState.Category = []string{"monitoring"}
 	result, output := filterRecommendations(mockRecommendations)
 
 	assert.Equal(t, len(result), 0)
@@ -39,7 +39,7 @@ func TestComplianceRecommendationsFilterNoResults(t *testing.T) {
 func TestComplianceRecommendationsFilterOnCategory(t *testing.T) {
 	mockRecommendations := []api.ComplianceRecommendation{mockRecommendationOne, mockRecommendationTwo,
 		mockRecommendationThree, mockRecommendationFour}
-	compCmdState.Category = "identity-and-access-management"
+	compCmdState.Category = []string{"identity-and-access-management"}
 	result, output := filterRecommendations(mockRecommendations)
 
 	assert.Equal(t, len(result), 1)
@@ -50,7 +50,7 @@ func TestComplianceRecommendationsFilterOnCategory(t *testing.T) {
 func TestComplianceRecommendationsFilterOnService(t *testing.T) {
 	mockRecommendations := []api.ComplianceRecommendation{mockRecommendationOne, mockRecommendationTwo,
 		mockRecommendationThree, mockRecommendationFour}
-	compCmdState.Service = "aws:cloudtrail"
+	compCmdState.Service = []string{"aws:cloudtrail"}
 	result, output := filterRecommendations(mockRecommendations)
 
 	assert.Equal(t, len(result), 2)
@@ -116,6 +116,30 @@ func TestComplianceRecommendationsFilterMultiple(t *testing.T) {
 	clearFilters()
 }
 
+func TestComplianceRecommendationsFilterMultipleCategories(t *testing.T) {
+	mockRecommendations := []api.ComplianceRecommendation{mockRecommendationOne, mockRecommendationTwo,
+		mockRecommendationThree, mockRecommendationFour}
+	compCmdState.Category = []string{"s3", "logging"}
+
+	result, output := filterRecommendations(mockRecommendations)
+
+	assert.Equal(t, len(result), 3)
+	assert.Equal(t, output, "3 of 4 recommendations showing \n")
+	clearFilters()
+}
+
+func TestComplianceRecommendationsFilterMultipleServices(t *testing.T) {
+	mockRecommendations := []api.ComplianceRecommendation{mockRecommendationOne, mockRecommendationTwo,
+		mockRecommendationThree, mockRecommendationFour}
+	compCmdState.Service = []string{"aws:s3", "aws:iam"}
+
+	result, output := filterRecommendations(mockRecommendations)
+
+	assert.Equal(t, len(result), 2)
+	assert.Equal(t, output, "2 of 4 recommendations showing \n")
+	clearFilters()
+}
+
 func TestStatusInputToProperTransform(t *testing.T) {
 	status := statusToProperTypes("non-compliant")
 	assert.Equal(t, status, "NonCompliant")
@@ -134,15 +158,15 @@ func TestFiltersEnabled(t *testing.T) {
 	NoneEnabled := filtersEnabled()
 	assert.Equal(t, NoneEnabled, false)
 
-	compCmdState.Category = "s3"
+	compCmdState.Category = []string{"s3"}
 	compCmdState.Status = "non-compliant"
 	compCmdState.Severity = "high"
-	compCmdState.Service = "aws:s3"
+	compCmdState.Service = []string{"aws:s3"}
 	AllEnabled := filtersEnabled()
 	assert.Equal(t, AllEnabled, true)
 
 	compCmdState.Severity = ""
-	compCmdState.Service = ""
+	compCmdState.Service = []string{}
 
 	SomeEnabled := filtersEnabled()
 	assert.Equal(t, SomeEnabled, true)
@@ -151,9 +175,9 @@ func TestFiltersEnabled(t *testing.T) {
 }
 
 func clearFilters() {
-	compCmdState.Category = ""
+	compCmdState.Category = []string{}
 	compCmdState.Severity = ""
-	compCmdState.Service = ""
+	compCmdState.Service = []string{}
 	compCmdState.Status = ""
 }
 

--- a/cli/cmd/compliance_test.go
+++ b/cli/cmd/compliance_test.go
@@ -1,0 +1,169 @@
+//
+// Author:: Darren Murray (<darren.murray@lacework.net>)
+// Copyright:: Copyright 2020, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/lacework/go-sdk/api"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestComplianceRecommendationsFilterNoResults(t *testing.T) {
+	mockRecommendations := []api.ComplianceRecommendation{mockRecommendationOne, mockRecommendationTwo,
+		mockRecommendationThree, mockRecommendationFour}
+	compCmdState.Category = "monitoring"
+	result, output := filterRecommendations(mockRecommendations)
+
+	assert.Equal(t, len(result), 0)
+	assert.Equal(t, output, "There are no recommendations with the specified filters.\n")
+	clearFilters()
+}
+
+func TestComplianceRecommendationsFilterOnCategory(t *testing.T) {
+	mockRecommendations := []api.ComplianceRecommendation{mockRecommendationOne, mockRecommendationTwo,
+		mockRecommendationThree, mockRecommendationFour}
+	compCmdState.Category = "identity-and-access-management"
+	result, output := filterRecommendations(mockRecommendations)
+
+	assert.Equal(t, len(result), 1)
+	assert.Equal(t, output, "1 of 4 recommendations showing \n")
+	clearFilters()
+}
+
+func TestComplianceRecommendationsFilterOnService(t *testing.T) {
+	mockRecommendations := []api.ComplianceRecommendation{mockRecommendationOne, mockRecommendationTwo,
+		mockRecommendationThree, mockRecommendationFour}
+	compCmdState.Service = "aws:cloudtrail"
+	result, output := filterRecommendations(mockRecommendations)
+
+	assert.Equal(t, len(result), 2)
+	assert.Equal(t, output, "2 of 4 recommendations showing \n")
+	clearFilters()
+}
+
+// Severity returns everything above the specified threshold eg. "low" returns low, medium, high, critical
+func TestComplianceRecommendationsFilterOnSeverityLow(t *testing.T) {
+	mockRecommendations := []api.ComplianceRecommendation{mockRecommendationOne, mockRecommendationTwo,
+		mockRecommendationThree, mockRecommendationFour}
+	compCmdState.Severity = "low"
+	result, output := filterRecommendations(mockRecommendations)
+
+	assert.Equal(t, len(result), 4)
+	assert.Equal(t, output, "4 of 4 recommendations showing \n")
+	clearFilters()
+}
+
+func TestComplianceRecommendationsFilterOnSeverityCritical(t *testing.T) {
+	mockRecommendations := []api.ComplianceRecommendation{mockRecommendationOne, mockRecommendationTwo,
+		mockRecommendationThree, mockRecommendationFour}
+	compCmdState.Severity = "low"
+	result, output := filterRecommendations(mockRecommendations)
+
+	assert.Equal(t, len(result), 4)
+	assert.Equal(t, output, "4 of 4 recommendations showing \n")
+	clearFilters()
+}
+
+func TestComplianceRecommendationsFilterOnStatus(t *testing.T) {
+	mockRecommendations := []api.ComplianceRecommendation{mockRecommendationOne, mockRecommendationTwo,
+		mockRecommendationThree, mockRecommendationFour}
+	compCmdState.Status = "non-compliant"
+	result, output := filterRecommendations(mockRecommendations)
+
+	assert.Equal(t, len(result), 2)
+	assert.Equal(t, output, "2 of 4 recommendations showing \n")
+	clearFilters()
+}
+
+func TestComplianceRecommendationsFilterMultiple(t *testing.T) {
+	mockRecommendations := []api.ComplianceRecommendation{mockRecommendationOne, mockRecommendationTwo,
+		mockRecommendationThree, mockRecommendationFour}
+	compCmdState.Severity = "high"
+	compCmdState.Status = "non-compliant"
+
+	result, output := filterRecommendations(mockRecommendations)
+
+	assert.Equal(t, len(result), 2)
+	assert.Equal(t, output, "2 of 4 recommendations showing \n")
+	clearFilters()
+}
+
+func clearFilters(){
+	compCmdState.Category = ""
+	compCmdState.Severity = ""
+	compCmdState.Service = ""
+	compCmdState.Status = ""
+}
+
+var (
+	mockRecommendationOne = api.ComplianceRecommendation{
+		RecID:                 "LW_S3_1",
+		AssessedResourceCount: 1,
+		ResourceCount:         1,
+		Category:              "S3",
+		InfoLink:              "",
+		Service:               "aws:s3",
+		Severity:              2,
+		Status:                "NonCompliant",
+		Suppressions:          []string{},
+		Title:                 "Mock S3",
+		Violations:            []api.ComplianceViolation{},
+	}
+	mockRecommendationTwo = api.ComplianceRecommendation{
+		RecID:                 "AWS_CIS_1_7",
+		AssessedResourceCount: 1,
+		ResourceCount:         1,
+		Category:              "Identity and Access Management",
+		InfoLink:              "",
+		Service:               "aws:iam",
+		Severity:              1,
+		Status:                "Compliant",
+		Suppressions:          []string{},
+		Title:                 "Mock IAM",
+		Violations:            []api.ComplianceViolation{},
+	}
+	mockRecommendationThree = api.ComplianceRecommendation{
+		RecID:                 "AWS_CIS_2_2",
+		AssessedResourceCount: 1,
+		ResourceCount:         1,
+		Category:              "Logging",
+		InfoLink:              "",
+		Service:               "aws:cloudtrail",
+		Severity:              2,
+		Status:                "NonCompliant",
+		Suppressions:          []string{},
+		Title:                 "Mock Log One",
+		Violations:            []api.ComplianceViolation{},
+	}
+
+	mockRecommendationFour = api.ComplianceRecommendation{
+		RecID:                 "AWS_CIS_2_2",
+		AssessedResourceCount: 1,
+		ResourceCount:         1,
+		Category:              "Logging",
+		InfoLink:              "",
+		Service:               "aws:cloudtrail",
+		Severity:              4,
+		Status:                "Compliant",
+		Suppressions:          []string{},
+		Title:                 "Mock Log Two",
+		Violations:            []api.ComplianceViolation{},
+	}
+)

--- a/integration/compliance_aws_test.go
+++ b/integration/compliance_aws_test.go
@@ -27,8 +27,60 @@ import (
 func TestComplianceAwsGetReportFilter(t *testing.T) {
 	account := os.Getenv("LW_INT_TEST_AWS_ACC")
 	detailsOutput := "recommendations showing"
-	out, err, exitcode := LaceworkCLIWithTOMLConfig("compliance", "aws", "get-report", account, "--details", "--status", "could-not-assess")
+	out, err, exitcode := LaceworkCLIWithTOMLConfig("compliance", "aws", "get-report", account, "--status", "compliant")
+
 	assert.Contains(t, out.String(), detailsOutput, "Filtered detail output should contain filtered result")
 	assert.Empty(t, err.String(), "STDERR should be empty")
 	assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
+	assert.Contains(t, out.String(), "COMPLIANCE REPORT DETAILS",
+		"STDOUT table headers changed, please check")
+	assert.Contains(t, out.String(), account,
+		"Account ID in compliance report is not correct")
+	assert.Contains(t, out.String(), "NON-COMPLIANT RECOMMENDATIONS",
+		"STDOUT table headers changed, please check")
+	assert.Contains(t, out.String(), "ID",
+		"STDOUT table headers changed, please check")
+	assert.Contains(t, out.String(), "RECOMMENDATION",
+		"STDOUT table headers changed, please check")
+	assert.Contains(t, out.String(), "STATUS",
+		"STDOUT table headers changed, please check")
+	assert.Contains(t, out.String(), "SEVERITY",
+		"STDOUT table headers changed, please check")
+	assert.Contains(t, out.String(), "SERVICE",
+		"STDOUT table headers changed, please check")
+	assert.Contains(t, out.String(), "AFFECTED",
+		"STDOUT table headers changed, please check")
+	assert.Contains(t, out.String(), "ASSESSED",
+		"STDOUT table headers changed, please check")
+}
+
+func TestComplianceAwsGetReportDetails(t *testing.T) {
+	account := os.Getenv("LW_INT_TEST_AWS_ACC")
+	detailsOutput := "recommendations showing"
+	out, err, exitcode := LaceworkCLIWithTOMLConfig("compliance", "aws", "get-report", account, "--details")
+
+	assert.NotContains(t, out.String(), detailsOutput,
+		"Details table without filter should not contain filtered output")
+	assert.Empty(t, err.String(), "STDERR should be empty")
+	assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
+	assert.Contains(t, out.String(), "COMPLIANCE REPORT DETAILS",
+		"STDOUT table headers changed, please check")
+	assert.Contains(t, out.String(), account,
+		"Account ID in compliance report is not correct")
+	assert.Contains(t, out.String(), "NON-COMPLIANT RECOMMENDATIONS",
+		"STDOUT table headers changed, please check")
+	assert.Contains(t, out.String(), "ID",
+		"STDOUT table headers changed, please check")
+	assert.Contains(t, out.String(), "RECOMMENDATION",
+		"STDOUT table headers changed, please check")
+	assert.Contains(t, out.String(), "STATUS",
+		"STDOUT table headers changed, please check")
+	assert.Contains(t, out.String(), "SEVERITY",
+		"STDOUT table headers changed, please check")
+	assert.Contains(t, out.String(), "SERVICE",
+		"STDOUT table headers changed, please check")
+	assert.Contains(t, out.String(), "AFFECTED",
+		"STDOUT table headers changed, please check")
+	assert.Contains(t, out.String(), "ASSESSED",
+		"STDOUT table headers changed, please check")
 }

--- a/integration/compliance_aws_test.go
+++ b/integration/compliance_aws_test.go
@@ -1,0 +1,34 @@
+//
+// Author:: Darren Murray (<darren.murray@lacework.net>)
+// Copyright:: Copyright 2020, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+package integration
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestComplianceAwsGetReportFilter(t *testing.T) {
+	account := os.Getenv("LW_INT_TEST_AWS_ACC")
+	detailsOutput := "recommendations showing"
+	out, err, exitcode := LaceworkCLIWithTOMLConfig("compliance", "aws", "get-report", account, "--details", "--status", "could-not-assess")
+	assert.Contains(t, out.String(), detailsOutput, "Filtered detail output should contain filtered result")
+	assert.Empty(t, err.String(),  "STDERR should be empty")
+	assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
+}

--- a/integration/compliance_aws_test.go
+++ b/integration/compliance_aws_test.go
@@ -29,6 +29,6 @@ func TestComplianceAwsGetReportFilter(t *testing.T) {
 	detailsOutput := "recommendations showing"
 	out, err, exitcode := LaceworkCLIWithTOMLConfig("compliance", "aws", "get-report", account, "--details", "--status", "could-not-assess")
 	assert.Contains(t, out.String(), detailsOutput, "Filtered detail output should contain filtered result")
-	assert.Empty(t, err.String(),  "STDERR should be empty")
+	assert.Empty(t, err.String(), "STDERR should be empty")
 	assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
 }

--- a/internal/array/contains.go
+++ b/internal/array/contains.go
@@ -46,3 +46,12 @@ func ContainsInt(array []int, expected int) bool {
 	}
 	return false
 }
+
+func ContainsBool(array []bool, expected bool) bool {
+	for _, value := range array {
+		if expected == value {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/array/contains.go
+++ b/internal/array/contains.go
@@ -29,6 +29,15 @@ func ContainsStr(array []string, expected string) bool {
 	return false
 }
 
+func ContainsStrCaseInsensitive(array []string, expected string) bool {
+	for _, value := range array {
+		if strings.EqualFold(expected, value) {
+			return true
+		}
+	}
+	return false
+}
+
 func ContainsPartialStr(array []string, expected string) bool {
 	for _, value := range array {
 		if strings.Contains(value, expected) {


### PR DESCRIPTION
Add filtering flags for compliance report recommendations

https://lacework.atlassian.net/browse/ALLY-361

```
--category string  filter the compliance report details view by category (identity-and-access-management, s3, logging...)
--severity string  filter compliance report details view by severity threshold (critical, high, medium, low, info)
--status string  filter compliance report details view by status (non-compliant, requires-manual-assessment, suppressed, compliant)
--service string  filter the compliance report details view by service (aws:s3, aws:iam, aws:cloudtrail ...)
```

Signed-off-by: Darren Murray <darren.murray@lacework.net>