### PR TITLE
fix(cli): match err message changed in server resp

### DIFF
--- a/cli/cmd/vuln_container.go
+++ b/cli/cmd/vuln_container.go
@@ -906,7 +906,7 @@ func getContainerRegistries() ([]string, error) {
 // Creates a user-friendly error message
 func userFriendlyErrorForOnDemandCtrVulnScan(err error, registry, repo, tag string) error {
 	if strings.Contains(err.Error(),
-		"Could not find integraion matching the registry provided",
+		"Could not find integration matching the registry provided",
 	) || strings.Contains(err.Error(),
 		"Could not find vulnerability integrations",
 	) {


### PR DESCRIPTION
We fixed a typo in the error message coming from the API server,
this change matches the fixed message. 😅

![tenor-173387588](https://user-images.githubusercontent.com/5712253/113790017-98d63700-96fd-11eb-86db-4accb11dd609.gif)

Contributes to RAIN-15971