### PR TITLE
refactor: migrate Agent Access Tokens to API v2 

### DIFF
--- a/api/agent_access_tokens.go
+++ b/api/agent_access_tokens.go
@@ -1,0 +1,171 @@
+//
+// Author:: Salim Afiune Maya (<afiune@lacework.net>)
+// Copyright:: Copyright 2021, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package api
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+// AgentAccessTokensService is the service that interacts with
+// the AgentAccessTokens schema from the Lacework APIv2 Server
+type AgentAccessTokensService struct {
+	client *Client
+}
+
+// List returns a list of Agent Access Tokens
+func (svc *AgentAccessTokensService) List() (response AgentAccessTokensResponse, err error) {
+	err = svc.client.RequestDecoder("GET", apiV2AgentAccessTokens, nil, &response)
+	return
+}
+
+// Create creates a single Agent Access Token
+func (svc *AgentAccessTokensService) Create(alias, desc string) (
+	response AgentAccessTokenResponse,
+	err error,
+) {
+	if alias == "" {
+		err = errors.New("token alias is required")
+		return
+	}
+
+	err = svc.client.RequestEncoderDecoder("POST",
+		apiV2AgentAccessTokens,
+		AgentAccessTokenRequest{
+			TokenAlias: alias,
+			Enabled:    1,
+			Props: &AgentAccessTokenProps{
+				Description: desc,
+			},
+		},
+		&response,
+	)
+	return
+}
+
+// Get returns an Agent Access Token with the matching ID (token)
+func (svc *AgentAccessTokensService) Get(token string) (
+	response AgentAccessTokenResponse,
+	err error,
+) {
+	err = svc.client.RequestDecoder("GET",
+		fmt.Sprintf(apiV2AgentAccessTokenFromID, token),
+		nil,
+		&response,
+	)
+	return
+}
+
+// Update updates an Agent Access Token with the provided request data
+func (svc *AgentAccessTokensService) Update(token string, data AgentAccessTokenRequest) (
+	response AgentAccessTokenResponse,
+	err error,
+) {
+	err = svc.client.RequestEncoderDecoder("PATCH",
+		fmt.Sprintf(apiV2AgentAccessTokenFromID, token),
+		data,
+		&response,
+	)
+	return
+}
+
+// UpdateState updates only the state of an Agent Access Token (enable or disable)
+func (svc *AgentAccessTokensService) UpdateState(token string, enable bool) (
+	response AgentAccessTokenResponse,
+	err error,
+) {
+
+	request := AgentAccessTokenRequest{Enabled: 0}
+	if enable {
+		request.Enabled = 1
+	}
+	err = svc.client.RequestEncoderDecoder("PATCH",
+		fmt.Sprintf(apiV2AgentAccessTokenFromID, token),
+		request,
+		&response,
+	)
+	return
+}
+
+// SearchAlias will search for an Agent Access Token that matches the provider token alias
+func (svc *AgentAccessTokensService) SearchAlias(alias string) (
+	response AgentAccessTokensResponse,
+	err error,
+) {
+
+	if alias == "" {
+		err = errors.New("specify a token alias to search")
+		return
+	}
+	err = svc.client.RequestEncoderDecoder("POST",
+		apiV2AgentAccessTokensSearch,
+		SearchFilter{
+			Filters: []Filter{
+				Filter{
+					Field:      "tokenAlias",
+					Expression: "eq",
+					Value:      alias,
+				},
+			},
+		},
+		&response,
+	)
+	return
+}
+
+type AgentAccessToken struct {
+	AccessToken string                `json:"accessToken"`
+	CreatedTime time.Time             `json:"createdTime"`
+	Props       AgentAccessTokenProps `json:"props,omitempty"`
+	TokenAlias  string                `json:"tokenAlias"`
+	Enabled     int                   `json:"tokenEnabled"`
+	Version     string                `json:"version"`
+}
+
+func (t AgentAccessToken) State() bool {
+	return t.Enabled == 1
+}
+
+func (t AgentAccessToken) PrettyState() string {
+	if t.State() {
+		return "Enabled"
+	}
+	return "Disabled"
+}
+
+type AgentAccessTokenProps struct {
+	CreatedTime time.Time `json:"createdTime,omitempty"`
+	Description string    `json:"description,omitempty"`
+}
+
+type AgentAccessTokenResponse struct {
+	Data AgentAccessToken `json:"data"`
+}
+
+type AgentAccessTokensResponse struct {
+	Data []AgentAccessToken `json:"data"`
+}
+
+type AgentAccessTokenRequest struct {
+	Enabled    int                    `json:"tokenEnabled"`
+	TokenAlias string                 `json:"tokenAlias,omitempty"`
+	Props      *AgentAccessTokenProps `json:"props,omitempty"`
+}

--- a/api/agent_access_tokens_test.go
+++ b/api/agent_access_tokens_test.go
@@ -1,0 +1,189 @@
+//
+// Author:: Salim Afiune Maya (<afiune@lacework.net>)
+// Copyright:: Copyright 2021, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package api_test
+
+import (
+	"fmt"
+	"math/rand"
+	"net/http"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/lacework/go-sdk/api"
+	"github.com/lacework/go-sdk/internal/lacework"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAgentAccessTokenPrettyState(t *testing.T) {
+	subject := api.AgentAccessToken{Enabled: 1}
+	assert.Equal(t, "Enabled", subject.PrettyState())
+
+	subject.Enabled = 0
+	assert.Equal(t, "Disabled", subject.PrettyState())
+	// anything else
+	subject.Enabled = 9
+	assert.Equal(t, "Disabled", subject.PrettyState())
+}
+
+func TestAgentAccessTokenState(t *testing.T) {
+	subject := api.AgentAccessToken{Enabled: 1}
+	assert.True(t, subject.State())
+
+	subject.Enabled = 0
+	assert.False(t, subject.State())
+	// anything else
+	subject.Enabled = 9
+	assert.False(t, subject.State())
+}
+
+func TestAgentAccessTokenGet(t *testing.T) {
+	var (
+		expectedTokenID    = mockToken()
+		expectedTokenAlias = "test-alias"
+		apiPath            = fmt.Sprintf("AgentAccessTokens/%s", expectedTokenID)
+		mockedAccessToken  = singleAgentAccessToken(expectedTokenID, expectedTokenAlias, "")
+		fakeServer         = lacework.MockServer()
+	)
+	fakeServer.UseApiV2()
+	fakeServer.MockToken("TOKEN")
+	defer fakeServer.Close()
+
+	fakeServer.MockAPI(apiPath,
+		func(w http.ResponseWriter, r *http.Request) {
+			if assert.Equal(t, "GET", r.Method, "Get() should be a GET method") {
+				fmt.Fprintf(w, generateV2Response(mockedAccessToken))
+			}
+		},
+	)
+
+	fakeServer.MockAPI("AgentAccessTokens/UNKNOWN_TOKEN",
+		func(w http.ResponseWriter, r *http.Request) {
+			if assert.Equal(t, "GET", r.Method, "Get() should be a GET method") {
+				http.Error(w, "{ \"message\": \"Not Found\"}", 404)
+			}
+		},
+	)
+
+	c, err := api.NewClient("test",
+		api.WithApiV2(),
+		api.WithToken("TOKEN"),
+		api.WithURL(fakeServer.URL()),
+	)
+	assert.Nil(t, err)
+
+	t.Run("when agent access token exists", func(t *testing.T) {
+		response, err := c.V2.AgentAccessTokens.Get(expectedTokenID)
+		assert.Nil(t, err)
+		if assert.NotNil(t, response) {
+			assert.Equal(t, expectedTokenID, response.Data.AccessToken)
+			assert.Equal(t, expectedTokenAlias, response.Data.TokenAlias)
+			assert.Equal(t, 1, response.Data.Enabled)
+		}
+	})
+
+	t.Run("when agent access token does NOT exist", func(t *testing.T) {
+		response, err := c.V2.AgentAccessTokens.Get("UNKNOWN_TOKEN")
+		assert.Empty(t, response)
+		if assert.NotNil(t, err) {
+			assert.Contains(t, err.Error(), "api/v2/AgentAccessTokens/UNKNOWN_TOKEN")
+			assert.Contains(t, err.Error(), "[404] Not Found")
+		}
+	})
+}
+
+func TestAgentAccessTokenList(t *testing.T) {
+	var (
+		expectedAgentAccTokens = []string{mockToken(), mockToken(), mockToken()}
+		expectedLen            = len(expectedAgentAccTokens)
+		fakeServer             = lacework.MockServer()
+	)
+	fakeServer.UseApiV2()
+	fakeServer.MockToken("TOKEN")
+	fakeServer.MockAPI("AgentAccessTokens",
+		func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "GET", r.Method, "List() should be a GET method")
+			fmt.Fprintf(w,
+				generateV2ArrayResponse(
+					generateAgentAccessTokens(expectedAgentAccTokens),
+				),
+			)
+		},
+	)
+	defer fakeServer.Close()
+
+	c, err := api.NewClient("test",
+		api.WithApiV2(),
+		api.WithToken("TOKEN"),
+		api.WithURL(fakeServer.URL()),
+	)
+	assert.Nil(t, err)
+
+	response, err := c.V2.AgentAccessTokens.List()
+	assert.Nil(t, err)
+	assert.NotNil(t, response)
+	assert.Equal(t, expectedLen, len(response.Data))
+	for _, d := range response.Data {
+		assert.Contains(t, expectedAgentAccTokens, d.AccessToken)
+	}
+}
+
+func generateAgentAccessTokens(ids []string) string {
+	agentAccessTokens := make([]string, len(ids))
+	for i, id := range ids {
+		agentAccessTokens[i] = singleAgentAccessToken(id, fmt.Sprintf("test-%d", i), "")
+	}
+	return strings.Join(agentAccessTokens, ", ")
+}
+
+func generateV2ArrayResponse(data string) string {
+	return `{ "data": [` + data + `] }`
+}
+
+func generateV2Response(data string) string {
+	return `{ "data": ` + data + ` }`
+}
+
+func singleAgentAccessToken(token, alias, desc string) string {
+	if token == "" {
+		return "{}"
+	}
+
+	return `
+  {
+    "accessToken": "` + token + `",
+    "createdTime": "2017-06-01T16:25:07.928Z",
+    "props": {
+      "description": "` + desc + `",
+      "createdTime": "2017-06-01T16:25:07.928Z"
+    },
+    "tokenAlias": "` + alias + `",
+    "tokenEnabled": 1,
+    "version": "0.1"
+  }
+`
+}
+
+// mockToken generates a mocked agent access token for test purposes
+func mockToken() string {
+	now := time.Now().UTC().UnixNano()
+	seed := rand.New(rand.NewSource(now))
+	return strconv.FormatInt(seed.Int63(), 16)
+}

--- a/api/api.go
+++ b/api/api.go
@@ -91,9 +91,14 @@ const (
 	// API v2 Endpoints
 	//
 	// These endpoints only exist in APIv2 and therefore we prefix them with 'v2/'
-	apiV2UserProfile          = "v2/UserProfile"
+	apiV2UserProfile = "v2/UserProfile"
+
 	apiV2CloudAccounts        = "v2/CloudAccounts"
 	apiV2CloudAccountFromGUID = "v2/CloudAccounts/%s"
+
+	apiV2AgentAccessTokens       = "v2/AgentAccessTokens"
+	apiV2AgentAccessTokensSearch = "v2/AgentAccessTokens/search"
+	apiV2AgentAccessTokenFromID  = "v2/AgentAccessTokens/%s"
 )
 
 // WithApiV2 configures the client to use the API version 2 (/api/v2)

--- a/api/v2.go
+++ b/api/v2.go
@@ -24,13 +24,15 @@ type V2Endpoints struct {
 	client *Client
 
 	// Every schema must have its own service
-	UserProfile   *UserProfileService
-	CloudAccounts *CloudAccountsService
+	UserProfile       *UserProfileService
+	CloudAccounts     *CloudAccountsService
+	AgentAccessTokens *AgentAccessTokensService
 }
 
 func NewV2Endpoints(c *Client) *V2Endpoints {
 	return &V2Endpoints{c,
 		&UserProfileService{c},
 		&CloudAccountsService{c},
+		&AgentAccessTokensService{c},
 	}
 }

--- a/api/v2_search_filters.go
+++ b/api/v2_search_filters.go
@@ -1,0 +1,54 @@
+//
+// Author:: Salim Afiune Maya (<afiune@lacework.net>)
+// Copyright:: Copyright 2021, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package api
+
+// SearchFilter is the representation of an advanced search payload
+// for retrieving information out of the Lacework APIv2 Server
+//
+// An advanced example of a SearchFilter to search for an Agent
+// Access Token that matches the provider token alias and return
+// only the token found:
+//
+//		SearchFilter{
+//			Filters: []Filter{
+//				Filter{
+//					Field:      "tokenAlias",
+//					Expression: "eq",
+//					Value:      "k8s-deployment,
+//				},
+//			},
+//			Returns: []string{"accessToken"},
+//		}
+type SearchFilter struct {
+	TimeFilter `json:"timeFilter"`
+	Filters    []Filter `json:"filters"`
+	Returns    []string `json:"returns"`
+}
+
+type Filter struct {
+	Expression string   `json:"expression"`
+	Field      string   `json:"field"`
+	Value      string   `json:"value"`
+	Values     []string `json:"values"`
+}
+
+type TimeFilter struct {
+	StartTime string `json:"startTime"`
+	EndTime   string `json:"endTime"`
+}

--- a/integration/agent_token_test.go
+++ b/integration/agent_token_test.go
@@ -56,7 +56,7 @@ func TestAgentTokenCommandList(t *testing.T) {
 		"STDOUT table headers changed, please check")
 	assert.Contains(t, out.String(), "NAME",
 		"STDOUT table headers changed, please check")
-	assert.Contains(t, out.String(), "STATUS",
+	assert.Contains(t, out.String(), "STATE",
 		"STDOUT table headers changed, please check")
 	assert.Empty(t,
 		err.String(),
@@ -67,11 +67,12 @@ func TestAgentTokenCommandList(t *testing.T) {
 
 func TestAgentTokenCommandEndToEnd(t *testing.T) {
 	var (
-		out              bytes.Buffer
-		err              bytes.Buffer
-		exitcode         int
-		agentTokens      []agentToken
-		tokenUpdatedTime time.Time
+		out         bytes.Buffer
+		err         bytes.Buffer
+		exitcode    int
+		agentTokens []agentToken
+		// @afiune last_updated_time doesn't seem to exist in API v2 ....
+		//tokenUpdatedTime time.Time
 	)
 	t.Run("list agent tokens", func(t *testing.T) {
 		out, err, exitcode = LaceworkCLIWithTOMLConfig("agent", "token", "list", "--json")
@@ -109,14 +110,14 @@ func TestAgentTokenCommandEndToEnd(t *testing.T) {
 
 		expectedOutput := []string{
 			// headers
-			"AGENT TOKEN DETAILS",
+			"AGENT ACCESS TOKEN DETAILS",
 			"NAME",
 			"DESCRIPTION",
-			"ACCOUNT",
 			"VERSION",
-			"STATUS",
+			"STATE",
 			"CREATED AT",
-			"UPDATED AT",
+			// @afiune last_updated_time doesn't seem to exist in API v2 ....
+			//"UPDATED AT",
 		}
 		for _, str := range expectedOutput {
 			assert.Contains(t, out.String(), str,
@@ -136,7 +137,7 @@ func TestAgentTokenCommandEndToEnd(t *testing.T) {
 		errJson := json.Unmarshal(out.Bytes(), &token)
 		assert.Nil(t, errJson)
 		assert.NotEmpty(t, token, "check JSON token show response while parsing update time")
-		tokenUpdatedTime = token.LastUpdatedTime
+		//tokenUpdatedTime = token.LastUpdatedTime
 	})
 
 	t.Run("token update: disable", func(t *testing.T) {
@@ -200,26 +201,24 @@ func TestAgentTokenCommandEndToEnd(t *testing.T) {
 		errJson := json.Unmarshal(out.Bytes(), &token)
 		assert.Nil(t, errJson)
 		assert.NotEmpty(t, token, "check JSON token show response while parsing update time")
-		assert.True(t,
-			tokenUpdatedTime.Before(token.LastUpdatedTime),
-			fmt.Sprintf("the agent access token last_update_time was NOT updated! check please. (old:%s) (new:%s)",
-				tokenUpdatedTime, token.LastUpdatedTime,
-			),
-		)
+		//assert.True(t,
+		//tokenUpdatedTime.Before(token.LastUpdatedTime),
+		//fmt.Sprintf("the agent access token last_update_time was NOT updated! check please. (old:%s) (new:%s)",
+		//tokenUpdatedTime, token.LastUpdatedTime,
+		//),
+		//)
 	})
 }
 
 type agentToken struct {
-	AccessToken     string          `json:"ACCESS_TOKEN"`
-	Account         string          `json:"ACCOUNT"`
-	LastUpdatedTime time.Time       `json:"LAST_UPDATED_TIME"`
-	Props           agentTokenProps `json:"PROPS,omitempty"`
-	TokenAlias      string          `json:"TOKEN_ALIAS"`
-	Enabled         string          `json:"TOKEN_ENABLED"`
-	Version         string          `json:"VERSION"`
+	AccessToken string          `json:"accessToken"`
+	Props       agentTokenProps `json:"props,omitempty"`
+	TokenAlias  string          `json:"tokenAlias"`
+	Enabled     int             `json:"tokenEnabled"`
+	Version     string          `json:"version"`
 }
 
 type agentTokenProps struct {
-	CreatedTime time.Time `json:"CREATED_TIME,omitempty"`
-	Description string    `json:"DESCRIPTION,omitempty"`
+	CreatedTime time.Time `json:"createdTime,omitempty"`
+	Description string    `json:"description,omitempty"`
 }

--- a/integration/agent_token_test.go
+++ b/integration/agent_token_test.go
@@ -65,6 +65,19 @@ func TestAgentTokenCommandList(t *testing.T) {
 		"EXITCODE is not the expected one")
 }
 
+func TestAgentTokenCommandShowNotFound(t *testing.T) {
+	out, err, exitcode := LaceworkCLIWithTOMLConfig("agent", "token", "show", "unknown_token")
+	assert.Contains(t, err.String(), "ERROR unable to get agent access token",
+		"STDERR message changed, please check")
+	//assert.Contains(t, err.String(), "[404] Not Found",
+	//"STDERR message changed, please check")
+	assert.Empty(t,
+		out.String(),
+		"STDOUT should be empty")
+	assert.Equal(t, 1, exitcode,
+		"EXITCODE is not the expected one")
+}
+
 func TestAgentTokenCommandEndToEnd(t *testing.T) {
 	var (
 		out         bytes.Buffer


### PR DESCRIPTION
During our discovery in https://lacework.atlassian.net/browse/ALLY-522 we have identified that
the Agent Access Token endpoints in API v1 does NOT respect the sub-account setting that we
want to release, that is, the `Account-Name` HTTP header.

This PR intends to migrate these endpoints to API v2.

Additionally, we are introducing a new APIv2 concept called Search Filters. This is the first iteration
where we only define the data structure but in upcoming PRs we will add more logic to easily
write filters for a number of API v2 endpoints.

JIRA: https://lacework.atlassian.net/browse/ALLY-523