### PR TITLE
fix(cli): Hard coding polling mechanism to start after 64 seconds

### DIFF
--- a/cli/cmd/vulnerability.go
+++ b/cli/cmd/vulnerability.go
@@ -225,6 +225,8 @@ func setActiveFlag(cmds ...*flag.FlagSet) {
 func pollScanStatus(requestID string) error {
 	cli.StartProgress(" Scan running...")
 
+	time.Sleep(time.Second * 64)
+
 	var (
 		retries      = 0
 		start        = time.Now()


### PR DESCRIPTION
This PR adds 64 seconds to the start time for the polling mechanism on container vulnerability scans. This fix is to mitigate issues in the field where long scan times cause API rate limits to be exceeded.

Signed-off-by: Scott Ford <scott.ford@lacework.net>