### PR TITLE
fix(api): type-o in host vulnerability status

### DIFF
--- a/api/vulnerabilities_host.go
+++ b/api/vulnerabilities_host.go
@@ -143,7 +143,7 @@ type HostVulnPackage struct {
 	Namespace           string `json:"namespace"`
 	Severity            string `json:"severity"`
 	Status              string `json:"status,omitempty"`
-	VulnerabilityStatus string `json:"vulnerabiliy_status,omitempty"` // @afiune typo
+	VulnerabilityStatus string `json:"vulnerability_status,omitempty"`
 	Version             string `json:"version"`
 	HostCount           string `json:"host_count"`
 	PackageStatus       string `json:"package_status"`


### PR DESCRIPTION
Tested and active vulnerabilities are displaying correctly...

```  
             HOST DETAILS                        VULNERABILITIES
-----------------------------------------+-----------------------------------
    Machine ID   30                           SEVERITY    COUNT   FIXABLE
    Hostname     circle-ci-test-node       -------------+-------+----------
    External IP  <redacted>                  Critical         0         0
    Internal IP  <redacted>                  High            27        27
    Os           linux                       Medium          48        48
    Arch         amd64                       Low              3         3
    Namespace    amzn:2                      Negligible       0         0
    Provider     AWS
    Instance ID  i-<redacted>
    AMI          <redacted>


      CVE ID        SEVERITY   SCORE   PACKAGE     CURRENT VERSION         FIX VERSION       PGK STATUS   VULN STATUS
------------------+----------+-------+---------+----------------------+--------------------+------------+--------------
  ALAS2-2021-1575   Medium     0       chrony    0:3.2-1.amzn2.0.5      3.5.1-1.amzn2.0.1    ACTIVE       Active
  ALAS2-2021-1611   Medium     0       python    0:2.7.18-1.amzn2.0.2   2.7.18-1.amzn2.0.3   ACTIVE       Active
```

Closes https://github.com/lacework/go-sdk/issues/335

Signed-off-by: Scott Ford <scott.ford@lacework.net>