### PR TITLE
feat: Filter vuln host list cves and show assessment by severity

### DIFF
--- a/cli/cmd/event.go
+++ b/cli/cmd/event.go
@@ -843,6 +843,8 @@ func severityToProperTypes(severity string) (int, string) {
 		return 4, "Low"
 	case "5", "info":
 		return 5, "Info"
+	case "6", "negligible":
+		return 6, "Negligible"
 	default:
 		return 0, "Unknown"
 	}

--- a/cli/cmd/event.go
+++ b/cli/cmd/event.go
@@ -843,8 +843,6 @@ func severityToProperTypes(severity string) (int, string) {
 		return 4, "Low"
 	case "5", "info":
 		return 5, "Info"
-	case "6", "negligible":
-		return 6, "Negligible"
 	default:
 		return 0, "Unknown"
 	}

--- a/cli/cmd/vuln_container.go
+++ b/cli/cmd/vuln_container.go
@@ -629,6 +629,8 @@ type packageTable struct {
 	packageName    string
 	currentVersion string
 	fixVersion     string
+	packageStatus  string
+	hostCount      int
 }
 
 func aggregatePackages(slice []packageTable, s packageTable) []packageTable {

--- a/cli/cmd/vuln_host.go
+++ b/cli/cmd/vuln_host.go
@@ -588,7 +588,7 @@ func hostVulnPackagesTable(cves []api.HostVulnCVE, withHosts bool) ([][]string, 
 	})
 
 	if len(filteredPackages) > 0 {
-		filteredOutput := fmt.Sprintf("%v of %v package(s) showing \n", len(out), len(aggregatedPackages)+len(filteredPackages))
+		filteredOutput := fmt.Sprintf("%d of %d package(s) showing \n", len(out), len(aggregatedPackages)+len(filteredPackages))
 		return out, filteredOutput
 	}
 

--- a/cli/cmd/vuln_host.go
+++ b/cli/cmd/vuln_host.go
@@ -586,7 +586,7 @@ func hostVulnPackagesTable(cves []api.HostVulnCVE, withHosts bool) ([][]string, 
 	})
 
 	if len(filteredPackages) > 0 {
-		filteredOutput := fmt.Sprintf("%v of %v packages showing \n", len(out), len(aggregatedPackages)+len(filteredPackages))
+		filteredOutput := fmt.Sprintf("%v of %v package(s) showing \n", len(out), len(aggregatedPackages)+len(filteredPackages))
 		return out, filteredOutput
 	}
 

--- a/cli/cmd/vuln_host.go
+++ b/cli/cmd/vuln_host.go
@@ -583,7 +583,8 @@ func hostVulnCVEsTable(cves []api.HostVulnCVE) ([][]string, string) {
 	}
 
 	if filteredCves > 0 {
-		return out, fmt.Sprintf("\n %v of %v cve(s) showing \n", filteredCves, totalCves)
+		showing :=  totalCves - filteredCves
+		return out, fmt.Sprintf("\n %v of %v cve(s) showing \n", showing, totalCves)
 	}
 
 	return out, ""
@@ -639,7 +640,7 @@ func hostVulnCVEsTableForSeverity(cves []api.HostVulnCVE, severity string) ([][]
 		return stringToInt(out[i][7]) > stringToInt(out[j][7])
 	})
 
-	return out, total-filtered, total
+	return out, filtered, total
 }
 
 func hostVulnHostDetailsToTable(assessment api.HostVulnHostAssessment) string {

--- a/cli/cmd/vuln_host.go
+++ b/cli/cmd/vuln_host.go
@@ -590,9 +590,11 @@ func hostVulnCVEsTable(cves []api.HostVulnCVE) ([][]string, string) {
 }
 
 func hostVulnCVEsTableForSeverity(cves []api.HostVulnCVE, severity string) ([][]string, int ,int) {
-	out := [][]string{}
-	var filtered = 0
-	var total = 0
+	var (
+		filtered = 0
+		total    = 0
+		out      = [][]string{}
+	)
 
 	for _, cve := range cves {
 		for _, pkg := range cve.Packages {

--- a/cli/cmd/vuln_host.go
+++ b/cli/cmd/vuln_host.go
@@ -566,18 +566,17 @@ func hostVulnPackagesTable(cves []api.HostVulnCVE, withHosts bool) ([][]string, 
 	}
 
 	for _, p := range aggregatedPackages {
-		out = append(out, []string{
+		output := []string{
 			strconv.Itoa(p.cveCount),
 			p.severity,
 			p.packageName,
 			p.currentVersion,
 			p.fixVersion,
-			p.packageStatus,
-		})
-
+			p.packageStatus}
 		if p.hostCount > 0 {
-			out = append(out, []string{strconv.Itoa(p.hostCount)})
+			output = append(output, strconv.Itoa(p.hostCount))
 		}
+		out = append(out, output)
 	}
 
 	// order by severity

--- a/cli/cmd/vuln_host.go
+++ b/cli/cmd/vuln_host.go
@@ -851,6 +851,11 @@ func buildHostVulnCVEsToTableError() string {
 	if vulCmdState.Fixable {
 		msg = fmt.Sprintf("%s fixable", msg)
 	}
+
+	if vulCmdState.Severity != "" {
+		msg = fmt.Sprintf("%s %s", msg, vulCmdState.Severity)
+	}
+
 	msg = fmt.Sprintf("%s vulnerabilities", msg)
 
 	if vulCmdState.Active {

--- a/cli/cmd/vuln_host.go
+++ b/cli/cmd/vuln_host.go
@@ -544,6 +544,9 @@ func hostVulnPackagesTable(cves []api.HostVulnCVE, withHosts bool) ([][]string, 
 				fixVersion:     pkg.FixedVersion,
 				packageStatus:  pkg.PackageStatus,
 			}
+			if withHosts {
+				pack.hostCount = 1
+			}
 
 			if vulCmdState.Active && pkg.PackageStatus == "" {
 				filteredPackages = aggregatePackagesWithHosts(filteredPackages, pack, withHosts)

--- a/cli/cmd/vuln_host.go
+++ b/cli/cmd/vuln_host.go
@@ -813,7 +813,7 @@ func hostVulnCVEsTableForHostView(cves []api.HostVulnCVE) ([][]string, string) {
 
 	if len(out) < total {
 		showing := total - len(out)
-		return out, fmt.Sprintf("\n %v of %v cve(s) showing \n", showing, total)
+		return out, fmt.Sprintf("\n%d of %d cve(s) showing \n", showing, total)
 	}
 
 	return out, ""

--- a/cli/cmd/vuln_host.go
+++ b/cli/cmd/vuln_host.go
@@ -610,7 +610,7 @@ func hostVulnCVEsTable(cves []api.HostVulnCVE) ([][]string, string) {
 
 	if filteredCves > 0 {
 		showing := totalCves - filteredCves
-		return out, fmt.Sprintf("\n %v of %v cve(s) showing \n", showing, totalCves)
+		return out, fmt.Sprintf("\n%d of %d cve(s) showing \n", showing, totalCves)
 	}
 
 	return out, ""

--- a/cli/cmd/vuln_host_test.go
+++ b/cli/cmd/vuln_host_test.go
@@ -26,13 +26,13 @@ import (
 
 func TestListCvesFilterSeverity(t *testing.T) {
 	vulCmdState.Severity = "critical"
+	defer clearVulnFilters()
+
 	mockCves := []api.HostVulnCVE{mockCveOne}
 	result, output := hostVulnCVEsTable(mockCves)
 
 	assert.Equal(t, len(result), 1)
 	assert.Equal(t, output, "\n 1 of 2 cve(s) showing \n")
-
-	clearVulnFilters()
 }
 
 func clearVulnFilters() {
@@ -40,7 +40,7 @@ func clearVulnFilters() {
 }
 
 var mockCveOne = api.HostVulnCVE{
-	ID:       "",
+	ID:       "TestID",
 	Packages: []api.HostVulnPackage{mockPackageOne, mockPackageTwo},
 	Summary: api.HostVulnCveSummary{
 		Severity: api.HostVulnSeverityCounts{
@@ -52,9 +52,6 @@ var mockCveOne = api.HostVulnCVE{
 				Fixable:         1,
 				Vulnerabilities: 1,
 			},
-			Medium:               nil,
-			Low:                  nil,
-			Negligible:           nil,
 		},
 		TotalVulnerabilities: 2,
 		LastEvaluationTime:   api.Json16DigitTime{},
@@ -66,16 +63,8 @@ var mockPackageOne = api.HostVulnPackage{
 	Namespace:           "rhel:8",
 	Severity:            "High",
 	Status:              "Active",
-	VulnerabilityStatus: "",
-	Version:             "",
 	HostCount:           "1",
-	PackageStatus:       "",
-	CveLink:             "",
-	CvssScore:           "",
-	CvssV2Score:         "",
-	CvssV3Score:         "",
 	FixAvailable:        "1",
-	FixedVersion:        "",
 }
 
 var mockPackageTwo = api.HostVulnPackage{
@@ -83,15 +72,7 @@ var mockPackageTwo = api.HostVulnPackage{
 	Namespace:           "rhel:8",
 	Severity:            "Critical",
 	Status:              "Active",
-	VulnerabilityStatus: "",
-	Version:             "",
 	HostCount:           "1",
-	PackageStatus:       "",
-	CveLink:             "",
-	CvssScore:           "",
-	CvssV2Score:         "",
-	CvssV3Score:         "",
 	FixAvailable:        "1",
-	FixedVersion:        "",
 }
 

--- a/cli/cmd/vuln_host_test.go
+++ b/cli/cmd/vuln_host_test.go
@@ -47,6 +47,18 @@ func TestShowAssessmentFilterSeverity(t *testing.T) {
 	assert.Equal(t, output, "\n 1 of 2 cve(s) showing \n")
 }
 
+func TestShowAssessmentFilterSeverityWithPackages(t *testing.T) {
+	vulCmdState.Severity = "critical"
+	vulCmdState.Packages = true
+	defer clearVulnFilters()
+
+	mockCves := []api.HostVulnCVE{mockCveOne}
+	result, output := hostVulnPackagesTable(mockCves, true)
+
+	assert.Equal(t, len(result), 1)
+	assert.Equal(t, output, "1 of 2 package(s) showing \n")
+}
+
 func clearVulnFilters() {
 	vulCmdState.Severity = ""
 }

--- a/cli/cmd/vuln_host_test.go
+++ b/cli/cmd/vuln_host_test.go
@@ -19,9 +19,10 @@
 package cmd
 
 import (
+	"testing"
+
 	"github.com/lacework/go-sdk/api"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestListCvesFilterSeverity(t *testing.T) {
@@ -30,6 +31,17 @@ func TestListCvesFilterSeverity(t *testing.T) {
 
 	mockCves := []api.HostVulnCVE{mockCveOne}
 	result, output := hostVulnCVEsTable(mockCves)
+
+	assert.Equal(t, len(result), 1)
+	assert.Equal(t, output, "\n 1 of 2 cve(s) showing \n")
+}
+
+func TestShowAssessmentFilterSeverity(t *testing.T) {
+	vulCmdState.Severity = "critical"
+	defer clearVulnFilters()
+
+	mockCves := []api.HostVulnCVE{mockCveOne}
+	result, output := hostVulnCVEsTableForHostView(mockCves)
 
 	assert.Equal(t, len(result), 1)
 	assert.Equal(t, output, "\n 1 of 2 cve(s) showing \n")
@@ -59,20 +71,19 @@ var mockCveOne = api.HostVulnCVE{
 }
 
 var mockPackageOne = api.HostVulnPackage{
-	Name:                "test",
-	Namespace:           "rhel:8",
-	Severity:            "High",
-	Status:              "Active",
-	HostCount:           "1",
-	FixAvailable:        "1",
+	Name:         "test",
+	Namespace:    "rhel:8",
+	Severity:     "High",
+	Status:       "Active",
+	HostCount:    "1",
+	FixAvailable: "1",
 }
 
 var mockPackageTwo = api.HostVulnPackage{
-	Name:                "test2",
-	Namespace:           "rhel:8",
-	Severity:            "Critical",
-	Status:              "Active",
-	HostCount:           "1",
-	FixAvailable:        "1",
+	Name:         "test2",
+	Namespace:    "rhel:8",
+	Severity:     "Critical",
+	Status:       "Active",
+	HostCount:    "1",
+	FixAvailable: "1",
 }
-

--- a/cli/cmd/vuln_host_test.go
+++ b/cli/cmd/vuln_host_test.go
@@ -33,7 +33,7 @@ func TestListCvesFilterSeverity(t *testing.T) {
 	result, output := hostVulnCVEsTable(mockCves)
 
 	assert.Equal(t, len(result), 1)
-	assert.Equal(t, output, "\n 1 of 2 cve(s) showing \n")
+	assert.Equal(t, output, "\n1 of 2 cve(s) showing \n")
 }
 
 func TestShowAssessmentFilterSeverity(t *testing.T) {

--- a/cli/cmd/vuln_host_test.go
+++ b/cli/cmd/vuln_host_test.go
@@ -1,0 +1,97 @@
+//
+// Author:: Darren Murray (<dmurray-lacework@lacework.net>)
+// Copyright:: Copyright 2021, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cmd
+
+import (
+	"github.com/lacework/go-sdk/api"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestListCvesFilterSeverity(t *testing.T) {
+	vulCmdState.Severity = "critical"
+	mockCves := []api.HostVulnCVE{mockCveOne}
+	result, output := hostVulnCVEsTable(mockCves)
+
+	assert.Equal(t, len(result), 1)
+	assert.Equal(t, output, "\n 1 of 2 cve(s) showing \n")
+
+	clearVulnFilters()
+}
+
+func clearVulnFilters() {
+	vulCmdState.Severity = ""
+}
+
+var mockCveOne = api.HostVulnCVE{
+	ID:       "",
+	Packages: []api.HostVulnPackage{mockPackageOne, mockPackageTwo},
+	Summary: api.HostVulnCveSummary{
+		Severity: api.HostVulnSeverityCounts{
+			Critical: &api.HostVulnSeverityCountsDetails{
+				Fixable:         1,
+				Vulnerabilities: 1,
+			},
+			High: &api.HostVulnSeverityCountsDetails{
+				Fixable:         1,
+				Vulnerabilities: 1,
+			},
+			Medium:               nil,
+			Low:                  nil,
+			Negligible:           nil,
+		},
+		TotalVulnerabilities: 2,
+		LastEvaluationTime:   api.Json16DigitTime{},
+	},
+}
+
+var mockPackageOne = api.HostVulnPackage{
+	Name:                "test",
+	Namespace:           "rhel:8",
+	Severity:            "High",
+	Status:              "Active",
+	VulnerabilityStatus: "",
+	Version:             "",
+	HostCount:           "1",
+	PackageStatus:       "",
+	CveLink:             "",
+	CvssScore:           "",
+	CvssV2Score:         "",
+	CvssV3Score:         "",
+	FixAvailable:        "1",
+	FixedVersion:        "",
+}
+
+var mockPackageTwo = api.HostVulnPackage{
+	Name:                "test2",
+	Namespace:           "rhel:8",
+	Severity:            "Critical",
+	Status:              "Active",
+	VulnerabilityStatus: "",
+	Version:             "",
+	HostCount:           "1",
+	PackageStatus:       "",
+	CveLink:             "",
+	CvssScore:           "",
+	CvssV2Score:         "",
+	CvssV3Score:         "",
+	FixAvailable:        "1",
+	FixedVersion:        "",
+}
+

--- a/cli/cmd/vuln_host_test.go
+++ b/cli/cmd/vuln_host_test.go
@@ -44,7 +44,7 @@ func TestShowAssessmentFilterSeverity(t *testing.T) {
 	result, output := hostVulnCVEsTableForHostView(mockCves)
 
 	assert.Equal(t, len(result), 1)
-	assert.Equal(t, output, "\n 1 of 2 cve(s) showing \n")
+	assert.Equal(t, output, "\n1 of 2 cve(s) showing \n")
 }
 
 func TestShowAssessmentFilterSeverityWithPackages(t *testing.T) {

--- a/integration/host_vulnerability_test.go
+++ b/integration/host_vulnerability_test.go
@@ -315,3 +315,14 @@ func TestHostVulnerabilityAssessmentFilterSeverity(t *testing.T) {
 	assert.Contains(t, showAssessmentOutput, "cve(s) showing",
 		"Filtered assessment output should contain filtered result ")
 }
+
+func TestHostVulnerabilityListCvesFilterSeverityWithPackages(t *testing.T) {
+	out, err, exitcode := LaceworkCLIWithTOMLConfig("vulnerability", "host", "list-cves", "--severity", "high", "--packages")
+
+	assert.Empty(t, err.String(), "STDERR should be empty")
+	assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
+
+	showAssessmentOutput := out.String()
+	assert.Contains(t, showAssessmentOutput, "package(s) showing",
+		"Filtered assessment output should contain filtered result ")
+}

--- a/integration/host_vulnerability_test.go
+++ b/integration/host_vulnerability_test.go
@@ -293,3 +293,25 @@ func TestHostVulnerabilityFailOnFixableWithJson(t *testing.T) {
 		"ERROR ENFORCE POLICY: fixable vulnerabilities found (exit code: 9)",
 		"STDERR does not match")
 }
+
+func TestHostVulnerabilityListCvesFilterSeverity(t *testing.T) {
+	out, err, exitcode := LaceworkCLIWithTOMLConfig("vulnerability", "host", "list-cves", "--severity", "high")
+
+	assert.Empty(t, err.String(), "STDERR should be empty")
+	assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
+
+	showAssessmentOutput := out.String()
+	assert.Contains(t, showAssessmentOutput, "cve(s) showing",
+		"Filtered assessment output should contain filtered result ")
+}
+
+func TestHostVulnerabilityAssessmentFilterSeverity(t *testing.T) {
+	out, err, exitcode := LaceworkCLIWithTOMLConfig("vulnerability", "host", "show-assessment", machineID, "--severity", "high")
+
+	assert.Empty(t, err.String(), "STDERR should be empty")
+	assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
+
+	showAssessmentOutput := out.String()
+	assert.Contains(t, showAssessmentOutput, "cve(s) showing",
+		"Filtered assessment output should contain filtered result ")
+}


### PR DESCRIPTION
Filter vuln host commands by severity:
- list cves 
- show assessment 

Usage :
`lacework vuln host list-cves --severity high`
`lacework vuln host list-cves --active --severity high --fixable `
`lacework vuln host show-assessment 101 --severity high`
`lacework vuln host show-assessment 101 --packages --severity high`



Output:
```
      CVE ID        SEVERITY   SCORE       PACKAGE         CURRENT VERSION         FIX VERSION        OS VERSION    HOSTS   PKG STATUS   VULN STATUS
------------------+----------+-------+-----------------+----------------------+--------------------+--------------+-------+------------+--------------
...

 10 of 100 cve(s) showing
```


Signed-off-by: Darren Murray <darren.murray@lacework.net>