### PR TITLE
fix(cli): Json output for vuln ctr adheres to filter flags

### DIFF
--- a/api/vulnerabilities_container.go
+++ b/api/vulnerabilities_container.go
@@ -266,7 +266,7 @@ func (report *VulnContainerAssessment) TotalFixableVulnerabilities() int32 {
 
 type VulnContainerImage struct {
 	ImageInfo   *vulnContainerImageInfo   `json:"image_info,omitempty"`
-	ImageLayers []vulnContainerImageLayer `json:"image_layers,omitempty"`
+	ImageLayers []VulnContainerImageLayer `json:"image_layers,omitempty"`
 }
 
 type vulnContainerImageInfo struct {
@@ -279,17 +279,17 @@ type vulnContainerImageInfo struct {
 	Tags        []string `json:"tags"`
 }
 
-type vulnContainerImageLayer struct {
+type VulnContainerImageLayer struct {
 	Hash      string                 `json:"hash"`
 	CreatedBy string                 `json:"created_by"`
-	Packages  []vulnContainerPackage `json:"packages"`
+	Packages  []VulnContainerPackage `json:"packages"`
 }
 
-type vulnContainerPackage struct {
+type VulnContainerPackage struct {
 	Name            string                   `json:"name"`
 	Namespace       string                   `json:"namescape"`
 	Version         string                   `json:"version"`
-	Vulnerabilities []containerVulnerability `json:"vulnerabilities"`
+	Vulnerabilities []ContainerVulnerability `json:"vulnerabilities"`
 
 	// @afiune maybe these fields are host related information and not container
 	FixAvailable  string `json:"fix_available,omitempty"`
@@ -304,7 +304,7 @@ type vulnContainerPackage struct {
 	FirstSeenTime string `json:"first_seen_time,omitempty"`
 }
 
-type containerVulnerability struct {
+type ContainerVulnerability struct {
 	Name        string                 `json:"name"`
 	Description string                 `json:"description"`
 	Severity    string                 `json:"severity"`
@@ -320,7 +320,7 @@ type containerVulnerability struct {
 //
 //          score := v.traverseMetadata("NVD", "CVSSv3", "Score")
 //
-func (v *containerVulnerability) traverseMetadata(fields ...string) interface{} {
+func (v *ContainerVulnerability) traverseMetadata(fields ...string) interface{} {
 
 	var (
 		metaInterface interface{}
@@ -347,7 +347,7 @@ func (v *containerVulnerability) traverseMetadata(fields ...string) interface{} 
 	return metaInterface
 }
 
-func (v *containerVulnerability) CVSSv3Score() float64 {
+func (v *ContainerVulnerability) CVSSv3Score() float64 {
 	score := v.traverseMetadata("NVD", "CVSSv3", "Score")
 
 	if f, ok := score.(float64); ok {
@@ -357,7 +357,7 @@ func (v *containerVulnerability) CVSSv3Score() float64 {
 	return 0
 }
 
-func (v *containerVulnerability) CVSSv2Score() float64 {
+func (v *ContainerVulnerability) CVSSv2Score() float64 {
 	score := v.traverseMetadata("NVD", "CVSSv2", "Score")
 
 	if f, ok := score.(float64); ok {

--- a/cli/cmd/vuln_container.go
+++ b/cli/cmd/vuln_container.go
@@ -424,7 +424,7 @@ func checkOnDemandContainerVulnerabilityStatus(reqID string) error {
 		return nil
 	}
 
-	if err := buildReports(results); err != nil {
+	if err := buildVulnContainerAssessmentReports(results); err != nil {
 		return err
 	}
 
@@ -470,7 +470,7 @@ func showContainerAssessmentsWithSha256(sha string) error {
 	status := assessment.CheckStatus()
 	switch status {
 	case "Success":
-		if err := buildReports(&assessment.Data); err != nil {
+		if err := buildVulnContainerAssessmentReports(&assessment.Data); err != nil {
 			return err
 		}
 	case "Unsupported":

--- a/cli/cmd/vuln_container.go
+++ b/cli/cmd/vuln_container.go
@@ -566,10 +566,6 @@ func buildVulnerabilityDetailsReportTable(details vulnerabilityDetailsReport) st
 				report.WriteString("\nTry adding '--packages' to show a list of packages with CVE count.\n")
 			}
 		}
-	} else if !vulCmdState.Html {
-		report.WriteString(
-			"Try adding '--details' to increase details shown about the vulnerability assessment.\n",
-		)
 	}
 
 	return report.String()

--- a/cli/cmd/vuln_container.go
+++ b/cli/cmd/vuln_container.go
@@ -193,11 +193,13 @@ filter on containers with vulnerabilities that have fixes available.`,
 				})
 			}
 
+			filteredAssessments := filterAssessments(assessments)
+
 			if cli.JSONOutput() {
-				return cli.OutputJSON(assessments)
+				return cli.OutputJSON(filteredAssessments)
 			}
 
-			rows := vulAssessmentsToTable(assessments)
+			rows := vulAssessmentsToTable(filteredAssessments)
 
 			// if the user wants to show only assessments of containers running
 			// and we don't have any, show a friendly message
@@ -422,18 +424,8 @@ func checkOnDemandContainerVulnerabilityStatus(reqID string) error {
 		return nil
 	}
 
-	if cli.JSONOutput() {
-		if err := cli.OutputJSON(results); err != nil {
-			return err
-		}
-	} else {
-		cli.OutputHuman(buildVulnerabilityReportTable(results))
-	}
-
-	if vulCmdState.Html {
-		if err := generateVulnAssessmentHTML(results); err != nil {
-			return err
-		}
+	if err := buildReports(results) ; err != nil{
+		return err
 	}
 
 	if vulFailureFlagsEnabled() {
@@ -478,20 +470,8 @@ func showContainerAssessmentsWithSha256(sha string) error {
 	status := assessment.CheckStatus()
 	switch status {
 	case "Success":
-
-		if cli.JSONOutput() {
-			if err := cli.OutputJSON(assessment.Data); err != nil {
-				return err
-			}
-		} else {
-			cli.OutputHuman(buildVulnerabilityReportTable(&assessment.Data))
-		}
-
-		// @afiune is this the best way to make sense of this new flag?
-		if vulCmdState.Html {
-			if err := generateVulnAssessmentHTML(&assessment.Data); err != nil {
-				return err
-			}
+		if err := buildReports(&assessment.Data) ; err != nil{
+			return err
 		}
 	case "Unsupported":
 		return errors.Errorf(
@@ -542,8 +522,60 @@ For more information about supported distributions, visit:
 	return nil
 }
 
-func buildVulnerabilityReportTable(assessment *api.VulnContainerAssessment) string {
-	if assessment.TotalVulnerabilities == 0 {
+func buildVulnerabilityDetailsReportTable(details vulnerabilityDetailsReport) string {
+	report := &strings.Builder{}
+
+	if vulCmdState.Details || vulCmdState.Packages || vulFiltersEnabled() {
+		if vulCmdState.Packages {
+			vulnPackagesTable := vulContainerImagePackagesToTable(details.packages)
+
+			report.WriteString(
+				renderSimpleTable(
+					[]string{"CVE Count", "Severity", "Package", "Current Version", "Fix Version"},
+					vulnPackagesTable,
+				),
+			)
+
+			if vulFiltersEnabled() {
+				filteredOutput := fmt.Sprintf("%v of %v packages showing \n", details.packages.totalPackages, details.packages.totalUnfiltered)
+				report.WriteString(filteredOutput)
+			}
+		} else {
+			vulnImageTable := vulContainerImageLayersToTable(details.vulns)
+
+			report.WriteString(
+				renderCustomTable(
+					[]string{"CVE ID", "Severity", "Package", "Current Version",
+						"Fix Version", "Introduced in Layer"},
+					vulnImageTable,
+					tableFunc(func(t *tablewriter.Table) {
+						t.SetBorder(false)
+						t.SetRowLine(true)
+						t.SetColumnSeparator(" ")
+						t.SetAlignment(tablewriter.ALIGN_LEFT)
+					}),
+				),
+			)
+
+			if vulFiltersEnabled() {
+				filteredOutput := fmt.Sprintf("%v of %v vulnerabilities showing \n", details.vulns.totalVulns, details.vulns.totalUnfiltered)
+				report.WriteString(filteredOutput)
+			}
+			if !vulCmdState.Html {
+				report.WriteString("\nTry adding '--packages' to show a list of packages with CVE count.\n")
+			}
+		}
+	} else if !vulCmdState.Html {
+		report.WriteString(
+			"Try adding '--details' to increase details shown about the vulnerability assessment.\n",
+		)
+	}
+
+	return report.String()
+}
+
+func buildVulnerabilityReportTable(summary vulnerabilitySummaryReport) string {
+	if summary.vulnCounts.totalVulnerabilities == 0 {
 		return fmt.Sprintf("Great news! This container image has no vulnerabilities... (time for %s)\n", randomEmoji())
 	}
 
@@ -556,7 +588,7 @@ func buildVulnerabilityReportTable(assessment *api.VulnContainerAssessment) stri
 			},
 			[][]string{[]string{
 				renderCustomTable([]string{},
-					vulContainerImageToTable(assessment.Image),
+					vulContainerImageToTable(&summary.image),
 					tableFunc(func(t *tablewriter.Table) {
 						t.SetBorder(false)
 						t.SetColumnSeparator("")
@@ -564,7 +596,7 @@ func buildVulnerabilityReportTable(assessment *api.VulnContainerAssessment) stri
 					}),
 				),
 				renderCustomTable([]string{"Severity", "Count", "Fixable"},
-					vulContainerAssessmentToCountsTable(assessment),
+					vulContainerAssessmentToCountsTable(summary.vulnCounts),
 					tableFunc(func(t *tablewriter.Table) {
 						t.SetBorder(false)
 						t.SetColumnSeparator(" ")
@@ -579,47 +611,6 @@ func buildVulnerabilityReportTable(assessment *api.VulnContainerAssessment) stri
 		),
 	)
 
-	if vulCmdState.Details || vulCmdState.Packages || vulFiltersEnabled() {
-		if vulCmdState.Packages {
-			vulnPackagesTable, filteredOutput := vulContainerImagePackagesToTable(assessment.Image)
-
-			mainReport.WriteString(
-				renderSimpleTable(
-					[]string{"CVE Count", "Severity", "Package", "Current Version", "Fix Version"},
-					vulnPackagesTable,
-				),
-			)
-			if filteredOutput != "" {
-				mainReport.WriteString(filteredOutput)
-			}
-		} else {
-			vulnTable, filteredOutput := vulContainerImageLayersToTable(assessment.Image)
-			mainReport.WriteString(
-				renderCustomTable(
-					[]string{"CVE ID", "Severity", "Package", "Current Version",
-						"Fix Version", "Introduced in Layer"},
-					vulnTable,
-					tableFunc(func(t *tablewriter.Table) {
-						t.SetBorder(false)
-						t.SetRowLine(true)
-						t.SetColumnSeparator(" ")
-						t.SetAlignment(tablewriter.ALIGN_LEFT)
-					}),
-				),
-			)
-			if filteredOutput != "" {
-				mainReport.WriteString(filteredOutput)
-			}
-			if !vulCmdState.Html {
-				mainReport.WriteString("\nTry adding '--packages' to show a list of packages with CVE count.\n")
-			}
-		}
-	} else if !vulCmdState.Html {
-		mainReport.WriteString(
-			"Try adding '--details' to increase details shown about the vulnerability assessment.\n",
-		)
-	}
-
 	return mainReport.String()
 }
 
@@ -631,6 +622,27 @@ type packageTable struct {
 	fixVersion     string
 	packageStatus  string
 	hostCount      int
+}
+
+type vulnTable struct {
+	name       string
+	severity       string
+	packageName    string
+	currentVersion string
+	fixVersion     string
+	createdBy  string
+}
+
+type filteredPackageTable struct {
+	packages []packageTable
+	totalPackages int
+	totalUnfiltered int
+}
+
+type filteredImageTable struct {
+	vulns []vulnTable
+	totalVulns int
+	totalUnfiltered int
 }
 
 func aggregatePackages(slice []packageTable, s packageTable) []packageTable {
@@ -646,15 +658,13 @@ func aggregatePackages(slice []packageTable, s packageTable) []packageTable {
 	return append(slice, s)
 }
 
-func vulContainerImagePackagesToTable(image *api.VulnContainerImage) ([][]string, string) {
+func filterVulnContainerImagePackages(image *api.VulnContainerImage) filteredPackageTable{
 	if image == nil {
-		return [][]string{}, ""
+		return filteredPackageTable{}
 	}
-	filteredOutput := ""
 	var filteredPackages []packageTable
 	var aggregatedPackages []packageTable
 
-	out := [][]string{}
 	for _, layer := range image.ImageLayers {
 		for _, pkg := range layer.Packages {
 			for _, vul := range pkg.Vulnerabilities {
@@ -681,8 +691,14 @@ func vulContainerImagePackagesToTable(image *api.VulnContainerImage) ([][]string
 			}
 		}
 	}
+	totalUnfiltered := len(filteredPackages) + len(filteredPackages)
+	return filteredPackageTable{packages: filteredPackages, totalPackages: len(filteredPackages), totalUnfiltered: totalUnfiltered}
+}
 
-	for _, p := range aggregatedPackages {
+func vulContainerImagePackagesToTable(packageTable filteredPackageTable) [][]string {
+	var out [][]string
+
+	for _, p := range packageTable.packages {
 		out = append(out, []string{
 			strconv.Itoa(p.cveCount),
 			p.severity,
@@ -692,26 +708,23 @@ func vulContainerImagePackagesToTable(image *api.VulnContainerImage) ([][]string
 		})
 	}
 
-	if vulFiltersEnabled() {
-		filteredOutput = fmt.Sprintf("%v of %v packages showing \n", len(out), len(aggregatedPackages)+len(filteredPackages))
-	}
-
 	// order by severity
 	sort.Slice(out, func(i, j int) bool {
 		return severityOrder(out[i][1]) < severityOrder(out[j][1])
 	})
 
-	return out, filteredOutput
+	return out
 }
 
-func vulContainerImageLayersToTable(image *api.VulnContainerImage) ([][]string, string) {
+func filterVulContainerImageLayers(image *api.VulnContainerImage) filteredImageTable {
 	if image == nil {
-		return [][]string{}, ""
+		return filteredImageTable{}
 	}
+	var (
+		vulns []vulnTable
+		vulnsCount int
+	)
 
-	out := [][]string{}
-	vulnsCount := 0
-	filteredOutput := ""
 	for _, layer := range image.ImageLayers {
 		for _, pkg := range layer.Packages {
 			for _, vul := range pkg.Vulnerabilities {
@@ -729,41 +742,52 @@ func vulContainerImageLayersToTable(image *api.VulnContainerImage) ([][]string, 
 				space := regexp.MustCompile(`\s+`)
 				createdBy := space.ReplaceAllString(layer.CreatedBy, " ")
 
-				out = append(out, []string{
-					vul.Name,
-					strings.Title(vul.Severity),
-					pkg.Name,
-					pkg.Version,
-					vul.FixVersion,
-					createdBy,
+				vulns = append(vulns, vulnTable{
+					name:           vul.Name,
+					severity:       strings.Title(vul.Severity),
+					packageName:    pkg.Name,
+					currentVersion: pkg.Version,
+					fixVersion:     vul.FixVersion,
+					createdBy:      createdBy,
 				})
 			}
 		}
 	}
+	return filteredImageTable{vulns: vulns, totalVulns: len(vulns), totalUnfiltered: vulnsCount}
+}
 
-	if vulFiltersEnabled() {
-		filteredOutput = fmt.Sprintf("%v of %v vulnerabilities showing \n", len(out), vulnsCount)
+	func vulContainerImageLayersToTable(imageTable filteredImageTable) [][]string {
+		var out [][]string
+	for _, vuln := range imageTable.vulns {
+				out = append(out, []string{
+					vuln.name,
+					vuln.severity,
+					vuln.packageName,
+					vuln.currentVersion,
+					vuln.fixVersion,
+					vuln.createdBy,
+				})
 	}
 
 	sort.Slice(out, func(i, j int) bool {
 		return severityOrder(out[i][1]) < severityOrder(out[j][1])
 	})
 
-	return out, filteredOutput
+	return out
 }
 
-func vulContainerAssessmentToCountsTable(assessment *api.VulnContainerAssessment) [][]string {
+func vulContainerAssessmentToCountsTable(count vulnCounts) [][]string {
 	return [][]string{
-		[]string{"Critical", fmt.Sprint(assessment.CriticalVulnerabilities),
-			fmt.Sprint(assessment.VulnFixableCount("critical"))},
-		[]string{"High", fmt.Sprint(assessment.HighVulnerabilities),
-			fmt.Sprint(assessment.VulnFixableCount("high"))},
-		[]string{"Medium", fmt.Sprint(assessment.MediumVulnerabilities),
-			fmt.Sprint(assessment.VulnFixableCount("medium"))},
-		[]string{"Low", fmt.Sprint(assessment.LowVulnerabilities),
-			fmt.Sprint(assessment.VulnFixableCount("low"))},
-		[]string{"Info", fmt.Sprint(assessment.InfoVulnerabilities),
-			fmt.Sprint(assessment.VulnFixableCount("info"))},
+		[]string{"Critical", fmt.Sprint(count.criticalVulnerabilities),
+			fmt.Sprint(count.fixableVulnCounts.fixableCriticalVulnerabilities)},
+		[]string{"High", fmt.Sprint(count.highVulnerabilities),
+			fmt.Sprint(count.fixableVulnCounts.fixableHighVulnerabilities)},
+		[]string{"Medium", fmt.Sprint(count.mediumVulnerabilities),
+			fmt.Sprint(count.fixableVulnCounts.fixableMediumVulnerabilities)},
+		[]string{"Low", fmt.Sprint(count.lowVulnerabilities),
+			fmt.Sprint(count.fixableVulnCounts.fixableLowVulnerabilities)},
+		[]string{"Info", fmt.Sprint(count.infoVulnerabilities),
+			fmt.Sprint(count.fixableVulnCounts.fixableInfoVulnerabilities)},
 	}
 }
 
@@ -808,8 +832,8 @@ func buildContainerAssessmentsError() string {
 	return fmt.Sprintf("%s in your environment.\n", msg)
 }
 
-func vulAssessmentsToTable(assessments []api.VulnContainerAssessmentSummary) [][]string {
-	out := [][]string{}
+func filterAssessments(assessments []api.VulnContainerAssessmentSummary) []assessmentOutput {
+	var out []assessmentOutput
 	for _, assessment := range assessments {
 		// do not add assessments that doesn't have running containers
 		// if the user wants to show only assessments of containers running
@@ -836,17 +860,44 @@ func vulAssessmentsToTable(assessments []api.VulnContainerAssessmentSummary) [][
 			continue
 		}
 
-		out = append(out, []string{
-			assessment.ImageRegistry,
-			assessment.ImageRepo,
-			assessment.StartTime.UTC().Format(time.RFC3339),
-			assessment.ImageScanStatus,
-			assessment.NdvContainers,
-			assessmentSummary,
-			assessment.ImageDigest,
+		out = append(out, assessmentOutput{
+			imageRegistry:     assessment.ImageRegistry,
+			imageRepo:         assessment.ImageRepo,
+			startTime:         assessment.StartTime.UTC().Format(time.RFC3339),
+			imageScanStatus:   assessment.ImageScanStatus,
+			ndvContainers:     assessment.NdvContainers,
+			assessmentSummary: assessmentSummary,
+			imageDigest:       assessment.ImageDigest,
 		})
 	}
 	return out
+}
+
+func vulAssessmentsToTable(assessments []assessmentOutput) [][]string {
+	var out [][]string
+	for _, assessment := range assessments {
+		out = append(out, []string{
+			assessment.imageRegistry,
+			assessment.imageRepo,
+			assessment.startTime,
+			assessment.imageScanStatus,
+			assessment.ndvContainers,
+			assessment.assessmentSummary,
+			assessment.imageDigest,
+		})
+	}
+	return out
+}
+
+type assessmentOutput struct {
+	imageRegistry string
+	imageRepo string
+	startTime string
+	imageScanStatus string
+	ndvContainers string
+	assessmentSummary string
+	imageDigest string
+
 }
 
 func vulSummaryFromAssessment(assessment *api.VulnContainerAssessmentSummary) (string, bool) {

--- a/cli/cmd/vuln_container.go
+++ b/cli/cmd/vuln_container.go
@@ -691,8 +691,8 @@ func filterVulnContainerImagePackages(image *api.VulnContainerImage) filteredPac
 			}
 		}
 	}
-	totalUnfiltered := len(filteredPackages) + len(filteredPackages)
-	return filteredPackageTable{packages: filteredPackages, totalPackages: len(filteredPackages), totalUnfiltered: totalUnfiltered}
+	totalUnfiltered := len(filteredPackages) + len(aggregatedPackages)
+	return filteredPackageTable{packages: aggregatedPackages, totalPackages: len(aggregatedPackages), totalUnfiltered: totalUnfiltered}
 }
 
 func vulContainerImagePackagesToTable(packageTable filteredPackageTable) [][]string {

--- a/cli/cmd/vulnerability.go
+++ b/cli/cmd/vulnerability.go
@@ -291,18 +291,8 @@ func pollScanStatus(requestID string) error {
 
 		cli.StopProgress()
 
-		if cli.JSONOutput() {
-			if err := cli.OutputJSON(assessment); err != nil {
-				return err
-			}
-		} else {
-			cli.OutputHuman(buildVulnerabilityReportTable(assessment))
-		}
-
-		if vulCmdState.Html {
-			if err := generateVulnAssessmentHTML(assessment); err != nil {
-				return err
-			}
+		if err := buildReports(assessment) ; err != nil{
+			return err
 		}
 
 		if vulFailureFlagsEnabled() {
@@ -322,6 +312,101 @@ func pollScanStatus(requestID string) error {
 
 		return nil
 	}
+}
+
+func buildReports(assessment *api.VulnContainerAssessment) error {
+	vulnReport := vulnerabilityReport{
+		summary: buildVulnerabilitySummaryReport(assessment),
+		details: vulnerabilityDetailsReport{
+			vulns: filterVulContainerImageLayers(assessment.Image),
+			packages: filterVulnContainerImagePackages(assessment.Image),
+		},
+	}
+
+	if cli.JSONOutput() {
+		if err := cli.OutputJSON(vulnReport); err != nil {
+			return err
+		}
+	} else {
+		cli.OutputHuman(buildReportTable(vulnReport))
+	}
+
+	if vulCmdState.Html {
+		if err := generateVulnAssessmentHTML(assessment); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func buildVulnerabilitySummaryReport(assessment *api.VulnContainerAssessment) vulnerabilitySummaryReport {
+	return vulnerabilitySummaryReport{
+		image:                   *assessment.Image,
+		vulnCounts: vulnCounts{
+			totalVulnerabilities:    assessment.TotalVulnerabilities,
+			criticalVulnerabilities: assessment.CriticalVulnerabilities,
+			highVulnerabilities:     assessment.HighVulnerabilities,
+			mediumVulnerabilities:   assessment.MediumVulnerabilities,
+			lowVulnerabilities:      assessment.LowVulnerabilities,
+			infoVulnerabilities:     assessment.InfoVulnerabilities,
+			fixableVulnCounts: fixableVulnCounts{
+				fixableVulns:                   assessment.FixableVulnerabilities,
+				fixableCriticalVulnerabilities: assessment.VulnFixableCount("critical"),
+				fixableHighVulnerabilities:     assessment.VulnFixableCount("high"),
+				fixableMediumVulnerabilities:   assessment.VulnFixableCount("medium"),
+				fixableLowVulnerabilities:      assessment.VulnFixableCount("low"),
+				fixableInfoVulnerabilities:     assessment.VulnFixableCount("info"),
+			},
+		},
+
+		lastEvaluationTime:      assessment.LastEvaluationTime,
+	}
+}
+
+type vulnerabilityDetailsReport struct {
+	vulns filteredImageTable
+	packages filteredPackageTable
+}
+
+type vulnerabilitySummaryReport struct {
+	image                   api.VulnContainerImage
+	vulnCounts				vulnCounts
+	lastEvaluationTime      string
+}
+
+type vulnCounts struct  {
+	totalVulnerabilities    int32
+	criticalVulnerabilities int32
+	highVulnerabilities     int32
+	mediumVulnerabilities   int32
+	lowVulnerabilities      int32
+	infoVulnerabilities     int32
+	fixableVulnCounts 		fixableVulnCounts
+}
+
+type fixableVulnCounts struct  {
+	fixableVulns int32
+	fixableCriticalVulnerabilities int32
+	fixableHighVulnerabilities     int32
+	fixableMediumVulnerabilities   int32
+	fixableLowVulnerabilities      int32
+	fixableInfoVulnerabilities     int32
+}
+
+type vulnerabilityReport struct {
+	summary vulnerabilitySummaryReport
+	details vulnerabilityDetailsReport
+}
+
+func buildReportTable(vulnReport vulnerabilityReport) string {
+	report := &strings.Builder{}
+
+	report.WriteString(buildVulnerabilityReportTable(vulnReport.summary))
+	if vulCmdState.Details || vulCmdState.Packages || vulFiltersEnabled() {
+		report.WriteString(buildVulnerabilityDetailsReportTable(vulnReport.details))
+	}
+
+	return report.String()
 }
 
 func checkScanStatus(requestID string) (*api.VulnContainerAssessment, error, bool) {

--- a/cli/cmd/vulnerability.go
+++ b/cli/cmd/vulnerability.go
@@ -315,11 +315,11 @@ func pollScanStatus(requestID string) error {
 }
 
 func buildReports(assessment *api.VulnContainerAssessment) error {
-	vulnReport := vulnerabilityReport{
-		summary: buildVulnerabilitySummaryReport(assessment),
-		details: vulnerabilityDetailsReport{
-			vulns: filterVulContainerImageLayers(assessment.Image),
-			packages: filterVulnContainerImagePackages(assessment.Image),
+	vulnReport := VulnerabilityReport{
+		Summary: buildVulnerabilitySummaryReport(assessment),
+		Details: vulnerabilityDetailsReport{
+			VulnerabilityDetails: filterVulContainerImageLayers(assessment.Image),
+			Packages: filterVulnContainerImagePackages(assessment.Image),
 		},
 	}
 
@@ -341,69 +341,87 @@ func buildReports(assessment *api.VulnContainerAssessment) error {
 
 func buildVulnerabilitySummaryReport(assessment *api.VulnContainerAssessment) vulnerabilitySummaryReport {
 	return vulnerabilitySummaryReport{
-		image:                   *assessment.Image,
-		vulnCounts: vulnCounts{
-			totalVulnerabilities:    assessment.TotalVulnerabilities,
-			criticalVulnerabilities: assessment.CriticalVulnerabilities,
-			highVulnerabilities:     assessment.HighVulnerabilities,
-			mediumVulnerabilities:   assessment.MediumVulnerabilities,
-			lowVulnerabilities:      assessment.LowVulnerabilities,
-			infoVulnerabilities:     assessment.InfoVulnerabilities,
-			fixableVulnCounts: fixableVulnCounts{
-				fixableVulns:                   assessment.FixableVulnerabilities,
-				fixableCriticalVulnerabilities: assessment.VulnFixableCount("critical"),
-				fixableHighVulnerabilities:     assessment.VulnFixableCount("high"),
-				fixableMediumVulnerabilities:   assessment.VulnFixableCount("medium"),
-				fixableLowVulnerabilities:      assessment.VulnFixableCount("low"),
-				fixableInfoVulnerabilities:     assessment.VulnFixableCount("info"),
+		ImageInfo:                   imageInfo{
+			ImageDigest: assessment.Image.ImageInfo.ImageDigest,
+			ImageID:     assessment.Image.ImageInfo.ImageID,
+			Registry:    assessment.Image.ImageInfo.Registry,
+			Repository:  assessment.Image.ImageInfo.Repository,
+			CreatedTime: assessment.Image.ImageInfo.CreatedTime,
+			Size:        assessment.Image.ImageInfo.Size,
+			Tags:        assessment.Image.ImageInfo.Tags,
+		},
+		VulnCounts: vulnCounts{
+			TotalVulnerabilities:    assessment.TotalVulnerabilities,
+			CriticalVulnerabilities: assessment.CriticalVulnerabilities,
+			HighVulnerabilities:     assessment.HighVulnerabilities,
+			MediumVulnerabilities:   assessment.MediumVulnerabilities,
+			LowVulnerabilities:      assessment.LowVulnerabilities,
+			InfoVulnerabilities:     assessment.InfoVulnerabilities,
+			FixableVulnCounts: fixableVulnCounts{
+				FixableVulns:                   assessment.FixableVulnerabilities,
+				FixableCriticalVulnerabilities: assessment.VulnFixableCount("critical"),
+				FixableHighVulnerabilities:     assessment.VulnFixableCount("high"),
+				FixableMediumVulnerabilities:   assessment.VulnFixableCount("medium"),
+				FixableLowVulnerabilities:      assessment.VulnFixableCount("low"),
+				FixableInfoVulnerabilities:     assessment.VulnFixableCount("info"),
 			},
 		},
 
-		lastEvaluationTime:      assessment.LastEvaluationTime,
+		LastEvaluationTime:      assessment.LastEvaluationTime,
 	}
 }
 
 type vulnerabilityDetailsReport struct {
-	vulns filteredImageTable
-	packages filteredPackageTable
+	VulnerabilityDetails filteredImageTable
+	Packages filteredPackageTable `json:"-"`
 }
 
 type vulnerabilitySummaryReport struct {
-	image                   api.VulnContainerImage
-	vulnCounts				vulnCounts
-	lastEvaluationTime      string
+	ImageInfo               imageInfo
+	VulnCounts				vulnCounts
+	LastEvaluationTime      string
+}
+
+type imageInfo struct {
+	ImageDigest string
+	ImageID     string
+	Registry    string
+	Repository  string
+	CreatedTime string
+	Size        int64
+	Tags        []string
 }
 
 type vulnCounts struct  {
-	totalVulnerabilities    int32
-	criticalVulnerabilities int32
-	highVulnerabilities     int32
-	mediumVulnerabilities   int32
-	lowVulnerabilities      int32
-	infoVulnerabilities     int32
-	fixableVulnCounts 		fixableVulnCounts
+	TotalVulnerabilities    int32
+	CriticalVulnerabilities int32
+	HighVulnerabilities     int32
+	MediumVulnerabilities   int32
+	LowVulnerabilities      int32
+	InfoVulnerabilities     int32
+	FixableVulnCounts 		fixableVulnCounts
 }
 
 type fixableVulnCounts struct  {
-	fixableVulns int32
-	fixableCriticalVulnerabilities int32
-	fixableHighVulnerabilities     int32
-	fixableMediumVulnerabilities   int32
-	fixableLowVulnerabilities      int32
-	fixableInfoVulnerabilities     int32
+	FixableVulns int32
+	FixableCriticalVulnerabilities int32
+	FixableHighVulnerabilities     int32
+	FixableMediumVulnerabilities   int32
+	FixableLowVulnerabilities      int32
+	FixableInfoVulnerabilities     int32
 }
 
-type vulnerabilityReport struct {
-	summary vulnerabilitySummaryReport
-	details vulnerabilityDetailsReport
+type VulnerabilityReport struct {
+	Summary vulnerabilitySummaryReport
+	Details vulnerabilityDetailsReport
 }
 
-func buildReportTable(vulnReport vulnerabilityReport) string {
+func buildReportTable(vulnReport VulnerabilityReport) string {
 	report := &strings.Builder{}
 
-	report.WriteString(buildVulnerabilityReportTable(vulnReport.summary))
+	report.WriteString(buildVulnerabilityReportTable(vulnReport.Summary))
 	if vulCmdState.Details || vulCmdState.Packages || vulFiltersEnabled() {
-		report.WriteString(buildVulnerabilityDetailsReportTable(vulnReport.details))
+		report.WriteString(buildVulnerabilityDetailsReportTable(vulnReport.Details))
 	}
 
 	return report.String()

--- a/cli/cmd/vulnerability.go
+++ b/cli/cmd/vulnerability.go
@@ -291,7 +291,7 @@ func pollScanStatus(requestID string) error {
 
 		cli.StopProgress()
 
-		if err := buildReports(assessment); err != nil {
+		if err := buildVulnContainerAssessmentReports(assessment); err != nil {
 			return err
 		}
 
@@ -332,7 +332,7 @@ func buildVulnContainerAssessmentReports(assessment *api.VulnContainerAssessment
 			return err
 		}
 	} else {
-		cli.OutputHuman(buildReportTable(summaryReport, detailsReport))
+		cli.OutputHuman(buildVulnContainerAssessmentReportTable(summaryReport, detailsReport))
 	}
 
 	if vulCmdState.Html {
@@ -348,7 +348,7 @@ type vulnerabilityDetailsReport struct {
 	Packages             filteredPackageTable
 }
 
-func buildReportTable(summary string, details string) string {
+func buildVulnContainerAssessmentReportTable(summary string, details string) string {
 	report := &strings.Builder{}
 
 	report.WriteString(summary)

--- a/cli/cmd/vulnerability.go
+++ b/cli/cmd/vulnerability.go
@@ -353,9 +353,11 @@ func buildReportTable(summary string, details string) string {
 	if vulCmdState.Details || vulCmdState.Packages || vulFiltersEnabled() {
 		report.WriteString(details)
 	} else {
-		report.WriteString(
-			"Try adding '--details' to increase details shown about the vulnerability assessment.\n",
-		)
+		if !vulCmdState.Html {
+			report.WriteString(
+				"Try adding '--details' to increase details shown about the vulnerability assessment.\n",
+			)
+		}
 	}
 
 	return report.String()

--- a/cli/cmd/vulnerability.go
+++ b/cli/cmd/vulnerability.go
@@ -352,6 +352,10 @@ func buildReportTable(summary string, details string) string {
 	report.WriteString(summary)
 	if vulCmdState.Details || vulCmdState.Packages || vulFiltersEnabled() {
 		report.WriteString(details)
+	} else {
+		report.WriteString(
+			"Try adding '--details' to increase details shown about the vulnerability assessment.\n",
+		)
 	}
 
 	return report.String()

--- a/cli/cmd/vulnerability.go
+++ b/cli/cmd/vulnerability.go
@@ -316,13 +316,15 @@ func pollScanStatus(requestID string) error {
 
 // Build the cli output for vuln ctr 'scan-status', 'scan' and 'show-assessment' commands
 func buildVulnContainerAssessmentReports(assessment *api.VulnContainerAssessment) error {
-	summaryReport := buildVulnerabilitySummaryReportTable(assessment)
-	details := vulnerabilityDetailsReport{
-		VulnerabilityDetails: filterVulContainerImageLayers(assessment.Image),
-		Packages:             filterVulnContainerImagePackages(assessment.Image),
-	}
-	detailsReport := buildVulnerabilityDetailsReportTable(details)
-	filteredAssessment := assessment
+	var (
+		summaryReport = buildVulnerabilitySummaryReportTable(assessment)
+		details       = vulnerabilityDetailsReport{
+			VulnerabilityDetails: filterVulContainerImageLayers(assessment.Image),
+			Packages:             filterVulnContainerImagePackages(assessment.Image),
+		}
+		detailsReport      = buildVulnerabilityDetailsReportTable(details)
+		filteredAssessment = assessment
+	)
 	filteredAssessment.Image.ImageLayers = details.VulnerabilityDetails.ImageLayers
 
 	if cli.JSONOutput() {

--- a/cli/cmd/vulnerability.go
+++ b/cli/cmd/vulnerability.go
@@ -291,7 +291,7 @@ func pollScanStatus(requestID string) error {
 
 		cli.StopProgress()
 
-		if err := buildReports(assessment) ; err != nil{
+		if err := buildReports(assessment); err != nil {
 			return err
 		}
 
@@ -314,24 +314,23 @@ func pollScanStatus(requestID string) error {
 	}
 }
 
+// Build the cli output for vuln ctr 'scan-status', 'scan' and 'show-assessment' commands
 func buildReports(assessment *api.VulnContainerAssessment) error {
-	vulnReport := VulnerabilityReport{
-		Summary: buildVulnerabilitySummaryReport(assessment),
-		Details: vulnerabilityDetailsReport{
-			VulnerabilityDetails: filterVulContainerImageLayers(assessment.Image),
-			Packages: filterVulnContainerImagePackages(assessment.Image),
-		},
+	summaryReport := buildVulnerabilitySummaryReportTable(assessment)
+	details := vulnerabilityDetailsReport{
+		VulnerabilityDetails: filterVulContainerImageLayers(assessment.Image),
+		Packages:             filterVulnContainerImagePackages(assessment.Image),
 	}
-
+	detailsReport := buildVulnerabilityDetailsReportTable(details)
 	filteredAssessment := assessment
-	filteredAssessment.Image.ImageLayers = vulnReport.Details.VulnerabilityDetails.ImageLayers
+	filteredAssessment.Image.ImageLayers = details.VulnerabilityDetails.ImageLayers
 
 	if cli.JSONOutput() {
 		if err := cli.OutputJSON(filteredAssessment); err != nil {
 			return err
 		}
 	} else {
-		cli.OutputHuman(buildReportTable(vulnReport))
+		cli.OutputHuman(buildReportTable(summaryReport, detailsReport))
 	}
 
 	if vulCmdState.Html {
@@ -342,89 +341,17 @@ func buildReports(assessment *api.VulnContainerAssessment) error {
 	return nil
 }
 
-func buildVulnerabilitySummaryReport(assessment *api.VulnContainerAssessment) vulnerabilitySummaryReport {
-	return vulnerabilitySummaryReport{
-		ImageInfo:                   imageInfo{
-			ImageDigest: assessment.Image.ImageInfo.ImageDigest,
-			ImageID:     assessment.Image.ImageInfo.ImageID,
-			Registry:    assessment.Image.ImageInfo.Registry,
-			Repository:  assessment.Image.ImageInfo.Repository,
-			CreatedTime: assessment.Image.ImageInfo.CreatedTime,
-			Size:        assessment.Image.ImageInfo.Size,
-			Tags:        assessment.Image.ImageInfo.Tags,
-		},
-		VulnCounts: vulnCounts{
-			TotalVulnerabilities:    assessment.TotalVulnerabilities,
-			CriticalVulnerabilities: assessment.CriticalVulnerabilities,
-			HighVulnerabilities:     assessment.HighVulnerabilities,
-			MediumVulnerabilities:   assessment.MediumVulnerabilities,
-			LowVulnerabilities:      assessment.LowVulnerabilities,
-			InfoVulnerabilities:     assessment.InfoVulnerabilities,
-			FixableVulnCounts: fixableVulnCounts{
-				FixableVulns:                   assessment.FixableVulnerabilities,
-				FixableCriticalVulnerabilities: assessment.VulnFixableCount("critical"),
-				FixableHighVulnerabilities:     assessment.VulnFixableCount("high"),
-				FixableMediumVulnerabilities:   assessment.VulnFixableCount("medium"),
-				FixableLowVulnerabilities:      assessment.VulnFixableCount("low"),
-				FixableInfoVulnerabilities:     assessment.VulnFixableCount("info"),
-			},
-		},
-
-		LastEvaluationTime:      assessment.LastEvaluationTime,
-	}
-}
-
 type vulnerabilityDetailsReport struct {
 	VulnerabilityDetails filteredImageTable
-	Packages filteredPackageTable `json:"-"`
+	Packages             filteredPackageTable
 }
 
-type vulnerabilitySummaryReport struct {
-	ImageInfo               imageInfo
-	VulnCounts				vulnCounts
-	LastEvaluationTime      string
-}
-
-type imageInfo struct {
-	ImageDigest string
-	ImageID     string
-	Registry    string
-	Repository  string
-	CreatedTime string
-	Size        int64
-	Tags        []string
-}
-
-type vulnCounts struct  {
-	TotalVulnerabilities    int32
-	CriticalVulnerabilities int32
-	HighVulnerabilities     int32
-	MediumVulnerabilities   int32
-	LowVulnerabilities      int32
-	InfoVulnerabilities     int32
-	FixableVulnCounts 		fixableVulnCounts
-}
-
-type fixableVulnCounts struct  {
-	FixableVulns int32
-	FixableCriticalVulnerabilities int32
-	FixableHighVulnerabilities     int32
-	FixableMediumVulnerabilities   int32
-	FixableLowVulnerabilities      int32
-	FixableInfoVulnerabilities     int32
-}
-
-type VulnerabilityReport struct {
-	Summary vulnerabilitySummaryReport
-	Details vulnerabilityDetailsReport
-}
-
-func buildReportTable(vulnReport VulnerabilityReport) string {
+func buildReportTable(summary string, details string) string {
 	report := &strings.Builder{}
 
-	report.WriteString(buildVulnerabilityReportTable(vulnReport.Summary))
+	report.WriteString(summary)
 	if vulCmdState.Details || vulCmdState.Packages || vulFiltersEnabled() {
-		report.WriteString(buildVulnerabilityDetailsReportTable(vulnReport.Details))
+		report.WriteString(details)
 	}
 
 	return report.String()

--- a/cli/cmd/vulnerability.go
+++ b/cli/cmd/vulnerability.go
@@ -323,8 +323,11 @@ func buildReports(assessment *api.VulnContainerAssessment) error {
 		},
 	}
 
+	filteredAssessment := assessment
+	filteredAssessment.Image.ImageLayers = vulnReport.Details.VulnerabilityDetails.ImageLayers
+
 	if cli.JSONOutput() {
-		if err := cli.OutputJSON(vulnReport); err != nil {
+		if err := cli.OutputJSON(filteredAssessment); err != nil {
 			return err
 		}
 	} else {

--- a/cli/cmd/vulnerability.go
+++ b/cli/cmd/vulnerability.go
@@ -315,7 +315,7 @@ func pollScanStatus(requestID string) error {
 }
 
 // Build the cli output for vuln ctr 'scan-status', 'scan' and 'show-assessment' commands
-func buildReports(assessment *api.VulnContainerAssessment) error {
+func buildVulnContainerAssessmentReports(assessment *api.VulnContainerAssessment) error {
 	summaryReport := buildVulnerabilitySummaryReportTable(assessment)
 	details := vulnerabilityDetailsReport{
 		VulnerabilityDetails: filterVulContainerImageLayers(assessment.Image),

--- a/integration/container_vulnerability_test.go
+++ b/integration/container_vulnerability_test.go
@@ -372,4 +372,18 @@ func TestContainerVulnerabilityCommandsEndToEnd(t *testing.T) {
 			"ERROR ENFORCE POLICY: fixable vulnerabilities found (exit code: 9)",
 			"STDERR doesn't match")
 	})
+
+	// filtering by severity critical with json flag should filter the json output
+	t.Run("test container vulnerability filter severity with json output", func(t *testing.T) {
+		out, err, exitcode = LaceworkCLIWithTOMLConfig(
+			"vulnerability", "container", "show-assessment", imageID, "--image_id", "--severity", "critical", "--json")
+		severities := []string{"\"severity\": 2","\"severity\": 3","\"severity\": 4", "\"severity\": 5"}
+		assert.Empty(t,
+			err.String(),
+			"STDERR should be empty")
+		assert.Equal(t, 0, exitcode,
+			"EXITCODE is not the expected one")
+		assert.NotContains(t, severities, out.String(),
+			"Json output does not adhere to severity filter")
+	})
 }

--- a/integration/container_vulnerability_test.go
+++ b/integration/container_vulnerability_test.go
@@ -377,7 +377,7 @@ func TestContainerVulnerabilityCommandsEndToEnd(t *testing.T) {
 	t.Run("test container vulnerability filter severity with json output", func(t *testing.T) {
 		out, err, exitcode = LaceworkCLIWithTOMLConfig(
 			"vulnerability", "container", "show-assessment", imageID, "--image_id", "--severity", "critical", "--json")
-		severities := []string{"\"severity\": 2","\"severity\": 3","\"severity\": 4", "\"severity\": 5"}
+		severities := []string{"\"severity\": 2", "\"severity\": 3", "\"severity\": 4", "\"severity\": 5"}
 		assert.Empty(t,
 			err.String(),
 			"STDERR should be empty")


### PR DESCRIPTION
Fix json output to should work in combination with any filtering flags

- vuln ctr list-assessments vuln_container.go:196
- vuln ctr scan vuln_container.go:392
- vuln ctr scan-status vuln_container.go:435
- vuln ctr show-assessment vuln_container.go:482

Signed-off-by: Darren Murray <darren.murray@lacework.net>