### PR TITLE
fix(cli): better error messaging for policy create

### DIFF
--- a/api/policy.go
+++ b/api/policy.go
@@ -57,6 +57,7 @@ func (svc *PolicyService) Create(policy string) (
 ) {
 	var p map[string]interface{}
 	if err = json.Unmarshal([]byte(policy), &p); err != nil {
+		err = errors.Wrap(err, "policy must be valid JSON")
 		return
 	}
 	err = svc.client.RequestEncoderDecoder("POST", apiPolicy, p, &response)
@@ -87,6 +88,7 @@ func (svc *PolicyService) Update(policyID, policy string) (
 ) {
 	var p map[string]interface{}
 	if err = json.Unmarshal([]byte(policy), &p); err != nil {
+		err = errors.Wrap(err, "policy must be valid JSON")
 		return
 	}
 

--- a/api/policy_test.go
+++ b/api/policy_test.go
@@ -116,7 +116,7 @@ func TestPolicyCreateBadInput(t *testing.T) {
 	assert.Nil(t, err)
 
 	_, err = c.Policy.Create("")
-	assert.Equal(t, "unexpected end of JSON input", err.Error())
+	assert.Equal(t, "policy must be valid JSON: unexpected end of JSON input", err.Error())
 }
 
 func TestPolicyCreateOK(t *testing.T) {


### PR DESCRIPTION
If policy input does not `json.Unmarshal` wrap a the error with `policy must be valid JSON`

ALLY-507