### PR TITLE
fix(cli): Json result adheres to filters for cmd get-report (aws,gcp,azure)

### DIFF
--- a/cli/cmd/compliance.go
+++ b/cli/cmd/compliance.go
@@ -189,12 +189,8 @@ func complianceReportSummaryTable(summaries []api.ComplianceSummary) [][]string 
 	}
 }
 
-func complianceReportRecommendationsTable(recommendations []api.ComplianceRecommendation) ([][]string, string) {
+func complianceReportRecommendationsTable(recommendations []api.ComplianceRecommendation) [][]string {
 	out := [][]string{}
-	var filteredOutput string
-	if complianceFiltersEnabled() {
-		recommendations, filteredOutput = filterRecommendations(recommendations)
-	}
 	for _, recommend := range recommendations {
 		out = append(out, []string{
 			recommend.RecID,
@@ -211,7 +207,7 @@ func complianceReportRecommendationsTable(recommendations []api.ComplianceRecomm
 		return severityOrder(out[i][3]) < severityOrder(out[j][3])
 	})
 
-	return out, filteredOutput
+	return out
 }
 
 func buildComplianceReportTable(detailsTable, summaryTable, recommendationsTable [][]string, filteredOutput string) string {

--- a/cli/cmd/compliance_aws.go
+++ b/cli/cmd/compliance_aws.go
@@ -159,12 +159,18 @@ To run an ad-hoc compliance assessment of an AWS account:
 				return errors.New("there is no data found in the report")
 			}
 
-			if cli.JSONOutput() {
-				return cli.OutputJSON(response.Data[0])
+			report := response.Data[0]
+			filteredOutput := ""
+
+			if complianceFiltersEnabled() {
+				report.Recommendations, filteredOutput = filterRecommendations(report.Recommendations)
 			}
 
-			report := response.Data[0]
-			recommendations, filteredOutput := complianceReportRecommendationsTable(report.Recommendations)
+			if cli.JSONOutput() {
+				return cli.OutputJSON(report)
+			}
+
+			recommendations := complianceReportRecommendationsTable(report.Recommendations)
 			cli.OutputHuman("\n")
 			cli.OutputHuman(
 				buildComplianceReportTable(

--- a/cli/cmd/compliance_azure.go
+++ b/cli/cmd/compliance_azure.go
@@ -188,12 +188,18 @@ To run an ad-hoc compliance assessment use the command:
 				return errors.New("there is no data found in the report")
 			}
 
-			if cli.JSONOutput() {
-				return cli.OutputJSON(response.Data[0])
+			report := response.Data[0]
+			filteredOutput := ""
+
+			if complianceFiltersEnabled() {
+				report.Recommendations, filteredOutput = filterRecommendations(report.Recommendations)
 			}
 
-			report := response.Data[0]
-			recommendations, filteredOutput := complianceReportRecommendationsTable(report.Recommendations)
+			if cli.JSONOutput() {
+				return cli.OutputJSON(report)
+			}
+
+			recommendations := complianceReportRecommendationsTable(report.Recommendations)
 			cli.OutputHuman("\n")
 			cli.OutputHuman(
 				buildComplianceReportTable(

--- a/cli/cmd/compliance_gcp.go
+++ b/cli/cmd/compliance_gcp.go
@@ -158,13 +158,19 @@ To run an ad-hoc compliance assessment use the command:
 				return errors.New("there is no data found in the report")
 			}
 
-			if cli.JSONOutput() {
-				return cli.OutputJSON(response.Data[0])
+			report := response.Data[0]
+			filteredOutput := ""
+
+			if complianceFiltersEnabled() {
+				report.Recommendations, filteredOutput = filterRecommendations(report.Recommendations)
 			}
 
-			report := response.Data[0]
+			if cli.JSONOutput() {
+				return cli.OutputJSON(report)
+			}
+
+			recommendations := complianceReportRecommendationsTable(report.Recommendations)
 			cli.OutputHuman("\n")
-			recommendations, filteredOutput := complianceReportRecommendationsTable(report.Recommendations)
 			cli.OutputHuman(
 				buildComplianceReportTable(
 					complianceGcpReportDetailsTable(&report),

--- a/integration/compliance_aws_test.go
+++ b/integration/compliance_aws_test.go
@@ -84,3 +84,14 @@ func TestComplianceAwsGetReportDetails(t *testing.T) {
 	assert.Contains(t, out.String(), "ASSESSED",
 		"STDOUT table headers changed, please check")
 }
+
+func TestComplianceAwsGetReportFiltersWithJsonOutput(t *testing.T) {
+	account := os.Getenv("LW_INT_TEST_AWS_ACC")
+	out, err, exitcode := LaceworkCLIWithTOMLConfig("compliance", "aws", "get-report", account, "--severity", "critical", "--json")
+	severities := []string{"\"severity\": 2","\"severity\": 3","\"severity\": 4", "\"severity\": 5"}
+	assert.Empty(t, err.String(), "STDERR should be empty")
+	assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
+	// When critical severity filter is set, other severities should not be returned in json result
+	assert.NotContains(t, severities, out.String(),
+		"Json output does not adhere to severity filter")
+}

--- a/integration/event_test.go
+++ b/integration/event_test.go
@@ -135,3 +135,15 @@ func TestEventCommandOpenError(t *testing.T) {
 	assert.Equal(t, 1, exitcode,
 		"EXITCODE is not the expected one")
 }
+
+func TestEventCommandListSeverityWithJsonFlag(t *testing.T) {
+	out, err, exitcode := LaceworkCLIWithTOMLConfig("event", "list", "--severity", "high", "--json")
+	severities := []string{"\"severity\": 3","\"severity\": 4", "\"severity\": 5"}
+	assert.Empty(t,
+		err.String(),
+		"STDERR should be empty")
+	assert.Equal(t, 0, exitcode,
+		"EXITCODE is not the expected one")
+	assert.NotContains(t, severities, out.String(),
+		"Json output does not adhere to severity filter")
+}


### PR DESCRIPTION
Fix json output to should work in combination with any filtering flags

- az get-report compliance_azure.go:191
- gcp get-report compliance_gcp.go:155
- aws get-report compliance_aws.go:162

Signed-off-by: Darren Murray <darren.murray@lacework.net>