### PR TITLE
chore: run goimports-reviser to order imports

### DIFF
--- a/api/events_test.go
+++ b/api/events_test.go
@@ -24,9 +24,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/lacework/go-sdk/api"
 	"github.com/lacework/go-sdk/internal/lacework"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestEventsSeverity(t *testing.T) {

--- a/api/http_test.go
+++ b/api/http_test.go
@@ -24,9 +24,10 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/lacework/go-sdk/api"
 	"github.com/lacework/go-sdk/internal/lacework"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestNewRequest(t *testing.T) {

--- a/api/integration_alert_channels_test.go
+++ b/api/integration_alert_channels_test.go
@@ -21,8 +21,9 @@ package api_test
 import (
 	"testing"
 
-	"github.com/lacework/go-sdk/api"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/lacework/go-sdk/api"
 )
 
 func TestAlertLevelValid(t *testing.T) {

--- a/api/integrations_ctr_reg_ecr_access_key_test.go
+++ b/api/integrations_ctr_reg_ecr_access_key_test.go
@@ -21,8 +21,9 @@ package api_test
 import (
 	"testing"
 
-	"github.com/lacework/go-sdk/api"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/lacework/go-sdk/api"
 )
 
 func TestIntegrationsNewAwsEcrAccessKeyIntegration(t *testing.T) {

--- a/api/integrations_ctr_reg_ecr_cross_account_test.go
+++ b/api/integrations_ctr_reg_ecr_cross_account_test.go
@@ -21,8 +21,9 @@ package api_test
 import (
 	"testing"
 
-	"github.com/lacework/go-sdk/api"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/lacework/go-sdk/api"
 )
 
 func TestIntegrationsNewAwsEcrWitCrossAccountIntegration(t *testing.T) {

--- a/api/integrations_ctr_reg_test.go
+++ b/api/integrations_ctr_reg_test.go
@@ -21,8 +21,9 @@ package api_test
 import (
 	"testing"
 
-	"github.com/lacework/go-sdk/api"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/lacework/go-sdk/api"
 )
 
 func TestIntegrationsNewContainerRegIntegration(t *testing.T) {

--- a/api/logging.go
+++ b/api/logging.go
@@ -24,10 +24,10 @@ import (
 	"os"
 	"syscall"
 
+	"github.com/pkg/errors"
 	"go.uber.org/zap"
 
 	"github.com/lacework/go-sdk/lwlogger"
-	"github.com/pkg/errors"
 )
 
 // WithLogLevel sets the log level of the client, available: info or debug

--- a/api/vulnerabilities_container.go
+++ b/api/vulnerabilities_container.go
@@ -24,8 +24,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/lacework/go-sdk/internal/array"
 	"github.com/pkg/errors"
+
+	"github.com/lacework/go-sdk/internal/array"
 )
 
 // ContainerVulnerabilityService is a service that interacts with the vulnerabilities

--- a/cli/cmd/access_token.go
+++ b/cli/cmd/access_token.go
@@ -21,9 +21,10 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/lacework/go-sdk/api"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+
+	"github.com/lacework/go-sdk/api"
 )
 
 var (

--- a/cli/cmd/compliance_gcp_test.go
+++ b/cli/cmd/compliance_gcp_test.go
@@ -22,8 +22,9 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/lacework/go-sdk/api"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/lacework/go-sdk/api"
 )
 
 func TestSplitIDAndAlias(t *testing.T) {

--- a/cli/cmd/compliance_test.go
+++ b/cli/cmd/compliance_test.go
@@ -21,8 +21,9 @@ package cmd
 import (
 	"testing"
 
-	"github.com/lacework/go-sdk/api"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/lacework/go-sdk/api"
 )
 
 func TestComplianceRecommendationsFilterNoResults(t *testing.T) {

--- a/cli/cmd/vuln_html.go
+++ b/cli/cmd/vuln_html.go
@@ -28,10 +28,10 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/lacework/go-sdk/internal/databox"
 	"github.com/pkg/errors"
 
 	"github.com/lacework/go-sdk/api"
+	"github.com/lacework/go-sdk/internal/databox"
 )
 
 const (

--- a/integration/host_vulnerability_test.go
+++ b/integration/host_vulnerability_test.go
@@ -25,8 +25,9 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/lacework/go-sdk/api"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/lacework/go-sdk/api"
 )
 
 // persistent host "ip-10-0-1-170.us-west-2.compute.internal"

--- a/integration/version_test.go
+++ b/integration/version_test.go
@@ -26,8 +26,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/lacework/go-sdk/lwupdater"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/lacework/go-sdk/lwupdater"
 )
 
 // To test the daily version check we need to set the environment


### PR DESCRIPTION
This is the first time I am using `goimports-reviser` to order our imports.
As a best practice, we must have a clean and understandable order of imports
and this tool might help us to do so.

https://github.com/incu6us/goimports-reviser

Commands I ran:
```
$ go get github.com/incu6us/goimports-reviser
$ find $(go list -f {{.Dir}} ./...) -name \*.go -type f -exec goimports-reviser -file-path {} -project-name github.com/lacework/go-sdk \;
```
## TODO
Discuss if this will be something we would like to adopt.

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>