### PR TITLE
fix(cli): split GCP projects with parentheses

### DIFF
--- a/cli/cmd/compliance_gcp.go
+++ b/cli/cmd/compliance_gcp.go
@@ -100,11 +100,17 @@ To run an ad-hoc compliance assessment use the command:
 `,
 		Args: cobra.ExactArgs(2),
 		RunE: func(_ *cobra.Command, args []string) error {
-			config := api.ComplianceGcpReportConfig{
-				OrganizationID: args[0],
-				ProjectID:      args[1],
-				Type:           compCmdState.Type,
-			}
+			var (
+				// clean projectID and orgID if they were provided
+				// with an Alias in between parentheses
+				orgID, _     = splitIDAndAlias(args[0])
+				projectID, _ = splitIDAndAlias(args[1])
+				config       = api.ComplianceGcpReportConfig{
+					OrganizationID: orgID,
+					ProjectID:      projectID,
+					Type:           compCmdState.Type,
+				}
+			)
 
 			if compCmdState.Pdf {
 				pdfName := fmt.Sprintf(
@@ -291,6 +297,8 @@ func splitIDAndAlias(text string) (id string, alias string) {
 	id = string(idBytes)
 	id = strings.Trim(id, "(")
 	id = strings.TrimSpace(id)
+
+	cli.Log.Infow("splitted", "text", text, "id", id, "alias", alias)
 	return
 }
 

--- a/integration/compliance_gcp_test.go
+++ b/integration/compliance_gcp_test.go
@@ -1,0 +1,40 @@
+//
+// Author:: Salim Afiune Maya (<afiune@lacework.net>)
+// Copyright:: Copyright 2021, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+package integration
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestComplianceGetReportOrgAndProjectWithAlias(t *testing.T) {
+	out, err, exitcode := LaceworkCLIWithTOMLConfig(
+		"compliance", "gcp", "get-report", "org-id (org-alias)", "proj-id (proj-alias)",
+	)
+	assert.Equal(t, 1, exitcode, "EXITCODE is not the expected one")
+	assert.Contains(t, out.String(),
+		"Getting compliance report...",
+		"STDOUT changed, please check")
+	assert.Contains(t, err.String(),
+		"unable to get gcp compliance report",
+		"STDERR changed, please check")
+	assert.Contains(t, err.String(),
+		"GCP_ORG_ID=org-id&GCP_PROJ_ID=proj-id&",
+		"STDERR changed, please check")
+}


### PR DESCRIPTION
Listing projects via UI versus CLI has different results,
this change is detecting when users provide a GCP project id or
organization id with their aliases in between parentheses and
it splits them and use only the IDs to download the compliance
report.

Closes ALLY-431

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>