### PR TITLE
feat: introducing first APIv2 endpoint UserProfile

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -25,6 +25,7 @@ import (
 )
 
 const (
+	// API v1 Endpoints
 	apiIntegrations        = "external/integrations"
 	apiIntegrationsByType  = "external/integrations/type/%s"
 	apiIntegrationFromGUID = "external/integrations/%s"
@@ -67,7 +68,19 @@ const (
 	ApiLQLDataSources = "external/lql/dataSources"
 	ApiLQLDescribe    = "external/lql/describe"
 	ApiLQLQuery       = "external/lql/query"
+
+	// API v2 Endpoints
+	apiV2UserProfile = "UserProfile"
 )
+
+// WithApiV1 configures the client to use the API version 1 (/api/v1)
+func WithApiV1() Option {
+	return clientFunc(func(c *Client) error {
+		c.log.Debug("setting up client", zap.String("api_version", "v1"))
+		c.apiVersion = "v1"
+		return nil
+	})
+}
 
 // WithApiV2 configures the client to use the API version 2 (/api/v2)
 func WithApiV2() Option {
@@ -76,6 +89,18 @@ func WithApiV2() Option {
 		c.apiVersion = "v2"
 		return nil
 	})
+}
+
+// UseApiV1 configures the client to use the API version 1 (/api/v1)
+func (c *Client) UseApiV1() {
+	c.log.Debug("setting up client", zap.String("api_version", "v1"))
+	c.apiVersion = "v1"
+}
+
+// UseApiV2 configures the client to use the API version 2 (/api/v2)
+func (c *Client) UseApiV2() {
+	c.log.Debug("setting up client", zap.String("api_version", "v2"))
+	c.apiVersion = "v2"
 }
 
 // ApiVersion returns the API client version

--- a/api/api.go
+++ b/api/api.go
@@ -20,87 +20,85 @@ package api
 
 import (
 	"fmt"
+	"strings"
 
 	"go.uber.org/zap"
 )
 
 const (
+	// Common endpoints
+	//
+	// There will be times where we will have common endpoints between
+	// different versions of our APIs, by default such endpoints will
+	// be driven by the global client.apiVersion setting, when we are
+	// ready to switch over/upgrade we can do so with the option
+	// WithApiV2() at the time that the caller initializes the Go Client
+	//
+	// Example:
+	// ```go
+	//   api.NewClient("my-account", api.WithApiV2())
+	// ```
+	apiTokens = "access/tokens" // Auth
+
 	// API v1 Endpoints
-	apiIntegrations        = "external/integrations"
-	apiIntegrationsByType  = "external/integrations/type/%s"
-	apiIntegrationFromGUID = "external/integrations/%s"
-	apiIntegrationSchema   = "external/integrations/schema/%s"
-	apiTokens              = "access/tokens"
+	//
+	// These endpoints only exist in APIv1 and therefore we prefix them with 'v1/'
+	apiIntegrations        = "v1/external/integrations"
+	apiIntegrationsByType  = "v1/external/integrations/type/%s"
+	apiIntegrationFromGUID = "v1/external/integrations/%s"
+	apiIntegrationSchema   = "v1/external/integrations/schema/%s"
 
-	apiAgentTokens      = "external/tokens"
-	apiAgentTokenFromID = "external/tokens/%s"
+	apiAgentTokens      = "v1/external/tokens"
+	apiAgentTokenFromID = "v1/external/tokens/%s"
 
-	apiVulnerabilitiesContainerScan             = "external/vulnerabilities/container/repository/images/scan"
-	apiVulnerabilitiesContainerScanStatus       = "external/vulnerabilities/container/reqId/%s"
-	apiVulnerabilitiesAssessmentFromImageID     = "external/vulnerabilities/container/imageId/%s"
-	apiVulnerabilitiesAssessmentFromImageDigest = "external/vulnerabilities/container/imageDigest/%s"
-	apiVulnContainerAssessmentsForDateRange     = "external/vulnerabilities/container/GetAssessmentsForDateRange"
+	apiVulnerabilitiesContainerScan             = "v1/external/vulnerabilities/container/repository/images/scan"
+	apiVulnerabilitiesContainerScanStatus       = "v1/external/vulnerabilities/container/reqId/%s"
+	apiVulnerabilitiesAssessmentFromImageID     = "v1/external/vulnerabilities/container/imageId/%s"
+	apiVulnerabilitiesAssessmentFromImageDigest = "v1/external/vulnerabilities/container/imageDigest/%s"
+	apiVulnContainerAssessmentsForDateRange     = "v1/external/vulnerabilities/container/GetAssessmentsForDateRange"
 
-	apiVulnerabilitiesScanPkgManifest             = "external/vulnerabilities/scan"
-	apiVulnerabilitiesHostListCves                = "external/vulnerabilities/host"
-	apiVulnerabilitiesListHostsWithCveID          = "external/vulnerabilities/host/cveId/%s"
-	apiVulnerabilitiesHostAssessmentFromMachineID = "external/vulnerabilities/host/machineId/%s"
+	apiVulnerabilitiesScanPkgManifest             = "v1/external/vulnerabilities/scan"
+	apiVulnerabilitiesHostListCves                = "v1/external/vulnerabilities/host"
+	apiVulnerabilitiesListHostsWithCveID          = "v1/external/vulnerabilities/host/cveId/%s"
+	apiVulnerabilitiesHostAssessmentFromMachineID = "v1/external/vulnerabilities/host/machineId/%s"
 
-	apiComplianceAwsLatestReport        = "external/compliance/aws/GetLatestComplianceReport?AWS_ACCOUNT_ID=%s"
-	apiComplianceGcpLatestReport        = "external/compliance/gcp/GetLatestComplianceReport?GCP_ORG_ID=%s&GCP_PROJ_ID=%s"
-	apiComplianceGcpListProjects        = "external/compliance/gcp/ListProjectsForOrganization?GCP_ORG_ID=%s"
-	apiComplianceAzureLatestReport      = "external/compliance/azure/GetLatestComplianceReport?AZURE_TENANT_ID=%s&AZURE_SUBS_ID=%s"
-	apiComplianceAzureListSubscriptions = "external/compliance/azure/ListSubscriptionsForTenant?AZURE_TENANT_ID=%s"
+	apiComplianceAwsLatestReport        = "v1/external/compliance/aws/GetLatestComplianceReport?AWS_ACCOUNT_ID=%s"
+	apiComplianceGcpLatestReport        = "v1/external/compliance/gcp/GetLatestComplianceReport?GCP_ORG_ID=%s&GCP_PROJ_ID=%s"
+	apiComplianceGcpListProjects        = "v1/external/compliance/gcp/ListProjectsForOrganization?GCP_ORG_ID=%s"
+	apiComplianceAzureLatestReport      = "v1/external/compliance/azure/GetLatestComplianceReport?AZURE_TENANT_ID=%s&AZURE_SUBS_ID=%s"
+	apiComplianceAzureListSubscriptions = "v1/external/compliance/azure/ListSubscriptionsForTenant?AZURE_TENANT_ID=%s"
 
-	apiRunReportIntegration = "external/runReport/integration/%s"
-	apiRunReportGcp         = "external/runReport/gcp/%s"
-	apiRunReportAws         = "external/runReport/aws/%s"
-	apiRunReportAzure       = "external/runReport/azure/%s"
+	apiRunReportIntegration = "v1/external/runReport/integration/%s"
+	apiRunReportGcp         = "v1/external/runReport/gcp/%s"
+	apiRunReportAws         = "v1/external/runReport/aws/%s"
+	apiRunReportAzure       = "v1/external/runReport/azure/%s"
 
-	apiEventsDetails   = "external/events/GetEventDetails"
-	apiEventsDateRange = "external/events/GetEventsForDateRange"
+	apiEventsDetails   = "v1/external/events/GetEventDetails"
+	apiEventsDateRange = "v1/external/events/GetEventsForDateRange"
 
-	apiAccountOrganizationInfo = "external/account/organizationInfo"
+	apiAccountOrganizationInfo = "v1/external/account/organizationInfo"
 
 	// Alpha
-	ApiLQL            = "external/lql"
-	ApiLQLCompile     = "external/lql/compile"
-	ApiLQLDataSources = "external/lql/dataSources"
-	ApiLQLDescribe    = "external/lql/describe"
-	ApiLQLQuery       = "external/lql/query"
+	apiLQL            = "v1/external/lql"
+	apiLQLCompile     = "v1/external/lql/compile"
+	apiLQLDataSources = "v1/external/lql/dataSources"
+	apiLQLDescribe    = "v1/external/lql/describe"
+	apiLQLQuery       = "v1/external/lql/query"
 
 	// API v2 Endpoints
-	apiV2UserProfile = "UserProfile"
+	//
+	// These endpoints only exist in APIv2 and therefore we prefix them with 'v2/'
+	apiV2UserProfile = "v2/UserProfile"
 )
 
-// WithApiV1 configures the client to use the API version 1 (/api/v1)
-func WithApiV1() Option {
-	return clientFunc(func(c *Client) error {
-		c.log.Debug("setting up client", zap.String("api_version", "v1"))
-		c.apiVersion = "v1"
-		return nil
-	})
-}
-
 // WithApiV2 configures the client to use the API version 2 (/api/v2)
+// for common API endpoints
 func WithApiV2() Option {
 	return clientFunc(func(c *Client) error {
 		c.log.Debug("setting up client", zap.String("api_version", "v2"))
 		c.apiVersion = "v2"
 		return nil
 	})
-}
-
-// UseApiV1 configures the client to use the API version 1 (/api/v1)
-func (c *Client) UseApiV1() {
-	c.log.Debug("setting up client", zap.String("api_version", "v1"))
-	c.apiVersion = "v1"
-}
-
-// UseApiV2 configures the client to use the API version 2 (/api/v2)
-func (c *Client) UseApiV2() {
-	c.log.Debug("setting up client", zap.String("api_version", "v2"))
-	c.apiVersion = "v2"
 }
 
 // ApiVersion returns the API client version
@@ -110,5 +108,9 @@ func (c *Client) ApiVersion() string {
 
 // apiPath builds a path by using the current API version
 func (c *Client) apiPath(p string) string {
+	if strings.HasPrefix(p, "v1") || strings.HasPrefix(p, "v2") {
+		return fmt.Sprintf("/api/%s", p)
+	}
+
 	return fmt.Sprintf("/api/%s/%s", c.apiVersion, p)
 }

--- a/api/auth_internal_test.go
+++ b/api/auth_internal_test.go
@@ -35,7 +35,7 @@ func TestApiPath(t *testing.T) {
 	c2 := &Client{apiVersion: "v2"}
 	assert.Equal(t, "/api/v2/bar", c2.apiPath("bar"), "api path mismatch")
 	assert.Equal(t,
-		"/api/v2/external/integrations",
-		c2.apiPath(apiIntegrations),
+		"/api/v2/UserProfile",
+		c2.apiPath(apiV2UserProfile),
 		"integrations api path mismatch")
 }

--- a/api/auth_test.go
+++ b/api/auth_test.go
@@ -37,7 +37,7 @@ func TestWithApiV2(t *testing.T) {
 func TestWithToken(t *testing.T) {
 	c, err := api.NewClient("test", api.WithToken("TOKEN"))
 	if assert.Nil(t, err) {
-		assert.Equal(t, "v1", c.ApiVersion(), "API version should be v2")
+		assert.Equal(t, "v1", c.ApiVersion(), "API version should be v1")
 	}
 }
 
@@ -69,6 +69,23 @@ func TestWithTokenFromKeys(t *testing.T) {
 	}
 }
 
+func TestGenerateTokenV2(t *testing.T) {
+	fakeServer := lacework.MockServer()
+	fakeServer.MockTokenV2("TOKEN")
+	defer fakeServer.Close()
+
+	c, err := api.NewClient("foo",
+		api.WithApiV2(),
+		api.WithURL(fakeServer.URL()),
+		api.WithApiKeys("KEY", "SECRET"),
+	)
+	if assert.Nil(t, err) {
+		response, err := c.GenerateToken()
+		assert.Nil(t, err)
+		assert.Equal(t, "TOKEN", response.Token, "token mismatch")
+	}
+}
+
 func TestGenerateToken(t *testing.T) {
 	fakeServer := lacework.MockServer()
 	fakeServer.MockToken("TOKEN")
@@ -81,7 +98,7 @@ func TestGenerateToken(t *testing.T) {
 	if assert.Nil(t, err) {
 		response, err := c.GenerateToken()
 		assert.Nil(t, err)
-		assert.Equal(t, "TOKEN", response.Token(), "token mismatch")
+		assert.Equal(t, "TOKEN", response.Token, "token mismatch")
 	}
 }
 
@@ -94,7 +111,7 @@ func TestGenerateTokenWithKeys(t *testing.T) {
 	if assert.Nil(t, err) {
 		response, err := c.GenerateTokenWithKeys("KEY", "SECRET")
 		assert.Nil(t, err)
-		assert.Equal(t, "TOKEN", response.Token(), "token mismatch")
+		assert.Equal(t, "TOKEN", response.Token, "token mismatch")
 	}
 }
 

--- a/api/client.go
+++ b/api/client.go
@@ -51,7 +51,8 @@ type Client struct {
 	Compliance      *ComplianceService
 	Integrations    *IntegrationsService
 	Vulnerabilities *VulnerabilitiesService
-	V2              *V2Endpoints
+
+	V2 *V2Endpoints
 }
 
 type Option interface {
@@ -102,7 +103,7 @@ func NewClient(account string, opts ...Option) (*Client, error) {
 	c.Compliance = &ComplianceService{c}
 	c.Integrations = &IntegrationsService{c}
 	c.Vulnerabilities = NewVulnerabilityService(c)
-	c.V2 = &V2Endpoints{c}
+	c.V2 = NewV2Endpoints(c)
 
 	// init logger, this could change if a user calls api.WithLogLevel()
 	c.initLogger()

--- a/api/client.go
+++ b/api/client.go
@@ -35,6 +35,7 @@ const defaultTimeout = 60 * time.Second
 type Client struct {
 	id         string
 	account    string
+	subaccount string
 	apiVersion string
 	logLevel   string
 	baseURL    *url.URL
@@ -50,6 +51,7 @@ type Client struct {
 	Compliance      *ComplianceService
 	Integrations    *IntegrationsService
 	Vulnerabilities *VulnerabilitiesService
+	V2              *V2Endpoints
 }
 
 type Option interface {
@@ -100,6 +102,7 @@ func NewClient(account string, opts ...Option) (*Client, error) {
 	c.Compliance = &ComplianceService{c}
 	c.Integrations = &IntegrationsService{c}
 	c.Vulnerabilities = NewVulnerabilityService(c)
+	c.V2 = &V2Endpoints{c}
 
 	// init logger, this could change if a user calls api.WithLogLevel()
 	c.initLogger()
@@ -117,6 +120,15 @@ func NewClient(account string, opts ...Option) (*Client, error) {
 		zap.Int("timeout", c.auth.expiration),
 	)
 	return c, nil
+}
+
+// WithSubaccount sets a subaccount
+func WithSubaccount(subaccount string) Option {
+	return clientFunc(func(c *Client) error {
+		c.log.Debug("setting up client", zap.Reflect("subaccount", subaccount))
+		c.subaccount = subaccount
+		return nil
+	})
 }
 
 // WithTimeout changes the default client timeout

--- a/api/lql.go
+++ b/api/lql.go
@@ -183,7 +183,7 @@ func (svc *LQLService) CreateQuery(query string) (
 		return
 	}
 
-	err = svc.client.RequestEncoderDecoder("POST", ApiLQL, lqlQuery, &response)
+	err = svc.client.RequestEncoderDecoder("POST", apiLQL, lqlQuery, &response)
 	return
 }
 
@@ -195,7 +195,7 @@ func (svc *LQLService) GetQueryByID(queryID string) (
 	response LQLQueryResponse,
 	err error,
 ) {
-	uri := ApiLQL
+	uri := apiLQL
 
 	if queryID != "" {
 		uri += "?LQL_ID=" + url.QueryEscape(queryID)
@@ -218,6 +218,6 @@ func (svc *LQLService) RunQuery(query, start, end string) (
 		return
 	}
 
-	err = svc.client.RequestEncoderDecoder("POST", ApiLQLQuery, lqlQuery, &response)
+	err = svc.client.RequestEncoderDecoder("POST", apiLQLQuery, lqlQuery, &response)
 	return
 }

--- a/api/lql_compile.go
+++ b/api/lql_compile.go
@@ -33,6 +33,6 @@ func (svc *LQLService) CompileQuery(query string) (
 		return
 	}
 
-	err = svc.client.RequestEncoderDecoder("POST", ApiLQLCompile, lqlQuery, &response)
+	err = svc.client.RequestEncoderDecoder("POST", apiLQLCompile, lqlQuery, &response)
 	return
 }

--- a/api/lql_compile_test.go
+++ b/api/lql_compile_test.go
@@ -82,7 +82,7 @@ var (
 func TestLQLCompileMethod(t *testing.T) {
 	fakeServer := lacework.MockServer()
 	fakeServer.MockAPI(
-		api.ApiLQLCompile,
+		"external/lql/compile",
 		func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, "POST", r.Method, "Compile should be a POST method")
 			fmt.Fprint(w, "{}")
@@ -103,7 +103,7 @@ func TestLQLCompileMethod(t *testing.T) {
 func TestLQLCompileBadInput(t *testing.T) {
 	fakeServer := lacework.MockServer()
 	fakeServer.MockAPI(
-		api.ApiLQLCompile,
+		"external/lql/compile",
 		func(w http.ResponseWriter, r *http.Request) {
 			fmt.Fprint(w, "{}")
 		},
@@ -125,7 +125,7 @@ func TestLQLCompileOK(t *testing.T) {
 
 	fakeServer := lacework.MockServer()
 	fakeServer.MockAPI(
-		api.ApiLQLCompile,
+		"external/lql/compile",
 		func(w http.ResponseWriter, r *http.Request) {
 			fmt.Fprint(w, mockResponse)
 		},
@@ -150,7 +150,7 @@ func TestLQLCompileOK(t *testing.T) {
 func TestLQLCompileError(t *testing.T) {
 	fakeServer := lacework.MockServer()
 	fakeServer.MockAPI(
-		api.ApiLQLCompile,
+		"external/lql/compile",
 		func(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, lqlErrorReponse, http.StatusInternalServerError)
 		},

--- a/api/lql_data_sources.go
+++ b/api/lql_data_sources.go
@@ -28,6 +28,6 @@ func (svc *LQLService) DataSources() (
 	response LQLDataSourcesResponse,
 	err error,
 ) {
-	err = svc.client.RequestDecoder("GET", ApiLQLDataSources, nil, &response)
+	err = svc.client.RequestDecoder("GET", apiLQLDataSources, nil, &response)
 	return
 }

--- a/api/lql_data_sources_test.go
+++ b/api/lql_data_sources_test.go
@@ -32,7 +32,7 @@ import (
 func TestLQLDataSourcesMethod(t *testing.T) {
 	fakeServer := lacework.MockServer()
 	fakeServer.MockAPI(
-		api.ApiLQLDataSources,
+		"external/lql/dataSources",
 		func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, "GET", r.Method, "DataSources should be a GET method")
 			fmt.Fprint(w, "{}")
@@ -61,7 +61,7 @@ func TestLQLDataSourcesOK(t *testing.T) {
 
 	fakeServer := lacework.MockServer()
 	fakeServer.MockAPI(
-		api.ApiLQLDataSources,
+		"external/lql/dataSources",
 		func(w http.ResponseWriter, r *http.Request) {
 			fmt.Fprint(w, mockResponse)
 		},
@@ -86,7 +86,7 @@ func TestLQLDataSourcesOK(t *testing.T) {
 func TestLQLDataSourcesError(t *testing.T) {
 	fakeServer := lacework.MockServer()
 	fakeServer.MockAPI(
-		api.ApiLQLDataSources,
+		"external/lql/dataSources",
 		func(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, lqlErrorReponse, http.StatusInternalServerError)
 		},

--- a/api/lql_delete.go
+++ b/api/lql_delete.go
@@ -49,7 +49,7 @@ func (svc *LQLService) DeleteQuery(queryID string) (
 
 	err = svc.client.RequestDecoder(
 		"DELETE",
-		fmt.Sprintf("%s?LQL_ID=%s", ApiLQL, url.QueryEscape(queryID)),
+		fmt.Sprintf("%s?LQL_ID=%s", apiLQL, url.QueryEscape(queryID)),
 		nil,
 		&response,
 	)

--- a/api/lql_delete_test.go
+++ b/api/lql_delete_test.go
@@ -32,13 +32,13 @@ import (
 func TestLQLDeleteMethod(t *testing.T) {
 	fakeServer := lacework.MockServer()
 	fakeServer.MockAPI(
-		api.ApiLQL,
+		"external/lql",
 		func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, "DELETE", r.Method, "Delete should be a DELETE method")
 			assert.Subset(
 				t,
 				[]byte(r.RequestURI),
-				[]byte(api.ApiLQL+"?LQL_ID=my_lql"),
+				[]byte("external/lql?LQL_ID=my_lql"),
 				"Delete should specify LQL_ID argument",
 			)
 			fmt.Fprint(w, "{}")
@@ -59,7 +59,7 @@ func TestLQLDeleteMethod(t *testing.T) {
 func TestLQLDeleteBadInput(t *testing.T) {
 	fakeServer := lacework.MockServer()
 	fakeServer.MockAPI(
-		api.ApiLQL,
+		"external/lql",
 		func(w http.ResponseWriter, r *http.Request) {
 			fmt.Fprint(w, "{}")
 		},
@@ -84,7 +84,7 @@ func TestLQLDeleteOK(t *testing.T) {
 
 	fakeServer := lacework.MockServer()
 	fakeServer.MockAPI(
-		api.ApiLQL,
+		"external/lql",
 		func(w http.ResponseWriter, r *http.Request) {
 			fmt.Fprint(w, mockResponse)
 		},
@@ -110,7 +110,7 @@ func TestLQLDeleteOK(t *testing.T) {
 func TestLQLDeleteNotFound(t *testing.T) {
 	fakeServer := lacework.MockServer()
 	fakeServer.MockAPI(
-		api.ApiLQLCompile,
+		"external/lql/compile",
 		func(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, lqlUnableResponse, http.StatusBadRequest)
 		},

--- a/api/lql_describe.go
+++ b/api/lql_describe.go
@@ -57,7 +57,7 @@ func (svc *LQLService) Describe(dataSource string) (
 	response LQLDescribeResponse,
 	err error,
 ) {
-	uri := fmt.Sprintf("%s/%s", ApiLQLDescribe, url.QueryEscape(dataSource))
+	uri := fmt.Sprintf("%s/%s", apiLQLDescribe, url.QueryEscape(dataSource))
 
 	err = svc.client.RequestDecoder("GET", uri, nil, &response)
 	return

--- a/api/lql_describe_test.go
+++ b/api/lql_describe_test.go
@@ -115,7 +115,7 @@ var (
 func TestLQLDescribeMethod(t *testing.T) {
 	fakeServer := lacework.MockServer()
 	fakeServer.MockAPI(
-		fmt.Sprintf("%s/%s", api.ApiLQLDescribe, url.QueryEscape(lqlDataSource)),
+		fmt.Sprintf("external/lql/describe/%s", url.QueryEscape(lqlDataSource)),
 		func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, "GET", r.Method, "Describe should be a GET method")
 			assert.Subset(
@@ -144,7 +144,7 @@ func TestLQLDescribeOK(t *testing.T) {
 
 	fakeServer := lacework.MockServer()
 	fakeServer.MockAPI(
-		fmt.Sprintf("%s/%s", api.ApiLQLDescribe, url.QueryEscape(lqlDataSource)),
+		fmt.Sprintf("external/lql/describe/%s", url.QueryEscape(lqlDataSource)),
 		func(w http.ResponseWriter, r *http.Request) {
 			fmt.Fprint(w, mockResponse)
 		},
@@ -170,7 +170,7 @@ func TestLQLDescribeOK(t *testing.T) {
 func TestLQLDescribeNotFound(t *testing.T) {
 	fakeServer := lacework.MockServer()
 	fakeServer.MockAPI(
-		fmt.Sprintf("%s/%s", api.ApiLQLDescribe, url.QueryEscape(lqlDataSource)),
+		fmt.Sprintf("external/lql/describe/%s", url.QueryEscape(lqlDataSource)),
 		func(w http.ResponseWriter, r *http.Request) {
 			fmt.Fprint(w, "{}")
 		},
@@ -190,7 +190,7 @@ func TestLQLDescribeNotFound(t *testing.T) {
 func TestLQLDescribeError(t *testing.T) {
 	fakeServer := lacework.MockServer()
 	fakeServer.MockAPI(
-		api.ApiLQLCompile,
+		"external/lql/compile",
 		func(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, lqlErrorReponse, http.StatusInternalServerError)
 		},

--- a/api/lql_test.go
+++ b/api/lql_test.go
@@ -396,7 +396,7 @@ func mockLQLMessageResponse(message string, ok string) string {
 func TestLQLCreateMethod(t *testing.T) {
 	fakeServer := lacework.MockServer()
 	fakeServer.MockAPI(
-		api.ApiLQL,
+		"external/lql",
 		func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, "POST", r.Method, "Create should be a POST method")
 			fmt.Fprint(w, "{}")
@@ -417,7 +417,7 @@ func TestLQLCreateMethod(t *testing.T) {
 func TestLQLCreateBadInput(t *testing.T) {
 	fakeServer := lacework.MockServer()
 	fakeServer.MockAPI(
-		api.ApiLQL,
+		"external/lql",
 		func(w http.ResponseWriter, r *http.Request) {
 			fmt.Fprint(w, "{}")
 		},
@@ -439,7 +439,7 @@ func TestLQLCreateOK(t *testing.T) {
 
 	fakeServer := lacework.MockServer()
 	fakeServer.MockAPI(
-		api.ApiLQL,
+		"external/lql",
 		func(w http.ResponseWriter, r *http.Request) {
 			fmt.Fprint(w, mockResponse)
 		},
@@ -465,7 +465,7 @@ func TestLQLCreateOK(t *testing.T) {
 func TestLQLCreateError(t *testing.T) {
 	fakeServer := lacework.MockServer()
 	fakeServer.MockAPI(
-		api.ApiLQL,
+		"external/lql",
 		func(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, lqlErrorReponse, http.StatusInternalServerError)
 		},
@@ -485,13 +485,13 @@ func TestLQLCreateError(t *testing.T) {
 func TestLQLGetQueriesMethod(t *testing.T) {
 	fakeServer := lacework.MockServer()
 	fakeServer.MockAPI(
-		api.ApiLQL,
+		"external/lql",
 		func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, "GET", r.Method, "Get should be a GET method")
 			assert.NotSubset(
 				t,
 				[]byte(r.RequestURI),
-				[]byte(api.ApiLQL+"?LQL_ID"),
+				[]byte("external/lql?LQL_ID"),
 				"GetQueries should not specify LQL_ID argument",
 			)
 			fmt.Fprint(w, "{}")
@@ -514,7 +514,7 @@ func TestLQLGetQueryByIDOK(t *testing.T) {
 
 	fakeServer := lacework.MockServer()
 	fakeServer.MockAPI(
-		api.ApiLQL,
+		"external/lql",
 		func(w http.ResponseWriter, r *http.Request) {
 			fmt.Fprint(w, mockResponse)
 		},
@@ -540,7 +540,7 @@ func TestLQLGetQueryByIDOK(t *testing.T) {
 func TestLQLGetQueryByIDNotFound(t *testing.T) {
 	fakeServer := lacework.MockServer()
 	fakeServer.MockAPI(
-		api.ApiLQL,
+		"external/lql",
 		func(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, lqlUnableResponse, http.StatusBadRequest)
 		},
@@ -560,7 +560,7 @@ func TestLQLGetQueryByIDNotFound(t *testing.T) {
 func TestLQLRunQueryMethod(t *testing.T) {
 	fakeServer := lacework.MockServer()
 	fakeServer.MockAPI(
-		api.ApiLQLQuery,
+		"external/lql/query",
 		func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, "POST", r.Method, "Run should be a POST method")
 			fmt.Fprint(w, "{}")
@@ -581,7 +581,7 @@ func TestLQLRunQueryMethod(t *testing.T) {
 func TestLQLRunQueryBadInput(t *testing.T) {
 	fakeServer := lacework.MockServer()
 	fakeServer.MockAPI(
-		api.ApiLQLQuery,
+		"external/lql/query",
 		func(w http.ResponseWriter, r *http.Request) {
 			fmt.Fprint(w, "{}")
 		},
@@ -603,7 +603,7 @@ func TestLQLRunQueryOK(t *testing.T) {
 
 	fakeServer := lacework.MockServer()
 	fakeServer.MockAPI(
-		api.ApiLQLQuery,
+		"external/lql/query",
 		func(w http.ResponseWriter, r *http.Request) {
 			fmt.Fprint(w, mockResponse)
 		},
@@ -629,7 +629,7 @@ func TestLQLRunQueryOK(t *testing.T) {
 func TestLQLRunQueryError(t *testing.T) {
 	fakeServer := lacework.MockServer()
 	fakeServer.MockAPI(
-		api.ApiLQL,
+		"external/lql",
 		func(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, lqlErrorReponse, http.StatusInternalServerError)
 		},

--- a/api/lql_update.go
+++ b/api/lql_update.go
@@ -36,6 +36,6 @@ func (svc *LQLService) UpdateQuery(query string) (
 		return
 	}
 
-	err = svc.client.RequestEncoderDecoder("PATCH", ApiLQL, lqlQuery, &response)
+	err = svc.client.RequestEncoderDecoder("PATCH", apiLQL, lqlQuery, &response)
 	return
 }

--- a/api/lql_update_test.go
+++ b/api/lql_update_test.go
@@ -32,7 +32,7 @@ import (
 func TestLQLUpdateMethod(t *testing.T) {
 	fakeServer := lacework.MockServer()
 	fakeServer.MockAPI(
-		api.ApiLQL,
+		"external/lql",
 		func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, "PATCH", r.Method, "Update should be a PATCH method")
 			fmt.Fprint(w, "{}")
@@ -53,7 +53,7 @@ func TestLQLUpdateMethod(t *testing.T) {
 func TestLQLUpdateBadInput(t *testing.T) {
 	fakeServer := lacework.MockServer()
 	fakeServer.MockAPI(
-		api.ApiLQL,
+		"external/lql",
 		func(w http.ResponseWriter, r *http.Request) {
 			fmt.Fprint(w, "{}")
 		},
@@ -78,7 +78,7 @@ func TestLQLUpdateOK(t *testing.T) {
 
 	fakeServer := lacework.MockServer()
 	fakeServer.MockAPI(
-		api.ApiLQL,
+		"external/lql",
 		func(w http.ResponseWriter, r *http.Request) {
 			fmt.Fprint(w, mockResponse)
 		},
@@ -104,7 +104,7 @@ func TestLQLUpdateOK(t *testing.T) {
 func TestLQLUpdateNotFound(t *testing.T) {
 	fakeServer := lacework.MockServer()
 	fakeServer.MockAPI(
-		api.ApiLQLCompile,
+		"external/lql/compile",
 		func(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, lqlUnableResponse, http.StatusBadRequest)
 		},

--- a/api/user_profile.go
+++ b/api/user_profile.go
@@ -25,7 +25,6 @@ type UserProfileService struct {
 }
 
 func (svc *UserProfileService) Get() (response UserProfileResponse, err error) {
-	svc.client.apiVersion = "v2"
 	err = svc.client.RequestDecoder("GET", apiV2UserProfile, nil, &response)
 	return
 }

--- a/api/user_profile.go
+++ b/api/user_profile.go
@@ -18,14 +18,15 @@
 
 package api
 
-// V2Endpoints
-type V2Endpoints struct {
+// UserProfileService is the service that interacts with the UserProfile
+// schema from the Lacework APIv2 Server
+type UserProfileService struct {
 	client *Client
 }
 
-func (v2 *V2Endpoints) GetUserProfile() (response UserProfileResponse, err error) {
-	v2.client.apiVersion = "v2"
-	err = v2.client.RequestDecoder("GET", apiV2UserProfile, nil, &response)
+func (svc *UserProfileService) Get() (response UserProfileResponse, err error) {
+	svc.client.apiVersion = "v2"
+	err = svc.client.RequestDecoder("GET", apiV2UserProfile, nil, &response)
 	return
 }
 

--- a/api/user_profile.go
+++ b/api/user_profile.go
@@ -1,0 +1,47 @@
+//
+// Author:: Salim Afiune Maya (<afiune@lacework.net>)
+// Copyright:: Copyright 2021, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package api
+
+// V2Endpoints
+type V2Endpoints struct {
+	client *Client
+}
+
+func (v2 *V2Endpoints) GetUserProfile() (response UserProfileResponse, err error) {
+	v2.client.apiVersion = "v2"
+	err = v2.client.RequestDecoder("GET", apiV2UserProfile, nil, &response)
+	return
+}
+
+type UserProfileResponse struct {
+	Data []struct {
+		Username   string `json:"username"`
+		OrgAccount bool   `json:"orgAccount"`
+		URL        string `json:"url"`
+		OrgAdmin   bool   `json:"orgAdmin"`
+		OrgUser    bool   `json:"orgUser"`
+		Accounts   []struct {
+			Admin       bool   `json:"admin"`
+			AccountName string `json:"accountName"`
+			CustGUID    string `json:"custGuid"`
+			UserGUID    string `json:"userGuid"`
+			UserEnabled int    `json:"userEnabled"`
+		} `json:"accounts"`
+	} `json:"data"`
+}

--- a/api/user_profile_test.go
+++ b/api/user_profile_test.go
@@ -77,8 +77,8 @@ func userProfileResponse() string {
         {
           "admin": true,
           "accountName": "CUSTOMERDEMO",
-          "custGuid": "CUSTOMER_721595854C4272A5AC58B9FAA369C0ABB05564A91DA0ED9",
-          "userGuid": "CUSTOMER_997F8E3EDECD89F30125BCCFCFD308CCABE8DF908A08DD3",
+          "custGuid": "CUSTOMER_123455854C4272A5AC58B9FAA369C0ABB05564A91DA0ED9",
+          "userGuid": "CUSTOMER_12345E3EDECD89F30125BCCFCFD308CCABE8DF908A08DD3",
           "userEnabled": 1
         }
       ]

--- a/api/user_profile_test.go
+++ b/api/user_profile_test.go
@@ -1,0 +1,89 @@
+//
+// Author:: Salim Afiune Maya (<afiune@lacework.net>)
+// Copyright:: Copyright 2021, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package api_test
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/lacework/go-sdk/api"
+	"github.com/lacework/go-sdk/internal/lacework"
+)
+
+func TestV2UserProfile(t *testing.T) {
+	fakeServer := lacework.MockServer()
+	fakeServer.UseApiV2()
+	fakeServer.MockAPI("UserProfile",
+		func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "GET", r.Method, "UserProfile should be a GET method")
+
+			fmt.Fprintf(w, userProfileResponse())
+		},
+	)
+	defer fakeServer.Close()
+
+	c, err := api.NewClient("test",
+		api.WithToken("TOKEN"),
+		api.WithURL(fakeServer.URL()),
+	)
+	assert.Nil(t, err)
+
+	response, err := c.V2.GetUserProfile()
+	assert.Nil(t, err)
+
+	if assert.NotNil(t, response) {
+		if assert.Equal(t, 1, len(response.Data)) {
+			profile := response.Data[0]
+			assert.Equal(t, "salim.afiunemaya@lacework.net", profile.Username)
+
+			if assert.Equal(t, 1, len(profile.Accounts)) {
+				assert.Equal(t, "CUSTOMERDEMO", profile.Accounts[0].AccountName)
+			}
+		}
+	}
+}
+
+// @afiune real response from a demo environment
+func userProfileResponse() string {
+	return `
+{
+  "data": [
+    {
+      "username": "salim.afiunemaya@lacework.net",
+      "orgAccount": true,
+      "url": "customerdemo.lacework.net",
+      "orgAdmin": true,
+      "orgUser": false,
+      "accounts": [
+        {
+          "admin": true,
+          "accountName": "CUSTOMERDEMO",
+          "custGuid": "CUSTOMER_721595854C4272A5AC58B9FAA369C0ABB05564A91DA0ED9",
+          "userGuid": "CUSTOMER_997F8E3EDECD89F30125BCCFCFD308CCABE8DF908A08DD3",
+          "userEnabled": 1
+        }
+      ]
+    }
+  ]
+}
+`
+}

--- a/api/user_profile_test.go
+++ b/api/user_profile_test.go
@@ -47,7 +47,7 @@ func TestV2UserProfile(t *testing.T) {
 	)
 	assert.Nil(t, err)
 
-	response, err := c.V2.GetUserProfile()
+	response, err := c.V2.UserProfile.Get()
 	assert.Nil(t, err)
 
 	if assert.NotNil(t, response) {

--- a/api/v2.go
+++ b/api/v2.go
@@ -21,7 +21,9 @@ package api
 // V2Endpoints groups all APIv2 endpoints available, they are grouped by
 // schema which matches with our service architecture
 type V2Endpoints struct {
-	client      *Client
+	client *Client
+
+	// Every schema must have its own service
 	UserProfile *UserProfileService
 }
 

--- a/api/v2.go
+++ b/api/v2.go
@@ -1,0 +1,32 @@
+//
+// Author:: Salim Afiune Maya (<afiune@lacework.net>)
+// Copyright:: Copyright 2021, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package api
+
+// V2Endpoints groups all APIv2 endpoints available, they are grouped by
+// schema which matches with our service architecture
+type V2Endpoints struct {
+	client      *Client
+	UserProfile *UserProfileService
+}
+
+func NewV2Endpoints(c *Client) *V2Endpoints {
+	return &V2Endpoints{c,
+		&UserProfileService{c},
+	}
+}

--- a/cli/cmd/access_token.go
+++ b/cli/cmd/access_token.go
@@ -54,7 +54,7 @@ func init() {
 
 func generateAccessToken(_ *cobra.Command, args []string) error {
 	var (
-		response api.TokenResponse
+		response *api.TokenData
 		err      error
 	)
 
@@ -81,22 +81,11 @@ func generateAccessToken(_ *cobra.Command, args []string) error {
 		}
 	}
 
-	if len(response.Data) == 0 {
-		return errors.New(`unable to generate access token
-
-The platform did not return any token in the response body, this is very
-unlikely to happen but, hey it happened. Please help us improve the
-Lacework CLI by reporting this issue at:
-
-  https://support.lacework.com/hc/en-us/requests/new
-`)
-	}
-
 	if cli.JSONOutput() {
-		return cli.OutputJSON(response.Data[0])
+		return cli.OutputJSON(response)
 	}
 
-	cli.OutputHuman(response.Token())
+	cli.OutputHuman(response.Token)
 	cli.OutputHuman("\n")
 	return nil
 }

--- a/cli/cmd/api.go
+++ b/cli/cmd/api.go
@@ -76,10 +76,32 @@ func runApiCommand(_ *cobra.Command, args []string) error {
 		}
 	}
 
-	response := new(map[string]interface{})
+	endpoint := args[1]
+	pathSplit := strings.Split(args[1], "/")
+	size := len(pathSplit)
+	if size > 0 {
+		switch pathSplit[0] {
+		case "v2":
+			cli.LwApi.UseApiV2()
+			endpoint = strings.Join(pathSplit[1:], "/")
+		case "v1":
+			endpoint = strings.Join(pathSplit[1:], "/")
+		}
+	}
+	if size > 1 {
+		switch pathSplit[1] {
+		case "v2":
+			cli.LwApi.UseApiV2()
+			endpoint = strings.Join(pathSplit[2:], "/")
+		case "v1":
+			endpoint = strings.Join(pathSplit[2:], "/")
+		}
+	}
+
+	response := new(interface{})
 	err := cli.LwApi.RequestDecoder(
 		strings.ToUpper(args[0]),
-		strings.TrimPrefix(args[1], "/"),
+		strings.TrimPrefix(endpoint, "/"),
 		strings.NewReader(apiData),
 		response,
 	)

--- a/cli/cmd/api.go
+++ b/cli/cmd/api.go
@@ -38,16 +38,28 @@ var (
 	// apiCmd represents the api command
 	apiCmd = &cobra.Command{
 		Use:   "api <method> <path>",
-		Short: "helper to call Lacework's RestfulAPI",
-		Long: `Use this command as a helper to call any available Lacework API endpoint.
+		Short: "helper to call Lacework's API",
+		Long: `Use this command as a helper to call any available Lacework API v1 & v2 endpoint.
 
-For example, to list all integrations configured in your account run:
+== For APIv1 ==
 
-    lacework api get /external/integrations
+To list all integrations configured in your account:
 
-For a complete list of available API endpoints visit:
+    lacework api get /v1/external/integrations
+
+For a complete list of available API v1 endpoints visit:
 
     https://<ACCOUNT>.lacework.net/api/v1/external/docs
+
+== For APIv2 ==
+
+To list all available Lacework schema types:
+
+    lacework api get /v2/schemas
+
+For a complete list of available API v1 endpoints visit:
+
+    https://<ACCOUNT>.lacework.net/api/v2/docs
 `,
 		Args: argsApiValidator,
 		RunE: runApiCommand,
@@ -76,32 +88,10 @@ func runApiCommand(_ *cobra.Command, args []string) error {
 		}
 	}
 
-	endpoint := args[1]
-	pathSplit := strings.Split(args[1], "/")
-	size := len(pathSplit)
-	if size > 0 {
-		switch pathSplit[0] {
-		case "v2":
-			cli.LwApi.UseApiV2()
-			endpoint = strings.Join(pathSplit[1:], "/")
-		case "v1":
-			endpoint = strings.Join(pathSplit[1:], "/")
-		}
-	}
-	if size > 1 {
-		switch pathSplit[1] {
-		case "v2":
-			cli.LwApi.UseApiV2()
-			endpoint = strings.Join(pathSplit[2:], "/")
-		case "v1":
-			endpoint = strings.Join(pathSplit[2:], "/")
-		}
-	}
-
 	response := new(interface{})
 	err := cli.LwApi.RequestDecoder(
 		strings.ToUpper(args[0]),
-		strings.TrimPrefix(endpoint, "/"),
+		strings.TrimPrefix(args[1], "/"),
 		strings.NewReader(apiData),
 		response,
 	)

--- a/cli/cmd/api.go
+++ b/cli/cmd/api.go
@@ -91,7 +91,7 @@ func runApiCommand(_ *cobra.Command, args []string) error {
 	response := new(interface{})
 	err := cli.LwApi.RequestDecoder(
 		strings.ToUpper(args[0]),
-		strings.TrimPrefix(args[1], "/"),
+		cleanupEndpoint(args[1]),
 		strings.NewReader(apiData),
 		response,
 	)
@@ -116,4 +116,20 @@ func argsApiValidator(_ *cobra.Command, args []string) error {
 		)
 	}
 	return nil
+}
+
+// cleanupEndpoint will make sure that any provided endpoint is well formatted
+// and doesn't contain known fields like /api/v1/foo
+func cleanupEndpoint(endpoint string) string {
+	splitEndpoint := strings.Split(endpoint, "/")
+
+	if len(splitEndpoint) > 0 && splitEndpoint[0] == "api" {
+		return strings.Join(splitEndpoint[1:], "/")
+	}
+
+	if len(splitEndpoint) > 1 && splitEndpoint[1] == "api" {
+		return strings.Join(splitEndpoint[2:], "/")
+	}
+
+	return strings.TrimPrefix(endpoint, "/")
 }

--- a/cli/cmd/api.go
+++ b/cli/cmd/api.go
@@ -66,13 +66,13 @@ func init() {
 
 func runApiCommand(_ *cobra.Command, args []string) error {
 	switch args[0] {
-	case "post", "patch":
+	case "patch":
 		if apiData == "" {
-			return fmt.Errorf("missing '--data' parameter for post or patch requests")
+			return fmt.Errorf("missing '--data' parameter patch requests")
 		}
-	case "delete", "get":
+	case "get":
 		if apiData != "" {
-			return fmt.Errorf("use '--data' only for post and patch requests")
+			return fmt.Errorf("use '--data' only for post, delete and patch requests")
 		}
 	}
 

--- a/cli/cmd/api_test.go
+++ b/cli/cmd/api_test.go
@@ -1,0 +1,51 @@
+//
+// Author:: Salim Afiune Maya (<afiune@lacework.net>)
+// Copyright:: Copyright 2021, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cmd
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAPICleanupEndpoint(t *testing.T) {
+
+	cases := []struct {
+		endpoint         string
+		expectedEndpoint string
+	}{
+		{"", ""},
+		{"/foo", "foo"},
+		{"/external/bar", "external/bar"},
+		{"/v1/bubulubu", "v1/bubulubu"},
+		{"/v2/bubulubu", "v2/bubulubu"},
+
+		{"/api/v2/schemas", "v2/schemas"},
+		{"/api/v1/external/foo", "v1/external/foo"},
+		{"api/v1/endpoint", "v1/endpoint"},
+		{"api/v2/coolendpoint", "v2/coolendpoint"},
+	}
+
+	for i, kase := range cases {
+		t.Run(fmt.Sprintf("test case %d", i), func(t *testing.T) {
+			assert.Equal(t, kase.expectedEndpoint, cleanupEndpoint(kase.endpoint))
+		})
+	}
+}

--- a/internal/lacework/server.go
+++ b/internal/lacework/server.go
@@ -57,6 +57,10 @@ func MockServer() *Mock {
 	}
 }
 
+func (m *Mock) UseApiV2() {
+	m.ApiVersion = "v2"
+}
+
 // MockAPI will mock the api path inside the server mutex with the provided handler function
 func (m *Mock) MockAPI(p string, handler func(http.ResponseWriter, *http.Request)) {
 	m.Mux.HandleFunc(fmt.Sprintf("/api/%s/%s", m.ApiVersion, p), handler)
@@ -73,6 +77,19 @@ func (s *Mock) MockToken(token string) {
         }],
         "ok": true,
         "message": "SUCCESS"
+      }
+    `)
+	})
+}
+
+func (s *Mock) MockTokenV2(token string) {
+	s.UseApiV2()
+	s.MockAPI("access/tokens", func(w http.ResponseWriter, r *http.Request) {
+		expiration := time.Now().AddDate(0, 0, 1)
+		fmt.Fprintf(w, `
+      {
+        "expiresAt": "`+expiration.Format(time.RFC3339)+`",
+        "token": "`+token+`"
       }
     `)
 	})


### PR DESCRIPTION
# User Story

As a Lacework engineer using the Go SDK,
I would like to have a path to implement endpoints from the new APIv2,
So I can start leveraging them and I can stop using APIv1 endpoints. 

# Description

This pull request is implementing one APIv2 endpoint, which includes a
defined architecture for implementing new APIv2 endpoints as well as a
new Authentication method.
 
This new implementation has to consider the fact that we will continue
to use APIv1 endpoints until we migrate them all to the new ones in APIv2.

# Acceptance Criteria

- [x] We will be able to authenticate to both, APIv2 and APIv1 at the same time.
- [x] We have implemented one APIv2 endpoint `/v2/UserProfile`
- [x] Clear documentation about how to use new APIv2 architecture

**JIRA: ALLY-375**

## EXTRA: Enable `lacework api` command to work for both API v1 & v2

Users will be able to run the following commands to access APIv1:
```
$ lacework api get /external/{endpoint}
$ lacework api get /v1/external/{endpoint}
$ lacework api get /api/v1/external/{endpoint}
```
And the following commands to access APIv2:
```
$ lacework api get /v2/{endpoint}
$ lacework api get /api/v2/{endpoint}
```
A few examples that work with this change:
```
$ lacework api get /api/v1/integrations
$ lacework api get /external/integrations
$ lacework api get /api/v2/schemas
$ lacework api get /api/v2/AlertRules
$ lacework api get /api/v2/ContractInfo

```
Signed-off-by: Salim Afiune Maya <afiune@lacework.net>