### PR TITLE
fix(cli): adding more policy keys for json output

### DIFF
--- a/api/policy.go
+++ b/api/policy.go
@@ -42,13 +42,18 @@ type PolicyResponse struct {
 }
 
 type Policy struct {
-	ID           string `json:"policy_id"`
-	Title        string `json:"title"`
-	Enabled      bool   `json:"enabled"`
-	AlertEnabled bool   `json:"alert_enabled"`
-	Frequency    string `json:"eval_frequency"`
-	Severity     string `json:"severity"`
-	QueryID      string `json:"lql_id"`
+	ID           string                 `json:"policy_id"`
+	Title        string                 `json:"title"`
+	Enabled      bool                   `json:"enabled"`
+	AlertEnabled bool                   `json:"alert_enabled"`
+	Frequency    string                 `json:"eval_frequency"`
+	Severity     string                 `json:"severity"`
+	QueryID      string                 `json:"lql_id"`
+	AlertProfile string                 `json:"alert_profile"`
+	Limit        int                    `json:"limit"`
+	Description  string                 `json:"description"`
+	Remediation  string                 `json:"remediation"`
+	Properties   map[string]interface{} `json:"properties"`
 }
 
 func (svc *PolicyService) Create(policy string) (


### PR DESCRIPTION
ALLY-506

```
❯ lacework-dev policy show lacework-custom-4 -p dev7 --json
[
  {
    "alert_enabled": true,
    "alert_profile": "LW_CloudTrail_Alerts.CloudTrailDefaultAlert_AwsResource",
    "description": "A KMS change occurred",
    "enabled": true,
    "eval_frequency": "Hourly",
    "limit": 100,
    "lql_id": "LW_Custom_AWS_CTA_KMSChange",
    "policy_id": "lacework-custom-4",
    "properties": {
      "policy_ui": {
        "domain": "AWS",
        "subdomain": "CloudTrail"
      }
    },
    "remediation": "Check the KMS change and ensure only specified users can make KMS changes",
    "severity": "high",
    "title": "KMS Change"
  }
]
```