### PR TITLE
fix(cli): migration of Frankfurt organizational accounts

### DIFF
--- a/cli/cmd/migration.go
+++ b/cli/cmd/migration.go
@@ -84,12 +84,21 @@ func (c *cliState) Migrations() (err error) {
 
 		// if the user is accessing a sub-account, that is, if the current
 		// account is different from the primary account name, set it as
-		// a what it is, the sub-account
+		// what it is, the sub-account
 		if primaryAccount != c.Account {
 			c.Log.Debugw("updating account settings for APIv2",
 				"old_account", c.Account,
 				"new_account", primaryAccount,
 			)
+
+			// ALLY-541: Frankfurt accounts will have the account as 'account.fra',
+			//           we need to remove the .fra domain to use it as a subaccount
+			if strings.Contains(c.Account, ".") {
+				c.Log.Debugw("subaccount needs cleanup", "subaccount", c.Account)
+				accSplit := strings.Split(c.Account, ".")
+				c.Account = accSplit[0]
+			}
+
 			c.Subaccount = c.Account
 			c.Account = primaryAccount
 

--- a/internal/domain/domain_test.go
+++ b/internal/domain/domain_test.go
@@ -80,6 +80,10 @@ func TestDomains(t *testing.T) {
 		// Errors!!!!
 		{URL: "",
 			expectedError: "domain not supported"},
+		{URL: "account.cluster",
+			expectedError: "domain not supported"},
+		{URL: "account.cluster.corp",
+			expectedError: "domain not supported"},
 		{URL: "account.lacework.com",
 			expectedError: "domain not supported"},
 		{URL: "account.c.not-corp.lacework.net",


### PR DESCRIPTION
During a migration of Frankfurt organizational accounts, we needed to
cleanup the cluster name from the account before using it as a
sub-account. This PR is adding that cleanup.

For testing purposes, add the `--debug` flag to see the following log
messages:
```
{"level":"debug","ts":"2021-06-16T11:04:24-07:00","caller":"cmd/migration.go:89","msg":"updating account settings for APIv2","old_account":"subaccount.fra","new_account":"account.fra"}
{"level":"debug","ts":"2021-06-16T11:04:24-07:00","caller":"cmd/migration.go:97","msg":"subaccount needs cleanup","subaccount":"subaccount.fra"}
```

**JIRA: ALLY-541**

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>