### PR TITLE
feat(cli): lacework query crumbs

### DIFF
--- a/cli/cmd/lql_create.go
+++ b/cli/cmd/lql_create.go
@@ -40,7 +40,7 @@ func init() {
 	// add sub-commands to the lql command
 	lqlCmd.AddCommand(lqlCreateCmd)
 
-	setQueryFlags(lqlCreateCmd.Flags())
+	setQuerySourceFlags(lqlCreateCmd)
 }
 
 func createQuery(cmd *cobra.Command, args []string) error {
@@ -53,6 +53,7 @@ func createQuery(cmd *cobra.Command, args []string) error {
 	create, err := cli.LwApi.LQL.CreateQuery(query)
 
 	if err != nil {
+		err = queryErrorCrumbs(query, err)
 		return errors.Wrap(err, "unable to create LQL query")
 	}
 	if cli.JSONOutput() {

--- a/cli/cmd/lql_update.go
+++ b/cli/cmd/lql_update.go
@@ -40,7 +40,7 @@ func init() {
 	// add sub-commands to the lql command
 	lqlCmd.AddCommand(lqlUpdateCmd)
 
-	setQueryFlags(lqlUpdateCmd.Flags())
+	setQuerySourceFlags(lqlUpdateCmd)
 }
 
 func updateQuery(cmd *cobra.Command, args []string) error {
@@ -55,6 +55,7 @@ func updateQuery(cmd *cobra.Command, args []string) error {
 	update, err := cli.LwApi.LQL.UpdateQuery(query)
 
 	if err != nil {
+		err = queryErrorCrumbs(query, err)
 		return errors.Wrap(err, lqlUpdateUnableMsg)
 	}
 	if cli.JSONOutput() {

--- a/cli/cmd/lql_validate.go
+++ b/cli/cmd/lql_validate.go
@@ -41,7 +41,7 @@ var (
 func init() {
 	lqlCmd.AddCommand(lqlValidateCmd)
 
-	setQueryFlags(lqlValidateCmd.Flags())
+	setQuerySourceFlags(lqlValidateCmd)
 }
 
 func validateQuery(cmd *cobra.Command, args []string) error {
@@ -58,6 +58,7 @@ func compileQueryAndOutput(query string) error {
 	compile, err := cli.LwApi.LQL.CompileQuery(query)
 
 	if err != nil {
+		err = queryErrorCrumbs(query, err)
 		return errors.Wrap(err, lqlValidateUnableMsg)
 	}
 	if cli.JSONOutput() {

--- a/integration/lql_test.go
+++ b/integration/lql_test.go
@@ -134,6 +134,56 @@ func TestQueryRunID(t *testing.T) {
 	assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
 }
 
+func TestQueryRunFileJSONCrumb(t *testing.T) {
+	if os.Getenv("CI_BETA") == "" {
+		t.Skip("skipping test in production mode")
+	}
+	// get temp file
+	file, err := ioutil.TempFile("", "TestQueryRunFile")
+	if err != nil {
+		t.FailNow()
+	}
+	defer os.Remove(file.Name())
+
+	// write-to and close file
+	_, err = file.Write([]byte("{"))
+	if err != nil {
+		t.FailNow()
+	}
+	file.Close()
+
+	// run
+	_, stderr, exitcode := LaceworkCLIWithTOMLConfig(
+		"query", "run", "-f", file.Name(), "--start", lqlQueryStart, "--end", lqlQueryEnd)
+	assert.Contains(t, stderr.String(), "LQL query in JSON format")
+	assert.Equal(t, 1, exitcode, "EXITCODE is not the expected one")
+}
+
+func TestQueryRunFilePlainCrumb(t *testing.T) {
+	if os.Getenv("CI_BETA") == "" {
+		t.Skip("skipping test in production mode")
+	}
+	// get temp file
+	file, err := ioutil.TempFile("", "TestQueryRunFile")
+	if err != nil {
+		t.FailNow()
+	}
+	defer os.Remove(file.Name())
+
+	// write-to and close file
+	_, err = file.Write([]byte("tigerking"))
+	if err != nil {
+		t.FailNow()
+	}
+	file.Close()
+
+	// run
+	_, stderr, exitcode := LaceworkCLIWithTOMLConfig(
+		"query", "run", "-f", file.Name(), "--start", lqlQueryStart, "--end", lqlQueryEnd)
+	assert.Contains(t, stderr.String(), "LQL query in plain text format")
+	assert.Equal(t, 1, exitcode, "EXITCODE is not the expected one")
+}
+
 func TestQueryRunFile(t *testing.T) {
 	if os.Getenv("CI_BETA") == "" {
 		t.Skip("skipping test in production mode")


### PR DESCRIPTION
1.  Adding verbosity to the output when query text is invalid
2.  Made query flag output dynamic based on command

ALLY-432