### PR TITLE
fix: Generate a new token upon a request with an expired token

### DIFF
--- a/api/auth.go
+++ b/api/auth.go
@@ -72,6 +72,7 @@ func WithToken(token string) Option {
 	return clientFunc(func(c *Client) error {
 		c.log.Debug("setting up auth", zap.String("token", token))
 		c.auth.token = token
+		c.auth.expiresAt = time.Now().Add(defaultTimeout)
 		return nil
 	})
 }

--- a/api/auth.go
+++ b/api/auth.go
@@ -72,7 +72,7 @@ func WithToken(token string) Option {
 	return clientFunc(func(c *Client) error {
 		c.log.Debug("setting up auth", zap.String("token", token))
 		c.auth.token = token
-		c.auth.expiresAt = time.Now().Add(defaultTimeout)
+		c.auth.expiresAt = time.Now().Add(DefaultTokenExpiryTime * time.Second)
 		return nil
 	})
 }

--- a/api/http.go
+++ b/api/http.go
@@ -52,8 +52,8 @@ func (c *Client) NewRequest(method string, apiURL string, body io.Reader) (*http
 	if apiURL == apiTokens {
 		headers["X-LW-UAKS"] = c.auth.secret
 	} else {
-		// verify that the client has a token, if not, try to generate one
-		if c.auth.token == "" {
+		// verify that the client has a token or token is not expired, if not, try to generate one
+		if c.auth.token == "" || c.TokenExpired() {
 			if _, err = c.GenerateToken(); err != nil {
 				return nil, err
 			}

--- a/integration/container_vulnerability_test.go
+++ b/integration/container_vulnerability_test.go
@@ -87,9 +87,7 @@ func TestContainerVulnerabilityCommandListAssessments(t *testing.T) {
 	})
 }
 
-// Disabling this test since it has been failing for over a week,
-// we will enable it once RAIN-15300 is solved
-func _TestContainerVulnerabilityCommandScanHumanReadablePollGenerateHtml(t *testing.T) {
+func TestContainerVulnerabilityCommandScanHumanReadablePollGenerateHtml(t *testing.T) {
 	// create a temporal directory to check that the HTML file is deployed
 	home := createTOMLConfigFromCIvars()
 	defer os.RemoveAll(home)
@@ -124,9 +122,7 @@ type containerVulnerabilityScan struct {
 	Status    string `json:"status"`
 }
 
-// Disabling this test since it has been failing for over a week,
-// we will enable it once RAIN-15300 is solved
-func _TestContainerVulnerabilityCommandsEndToEnd(t *testing.T) {
+func TestContainerVulnerabilityCommandsEndToEnd(t *testing.T) {
 	var (
 		out      bytes.Buffer
 		err      bytes.Buffer

--- a/internal/lacework/server.go
+++ b/internal/lacework/server.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"time"
 )
 
 // Mock is a quick HTTP server that can be used to mock a Lacework API
@@ -63,10 +64,11 @@ func (m *Mock) MockAPI(p string, handler func(http.ResponseWriter, *http.Request
 
 func (s *Mock) MockToken(token string) {
 	s.MockAPI("access/tokens", func(w http.ResponseWriter, r *http.Request) {
+		expiration := time.Now().AddDate(0, 0, 1)
 		fmt.Fprintf(w, `
       {
         "data": [{
-          "expiresAt": "Mar 10 2020 08:10",
+          "expiresAt": "`+expiration.Format("Jan 02 2006 15:04")+`",
           "token": "`+token+`"
         }],
         "ok": true,


### PR DESCRIPTION
When the Go client tries to submit an API request and the token stored in memory is expired, attempt to generate a new token.

https://lacework.atlassian.net/browse/ALLY-363

Signed-off-by: Darren Murray <darren.murray@lacework.net>

