### PR TITLE
feat(cli): Automate migration of v2 configuration

### DIFF
--- a/api/account_test.go
+++ b/api/account_test.go
@@ -47,7 +47,8 @@ func TestAccountOrganizationInfoForStandalone(t *testing.T) {
 	assert.Nil(t, err)
 	if assert.NotNil(t, response) {
 		assert.False(t, response.OrgAccount)
-		assert.Empty(t, response.OrgAccountName)
+		assert.Empty(t, response.OrgAccountURL)
+		assert.Empty(t, response.AccountName())
 	}
 }
 
@@ -69,7 +70,8 @@ func TestAccountOrganizationInfoForOrganizational(t *testing.T) {
 	assert.Nil(t, err)
 	if assert.NotNil(t, response) {
 		assert.True(t, response.OrgAccount)
-		assert.Equal(t, "test-org", response.OrgAccountName)
+		assert.Equal(t, "test-org", response.AccountName())
+		assert.Equal(t, "test-org.lacework.net", response.OrgAccountURL)
 	}
 }
 
@@ -80,6 +82,6 @@ func accountOrganizationInfoResponseStandalone() string {
 func accountOrganizationInfoResponseOrganizational(name string) string {
 	return `{
   "orgAccount": true,
-  "orgAccountName": "` + name + `"
+  "orgAccountUrl": "` + name + `.lacework.net"
 }`
 }

--- a/cli/cmd/cli_state.go
+++ b/cli/cmd/cli_state.go
@@ -160,7 +160,7 @@ func (c *cliState) LoadProfiles() (lwconfig.Profiles, error) {
 	return lwconfig.LoadProfilesFrom(confPath)
 }
 
-// VerifySettings checks if the CLI state has the neccessary settings to run,
+// VerifySettings checks if the CLI state has the necessary settings to run,
 // if not, it throws an error with breadcrumbs to help the user configure the CLI
 func (c *cliState) VerifySettings() error {
 	c.Log.Debugw("verifying config", "version", c.CfgVersion)

--- a/cli/cmd/file.go
+++ b/cli/cmd/file.go
@@ -16,34 +16,15 @@
 // limitations under the License.
 //
 
-package api
+package cmd
 
-import "github.com/lacework/go-sdk/internal/domain"
+import "os"
 
-// AccountService is a service that interacts with Account related
-// endpoints from the Lacework Server
-type AccountService struct {
-	client *Client
-}
-
-func (svc *AccountService) GetOrganizationInfo() (
-	response accountOrganizationInfoResponse,
-	err error,
-) {
-	err = svc.client.RequestDecoder("GET",
-		apiAccountOrganizationInfo,
-		nil,
-		&response,
-	)
-	return
-}
-
-type accountOrganizationInfoResponse struct {
-	OrgAccount    bool   `json:"orgAccount"`
-	OrgAccountURL string `json:"orgAccountUrl,omitempty"`
-}
-
-func (r accountOrganizationInfoResponse) AccountName() string {
-	d, _ := domain.New(r.OrgAccountURL)
-	return d.String()
+// fileExists checks if a file exists and is not a directory
+func fileExists(filename string) bool {
+	f, err := os.Stat(filename)
+	if os.IsNotExist(err) {
+		return false
+	}
+	return !f.IsDir()
 }

--- a/cli/cmd/file_test.go
+++ b/cli/cmd/file_test.go
@@ -16,34 +16,32 @@
 // limitations under the License.
 //
 
-package api
+package cmd
 
-import "github.com/lacework/go-sdk/internal/domain"
+import (
+	"io/ioutil"
+	"os"
+	"testing"
 
-// AccountService is a service that interacts with Account related
-// endpoints from the Lacework Server
-type AccountService struct {
-	client *Client
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFileExistsWhenFileActuallyExists(t *testing.T) {
+	file, err := ioutil.TempFile("", "bar")
+	if assert.Nil(t, err) {
+		assert.True(t, fileExists(file.Name()))
+		os.Remove(file.Name())
+	}
 }
 
-func (svc *AccountService) GetOrganizationInfo() (
-	response accountOrganizationInfoResponse,
-	err error,
-) {
-	err = svc.client.RequestDecoder("GET",
-		apiAccountOrganizationInfo,
-		nil,
-		&response,
-	)
-	return
+func TestFileExistsWhenFileIsADirectory(t *testing.T) {
+	dir, err := ioutil.TempDir("", "bar")
+	if assert.Nil(t, err) {
+		assert.False(t, fileExists(dir))
+		os.RemoveAll(dir)
+	}
 }
 
-type accountOrganizationInfoResponse struct {
-	OrgAccount    bool   `json:"orgAccount"`
-	OrgAccountURL string `json:"orgAccountUrl,omitempty"`
-}
-
-func (r accountOrganizationInfoResponse) AccountName() string {
-	d, _ := domain.New(r.OrgAccountURL)
-	return d.String()
+func TestFileExistsWhenFileDoesNotExists(t *testing.T) {
+	assert.False(t, fileExists("file.name"))
 }

--- a/cli/cmd/honeyvent.go
+++ b/cli/cmd/honeyvent.go
@@ -82,6 +82,9 @@ const (
 
 	// Split package manifest feature
 	featSplitPkgManifest = "split_pkg_manifest"
+
+	// Migration API v1 -> v2 feature
+	featMigrateConfigV2 = "migrate_config_v2"
 )
 
 // Honeyvent defines what a Honeycomb event looks like for the Lacework CLI

--- a/cli/cmd/migration.go
+++ b/cli/cmd/migration.go
@@ -1,0 +1,168 @@
+//
+// Author:: Salim Afiune Maya (<afiune@lacework.net>)
+// Copyright:: Copyright 2021, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/viper"
+
+	"github.com/lacework/go-sdk/lwconfig"
+)
+
+// The name of the directory we will store backups of configuration files before migrating them
+const ConfigBackupDir = "cfg_backups"
+
+// Migrations executes automatic configuration migrations,
+// if a configuration file does not exist, it will only update
+// the CLI state to the appropriate parameters
+func (c *cliState) Migrations() (err error) {
+	if !needMigration() {
+		return nil
+	}
+
+	c.Log.Debugw("executing v2 migration")
+	c.Event.Feature = featMigrateConfigV2
+	defer func() {
+		if err == nil {
+			c.SendHoneyvent()
+		} else {
+			err = errors.Wrap(err, "during v2 migration")
+		}
+
+		// update global honeyvent with updated state
+		c.Event.Account = c.Account
+		c.Event.Subaccount = c.Subaccount
+		c.Event.CfgVersion = c.CfgVersion
+	}()
+
+	err = c.VerifySettings()
+	if err != nil {
+		return err
+	}
+
+	orgInfo, err := c.LwApi.Account.GetOrganizationInfo()
+	if err != nil {
+		return err
+	}
+
+	// set new v2 config version and notify our feature event
+	c.CfgVersion = 2
+	c.Event.AddFeatureField("config_version", c.CfgVersion)
+	c.Event.AddFeatureField("org_account", orgInfo.OrgAccount)
+	// NOTE: @afiune this will be a constant pattern below where
+	// we will update settings and notify the feature event
+
+	if orgInfo.OrgAccount {
+		// we only need to update the account/sub-account
+		// if the user has an organizational account
+		c.Log.Debugw("organizational account detected")
+		c.Event.AddFeatureField("org_account_url", orgInfo.OrgAccountURL)
+
+		primaryAccount := strings.ToLower(orgInfo.AccountName())
+
+		// if the user is accessing a sub-account, that is, if the current
+		// account is different from the primary account name, set it as
+		// a what it is, the sub-account
+		if primaryAccount != c.Account {
+			c.Log.Debugw("updating account settings for APIv2",
+				"old_account", c.Account,
+				"new_account", primaryAccount,
+			)
+			c.Subaccount = c.Account
+			c.Account = primaryAccount
+
+			c.Event.AddFeatureField("account", c.Account)
+			c.Event.AddFeatureField("subaccount", c.Subaccount)
+
+			c.Log.Debugw("generating new API client")
+			err = c.NewClient()
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	// if the configuration file does not exist, most likely the user
+	// is executing the CLI via env variables or flags, update feature
+	// field and exit migration
+	if !fileExists(viper.ConfigFileUsed()) {
+		c.Log.Debugw("config file not found, skipping profile migration")
+		c.Event.AddFeatureField("config_file", "not_found")
+		return nil
+	}
+
+	c.Log.Debugw("config found, migrating profile", "profile", c.Profile)
+	migratedProfile := lwconfig.Profile{
+		Account:    c.Account,
+		Subaccount: c.Subaccount,
+		ApiKey:     c.KeyID,
+		ApiSecret:  c.Secret,
+		Version:    c.CfgVersion,
+	}
+
+	// create a backup before modifying the user's configuration
+	bkpPath, err := createConfigurationBackup()
+	if err != nil {
+		return err
+	}
+	c.Log.Debugw("configuration backup", "path", bkpPath)
+	c.Event.AddFeatureField("backup_file", path.Base(bkpPath))
+
+	// store the migrated profile
+	err = lwconfig.StoreProfileAt(viper.ConfigFileUsed(), c.Profile, migratedProfile)
+	if err != nil {
+		return errors.Wrap(err, "unable to store migrated profile")
+	}
+
+	c.Log.Debugw("configuration migrated successfully")
+	return nil
+}
+
+func createConfigurationBackup() (string, error) {
+	profiles, err := lwconfig.LoadProfilesFrom(viper.ConfigFileUsed())
+	if err != nil {
+		return "", err
+	}
+
+	cacheDir, err := versionCacheDir()
+	if err != nil {
+		return "", err
+	}
+
+	backupDir := path.Join(cacheDir, ConfigBackupDir)
+	if err := os.MkdirAll(backupDir, 0755); err != nil {
+		return "", err
+	}
+
+	backupCfgPath := path.Join(backupDir,
+		fmt.Sprintf(".lacework.toml.%s.%s.bkp",
+			time.Now().Format("20060102150405"), newID()),
+	)
+	return backupCfgPath, lwconfig.StoreAt(backupCfgPath, profiles)
+}
+
+func needMigration() bool {
+	return cli.CfgVersion != 2 // &&
+}

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -64,7 +64,13 @@ This will prompt you for your Lacework account and a set of API access keys.`,
 				if cmd.HasParent() && cmd.Parent().Use == "configure" {
 					return nil
 				}
-				return cli.NewClient()
+
+				if err := cli.NewClient(); err != nil {
+					return err
+				}
+
+				// @afiune execute any necessary migration, if any
+				return cli.Migrations()
 			}
 		},
 		PersistentPostRunE: func(cmd *cobra.Command, _ []string) error {

--- a/cli/cmd/version.go
+++ b/cli/cmd/version.go
@@ -124,7 +124,7 @@ func dailyVersionCheck() error {
 	}
 
 	cacheFile := path.Join(cacheDir, VersionCacheFile)
-	if _, err := os.Stat(cacheFile); os.IsNotExist(err) {
+	if !fileExists(cacheFile) {
 		// first time running the daily version check, create directory
 		if err := os.MkdirAll(cacheDir, 0755); err != nil {
 			return err

--- a/integration/migration_test.go
+++ b/integration/migration_test.go
@@ -1,0 +1,109 @@
+//
+// Author:: Salim Afiune Maya (<afiune@lacework.net>)
+// Copyright:: Copyright 2021, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package integration
+
+import (
+	"io/ioutil"
+	"os"
+	"path"
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestV2MigrationWithConfigFile(t *testing.T) {
+	// create a temporal directory to use it as our home directory to test
+	// the version_cache mechanism
+	home := createTOMLConfigFromCIvars()
+	defer os.RemoveAll(home)
+
+	out, err, exitcode := LaceworkCLIWithHome(home, "agent", "token", "list")
+	assert.Equal(t, 0, exitcode,
+		"EXITCODE is not the expected one")
+	assert.Empty(t,
+		err.String(),
+		"STDERR should be empty")
+	assert.NotEmpty(t,
+		out.String(),
+		"STDOUT should not be empty")
+
+	// @afiune the command is not really important but the actual result in the config
+
+	t.Run("check the backup dir", func(t *testing.T) {
+		backupsDir := path.Join(home, ".config", "lacework", "cfg_backups")
+		if assert.DirExists(t, backupsDir, "the config backups directory is missing") {
+
+			f, _ := os.Open(backupsDir)
+			defer f.Close()
+
+			fileNames, _ := f.Readdirnames(0)
+			if assert.Equal(t, 1, len(fileNames), "a single backup should exist") {
+				assert.Regexpf(t, regexp.MustCompile(".lacework.toml.*.*.bkp"), fileNames[0], "backup config file mismatch")
+			}
+		}
+	})
+
+	t.Run("check migrated config file", func(t *testing.T) {
+		configPath := path.Join(home, ".lacework.toml")
+		if assert.FileExists(t, configPath, "the configuration file is missing") {
+			laceworkTOML, err := ioutil.ReadFile(configPath)
+			if assert.Nil(t, err) {
+				laceworkTOMLString := string(laceworkTOML)
+				assert.Contains(t, laceworkTOMLString, "account", "there is a problem with the v2 migrated config")
+				assert.Contains(t, laceworkTOMLString, "subaccount", "there is a problem with the v2 migrated config") // only for our tech-ally account
+				assert.Contains(t, laceworkTOMLString, "api_key", "there is a problem with the v2 migrated config")
+				assert.Contains(t, laceworkTOMLString, "api_secret", "there is a problem with the v2 migrated config")
+				assert.Contains(t, laceworkTOMLString, "version = 2", "there is a problem with the v2 migrated config")
+			}
+		}
+	})
+}
+
+func TestV2MigrationWithFlagsOrEnvVariables(t *testing.T) {
+	home, errDir := ioutil.TempDir("", "lacework-cli")
+	if errDir != nil {
+		panic(errDir)
+	}
+	defer os.RemoveAll(home)
+
+	out, err, exitcode := LaceworkCLIWithHome(home, "agent", "token", "list",
+		"-a", os.Getenv("CI_ACCOUNT"), "-k", os.Getenv("CI_API_KEY"), "-s", os.Getenv("CI_API_SECRET"),
+	)
+	assert.Equal(t, 0, exitcode,
+		"EXITCODE is not the expected one")
+	assert.Empty(t,
+		err.String(),
+		"STDERR should be empty")
+	assert.NotEmpty(t,
+		out.String(),
+		"STDOUT should not be empty")
+
+	// @afiune the command is not really important but the actual result in the config
+
+	t.Run("check the backup dir", func(t *testing.T) {
+		backupsDir := path.Join(home, ".config", "lacework", "cfg_backups")
+		assert.NoDirExists(t, backupsDir, "the config backups directory should not exist")
+	})
+
+	t.Run("check migrated config file", func(t *testing.T) {
+		configPath := path.Join(home, ".lacework.toml")
+		assert.NoFileExists(t, configPath, "the configuration file should not exist")
+	})
+}

--- a/internal/domain/domain_test.go
+++ b/internal/domain/domain_test.go
@@ -78,6 +78,8 @@ func TestDomains(t *testing.T) {
 			expectedInternal: true},
 
 		// Errors!!!!
+		{URL: "",
+			expectedError: "domain not supported"},
 		{URL: "account.lacework.com",
 			expectedError: "domain not supported"},
 		{URL: "account.c.not-corp.lacework.net",

--- a/lwconfig/config.go
+++ b/lwconfig/config.go
@@ -130,8 +130,21 @@ func StoreProfileAt(configPath, name string, profile Profile) error {
 	}
 
 	profiles[name] = profile
+	return StoreAt(configPath, profiles)
+}
+
+// StoreAt stores the provided profiles into the selected configuration file
+func StoreAt(configPath string, profiles Profiles) error {
+	if configPath == "" {
+		defaultPath, err := DefaultConfigPath()
+		if err != nil {
+			return err
+		}
+		configPath = defaultPath
+	}
+
 	var buf = new(bytes.Buffer)
-	if err = toml.NewEncoder(buf).Encode(profiles); err != nil {
+	if err := toml.NewEncoder(buf).Encode(profiles); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
**User Story**
As a Lacework CLI User, I won't like to be disrupted during the
migration of the Lacework CLI from APIv1 to APIv2, So I can
continue accessing my Lacework data at all times and I don't have
to reconfigure all my profiles.

**Feature Description**
During the migration of our tools and integrations (in this case,
the Lacework CLI) we won't disrupt any of our customers, instead,
we are codifying and automating the migration by steps, tiny steps
that won't be noticed by our customers.

The first step of our plan is to automate the migration of the
configuration of existing customers so that the Lacework CLI can access
both, APIv1 and APIv2 at the same time for a short period of time (while
we slowly migrate existing functionality to APIv2). To do that, we send
an APIv1 request that describes the type of Lacework Account that our
customers have, there are two types, standalone accounts, and
organizational accounts.

For standalone accounts, the new configuration version 2 might look
practically the same as version 1, but the fact that we add the version
to the configuration will indicate that we no longer need to migrate it.

Example of version 1 standalone config:
```toml
[default]
  account = "standalone"
  api_key = "STANDALONE_13C8910D0BDCDBD7AFD4355A1C5284104AAA2AE5953938C"
  api_secret = "_123abc32a752e5f94651bcb6e6c798f1"
```

Example of version 2 standalone config:
```toml
[default]
  account = "standalone"
  api_key = "STANDALONE_13C8910D0BDCDBD7AFD4355A1C5284104AAA2AE5953938C"
  api_secret = "_123abc32a752e5f94651bcb6e6c798f1"
  version = 2
```

For organizational accounts, the new configuration version 2 will have a
new field named `subaccount`, and the field account will change to point
to the primary account (unique account URL).

Example of version 1 organizational account config:
```toml
[default]
  account = "sub-account"
  api_key = "SUBACCOUNT_13C8910D0BDCDBD7AFD4355A1C5284104AAA2AE5953938C"
  api_secret = "_123abc32a752e5f94651bcb6e6c798f1"
```

Example of version 2 standalone config:
```toml
[default]
  account = "org-account"
  subaccount = "sub-account"
  api_key = "SUBACCOUNT_13C8910D0BDCDBD7AFD4355A1C5284104AAA2AE5953938C"
  api_secret = "_123abc32a752e5f94651bcb6e6c798f1"
  version = 2
```

For more details, refer to the migration document of the EPIC.

**Acceptance Criteria**
Users using this feature will start the process of migrating their
Lacework CLI configuration. If we do this right, our customers won't
notice that this change happened. Additionally, we will be able to start
leveraging APIv2 endpoints from this new version of the CLI.

This ticket adds a new Honeycomb Feature Event (metric) to detect
when customers have been migrated to the new CLI configuration v2.

Feature Name: `migrate_config_v2`

JIRA https://lacework.atlassian.net/browse/ALLY-376

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>