### PR TITLE
feat: new lwconfig Go package to handle Lacework config

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ import (
 func main() {
 	profiles, err := lwconfig.LoadProfiles()
 	if err != nil {
-		fmt.Printf("Unable to load profiles: %s", err)
+		fmt.Printf("Unable to load profiles: %s\n", err)
 	} else {
 		fmt.Printf("You have '%d' profiles configured!\n", len(profiles))
 	}

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ import (
 func main() {
 	profiles, err := lwconfig.LoadProfiles()
 	if err != nil {
-		fmt.Println("Unable to load profiles: %s", err)
+		fmt.Printf("Unable to load profiles: %s", err)
 	} else {
 		fmt.Printf("You have '%d' profiles configured!\n", len(profiles))
 	}

--- a/README.md
+++ b/README.md
@@ -125,6 +125,32 @@ func main() {
 
 Set the environment variable `LW_UPDATES_DISABLE=1` to avoid checking for updates.
 
+## Lacework Config ([`lwconfig`](lwconfig/))
+
+A Go library to help you manage the Lacework configuration file (`$HOME/.lacework.toml`)
+
+### Basic Usage
+```go
+package main
+
+import (
+	"fmt"
+
+	"github.com/lacework/go-sdk/lwconfig"
+)
+
+func main() {
+	profiles, err := lwconfig.LoadProfiles()
+	if err != nil {
+		fmt.Println("Unable to load profiles: %s", err)
+	} else {
+		fmt.Println("You have '%d' profiles configured!", len(profiles))
+	}
+}
+```
+
+Look at the [lwconfig/](lwconfig/) folder for more information.
+
 ## Release Process
 
 The release process of this repository is documented at the following [Wiki page](https://github.com/lacework/go-sdk/wiki/Release-Process).

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ func main() {
 	if err != nil {
 		fmt.Println("Unable to load profiles: %s", err)
 	} else {
-		fmt.Println("You have '%d' profiles configured!", len(profiles))
+		fmt.Printf("You have '%d' profiles configured!\n", len(profiles))
 	}
 }
 ```

--- a/lwconfig/README.md
+++ b/lwconfig/README.md
@@ -1,0 +1,46 @@
+# Lacework Config
+
+A Go library to help you manage the Lacework configuration file (`$HOME/.lacework.toml`)
+
+## Usage
+
+Download the library into your `$GOPATH`:
+
+    $ go get github.com/lacework/go-sdk/lwconfig
+
+Import the library into your tool:
+
+```go
+import "github.com/lacework/go-sdk/lwconfig"
+```
+
+## Examples
+
+Load the default Lacework configuration file and detect if there is a profile named `test`:
+```go
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/lacework/go-sdk/lwconfig"
+)
+
+func main() {
+	profiles, err := lwconfig.LoadProfiles()
+	if err != nil {
+		fmt.Println("Error trying to load profiles: %s", err)
+		os.Exit(1)
+	}
+
+	config, ok := profiles["test"]
+	if !ok {
+		fmt.Println("You have a test profile configured!")
+	} else {
+		fmt.Println("'test' profile not found")
+	}
+}
+```
+
+Look at the [examples/](examples/) folder for more examples.

--- a/lwconfig/README.md
+++ b/lwconfig/README.md
@@ -30,7 +30,7 @@ import (
 func main() {
 	profiles, err := lwconfig.LoadProfiles()
 	if err != nil {
-		fmt.Println("Error trying to load profiles: %s", err)
+		fmt.Printf("Error trying to load profiles: %s\n", err)
 		os.Exit(1)
 	}
 

--- a/lwconfig/_examples/main.go
+++ b/lwconfig/_examples/main.go
@@ -10,13 +10,13 @@ import (
 func main() {
 	cPath, err := lwconfig.DefaultConfigPath()
 	if err != nil {
-		fmt.Println("Unable to detect default config path location: %s", err)
+		fmt.Printf("Unable to detect default config path location: %s\n", err)
 		os.Exit(1)
 	}
 
 	profiles, err := lwconfig.LoadProfilesFrom(cPath)
 	if err != nil {
-		fmt.Println("Error trying to load profiles: %s", err)
+		fmt.Printf("Error trying to load profiles: %s\n", err)
 		os.Exit(1)
 	}
 

--- a/lwconfig/_examples/main.go
+++ b/lwconfig/_examples/main.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/lacework/go-sdk/lwconfig"
+)
+
+func main() {
+	cPath, err := lwconfig.DefaultConfigPath()
+	if err != nil {
+		fmt.Println("Unable to detect default config path location: %s", err)
+		os.Exit(1)
+	}
+
+	profiles, err := lwconfig.LoadProfilesFrom(cPath)
+	if err != nil {
+		fmt.Println("Error trying to load profiles: %s", err)
+		os.Exit(1)
+	}
+
+	config, ok := profiles["default"]
+	if !ok {
+		fmt.Println("You have a default profile configured!")
+	} else {
+		fmt.Println("'default' profile not found")
+	}
+}

--- a/lwconfig/config.go
+++ b/lwconfig/config.go
@@ -111,21 +111,20 @@ func LoadProfilesFrom(configPath string) (Profiles, error) {
 
 // StoreProfileAt updates a single profile from the provided configuration file
 func StoreProfileAt(configPath, name string, profile Profile) error {
-	cPath := configPath
-	if cPath == "" {
+	if configPath == "" {
 		defaultPath, err := DefaultConfigPath()
 		if err != nil {
 			return err
 		}
-		cPath = defaultPath
+		configPath = defaultPath
 	}
 
 	var (
 		profiles = Profiles{}
 		err      error
 	)
-	if _, err = os.Stat(cPath); err == nil {
-		if profiles, err = LoadProfilesFrom(cPath); err != nil {
+	if _, err = os.Stat(configPath); err == nil {
+		if profiles, err = LoadProfilesFrom(configPath); err != nil {
 			return err
 		}
 	}
@@ -136,5 +135,4 @@ func StoreProfileAt(configPath, name string, profile Profile) error {
 		return err
 	}
 
-	return ioutil.WriteFile(cPath, buf.Bytes(), 0600)
-}
+	return ioutil.WriteFile(configPath, buf.Bytes(), 0600)

--- a/lwconfig/config.go
+++ b/lwconfig/config.go
@@ -136,3 +136,4 @@ func StoreProfileAt(configPath, name string, profile Profile) error {
 	}
 
 	return ioutil.WriteFile(configPath, buf.Bytes(), 0600)
+}

--- a/lwconfig/config.go
+++ b/lwconfig/config.go
@@ -1,0 +1,137 @@
+//
+// Author:: Salim Afiune Maya (<afiune@lacework.net>)
+// Copyright:: Copyright 2021, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+// Helps you manage the Lacework configuration file ($HOME/.lacework.toml)
+package lwconfig
+
+import (
+	"bytes"
+	"io/ioutil"
+	"path"
+
+	"github.com/BurntSushi/toml"
+	"github.com/mitchellh/go-homedir"
+	"github.com/pkg/errors"
+)
+
+// Profiles is the representation of the $HOME/.lacework.toml
+//
+// Example:
+//
+// [default]
+// account = "example"
+// api_key = "EXAMPLE_0123456789"
+// api_secret = "_0123456789"
+//
+// [dev]
+// account = "dev"
+// api_key = "DEV_0123456789"
+// api_secret = "_0123456789"
+//
+// [prod]
+// account = "coolcorp"
+// subaccount = "prod-business"
+// api_key = "PROD_0123456789"
+// api_secret = "_0123456789"
+// version = 2
+type Profiles map[string]Profile
+
+// Profile represents a single profile within a configuration file
+type Profile struct {
+	Account    string `toml:"account"`
+	Subaccount string `toml:"subaccount,omitempty"`
+	ApiKey     string `toml:"api_key" survey:"api_key"`
+	ApiSecret  string `toml:"api_secret" survey:"api_secret"`
+	Version    int    `toml:"version,omitzero"`
+}
+
+// Verify will return an error is there is one required setting missing
+func (p *Profile) Verify() error {
+	if p.Account == "" {
+		return errors.New("account missing")
+	}
+	if p.ApiKey == "" {
+		return errors.New("api_key missing")
+	}
+	if p.ApiSecret == "" {
+		return errors.New("api_secret missing")
+	}
+	return nil
+}
+
+// DefaultConfigPath returns the default path where the Lacework config file
+// is located, which is at $HOME/.lacework.toml
+func DefaultConfigPath() (string, error) {
+	home, err := homedir.Dir()
+	if err != nil {
+		return "", err
+	}
+	return path.Join(home, ".lacework.toml"), nil
+}
+
+// LoadProfiles loads all the profiles from the default location ($HOME/.lacework.toml)
+func LoadProfiles() (Profiles, error) {
+	path, err = DefaultConfigPath()
+	if err != nil {
+		return Profiles{}, err
+	}
+
+	return LoadProfilesFrom(path)
+}
+
+// LoadProfilesFrom loads all the profiles from the provided location
+func LoadProfilesFrom(path string) (Profiles, error) {
+	if path == "" {
+		return Profiles{}, errors.New("unable to load profiles. Specify a configuration file.")
+	}
+
+	var profiles Profiles
+	if _, err := toml.DecodeFile(path, &profiles); err != nil {
+		return profiles, errors.Wrap(err, "unable to decode profiles from config")
+	}
+
+	return profiles, nil
+}
+
+// StoreProfileAt updates a single profile from the provided configuration file
+func StoreProfileAt(path, name string, profile Profile) error {
+	var (
+		profiles = Profiles{}
+		buf      = new(bytes.Buffer)
+		err      error
+	)
+
+	if path == "" {
+		path, err = DefaultConfigPath()
+		if err != nil {
+			return err
+		}
+	}
+
+	profiles, err = LoadProfilesFrom(path)
+	if err != nil {
+		return err
+	}
+
+	profiles[name] = profile
+	if err = toml.NewEncoder(buf).Encode(profiles); err != nil {
+		return err
+	}
+
+	return ioutil.WriteFile(path, buf.Bytes(), 0600)
+}


### PR DESCRIPTION
# New Lacework Config Go Package (`lwconfig`)

A Go library to help you manage the Lacework configuration file (`$HOME/.lacework.toml`)

## Usage

Download the library into your `$GOPATH`:

    $ go get github.com/lacework/go-sdk/lwconfig

Import the library into your tool:

```go
import "github.com/lacework/go-sdk/lwconfig"
```

## Examples

Load the default Lacework configuration file and detect if there is a profile named `test`:
```go
package main

import (
	"fmt"
	"os"

	"github.com/lacework/go-sdk/lwconfig"
)

func main() {
	profiles, err := lwconfig.LoadProfiles()
	if err != nil {
		fmt.Println("Error trying to load profiles: %s", err)
		os.Exit(1)
	}

	config, ok := profiles["test"]
	if !ok {
		fmt.Println("You have a test profile configured!")
	} else {
		fmt.Println("'test' profile not found")
	}
}
```

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>