### PR TITLE
feat(cli): v2 configure cmd undestands subaccounts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,10 @@ GOFLAGS=-mod=vendor
 CGO_ENABLED?=0
 export GOFLAGS GO_LDFLAGS CGO_ENABLED
 
+# CI variables
+CI_V2_ACCOUNT?=customerdemo
+export CI_V2_ACCOUNT
+
 prepare: install-tools go-vendor
 
 test: prepare

--- a/api/client.go
+++ b/api/client.go
@@ -123,14 +123,6 @@ func NewClient(account string, opts ...Option) (*Client, error) {
 	return c, nil
 }
 
-// RemoveSubaccount removes the subaccount from the API client
-func (c *Client) RemoveSubaccount() {
-	c.log.Debug("removing subaccount from client")
-	c.subaccount = ""
-	c.log.Debug("removing header", zap.String("field", "Account-Name"))
-	delete(c.headers, "Account-Name")
-}
-
 // WithSubaccount sets a subaccount into an API client
 func WithSubaccount(subaccount string) Option {
 	return clientFunc(func(c *Client) error {

--- a/api/client.go
+++ b/api/client.go
@@ -123,11 +123,23 @@ func NewClient(account string, opts ...Option) (*Client, error) {
 	return c, nil
 }
 
-// WithSubaccount sets a subaccount
+// RemoveSubaccount removes the subaccount from the API client
+func (c *Client) RemoveSubaccount() {
+	c.log.Debug("removing subaccount from client")
+	c.subaccount = ""
+	c.log.Debug("removing header", zap.String("field", "Account-Name"))
+	delete(c.headers, "Account-Name")
+}
+
+// WithSubaccount sets a subaccount into an API client
 func WithSubaccount(subaccount string) Option {
 	return clientFunc(func(c *Client) error {
-		c.log.Debug("setting up client", zap.Reflect("subaccount", subaccount))
-		c.subaccount = subaccount
+		if subaccount != "" {
+			c.log.Debug("setting up client", zap.String("subaccount", subaccount))
+			c.subaccount = subaccount
+			c.log.Debug("setting up header", zap.String("Account-Name", subaccount))
+			c.headers["Account-Name"] = subaccount
+		}
 		return nil
 	})
 }

--- a/api/user_profile.go
+++ b/api/user_profile.go
@@ -19,8 +19,9 @@
 package api
 
 import (
-	"regexp"
 	"strings"
+
+	"github.com/lacework/go-sdk/internal/domain"
 )
 
 // UserProfileService is the service that interacts with the UserProfile
@@ -48,15 +49,11 @@ type UserProfile struct {
 }
 
 func (p *UserProfile) OrgAccountName() string {
-	// TODO @afiune should we handle other datacenters?
-	rx, err := regexp.Compile(`\.lacework\.net.*`)
-	if err == nil {
-		if split := rx.Split(p.URL, -1); len(split) != 0 {
-			return strings.ToLower(split[0])
-		}
+	d, err := domain.New(p.URL)
+	if err != nil {
+		return p.URL
 	}
-
-	return p.URL
+	return d.Account
 }
 
 func (p *UserProfile) SubAccountNames() []string {

--- a/api/user_profile.go
+++ b/api/user_profile.go
@@ -18,6 +18,11 @@
 
 package api
 
+import (
+	"regexp"
+	"strings"
+)
+
 // UserProfileService is the service that interacts with the UserProfile
 // schema from the Lacework APIv2 Server
 type UserProfileService struct {
@@ -30,18 +35,53 @@ func (svc *UserProfileService) Get() (response UserProfileResponse, err error) {
 }
 
 type UserProfileResponse struct {
-	Data []struct {
-		Username   string `json:"username"`
-		OrgAccount bool   `json:"orgAccount"`
-		URL        string `json:"url"`
-		OrgAdmin   bool   `json:"orgAdmin"`
-		OrgUser    bool   `json:"orgUser"`
-		Accounts   []struct {
-			Admin       bool   `json:"admin"`
-			AccountName string `json:"accountName"`
-			CustGUID    string `json:"custGuid"`
-			UserGUID    string `json:"userGuid"`
-			UserEnabled int    `json:"userEnabled"`
-		} `json:"accounts"`
-	} `json:"data"`
+	Data []UserProfile `json:"data"`
+}
+
+type UserProfile struct {
+	Username   string    `json:"username"`
+	OrgAccount bool      `json:"orgAccount"`
+	URL        string    `json:"url"`
+	OrgAdmin   bool      `json:"orgAdmin"`
+	OrgUser    bool      `json:"orgUser"`
+	Accounts   []Account `json:"accounts"`
+}
+
+func (p *UserProfile) OrgAccountName() string {
+	// TODO @afiune should we handle other datacenters?
+	rx, err := regexp.Compile(`\.lacework\.net.*`)
+	if err == nil {
+		if split := rx.Split(p.URL, -1); len(split) != 0 {
+			return strings.ToLower(split[0])
+		}
+	}
+
+	return p.URL
+}
+
+func (p *UserProfile) SubAccountNames() []string {
+	names := make([]string, 0)
+	orgAccountName := p.OrgAccountName()
+	for _, acc := range p.Accounts {
+		accName := strings.ToLower(acc.AccountName)
+		if accName == orgAccountName {
+			continue
+		}
+		if acc.Enabled() {
+			names = append(names, accName)
+		}
+	}
+	return names
+}
+
+type Account struct {
+	Admin       bool   `json:"admin"`
+	AccountName string `json:"accountName"`
+	CustGUID    string `json:"custGuid"`
+	UserGUID    string `json:"userGuid"`
+	UserEnabled int    `json:"userEnabled"`
+}
+
+func (a *Account) Enabled() bool {
+	return a.UserEnabled == 1
 }

--- a/cli/README.md
+++ b/cli/README.md
@@ -158,7 +158,11 @@ Server, for that reason, it requires a set of Lacework API keys. To run these te
 locally you need to setup the following environment variables and use the directive
 `make integration`, an example of the command you can use is:
 ```
-$ CI_ACCOUNT="<YOUR_ACCOUNT>" CI_API_KEY="<YOUR_API_KEY>" CI_API_SECRET="<YOUR_API_SECRET>" LW_INT_TEST_AWS_ACC="<YOUR_AWS_ACCOUNT>" make integration
+$ CI_ACCOUNT="<YOUR_ACCOUNT>" \
+  CI_V2_ACCOUNT="<YOUR_APIV2_PRIMARY_ACCOUNT>" \
+  CI_API_KEY="<YOUR_API_KEY>" \
+  CI_API_SECRET="<YOUR_API_SECRET>" \
+  LW_INT_TEST_AWS_ACC="<YOUR_AWS_ACCOUNT>" make integration
 ```
 This is a list of all environment variables used in the running the integration tests.
 

--- a/cli/cmd/cli_state.go
+++ b/cli/cmd/cli_state.go
@@ -21,11 +21,12 @@ package cmd
 import (
 	"fmt"
 	"math/rand"
+	"os"
+	"reflect"
 	"strconv"
 	"sync"
 	"time"
 
-	"github.com/BurntSushi/toml"
 	"github.com/briandowns/spinner"
 	"github.com/fatih/color"
 	prettyjson "github.com/hokaccha/go-prettyjson"
@@ -34,17 +35,21 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/lacework/go-sdk/api"
+	"github.com/lacework/go-sdk/lwconfig"
 	"github.com/lacework/go-sdk/lwlogger"
 )
 
 // cliState holds the state of the entire Lacework CLI
 type cliState struct {
-	Profile  string
-	Account  string
-	KeyID    string
-	Secret   string
-	Token    string
-	LogLevel string
+	Profile    string
+	Account    string
+	Subaccount string
+	KeyID      string
+	Secret     string
+	Token      string
+	LogLevel   string
+	OrgLevel   bool
+	CfgVersion int
 
 	LwApi *api.Client
 	JsonF *prettyjson.Formatter
@@ -105,8 +110,10 @@ func (c *cliState) LoadState() error {
 	defer func() {
 		// update global honeyvent with loaded state
 		c.Event.Account = c.Account
+		c.Event.Subaccount = c.Subaccount
 		c.Event.Profile = c.Profile
 		c.Event.ApiKey = c.KeyID
+		c.Event.CfgVersion = c.CfgVersion
 	}()
 
 	c.profileDetails = viper.GetStringMap(c.Profile)
@@ -126,12 +133,16 @@ func (c *cliState) LoadState() error {
 	c.KeyID = c.extractValueString("api_key")
 	c.Secret = c.extractValueString("api_secret")
 	c.Account = c.extractValueString("account")
+	c.Subaccount = c.extractValueString("subaccount")
+	c.CfgVersion = c.extractValueInt("version")
 
 	c.Log.Debugw("state loaded",
 		"profile", c.Profile,
 		"account", c.Account,
+		"subaccount", c.Subaccount,
 		"api_key", c.KeyID,
 		"api_secret", c.Secret,
+		"config_version", c.CfgVersion,
 	)
 
 	c.loadStateFromViper()
@@ -139,28 +150,20 @@ func (c *cliState) LoadState() error {
 }
 
 // LoadProfiles loads all the profiles from the configuration file
-func (c *cliState) LoadProfiles() (Profiles, error) {
-	var (
-		profiles = Profiles{}
-		confPath = viper.ConfigFileUsed()
-	)
+func (c *cliState) LoadProfiles() (lwconfig.Profiles, error) {
+	confPath := viper.ConfigFileUsed()
 
 	if confPath == "" {
-		return profiles, errors.New("unable to load profiles. No configuration file found.")
+		return nil, errors.New("unable to load profiles. No configuration file found.")
 	}
 
-	cli.Log.Debugw("decoding config", "path", confPath)
-	if _, err := toml.DecodeFile(confPath, &profiles); err != nil {
-		return profiles, errors.Wrap(err, "unable to decode profiles from config")
-	}
-
-	cli.Log.Debugw("profiles loaded from config", "profiles", profiles)
-	return profiles, nil
+	return lwconfig.LoadProfilesFrom(confPath)
 }
 
 // VerifySettings checks if the CLI state has the neccessary settings to run,
 // if not, it throws an error with breadcrumbs to help the user configure the CLI
 func (c *cliState) VerifySettings() error {
+	c.Log.Debugw("verifying config", "version", c.CfgVersion)
 	if c.Profile == "" ||
 		c.Account == "" ||
 		c.Secret == "" ||
@@ -180,12 +183,23 @@ func (c *cliState) NewClient() error {
 		return err
 	}
 
-	client, err := api.NewClient(c.Account,
+	apiOpts := []api.Option{
 		api.WithLogLevel(c.LogLevel),
+		api.WithSubaccount(c.Subaccount),
 		api.WithApiKeys(c.KeyID, c.Secret),
-		api.WithTimeout(time.Second*125),
+		api.WithTimeout(time.Second * 125),
 		api.WithHeader("User-Agent", fmt.Sprintf("Command-Line/%s", Version)),
-	)
+	}
+
+	if c.CfgVersion == 2 {
+		apiOpts = append(apiOpts, api.WithApiV2())
+	}
+
+	if os.Getenv("LW_API_SERVER_URL") != "" {
+		apiOpts = append(apiOpts, api.WithURL(os.Getenv("LW_API_SERVER_URL")))
+	}
+
+	client, err := api.NewClient(c.Account, apiOpts...)
 	if err != nil {
 		return errors.Wrap(err, "unable to generate api client")
 	}
@@ -287,6 +301,11 @@ func (c *cliState) loadStateFromViper() {
 		c.Account = v
 		c.Log.Debugw("state updated", "account", c.Account)
 	}
+
+	if v := viper.GetString("subaccount"); v != "" {
+		c.Subaccount = v
+		c.Log.Debugw("state updated", "subaccount", c.Subaccount)
+	}
 }
 
 func (c *cliState) extractValueString(key string) string {
@@ -296,6 +315,7 @@ func (c *cliState) extractValueString(key string) string {
 		}
 		c.Log.Warnw("config value type mismatch",
 			"expected_type", "string",
+			"actual_type", reflect.TypeOf(val),
 			"file", viper.ConfigFileUsed(),
 			"profile", c.Profile,
 			"key", key,
@@ -309,6 +329,29 @@ func (c *cliState) extractValueString(key string) string {
 		"key", key,
 	)
 	return ""
+}
+
+func (c *cliState) extractValueInt(key string) int {
+	if val, ok := c.profileDetails[key]; ok {
+		if i, ok := val.(int64); ok {
+			return int(i)
+		}
+		c.Log.Warnw("config value type mismatch",
+			"expected_type", "int",
+			"actual_type", reflect.TypeOf(val),
+			"file", viper.ConfigFileUsed(),
+			"profile", c.Profile,
+			"key", key,
+			"value", val,
+		)
+		return 0
+	}
+	c.Log.Warnw("unable to find key from config",
+		"file", viper.ConfigFileUsed(),
+		"profile", c.Profile,
+		"key", key,
+	)
+	return 0
 }
 
 // newID generates a new client id, this id is useful for logging purposes

--- a/cli/cmd/configure.go
+++ b/cli/cmd/configure.go
@@ -202,9 +202,6 @@ func runConfigureSetup() error {
 			return err
 		}
 
-		// remove the sub-account, if any, for organization admins only
-		cli.LwApi.RemoveSubaccount()
-
 		// get sub-accounts from organizational accounts
 		subaccount, err := getSubAccountForOrgAdmins()
 		if err != nil {

--- a/cli/cmd/honeyvent.go
+++ b/cli/cmd/honeyvent.go
@@ -87,11 +87,13 @@ const (
 // Honeyvent defines what a Honeycomb event looks like for the Lacework CLI
 type Honeyvent struct {
 	Version       string      `json:"version"`
+	CfgVersion    int         `json:"config_version"`
 	Os            string      `json:"os"`
 	Arch          string      `json:"arch"`
 	Command       string      `json:"command,omitempty"`
 	Args          []string    `json:"args,omitempty"`
 	Account       string      `json:"account,omitempty"`
+	Subaccount    string      `json:"subaccount,omitempty"`
 	Profile       string      `json:"profile,omitempty"`
 	ApiKey        string      `json:"api_key,omitempty"`
 	Feature       string      `json:"feature,omitempty"`
@@ -123,7 +125,9 @@ func (c *cliState) InitHoneyvent() {
 		Version:       Version,
 		Profile:       c.Profile,
 		Account:       c.Account,
+		Subaccount:    c.Subaccount,
 		ApiKey:        c.KeyID,
+		CfgVersion:    c.CfgVersion,
 		TraceID:       newID(),
 		InstallMethod: installMethod(),
 	}

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -140,6 +140,9 @@ func init() {
 	rootCmd.PersistentFlags().StringP("account", "a", "",
 		"account subdomain of URL (i.e. <ACCOUNT>.lacework.net)",
 	)
+	rootCmd.PersistentFlags().StringP("subaccount", "u", "",
+		"sub-account name inside your organization (org admins only)",
+	)
 
 	errcheckWARN(viper.BindPFlag("debug", rootCmd.PersistentFlags().Lookup("debug")))
 	errcheckWARN(viper.BindPFlag("nocolor", rootCmd.PersistentFlags().Lookup("nocolor")))
@@ -149,6 +152,7 @@ func init() {
 	errcheckWARN(viper.BindPFlag("account", rootCmd.PersistentFlags().Lookup("account")))
 	errcheckWARN(viper.BindPFlag("api_key", rootCmd.PersistentFlags().Lookup("api_key")))
 	errcheckWARN(viper.BindPFlag("api_secret", rootCmd.PersistentFlags().Lookup("api_secret")))
+	errcheckWARN(viper.BindPFlag("subaccount", rootCmd.PersistentFlags().Lookup("subaccount")))
 }
 
 // initConfig reads in config file and ENV variables if set

--- a/integration/compliance_test.go
+++ b/integration/compliance_test.go
@@ -70,6 +70,7 @@ Global Flags:
       --nocolor             turn off colors
       --noninteractive      turn off interactive mode (disable spinners, prompts, etc.)
   -p, --profile string      switch between profiles configured at ~/.lacework.toml
+  -u, --subaccount string   sub-account name inside your organization (org admins only)
 
 Use "lacework compliance [command] --help" for more information about a command.
 `,

--- a/integration/configure_list_test.go
+++ b/integration/configure_list_test.go
@@ -36,8 +36,10 @@ func TestConfigureListCommandWithConfig(t *testing.T) {
 		// headers
 		"PROFILE",
 		"ACCOUNT",
+		"SUBACCOUNT",
 		"API KEY",
 		"API SECRET",
+		"V",
 
 		// column 1
 		"> default",
@@ -52,12 +54,19 @@ func TestConfigureListCommandWithConfig(t *testing.T) {
 		"*****************************1111",
 
 		// column 3
+		"v2",
+		"v2.config",
+		"subaccount.example",
+		"V2_ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890AAABBBCCC00",
+		"*****************************2222",
+
+		// column 4
 		"integration",
 		"integration",
 		"INTEGRATION_3DF1234AABBCCDD5678XXYYZZ1234ABC8BEC6500DC70",
 		"*****************************4abc",
 
-		// column 3
+		// column 5
 		"test",
 		"test.account",
 		"INTTEST_ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890AAABBBCCC00",

--- a/integration/configure_show_test.go
+++ b/integration/configure_show_test.go
@@ -31,7 +31,7 @@ func TestConfigureShowCommandWrongKey(t *testing.T) {
 		"STDOUT should be empty")
 	assert.Contains(t, err.String(), "unknown configuration key.",
 		"STDERR is not correct, please update")
-	assert.Contains(t, err.String(), "(available: profile, account, api_secret, api_key)",
+	assert.Contains(t, err.String(), "(available: profile, account, subaccount, api_secret, api_key, version)",
 		"STDERR is not correct, please update")
 	assert.Equal(t, 1, exitcode,
 		"EXITCODE is not the expected one")
@@ -56,7 +56,7 @@ func TestConfigureShowCommandWithoutConfig(t *testing.T) {
 	assert.Empty(t,
 		out.String(),
 		"STDOUT should be empty")
-	assert.Equal(t, 1, exitcode,
+	assert.Equal(t, 0, exitcode,
 		"EXITCODE is not the expected one")
 }
 
@@ -99,7 +99,7 @@ func TestConfigureShowCommandWithConfigAndProfile(t *testing.T) {
 		assert.Empty(t,
 			err.String(),
 			"STDERR should be empty")
-		assert.Equal(t, 1, exitcode,
+		assert.Equal(t, 0, exitcode,
 			"EXITCODE is not the expected one")
 		assert.Empty(t,
 			out.String(),

--- a/integration/configure_show_test.go
+++ b/integration/configure_show_test.go
@@ -94,6 +94,28 @@ func TestConfigureShowCommandWithConfigAndProfile(t *testing.T) {
 			"STDOUT does not match with the correct value")
 	})
 
+	t.Run("v2.subaccount", func(t *testing.T) {
+		out, err, exitcode := LaceworkCLIWithDummyConfig("configure", "show", "subaccount", "--profile", "v2")
+		assert.Empty(t,
+			err.String(),
+			"STDERR should be empty")
+		assert.Equal(t, 0, exitcode,
+			"EXITCODE is not the expected one")
+		assert.Equal(t, "subaccount.example\n", out.String(),
+			"STDOUT does not match with the correct value")
+	})
+
+	t.Run("v2.version", func(t *testing.T) {
+		out, err, exitcode := LaceworkCLIWithDummyConfig("configure", "show", "version", "-p", "v2")
+		assert.Empty(t,
+			err.String(),
+			"STDERR should be empty")
+		assert.Equal(t, 0, exitcode,
+			"EXITCODE is not the expected one")
+		assert.Equal(t, "2\n", out.String(),
+			"STDOUT does not match with the correct value")
+	})
+
 	t.Run("foo.unknown", func(t *testing.T) {
 		out, err, exitcode := LaceworkCLIWithDummyConfig("configure", "show", "account", "-p", "foo")
 		assert.Empty(t,

--- a/integration/configure_test.go
+++ b/integration/configure_test.go
@@ -42,6 +42,7 @@ func TestConfigureCommandNonInteractive(t *testing.T) {
 		"-a", "my-account",
 		"-k", "my-key",
 		"-s", "my-secret",
+		"-u", "my-sub-account",
 	)
 
 	assert.Empty(t, errB.String())
@@ -58,8 +59,10 @@ func TestConfigureCommandNonInteractive(t *testing.T) {
 
 	assert.Equal(t, `[default]
   account = "my-account"
+  subaccount = "my-sub-account"
   api_key = "my-key"
   api_secret = "my-secret"
+  version = 2
 `, string(laceworkTOML), "there is a problem with the generated config")
 }
 
@@ -87,16 +90,24 @@ func createTOMLConfig() string {
 account = 'test.account'
 api_key = 'INTTEST_ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890AAABBBCCC00'
 api_secret = '_00000000000000000000000000000000'
+version = 2
 
 [integration]
 account = 'integration'
 api_key = 'INTEGRATION_3DF1234AABBCCDD5678XXYYZZ1234ABC8BEC6500DC70001'
 api_secret = '_1234abdc00ff11vv22zz33xyz1234abc'
+version = 2
 
 [dev]
 account = 'dev.example'
 api_key = 'DEVDEV_ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890AAABBBCCC000'
 api_secret = '_11111111111111111111111111111111'
+version = 2
+
+[v1]
+account = 'v1.example'
+api_key = 'V1CONFIG_KEY'
+api_secret = '_secret'
 `)
 	err = ioutil.WriteFile(configFile, c, 0644)
 	if err != nil {

--- a/integration/configure_unix_test.go
+++ b/integration/configure_unix_test.go
@@ -48,6 +48,7 @@ func TestConfigureCommand(t *testing.T) {
   account = "test-account"
   api_key = "INTTEST_ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890AAABBBCCC00"
   api_secret = "_00000000000000000000000000000000"
+  version = 2
 `, laceworkTOML, "there is a problem with the generated config")
 }
 
@@ -69,6 +70,7 @@ func TestConfigureCommandWithProfileFlag(t *testing.T) {
   account = "test-account"
   api_key = "INTTEST_ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890AAABBBCCC00"
   api_secret = "_00000000000000000000000000000000"
+  version = 2
 `, laceworkTOML, "there is a problem with the generated config")
 }
 
@@ -100,6 +102,7 @@ func TestConfigureCommandWithNewJSONFileFlagForStandaloneAccounts(t *testing.T) 
   account = "standalone"
   api_key = "INTTEST_ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890AAABBBCCC00"
   api_secret = "_cccccccccccccccccccccccccccccccc"
+  version = 2
 `, laceworkTOML, "there is a problem with the generated config")
 }
 
@@ -129,9 +132,11 @@ func TestConfigureCommandWithNewJSONFileFlagForOrganizationalAccounts(t *testing
 	)
 
 	assert.Equal(t, `[default]
-  account = "sub-account-name"
+  account = "organization"
+  subaccount = "sub-account-name"
   api_key = "INTTEST_ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890AAABBBCCC00"
   api_secret = "_cccccccccccccccccccccccccccccccc"
+  version = 2
 `, laceworkTOML, "there is a problem with the generated config")
 }
 
@@ -157,6 +162,7 @@ func TestConfigureCommandWithOldJSONFileFlag(t *testing.T) {
   account = "web-ui-test"
   api_key = "INTTEST_ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890AAABBBCCC00"
   api_secret = "_cccccccccccccccccccccccccccccccc"
+  version = 2
 `, laceworkTOML, "there is a problem with the generated config")
 }
 
@@ -185,6 +191,7 @@ func TestConfigureCommandWithEnvironmentVariables(t *testing.T) {
   account = "env-vars"
   api_key = "INTTEST_ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890AAABBBCCC00"
   api_secret = "_cccccccccccccccccccccccccccccccc"
+  version = 2
 `, laceworkTOML, "there is a problem with the generated config")
 }
 
@@ -209,6 +216,7 @@ func TestConfigureCommandWithAPIkeysFromFlags(t *testing.T) {
   account = "from-flags"
   api_key = "INTTEST_ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890AAABBBCCC00"
   api_secret = "_cccccccccccccccccccccccccccccccc"
+  version = 2
 `, laceworkTOML, "there is a problem with the generated config")
 }
 
@@ -233,21 +241,30 @@ func TestConfigureCommandWithExistingConfigAndMultiProfile(t *testing.T) {
   account = "test.account"
   api_key = "INTTEST_ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890AAABBBCCC00"
   api_secret = "_00000000000000000000000000000000"
+  version = 2
 
 [dev]
   account = "dev.example"
   api_key = "DEVDEV_ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890AAABBBCCC000"
   api_secret = "_11111111111111111111111111111111"
+  version = 2
 
 [integration]
   account = "integration"
   api_key = "INTEGRATION_3DF1234AABBCCDD5678XXYYZZ1234ABC8BEC6500DC70001"
   api_secret = "_1234abdc00ff11vv22zz33xyz1234abc"
+  version = 2
 
 [new-profile]
   account = "super-cool-profile"
   api_key = "TEST_ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ"
   api_secret = "_uuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuu"
+  version = 2
+
+[v1]
+  account = "v1.example"
+  api_key = "V1CONFIG_KEY"
+  api_secret = "_secret"
 `, laceworkTOML, "there is a problem with the generated config")
 }
 
@@ -276,6 +293,7 @@ func TestConfigureCommandErrors(t *testing.T) {
   account = "my-account"
   api_key = "INTTEST_ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890AAABBBCCC00"
   api_secret = "_00000000000000000000000000000000"
+  version = 2
 `, laceworkTOML, "there is a problem with the generated config")
 }
 

--- a/integration/configure_unix_test.go
+++ b/integration/configure_unix_test.go
@@ -76,6 +76,32 @@ func TestConfigureCommandForFrankfurtDatacenter(t *testing.T) {
 `, laceworkTOML, "there is a problem with the generated config")
 }
 
+func TestConfigureCommandForOrgAdmins(t *testing.T) {
+	_, laceworkTOML := runConfigureTest(t,
+		func(c *expect.Console) {
+			c.ExpectString("Account:")
+			c.SendLine(os.Getenv("CI_V2_ACCOUNT"))
+			c.ExpectString("Access Key ID:")
+			c.SendLine(os.Getenv("CI_API_KEY"))
+			c.ExpectString("Secret Access Key:")
+			c.SendLine(os.Getenv("CI_API_SECRET"))
+			c.ExpectString("Verifying credentials ...")
+			c.ExpectString("(Org Admins) Managing a sub-account?")
+			c.SendLine(os.Getenv("CI_ACCOUNT"))
+			c.ExpectString("You are all set!")
+		},
+		"configure",
+	)
+
+	assert.Equal(t, `[default]
+  account = "`+os.Getenv("CI_V2_ACCOUNT")+`"
+  subaccount = "`+os.Getenv("CI_ACCOUNT")+`"
+  api_key = "`+os.Getenv("CI_API_KEY")+`"
+  api_secret = "`+os.Getenv("CI_API_SECRET")+`"
+  version = 2
+`, laceworkTOML, "there is a problem with the generated config")
+}
+
 func TestConfigureCommandWithProfileFlag(t *testing.T) {
 	_, laceworkTOML := runConfigureTest(t,
 		func(c *expect.Console) {

--- a/integration/configure_unix_test.go
+++ b/integration/configure_unix_test.go
@@ -21,6 +21,7 @@ package integration
 
 import (
 	"io/ioutil"
+	"log"
 	"os"
 	"path"
 	"testing"
@@ -373,6 +374,10 @@ func runConfigureTestFromDir(t *testing.T, dir string, conditions func(*expect.C
 		panic(err)
 	}
 	defer console.Close()
+
+	if os.Getenv("DEBUG") != "" {
+		state.DebugLogger = log.Default()
+	}
 
 	donec := make(chan struct{})
 	go func() {

--- a/integration/framework_test.go
+++ b/integration/framework_test.go
@@ -206,6 +206,13 @@ account = 'test.account'
 api_key = 'INTTEST_ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890AAABBBCCC00'
 api_secret = '_00000000000000000000000000000000'
 
+[v2]
+account = 'v2.config'
+subaccount = 'subaccount.example'
+api_key = 'V2_ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890AAABBBCCC00'
+api_secret = '_22222222222222222222222222222222'
+version = 2
+
 [integration]
 account = 'integration'
 api_key = 'INTEGRATION_3DF1234AABBCCDD5678XXYYZZ1234ABC8BEC6500DC70'

--- a/integration/help_test.go
+++ b/integration/help_test.go
@@ -80,6 +80,7 @@ Global Flags:
       --nocolor             turn off colors
       --noninteractive      turn off interactive mode (disable spinners, prompts, etc.)
   -p, --profile string      switch between profiles configured at ~/.lacework.toml
+  -u, --subaccount string   sub-account name inside your organization (org admins only)
 
 Use "lacework configure [command] --help" for more information about a command.
 `,
@@ -159,6 +160,7 @@ Flags:
       --nocolor             turn off colors
       --noninteractive      turn off interactive mode (disable spinners, prompts, etc.)
   -p, --profile string      switch between profiles configured at ~/.lacework.toml
+  -u, --subaccount string   sub-account name inside your organization (org admins only)
 
 Use "lacework [command] --help" for more information about a command.
 `,

--- a/internal/domain/domain.go
+++ b/internal/domain/domain.go
@@ -1,0 +1,101 @@
+//
+// Author:: Salim Afiune Maya (<afiune@lacework.net>)
+// Copyright:: Copyright 2021, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package domain
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+// Use this package to disseminate a domain URL into
+// account, cluster and whether or not it is internal
+
+type domain struct {
+	Account  string
+	Cluster  string
+	Internal bool
+}
+
+// New returns domain information from the provided URL
+//
+// For instance, the following URL:
+// ```
+// d := domain.New("https://account.fra.lacework.net")
+// ```
+// Would be dessiminated into:
+// * `account` as the account name
+// * `fra` as the cluster name
+func New(url string) (domain, error) {
+	// for the full url https://ACCOUNT.lacework.net
+	// remove the prefixes https:// or http://
+	rx, err := regexp.Compile(`(http://|https://)`)
+	if err == nil {
+		url = rx.ReplaceAllString(url, "")
+	}
+
+	// for the full domain ACCOUNT[.CUSTER][.corp].lacework.net
+	// subtract the account and cluster name, also detect if the
+	// domain is internal (dev, qa, preprod, etc)
+	rx, err = regexp.Compile(`\.lacework\.net.*`)
+	if err == nil {
+		domainSplit := rx.Split(url, -1)
+		if len(domainSplit) > 1 {
+			url = domainSplit[0]
+		} else {
+			return domain{}, errors.New("domain not supported")
+		}
+	}
+
+	domainInfo := strings.Split(url, ".")
+	switch len(domainInfo) {
+	case 1:
+		return domain{Account: domainInfo[0]}, nil
+	case 2:
+		return domain{
+			Account: domainInfo[0],
+			Cluster: domainInfo[1],
+		}, nil
+	case 3:
+		if domainInfo[2] != "corp" {
+			return domain{}, errors.New("unable to detect if domain is internal")
+		}
+		return domain{
+			Account:  domainInfo[0],
+			Cluster:  domainInfo[1],
+			Internal: true,
+		}, nil
+	default:
+		return domain{}, errors.New("unable to detect domain information")
+	}
+}
+
+func (d *domain) String() string {
+	if d.Internal {
+		return fmt.Sprintf("%s.%s.corp", d.Account, d.Cluster)
+	}
+
+	if d.Cluster != "" {
+		return fmt.Sprintf("%s.%s", d.Account, d.Cluster)
+	}
+
+	return d.Account
+}

--- a/internal/domain/domain_test.go
+++ b/internal/domain/domain_test.go
@@ -1,0 +1,100 @@
+//
+// Author:: Salim Afiune Maya (<afiune@lacework.net>)
+// Copyright:: Copyright 2021, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package domain_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	subject "github.com/lacework/go-sdk/internal/domain"
+)
+
+func TestDomains(t *testing.T) {
+	cases := []struct {
+		URL              string
+		expectedAccount  string
+		expectedCluster  string
+		expectedInternal bool
+		expectedString   string
+		expectedError    string
+	}{
+		{URL: "account.lacework.net",
+			expectedAccount:  "account",
+			expectedCluster:  "",
+			expectedString:   "account",
+			expectedInternal: false},
+		{URL: "account.fra.lacework.net",
+			expectedAccount:  "account",
+			expectedCluster:  "fra",
+			expectedString:   "account.fra",
+			expectedInternal: false},
+		{URL: "abc.abc.corp.lacework.net",
+			expectedAccount:  "abc",
+			expectedCluster:  "abc",
+			expectedString:   "abc.abc.corp",
+			expectedInternal: true},
+		{URL: "http://account.lacework.net",
+			expectedAccount:  "account",
+			expectedCluster:  "",
+			expectedString:   "account",
+			expectedInternal: false},
+		{URL: "https://account.lacework.net",
+			expectedAccount:  "account",
+			expectedCluster:  "",
+			expectedString:   "account",
+			expectedInternal: false},
+		{URL: "https://account.lacework.net/foo/bar",
+			expectedAccount:  "account",
+			expectedCluster:  "",
+			expectedString:   "account",
+			expectedInternal: false},
+		{URL: "https://account.fra.lacework.net",
+			expectedAccount:  "account",
+			expectedCluster:  "fra",
+			expectedString:   "account.fra",
+			expectedInternal: false},
+		{URL: "https://my-super-long-account.devc.corp.lacework.net/bubulubu",
+			expectedAccount:  "my-super-long-account",
+			expectedCluster:  "devc",
+			expectedString:   "my-super-long-account.devc.corp",
+			expectedInternal: true},
+
+		// Errors!!!!
+		{URL: "account.lacework.com",
+			expectedError: "domain not supported"},
+		{URL: "account.c.not-corp.lacework.net",
+			expectedError: "unable to detect if domain is internal"},
+		{URL: "too.many.sub.domains.corp.lacework.net",
+			expectedError: "unable to detect domain information"},
+	}
+	for i, kase := range cases {
+		t.Run(fmt.Sprintf("test case %d", i), func(t *testing.T) {
+			d, err := subject.New(kase.URL)
+			if err != nil {
+				assert.Equal(t, kase.expectedError, err.Error())
+			}
+			assert.Equal(t, kase.expectedAccount, d.Account)
+			assert.Equal(t, kase.expectedCluster, d.Cluster)
+			assert.Equal(t, kase.expectedInternal, d.Internal)
+			assert.Equal(t, kase.expectedString, d.String())
+		})
+	}
+}


### PR DESCRIPTION
This change also adds a global flag `--subaccount` to switch between
accounts. (ALLY-378)

**User Story**
As a Lacework CLI User, I would like to avoid introducing my account and
sub-account information, So that I don't do any mistakes and my CLI
configuration is faster.

**Description**
The Lacework CLI needs to understand the new JSON fields that users can
download from their accounts:
```json
{
  "keyId": "MINIALLY_138DB0DAA9084BD93E50F587A58DEA572E543A5C8C20006",
  "secret": "_f28a1c84014f34b948422395fb0691f3",
  "subAccount": "mini-ally",
  "account": "customerdemo.lacework.net"
}
```
The two new fields, `account`, and `subAccount`, will be stored inside
the configuration file stored at `~/.lacework.toml` and marked as
`version 2`
```toml
[default]
  account = "CORP"
  subaccount = "CORP-PROD"
  api_key = "CORP_A3C8910D0BDCDBD7AFD4355A1C5284104AAA2AE5953938C"
  api_secret = "_1234abca752e65f94651bcb6e6c798f1"
  version = 2
```

This change is backward compatible with the previous JSON format for
API keys as well as previous profiles inside the configuration file.

**Acceptance Criteria**
After completing this task, new Lacework CLI users that download the new
JSON format of an API key from the UI will be able to configure the CLI
without any human interaction (since all necessary fields are already
inside the JSON file).

Additionally, old profiles configured should continue to work.

JIRA: ALLY-374

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>