### PR TITLE
refactor(cli): Switch the creation of Cloudtrail Integrations to APIv2

### DIFF
--- a/cli/cmd/cli_state.go
+++ b/cli/cmd/cli_state.go
@@ -196,6 +196,11 @@ func (c *cliState) NewClient() error {
 		apiOpts = append(apiOpts, api.WithApiV2())
 	}
 
+	if c.OrgLevel {
+		c.Log.Debug("accessing organization level data sets")
+		apiOpts = append(apiOpts, api.WithOrgAccess())
+	}
+
 	if os.Getenv("LW_API_SERVER_URL") != "" {
 		apiOpts = append(apiOpts, api.WithURL(os.Getenv("LW_API_SERVER_URL")))
 	}
@@ -317,6 +322,11 @@ func (c *cliState) loadStateFromViper() {
 	if v := viper.GetString("subaccount"); v != "" {
 		c.Subaccount = v
 		c.Log.Debugw("state updated", "subaccount", c.Subaccount)
+	}
+
+	if viper.GetBool("organization") {
+		c.OrgLevel = true
+		c.Log.Debugw("state updated", "organization", "true")
 	}
 }
 

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -149,6 +149,9 @@ func init() {
 	rootCmd.PersistentFlags().String("subaccount", "",
 		"sub-account name inside your organization (org admins only)",
 	)
+	rootCmd.PersistentFlags().Bool("organization", false,
+		"access organization level data sets (org admins only)",
+	)
 
 	errcheckWARN(viper.BindPFlag("debug", rootCmd.PersistentFlags().Lookup("debug")))
 	errcheckWARN(viper.BindPFlag("nocolor", rootCmd.PersistentFlags().Lookup("nocolor")))
@@ -159,6 +162,7 @@ func init() {
 	errcheckWARN(viper.BindPFlag("api_key", rootCmd.PersistentFlags().Lookup("api_key")))
 	errcheckWARN(viper.BindPFlag("api_secret", rootCmd.PersistentFlags().Lookup("api_secret")))
 	errcheckWARN(viper.BindPFlag("subaccount", rootCmd.PersistentFlags().Lookup("subaccount")))
+	errcheckWARN(viper.BindPFlag("organization", rootCmd.PersistentFlags().Lookup("organization")))
 }
 
 // initConfig reads in config file and ENV variables if set

--- a/integration/compliance_test.go
+++ b/integration/compliance_test.go
@@ -69,6 +69,7 @@ Global Flags:
       --json                switch commands output from human-readable to json format
       --nocolor             turn off colors
       --noninteractive      turn off interactive mode (disable spinners, prompts, etc.)
+      --organization        access organization level data sets (org admins only)
   -p, --profile string      switch between profiles configured at ~/.lacework.toml
       --subaccount string   sub-account name inside your organization (org admins only)
 

--- a/integration/help_test.go
+++ b/integration/help_test.go
@@ -79,6 +79,7 @@ Global Flags:
       --json                switch commands output from human-readable to json format
       --nocolor             turn off colors
       --noninteractive      turn off interactive mode (disable spinners, prompts, etc.)
+      --organization        access organization level data sets (org admins only)
   -p, --profile string      switch between profiles configured at ~/.lacework.toml
       --subaccount string   sub-account name inside your organization (org admins only)
 
@@ -160,6 +161,7 @@ Flags:
       --json                switch commands output from human-readable to json format
       --nocolor             turn off colors
       --noninteractive      turn off interactive mode (disable spinners, prompts, etc.)
+      --organization        access organization level data sets (org admins only)
   -p, --profile string      switch between profiles configured at ~/.lacework.toml
       --subaccount string   sub-account name inside your organization (org admins only)
 


### PR DESCRIPTION
As part of our plan to migrate to APIv2, we are slowly switching existing functionality
like this one. Here we are creating Cloudtail Integrations in the CLI via APIv2, our next
move will be to switch this same functionality in Terraform and other integrations.

This change is also enabling our users to be able to create CloudTrail integrations at
the organization level when they want to add an Org Account Mappings file, which
before, in APIv1, it was disallowed.

When a user tries to create such Org CloudTrail integration, they will experience:

![Screen Shot 2021-06-24 at 9 26 08 AM](https://user-images.githubusercontent.com/5712253/123299494-d2396a00-d4d6-11eb-8e03-6d379275f49e.png)

JIRA: https://lacework.atlassian.net/browse/ALLY-539