### PR TITLE
fix(cli): non-interactive should not run daily version check

### DIFF
--- a/cli/cmd/cli_state.go
+++ b/cli/cmd/cli_state.go
@@ -216,7 +216,7 @@ func (c *cliState) NewClient() error {
 
 // InteractiveMode returns true if the cli is running in interactive mode
 func (c *cliState) InteractiveMode() bool {
-	return !c.nonInteractive && !c.csvOutput
+	return !c.nonInteractive && !c.csvOutput && !c.jsonOutput
 }
 
 // NonInteractive turns off interactive mode, that is, no progress bars and spinners

--- a/cli/cmd/version.go
+++ b/cli/cmd/version.go
@@ -118,6 +118,10 @@ func dailyVersionCheck() error {
 		return nil
 	}
 
+	if !cli.InteractiveMode() {
+		return nil
+	}
+
 	cacheDir, err := versionCacheDir()
 	if err != nil {
 		return err

--- a/integration/version_test.go
+++ b/integration/version_test.go
@@ -127,3 +127,22 @@ func TestVersionCommand(t *testing.T) {
 		"version update message should be displayed",
 	)
 }
+
+func TestDailyVersionCheckShouldNotRunWhenInNonInteractiveMode(t *testing.T) {
+	enableTestingUpdaterEnv()
+	defer disableTestingUpdaterEnv()
+
+	home := createTOMLConfigFromCIvars()
+	defer os.RemoveAll(home)
+
+	out, err, exitcode := LaceworkCLIWithHome(home, "configure", "list", "--noninteractive")
+	assert.Empty(t, err.String())
+	assert.Equal(t, 0, exitcode)
+	assert.NotContains(t, out.String(),
+		"A newer version of the Lacework CLI is available! The latest version is v",
+		"we shouldn't see this daily version check message",
+	)
+
+	versionCacheFile := path.Join(home, ".config", "lacework", "version_cache")
+	assert.NoFileExists(t, versionCacheFile, "the version_cache file is missing")
+}


### PR DESCRIPTION
If a user is running in non-interactive mode, the Lacework CLI should avoid
the daily version check feature.

JIRA: https://lacework.atlassian.net/browse/ALLY-551

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>