### PR TITLE
fix: Fix vuln container list-assessments json output

### DIFF
--- a/integration/container_vulnerability_test.go
+++ b/integration/container_vulnerability_test.go
@@ -61,11 +61,7 @@ func TestContainerVulnerabilityCommandListRegistries(t *testing.T) {
 		"EXITCODE is not the expected one")
 }
 
-// !!! DISABLE TEST !!!        :sadpanda:
-//
-// We will re-enable them with https://github.com/lacework/go-sdk/issues/399
-//
-func _TestContainerVulnerabilityCommandListAssessments(t *testing.T) {
+func TestContainerVulnerabilityCommandListAssessments(t *testing.T) {
 	out, err, exitcode := LaceworkCLIWithTOMLConfig("vulnerability", "container", "list-assessments")
 	expectedHeaders := []string{
 		"REGISTRY",
@@ -99,6 +95,58 @@ func _TestContainerVulnerabilityCommandListAssessments(t *testing.T) {
 		for _, field := range expectedFields {
 			assert.Contains(t, out.String(), field,
 				"STDOUT table does not contain the '"+field+"' field")
+		}
+	})
+}
+
+func TestContainerVulnerabilityCommandListAssessmentsJson(t *testing.T) {
+	out, err, exitcode := LaceworkCLIWithTOMLConfig("vulnerability", "container", "list-assessments", "--json")
+	expectedJsonKeys := []string{
+		"eval_guid",
+		"eval_status",
+		"eval_type",
+		"image_created_time",
+		"image_digest",
+		"image_id",
+		"image_namespace",
+		"image_registry",
+		"image_repo",
+		"image_scan_error_msg",
+		"image_scan_status",
+		"image_scan_time",
+		"image_size",
+		"image_tags",
+		"ndv_containers",
+		"num_fixes",
+		"num_vulnerabilities_severity_1",
+		"num_vulnerabilities_severity_2",
+		"num_vulnerabilities_severity_3",
+		"num_vulnerabilities_severity_4",
+		"num_vulnerabilities_severity_5",
+		"start_time",
+	}
+	t.Run("verify json keys", func(t *testing.T) {
+		for _, header := range expectedJsonKeys {
+			assert.Contains(t, out.String(), header,
+				"STDOUT json keys changed, please check")
+		}
+	})
+	assert.Empty(t,
+		err.String(),
+		"STDERR should be empty")
+	assert.Equal(t, 0, exitcode,
+		"EXITCODE is not the expected one")
+
+	expectedFields := []string{
+		registry,
+		dirtyRepository,
+		"Success", // status
+		"sha256:", // image digest
+	}
+	t.Run("verify json fields", func(t *testing.T) {
+		for _, field := range expectedFields {
+			assert.Contains(t, out.String(), field,
+				"STDOUT json output does not contain the '"+field+"' field")
 		}
 	})
 }


### PR DESCRIPTION
`lacework vuln ctr list-assessments --json` 

json output was attempting to use a struct with unexported fields. 
The filter function has been changed to return []api.VulnContainerAssessmentSummary which is then passed to the json output.

Logic to transform assessment data to the table format has been moved to assessmentSummaryToOutputFormat() and called inside vulAssessmentsToTable()

Added new test TestContainerVulnerabilityCommandListAssessmentsJson 
Reenabled TestContainerVulnerabilityCommandListAssessments

JIRA : [ALLY-509](https://lacework.atlassian.net/browse/ALLY-509)

Signed-off-by: Darren Murray <darren.murray@lacework.net>