### PR TITLE
feat(cli): new account list command

### DIFF
--- a/cli/cmd/account.go
+++ b/cli/cmd/account.go
@@ -1,0 +1,88 @@
+//
+// Author:: Salim Afiune Maya (<afiune@lacework.net>)
+// Copyright:: Copyright 2021, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var (
+	// accountCmd represents the account command
+	accountCmd = &cobra.Command{
+		Use:     "account",
+		Aliases: []string{"accounts", "acc", "org"},
+		Short:   "manage accounts in an organization (org admins only)",
+		Long: `Manage accounts inside your Lacework organization.
+
+An organization can contain multiple accounts so you can also manage components
+such as alerts, resource groups, team members, and audit logs at a more granular
+level inside an organization. A team member may have access to multiple accounts
+and can easily switch between them.
+
+To enroll your Lacework account in an organization follow the documentation:
+
+  https://support.lacework.com/hc/en-us/articles/360041727394-Organization-Overview
+    `,
+	}
+
+	// accountListCmd represents the list command inside the account command
+	accountListCmd = &cobra.Command{
+		Use:     "list",
+		Aliases: []string{"ls"},
+		Short:   "list all accounts",
+		Long:    `List all accounts in your organization.`,
+		Args:    cobra.NoArgs,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			cli.StartProgress(" Loading account information ...")
+			user, err := cli.LwApi.V2.UserProfile.Get()
+			cli.StopProgress()
+			if err != nil {
+				return err
+			}
+
+			if cli.JSONOutput() {
+				return cli.OutputJSON(user.Data)
+			}
+
+			if len(user.Data) == 0 {
+				return yikes("unable to load account information.")
+			}
+
+			profile := user.Data[0]
+			if !profile.OrgAccount {
+				cli.OutputHuman("Your account is not enrolled in an organization.\n")
+				return nil
+			}
+
+			rows := [][]string{{profile.OrgAccountName()}}
+			for _, acc := range profile.SubAccountNames() {
+				rows = append(rows, []string{acc})
+			}
+
+			cli.OutputHuman(renderSimpleTable([]string{"Accounts"}, rows))
+			cli.OutputHuman("\nUse '--subaccount <name>' to switch any command to a different account.\n")
+			return nil
+		},
+	}
+)
+
+func init() {
+	rootCmd.AddCommand(accountCmd)
+	accountCmd.AddCommand(accountListCmd)
+}

--- a/cli/cmd/account.go
+++ b/cli/cmd/account.go
@@ -26,7 +26,7 @@ var (
 	// accountCmd represents the account command
 	accountCmd = &cobra.Command{
 		Use:     "account",
-		Aliases: []string{"accounts", "acc", "org"},
+		Aliases: []string{"accounts", "acc"},
 		Short:   "manage accounts in an organization (org admins only)",
 		Long: `Manage accounts inside your Lacework organization.
 

--- a/integration/account_test.go
+++ b/integration/account_test.go
@@ -1,0 +1,58 @@
+//
+// Author:: Salim Afiune Maya (<afiune@lacework.net>)
+// Copyright:: Copyright 2021, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package integration
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAccountCommandAliases(t *testing.T) {
+	// lacework account
+	out, err, exitcode := LaceworkCLI("help", "account")
+	assert.Contains(t, out.String(), "lacework account")
+	assert.Empty(t, err.String(), "STDERR should be empty")
+	assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
+
+	// lacework account list
+	out, err, exitcode = LaceworkCLI("help", "acc", "ls")
+	assert.Contains(t, out.String(), "lacework account list [flags]")
+	assert.Empty(t, err.String(), "STDERR should be empty")
+	assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
+}
+
+func TestAccountCommandList(t *testing.T) {
+	out, err, exitcode := LaceworkCLIWithTOMLConfig("account", "list")
+	assert.Contains(t, out.String(), "ACCOUNTS",
+		"STDOUT table headers changed, please check")
+	assert.Contains(t, out.String(), os.Getenv("CI_ACCOUNT"),
+		"STDOUT unable to find account, please check")
+	assert.Contains(t, out.String(), os.Getenv("CI_V2_ACCOUNT"),
+		"STDOUT unable to find account, please check")
+	assert.Contains(t, out.String(),
+		"Use '--subaccount <name>' to switch any command to a different account.",
+		"STDOUT wrong breadcrumbs, please check")
+	assert.Empty(t,
+		err.String(),
+		"STDERR should be empty")
+	assert.Equal(t, 0, exitcode,
+		"EXITCODE is not the expected one")
+}

--- a/integration/help_test.go
+++ b/integration/help_test.go
@@ -142,6 +142,7 @@ Usage:
 
 Available Commands:
   access-token  generate temporary API access tokens
+  account       manage accounts in an organization (org admins only)
   agent         manage Lacework agents
   api           helper to call Lacework's API
   compliance    manage compliance reports


### PR DESCRIPTION
**User Story**

As a Lacework CLI user,
I would like to have a way to describe what sub-accounts can I manage,
So I can easily switch between them and avoid having to log in to the
UI to know the name of my sub-accounts.

**Description**

We need to add a new command to manage organizational accounts. This new
command will list all accounts that the user can manage.
```
$ lacework account list
```

In the future, this new command could leverage new APIv2 endpoints to
create new sub-accounts or update them, just like the UI does.
```
$ lacework account create
```

**Acceptance Criteria**

After completing this ticket, the user will have a way (new CLI command)
to list all accounts that he or she manages.

JIRA: ALLY-380

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>