### PR TITLE
feat: Add List Azure Tenants command

### DIFF
--- a/api/compliance_azure.go
+++ b/api/compliance_azure.go
@@ -33,20 +33,6 @@ type ComplianceAzureReportConfig struct {
 	Type           string
 }
 
-func (svc *ComplianceService) ListAzureTenants() ([]string, error) {
-	var response AzureIntegrationsResponse
-	var tenants []string
-
-	err := svc.client.RequestDecoder("GET", fmt.Sprintf(apiIntegrationsByType, "AZURE_CFG"), nil, &response)
-	if err != nil {
-		return nil, err
-	}
-	for _, azure := range response.Data {
-		tenants = append(tenants, azure.Data.TenantID)
-	}
-	return tenants, err
-}
-
 func (svc *ComplianceService) ListAzureSubscriptions(tenantID string) (
 	response compAzureSubsResponse,
 	err error,

--- a/api/compliance_azure.go
+++ b/api/compliance_azure.go
@@ -33,7 +33,7 @@ type ComplianceAzureReportConfig struct {
 	Type           string
 }
 
-func (svc *ComplianceService) ListAzureTenants() ([]string, error){
+func (svc *ComplianceService) ListAzureTenants() ([]string, error) {
 	var response AzureIntegrationsResponse
 	var tenants []string
 

--- a/api/compliance_azure.go
+++ b/api/compliance_azure.go
@@ -33,6 +33,20 @@ type ComplianceAzureReportConfig struct {
 	Type           string
 }
 
+func (svc *ComplianceService) ListAzureTenants() ([]string, error){
+	var response AzureIntegrationsResponse
+	var tenants []string
+
+	err := svc.client.RequestDecoder("GET", fmt.Sprintf(apiIntegrationsByType, "AZURE_CFG"), nil, &response)
+	if err != nil {
+		return nil, err
+	}
+	for _, azure := range response.Data {
+		tenants = append(tenants, azure.Data.TenantID)
+	}
+	return tenants, err
+}
+
 func (svc *ComplianceService) ListAzureSubscriptions(tenantID string) (
 	response compAzureSubsResponse,
 	err error,

--- a/cli/cmd/compliance.go
+++ b/cli/cmd/compliance.go
@@ -93,25 +93,19 @@ Use the following command to list all available integrations in your account:
 		Short:   "compliance for Azure Cloud",
 		Long: `Manage compliance reports for Azure Cloud.
 
+To list all Azure Tenants configured in your account:
+
+    $ lacework compliance azure list-tenants
+
+To list all Azure Subscriptions from a Tenant, use the command:
+
+    $ lacework compliance azure list-subscriptions <tenant_id>
+
 To get the latest Azure compliance assessment report, use the command:
 
     $ lacework compliance azure get-report <tenant_id> <subscriptions_id>
 
 These reports run on a regular schedule, typically once a day.
-
-To find out which Azure tenants/subscriptions are connected to your
-Lacework account, use the following command:
-
-    $ lacework integrations list --type AZURE_CFG
-
-Then, choose one integration, copy the GUID and visualize its details
-using the command:
-
-    $ lacework integration show <int_guid>
-
-To list all Azure subscriptions from a tenant, use the command:
-
-    $ lacework compliance azure list-subscriptions <tenant_id>
 
 To run an ad-hoc compliance assessment use the command:
 

--- a/cli/cmd/compliance_azure.go
+++ b/cli/cmd/compliance_azure.go
@@ -76,18 +76,18 @@ Then, select one GUID from an integration and visualize its details using the co
 		Long:    `List all Azure Tenants.`,
 		Args:    cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
-			response, err := cli.LwApi.Compliance.ListAzureTenants()
+			response, err := cli.LwApi.Integrations.ListAzureCfg()
 			if err != nil {
 				return errors.Wrap(err, "unable to list azure tenants")
 			}
 
 			if cli.JSONOutput() {
-				return cli.OutputJSON(response)
+				return cli.OutputJSON(response.Data[0])
 			}
 
 			var rows [][]string
-			for _, tenant := range response {
-				rows = append(rows, []string{tenant})
+			for _, azure := range response.Data {
+				rows = append(rows, []string{azure.Data.TenantID})
 			}
 
 			cli.OutputHuman(renderSimpleTable([]string{"Tenants"}, rows))

--- a/cli/cmd/compliance_azure.go
+++ b/cli/cmd/compliance_azure.go
@@ -34,7 +34,7 @@ var (
 	// complianceAzureListSubsCmd represents the list-subscriptions sub-command inside the azure command
 	complianceAzureListSubsCmd = &cobra.Command{
 		Use:     "list-subscriptions <tenant_id>",
-		Aliases: []string{"list-subs", "list"},
+		Aliases: []string{"list-subs"},
 		Short:   "list subscriptions from tenant",
 		Long: `List all Azure subscriptions from the provided tenant ID.
 
@@ -64,6 +64,33 @@ Then, select one GUID from an integration and visualize its details using the co
 				}
 			}
 			cli.OutputHuman(renderSimpleTable([]string{"Subscriptions"}, rows))
+			return nil
+		},
+	}
+
+	// complianceAzureListTenantsCmd represents the list-tenants sub-command inside the azure command
+	complianceAzureListTenantsCmd = &cobra.Command{
+		Use:     "list-tenants",
+		Aliases: []string{"list"},
+		Short:   "list subscriptions from tenant",
+		Long: `List all Azure Tenants.`,
+		Args:  cobra.NoArgs,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			response, err := cli.LwApi.Compliance.ListAzureTenants()
+			if err != nil {
+				return errors.Wrap(err, "unable to list azure tenants")
+			}
+
+			if cli.JSONOutput() {
+				return cli.OutputJSON(response)
+			}
+
+			var rows [][]string
+			for _, tenant := range response {
+				rows = append(rows, []string{tenant})
+			}
+
+			cli.OutputHuman(renderSimpleTable([]string{"Tenants"}, rows))
 			return nil
 		},
 	}
@@ -201,6 +228,7 @@ To run an ad-hoc compliance assessment use the command:
 func init() {
 	// add sub-commands to the azure command
 	complianceAzureCmd.AddCommand(complianceAzureListSubsCmd)
+	complianceAzureCmd.AddCommand(complianceAzureListTenantsCmd)
 	complianceAzureCmd.AddCommand(complianceAzureGetReportCmd)
 	complianceAzureCmd.AddCommand(complianceAzureRunAssessmentCmd)
 

--- a/cli/cmd/compliance_azure.go
+++ b/cli/cmd/compliance_azure.go
@@ -73,8 +73,8 @@ Then, select one GUID from an integration and visualize its details using the co
 		Use:     "list-tenants",
 		Aliases: []string{"list"},
 		Short:   "list subscriptions from tenant",
-		Long: `List all Azure Tenants.`,
-		Args:  cobra.NoArgs,
+		Long:    `List all Azure Tenants.`,
+		Args:    cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			response, err := cli.LwApi.Compliance.ListAzureTenants()
 			if err != nil {

--- a/integration/compliance_azure_test.go
+++ b/integration/compliance_azure_test.go
@@ -1,0 +1,33 @@
+//
+// Author:: Darren Murray (<darren.murray@lacework.net>)
+// Copyright:: Copyright 2020, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+package integration
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestComplianceAzureListTenants(t *testing.T) {
+	out, err, exitcode := LaceworkCLIWithTOMLConfig("compliance", "az", "list-tenants")
+
+	assert.Empty(t, err.String(), "STDERR should be empty")
+	assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
+	assert.Contains(t, out.String(), "TENANTS",
+		"STDOUT table headers changed, please check")
+}


### PR DESCRIPTION
Add new command to list Azure Tenants
Usage: 
`$ lacework compliance azure list-tenants`

Output:
```
                TENANTS
----------------------------------------
  1aa11111-aa11-111a-1111-aaa11111aa11
```

Signed-off-by: Darren Murray <darren.murray@lacework.net>