### PR TITLE
feat(api): implement account information endpoint

### DIFF
--- a/api/account.go
+++ b/api/account.go
@@ -24,7 +24,7 @@ type AccountService struct {
 	client *Client
 }
 
-func (svc *AccountService) OrganizationInfo() (
+func (svc *AccountService) GetOrganizationInfo() (
 	response accountOrganizationInfoResponse,
 	err error,
 ) {

--- a/api/account.go
+++ b/api/account.go
@@ -1,0 +1,42 @@
+//
+// Author:: Salim Afiune Maya (<afiune@lacework.net>)
+// Copyright:: Copyright 2021, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package api
+
+// AccountService is a service that interacts with Account related
+// endpoints from the Lacework Server
+type AccountService struct {
+	client *Client
+}
+
+func (svc *AccountService) OrganizationInfo() (
+	response accountOrganizationInfoResponse,
+	err error,
+) {
+	err = svc.client.RequestDecoder("GET",
+		apiAccountOrganizationInfo,
+		nil,
+		&response,
+	)
+	return
+}
+
+type accountOrganizationInfoResponse struct {
+	OrgAccount     bool   `json:"orgAccount"`
+	OrgAccountName string `json:"orgAccountName,omitempty"`
+}

--- a/api/account_test.go
+++ b/api/account_test.go
@@ -1,0 +1,85 @@
+//
+// Author:: Salim Afiune Maya (<afiune@lacework.net>)
+// Copyright:: Copyright 2021, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package api_test
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/lacework/go-sdk/api"
+	"github.com/lacework/go-sdk/internal/lacework"
+)
+
+func TestAccountOrganizationInfoForStandalone(t *testing.T) {
+	var fakeServer = lacework.MockServer()
+	fakeServer.MockAPI("external/account/organizationInfo", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method, "GetOrganizationInfo should be a GET method")
+		fmt.Fprintf(w, accountOrganizationInfoResponseStandalone())
+	})
+	defer fakeServer.Close()
+
+	c, err := api.NewClient("test",
+		api.WithToken("TOKEN"),
+		api.WithURL(fakeServer.URL()),
+	)
+	assert.Nil(t, err)
+
+	response, err := c.Account.GetOrganizationInfo()
+	assert.Nil(t, err)
+	if assert.NotNil(t, response) {
+		assert.False(t, response.OrgAccount)
+		assert.Empty(t, response.OrgAccountName)
+	}
+}
+
+func TestAccountOrganizationInfoForOrganizational(t *testing.T) {
+	var fakeServer = lacework.MockServer()
+	fakeServer.MockAPI("external/account/organizationInfo", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method, "GetOrganizationInfo should be a GET method")
+		fmt.Fprintf(w, accountOrganizationInfoResponseOrganizational("test-org"))
+	})
+	defer fakeServer.Close()
+
+	c, err := api.NewClient("test",
+		api.WithToken("TOKEN"),
+		api.WithURL(fakeServer.URL()),
+	)
+	assert.Nil(t, err)
+
+	response, err := c.Account.GetOrganizationInfo()
+	assert.Nil(t, err)
+	if assert.NotNil(t, response) {
+		assert.True(t, response.OrgAccount)
+		assert.Equal(t, "test-org", response.OrgAccountName)
+	}
+}
+
+func accountOrganizationInfoResponseStandalone() string {
+	return `{ "orgAccount": false }`
+}
+
+func accountOrganizationInfoResponseOrganizational(name string) string {
+	return `{
+  "orgAccount": true,
+  "orgAccountName": "` + name + `"
+}`
+}

--- a/api/api.go
+++ b/api/api.go
@@ -59,6 +59,8 @@ const (
 	apiEventsDetails   = "external/events/GetEventDetails"
 	apiEventsDateRange = "external/events/GetEventsForDateRange"
 
+	apiAccountOrganizationInfo = "external/account/organizationInfo"
+
 	// Alpha
 	apiLQLQuery = "external/lql/query"
 )

--- a/api/client.go
+++ b/api/client.go
@@ -44,6 +44,7 @@ type Client struct {
 	headers    map[string]string
 
 	LQL             *LQLService
+	Account         *AccountService
 	Agents          *AgentsService
 	Events          *EventsService
 	Compliance      *ComplianceService
@@ -93,6 +94,7 @@ func NewClient(account string, opts ...Option) (*Client, error) {
 		c: &http.Client{Timeout: defaultTimeout},
 	}
 	c.LQL = &LQLService{c}
+	c.Account = &AccountService{c}
 	c.Agents = &AgentsService{c}
 	c.Events = &EventsService{c}
 	c.Compliance = &ComplianceService{c}


### PR DESCRIPTION
As a Lacework Engineer that needs to migrate tools and integrations from APIv1 to APIv2,
 I need to have a mechanism to identify both authentication methods,
So that I can start using both API versions and migrate endpoints gradually (not all at once).

JIRA ALLY-369

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>