### PR TITLE
test(cli): add lacework query integration test resource

### DIFF
--- a/integration/test_resources/lql/my.lql
+++ b/integration/test_resources/lql/my.lql
@@ -1,0 +1,6 @@
+--- This query produces a web (github) hosted object for "lacework query" integration testing
+--- Specifically: TestQueryRunURL
+MyLQL(CloudTrailRawEvents e) {
+    SELECT INSERT_ID
+    LIMIT 1
+}


### PR DESCRIPTION
Adding static resource for lacework query integration test

```
~/Applications/src/lacework/go-sdk luna*
❯ lacework-dev query run -u https://raw.githubusercontent.com/lacework/go-sdk/b76818dd50908a65fa0987e6a135d6747ad29969/integration/test_resources/lql/my.lql --start "2021-03-31T00:00:00Z" --end "2021-04-01T00:00:00Z"
[
  {
    "INSERT_ID": "81550527"
  }
]
```