### PR TITLE
feat(api): propagate APIv2 error messages

### DIFF
--- a/api/errors.go
+++ b/api/errors.go
@@ -32,8 +32,9 @@ type errorResponse struct {
 }
 
 type apiErrorResponse struct {
-	Ok   bool `json:"ok"`
-	Data struct {
+	Ok        bool   `json:"ok"`
+	V2Message string `json:"message"`
+	Data      struct {
 		Message       string `json:"message"`
 		StatusMessage string `json:"statusMessage"`
 		ErrorMsg      string `json:"ErrorMsg"`
@@ -43,11 +44,14 @@ type apiErrorResponse struct {
 // Message extracts the message from an api error response
 func (r *apiErrorResponse) Message() string {
 	if r != nil {
+		if r.Data.ErrorMsg != "" {
+			return r.Data.ErrorMsg
+		}
 		if r.Data.Message != "" {
 			return r.Data.Message
 		}
-		if r.Data.ErrorMsg != "" {
-			return r.Data.ErrorMsg
+		if r.V2Message != "" && r.V2Message != "SUCCESS" {
+			return r.V2Message
 		}
 		if r.Data.StatusMessage != "" {
 			return r.Data.StatusMessage

--- a/cli/cmd/package_manifest_test.go
+++ b/cli/cmd/package_manifest_test.go
@@ -160,7 +160,7 @@ func TestFanOutHostScans(t *testing.T) {
 	subject, err = fanOutHostScans(&api.PackageManifest{})
 	if assert.NotNil(t, err) {
 		assert.Contains(t, err.Error(),
-			"[403] Forbidden", // intentional error since we are mocking the api token
+			"[403] Unauthorized Access", // intentional error since we are mocking the api token
 		)
 	}
 	assert.Equal(t, api.HostVulnScanPkgManifestResponse{}, subject)


### PR DESCRIPTION
New APIv2 endpoints contain the error message inside the `message`
field at the top level of the JSON response, we will now propagate this
message.

Example API v2 error response:
```
{
  "message": "This is an APIv2 error messages. Catch it!"
}
```
Signed-off-by: Salim Afiune Maya <afiune@lacework.net>