### PR TITLE
chore: Validation script for git commit message conventions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,3 +98,6 @@ endif
 ifeq (, $(shell which gox))
 	go get github.com/mitchellh/gox
 endif
+
+git-env:
+	scripts/git_env.sh

--- a/scripts/git_env.sh
+++ b/scripts/git_env.sh
@@ -1,3 +1,4 @@
+
 #!/bin/bash
 #
 # Name::        git_env.sh
@@ -5,7 +6,7 @@
 # Author::      Darren Murray (<dmurray-lacework@lacework.net>)
 #
 
-readonly commit_hook=scripts/githooks/prepare-commit-msg
+readonly commit_hook=scripts/githooks/commit-msg
 readonly hooks_path=scripts/githooks/
 readonly project_name=go-sdk
 

--- a/scripts/git_env.sh
+++ b/scripts/git_env.sh
@@ -1,40 +1,22 @@
 #!/bin/bash
 #
 # Name::        git_env.sh
-# Description:: Use this script to configure local git env,
-#               including commit message validation
+# Description:: Use this script to configure local git env
 # Author::      Darren Murray (<dmurray-lacework@lacework.net>)
 #
 
-readonly commit_hook=.git/hooks/prepare-commit-msg
-readonly new_commit_hook=scripts/githooks/prepare-commit-msg
+readonly commit_hook=scripts/githooks/prepare-commit-msg
+readonly hooks_path=scripts/githooks/
 readonly project_name=go-sdk
 
-create_prepare_commit_msg(){
-  if [ ! -f $commit_hook ]; then
-    log "Adding git commit hooks"
-    cp scripts/githooks/prepare-commit-msg $commit_hook
-    chmod +x $commit_hook
-  else 
-    log "Git commit hook already exists"
-    update
-  fi
-}
-
-update() {
-  currentVersion=$(cat $commit_hook | grep 'readonly version=v'| sed 's/.*readonly version=\(.*\)/\1/')
-  newVersion=$(cat $new_commit_hook | grep 'readonly version=v'| sed 's/.*readonly version=\(.*\)/\1/')
-    if [ $newVersion != $currentVersion ]; then
-        log "Updating git commit hooks version $currentVersion -> $newVersion"
-        cp scripts/githooks/prepare-commit-msg $commit_hook
-        chmod +x $commit_hook
-    else 
-        log "No changes made to version"
-  fi
+prepare_git_env(){
+  chmod +x $commit_hook
+  log "Setting git-hooks path to $hooks_path"
+  git config core.hooksPath $hooks_path
 }
 
 log() {
   echo "--> ${project_name}: $1"
 }
 
-create_prepare_commit_msg
+prepare_git_env

--- a/scripts/git_env.sh
+++ b/scripts/git_env.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+#
+# Name::        git_env.sh
+# Description:: Use this script to configure local git env,
+#               including commit message validation
+# Author::      Darren Murray (<dmurray-lacework@lacework.net>)
+#
+
+readonly commit_hook=.git/hooks/prepare-commit-msg
+readonly new_commit_hook=scripts/githooks/prepare-commit-msg
+readonly project_name=go-sdk
+
+create_prepare_commit_msg(){
+  if [ ! -f $commit_hook ]; then
+    log "Adding git commit hooks"
+    cp scripts/githooks/prepare-commit-msg $commit_hook
+    chmod +x $commit_hook
+  else 
+    log "Git commit hook already exists"
+    update
+  fi
+}
+
+update() {
+  currentVersion=$(cat $commit_hook | grep 'readonly version=v'| sed 's/.*readonly version=\(.*\)/\1/')
+  newVersion=$(cat $new_commit_hook | grep 'readonly version=v'| sed 's/.*readonly version=\(.*\)/\1/')
+    if [ $newVersion != $currentVersion ]; then
+        log "Updating git commit hooks version $currentVersion -> $newVersion"
+        cp scripts/githooks/prepare-commit-msg $commit_hook
+        chmod +x $commit_hook
+    else 
+        log "No changes made to version"
+  fi
+}
+
+log() {
+  echo "--> ${project_name}: $1"
+}
+
+create_prepare_commit_msg

--- a/scripts/githooks/commit-msg
+++ b/scripts/githooks/commit-msg
@@ -2,14 +2,15 @@
 readonly project_name=go-sdk
 readonly commit_tags="feat(:|\(.*\):)|fix(:|\(.*\):)|style(:|\(.*\):)|refactor(:|\(.*\):)\|test(:|\(.*\):)\|docs(:|\(.*\):)\|chore(:|\(.*\):)\|build(:|\(.*\):)\|ci(:|\(.*\):)\|perf(:|\(.*\):)\|metric(:|\(.*\):)\|misc(:|\(.*\):)"
 readonly commit_message=`cat $1`
+readonly blah="Please enter the commit message for your changes"
 
 validate_commit_message(){
-    if ! [[ $commit_message =~ $commit_tags ]]; then
-        invalid_message
-        exit 1
-    fi
-    log "Commit message is valid"
-}
+        if ! [[ $commit_message =~ $commit_tags ]]; then
+            invalid_message
+            exit 1
+        fi
+            log "Commit message is valid"
+} 
 
 invalid_message(){
     log "Invalid commit message"

--- a/scripts/githooks/prepare-commit-msg
+++ b/scripts/githooks/prepare-commit-msg
@@ -1,5 +1,4 @@
 #!/bin/bash
-readonly version=v0.0.1
 readonly project_name=go-sdk
 readonly commit_tags=feat:\|fix:\|style:\|refactor:\|test:\|docs:\|chore:\|build:\|ci:\|perf:\|metric:\|misc:
 readonly commit_message=`cat $1`

--- a/scripts/githooks/prepare-commit-msg
+++ b/scripts/githooks/prepare-commit-msg
@@ -1,6 +1,6 @@
 #!/bin/bash
 readonly project_name=go-sdk
-readonly commit_tags=feat:\|fix:\|style:\|refactor:\|test:\|docs:\|chore:\|build:\|ci:\|perf:\|metric:\|misc:
+readonly commit_tags="feat(:|\(.*\):)|fix(:|(.*):)|style(:|(.*):)|refactor(:|(.*):)\|test(:|(.*):)\|docs(:|(.*):)\|chore(:|(.*):)\|build(:|(.*):)\|ci(:|(.*):)\|perf(:|(.*):)\|metric(:|(.*):)\|misc(:|(.*):)"
 readonly commit_message=`cat $1`
 
 validate_commit_message(){
@@ -13,7 +13,8 @@ validate_commit_message(){
 
 invalid_message(){
     log "Invalid commit message"
-    log "Message must contain one of $commit_tags"
+    log "Message must contain one of feat: | fix: | style: | refactor: | test: | docs: | chore: | build: | ci: | perf: | metric: | misc:
+      Or with scope in parenthesis eg. feat(cli): Add new feature"
 }
 
 log() {

--- a/scripts/githooks/prepare-commit-msg
+++ b/scripts/githooks/prepare-commit-msg
@@ -1,0 +1,25 @@
+#!/bin/bash
+readonly version=v0.0.1
+readonly project_name=go-sdk
+readonly commit_tags=feat:\|fix:\|style:\|refactor:\|test:\|docs:\|chore:\|build:\|ci:\|perf:\|metric:\|misc:
+readonly commit_message=`cat $1`
+
+validate_commit_message(){
+    if ! [[ $commit_message =~ $commit_tags ]]; then
+        invalid_message
+        exit 1
+    fi
+    log "Commit message is valid"
+}
+
+invalid_message(){
+    log "Invalid commit message"
+    log "Message must contain one of $commit_tags"
+}
+
+log() {
+  echo "--> ${project_name}: $1"
+}
+
+validate_commit_message
+

--- a/scripts/githooks/prepare-commit-msg
+++ b/scripts/githooks/prepare-commit-msg
@@ -1,6 +1,6 @@
 #!/bin/bash
 readonly project_name=go-sdk
-readonly commit_tags="feat(:|\(.*\):)|fix(:|(.*):)|style(:|(.*):)|refactor(:|(.*):)\|test(:|(.*):)\|docs(:|(.*):)\|chore(:|(.*):)\|build(:|(.*):)\|ci(:|(.*):)\|perf(:|(.*):)\|metric(:|(.*):)\|misc(:|(.*):)"
+readonly commit_tags="feat(:|\(.*\):)|fix(:|\(.*\):)|style(:|\(.*\):)|refactor(:|\(.*\):)\|test(:|\(.*\):)\|docs(:|\(.*\):)\|chore(:|\(.*\):)\|build(:|\(.*\):)\|ci(:|\(.*\):)\|perf(:|\(.*\):)\|metric(:|\(.*\):)\|misc(:|\(.*\):)"
 readonly commit_message=`cat $1`
 
 validate_commit_message(){


### PR DESCRIPTION
Add githook for commit message validation.
Add script and make cmd for updating the githook

The githook checks if commit message contains one of `feat:\|fix:\|style:\|refactor:\|test:\|docs:\|chore:\|build:\|ci:\|perf:\|metric:\|misc:`

In order for the githook to be used when `git commit` is called, it must be moved to .git/hooks/ directory.
`make git-env` checks if the hook exists or is not latest version before adding it to .git/hooks/ 

Upon success output is 
```
❯ gc -m "chore: Validation script for git commit message conventions"
--> go-sdk: Commit message is valid
[dmurray-lacework/enforce-commit-message 491a091] chore: Validation script for git commit message conventions
...
```

Upon failure output is 
```
❯ gc -m "cho: Add make cmd for git hooks update" 
--> go-sdk: Invalid commit message
--> go-sdk: Message must contain one of feat:|fix:|style:|refactor:|test:|docs:|chore:|build:|ci:|perf:|metric:|misc:
```




Signed-off-by: Darren Murray <darren.murray@lacework.net>