### PR TITLE
fix(api): graceful degradation for HTTP 204

### DIFF
--- a/api/http.go
+++ b/api/http.go
@@ -99,6 +99,10 @@ func (c *Client) DoDecoder(req *http.Request, v interface{}) (*http.Response, er
 	if err != nil {
 		return nil, err
 	}
+	// optimized return for HTTP 204 as there's nothing to decode onto v
+	if res.StatusCode == http.StatusNoContent {
+		return res, nil
+	}
 
 	err = checkErrorInResponse(res)
 	if err != nil {

--- a/api/http_test.go
+++ b/api/http_test.go
@@ -38,6 +38,25 @@ func TestDoDecoder(t *testing.T) {
 	// TODO @afiune to-be-implemented!
 }
 
+func TestDoDecoder204(t *testing.T) {
+	fakeServer := lacework.MockServer()
+	fakeServer.MockToken("TOKEN")
+	fakeServer.MockAPI(
+		"foo",
+		func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, "", http.StatusNoContent)
+		},
+	)
+	defer fakeServer.Close()
+
+	c, _ := api.NewClient("foo", api.WithURL(fakeServer.URL()), api.WithTokenFromKeys("KEY", "SECRET"), api.WithExpirationTime(-60))
+	request, _ := c.NewRequest("GET", "foo", nil)
+
+	var v interface{}
+	_, err := c.DoDecoder(request, v)
+	assert.Nil(t, err)
+}
+
 func TestRequestDecoder(t *testing.T) {
 	// TODO @afiune to-be-implemented!
 }


### PR DESCRIPTION
If the Lacework API returns a 204, we get an EOF error when attempting to JSON decode.  This causes the UI to present an error even though the request was successful.

ALLY-479