### PR TITLE
test(cli): create VMs of supported platforms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ bin/
 # vscode debug.test
 **/debug.test
 
+# Vagrant
+**/.vagrant/*
+
 # Terraform
 **/.terraform/*
 *.tfstate

--- a/Makefile
+++ b/Makefile
@@ -123,3 +123,28 @@ endif
 
 git-env:
 	scripts/git_env.sh
+
+vagrant-macos-up: build-cli-cross-platform
+	$(call run_vagrant,macos-sierra,up)
+vagrant-macos-login: build-cli-cross-platform
+	$(call run_vagrant,macos-sierra,ssh)
+vagrant-macos-destroy:
+	$(call run_vagrant,macos-sierra,destroy -f)
+
+vagrant-linux-up: build-cli-cross-platform
+	$(call run_vagrant,ubuntu-1804,up)
+vagrant-linux-login: build-cli-cross-platform
+	$(call run_vagrant,ubuntu-1804,ssh)
+vagrant-linux-destroy:
+	$(call run_vagrant,ubuntu-1804,destroy -f)
+
+vagrant-windows-up: build-cli-cross-platform
+	$(call run_vagrant,windows-10,up)
+vagrant-windows-login: build-cli-cross-platform
+	$(call run_vagrant,windows-10,powershell)
+vagrant-windows-destroy:
+	$(call run_vagrant,windows-10,destroy -f)
+
+define run_vagrant
+	cd cli/vagrant/${1}; vagrant ${2}
+endef

--- a/cli/README.md
+++ b/cli/README.md
@@ -13,7 +13,7 @@ reports, external integrations, vulnerability scans, and other operations.
 ### Bash:
 
 ```
-$ curl https://raw.githubusercontent.com/lacework/go-sdk/main/cli/install.sh | bash
+curl https://raw.githubusercontent.com/lacework/go-sdk/main/cli/install.sh | bash
 ```
 
 ### Powershell:
@@ -25,7 +25,7 @@ C:\> iex ((New-Object System.Net.WebClient).DownloadString('https://raw.githubus
 
 ### Homebrew:
 ```
-$ brew install lacework/tap/lacework-cli
+brew install lacework/tap/lacework-cli
 ```
 ## Quick Configuration
 
@@ -102,6 +102,7 @@ operation of the Lacework CLI.
 | Environment Variable | Description |
 |----------------------|-------------|
 |`LW_NOCOLOR=1`|turn off colors|
+|`LW_NOCACHE=1`|turn off caching|
 |`LW_DEBUG=1`|turn on debug logging|
 |`LW_JSON=1`|switch commands output from human-readable to JSON format|
 |`LW_NONINTERACTIVE=1`|disable interactive progress bars (i.e. spinners)|
@@ -142,9 +143,41 @@ To build and install the CLI from source, use the `make install-cli` directive
 defined at the top level of this repository, the automation will install the
 tool at `/usr/local/bin/lacework`:
 ```
+$ make prepare
 $ make install-cli
 $ lacework version
 lacework 0.1.1-dev (sha:ca9f95d17f4f2092f89dba7b64eaed6db7493a5a) (time:20200406091143)
+```
+
+### Test Supported Platforms
+
+The Lacework CLI runs on almost any operating system out there, it runs on Darwin,
+Windows, and many Linux distributions. After setting up your development environment
+you can test the generated binary by standing up a virtual machine of any supported
+platform, to do that, you will need to install [Vagrant](https://www.vagrantup.com/) and
+[VirtualBox](https://www.virtualbox.org/wiki/Downloads) on your workstation.
+
+To start a supported host, run:
+```
+$ make vagrant-windows-up  # Stand up a Windows 10 VM
+$ make vagrant-macos-up    # Stand up a Macos Sierra VM
+$ make vagrant-linux-up    # Stand up a Ubuntu 18.04 VM
+```
+
+To access the VM, run:
+```
+$ make vagrant-windows-login  # Access the Windows 10 VM via WinRM/Powershell
+$ make vagrant-macos-login    # Access the Macos Sierra VM via SSH
+$ make vagrant-linux-login    # Access the Ubuntu 18.04 VM via SSH
+```
+__NOTE: When accessing a Windows VM from a Linux or MacOS system, you will need
+to use the VirtualBox GUI rather than your terminal.__
+
+To destroy the VM, run:
+```
+$ make vagrant-windows-destroy  # Destroy the Windows 10 VM
+$ make vagrant-macos-destroy    # Destroy the Macos Sierra VM
+$ make vagrant-linux-destroy    # Destroy the Ubuntu 18.04 VM
 ```
 
 ### Unit Tests

--- a/cli/vagrant/macos-sierra/Vagrantfile
+++ b/cli/vagrant/macos-sierra/Vagrantfile
@@ -1,0 +1,13 @@
+Vagrant.configure("2") do |config|
+  config.vm.box = "jhcook/macos-sierra"
+
+  config.vm.provider "virtualbox" do |vb|
+    vb.customize ["modifyvm", :id, "--usb", "on"]
+    vb.customize ["modifyvm", :id, "--usbehci", "off"]
+  end
+
+  config.vm.network "private_network", ip: "192.168.50.4"
+  config.vm.synced_folder "../../../bin", "/devcli", type: "nfs"
+
+  config.vm.provision "shell", inline: "ln -s /devcli/lacework-cli-darwin-amd64 /home/vagrant/lacework"
+end

--- a/cli/vagrant/ubuntu-1804/Vagrantfile
+++ b/cli/vagrant/ubuntu-1804/Vagrantfile
@@ -1,0 +1,5 @@
+Vagrant.configure("2") do |config|
+  config.vm.box = "bento/ubuntu-18.04"
+  config.vm.synced_folder "../../../bin", "/devcli"
+  config.vm.provision "shell", inline: "ln -s /devcli/lacework-cli-linux-amd64 /home/vagrant/lacework"
+end

--- a/cli/vagrant/windows-10/Vagrantfile
+++ b/cli/vagrant/windows-10/Vagrantfile
@@ -1,0 +1,12 @@
+Vagrant.configure("2") do |config|
+  config.vm.box = "senglin/win-10-enterprise-vs2015community"
+  config.vm.box_version = "1.0.0"
+  config.vm.synced_folder "../../../bin", "/devcli"
+  config.vm.provision "shell",
+    inline: "New-Item -ItemType SymbolicLink -Target \"C:/devcli/lacework-cli-windows-amd64.exe\" -Path \"C:/Users/vagrant/lacework.exe\""
+
+  config.vm.provider "virtualbox" do |v|
+    v.gui = true
+  end
+end
+


### PR DESCRIPTION
The Lacework CLI runs on almost any operating system out there, it runs on Darwin,
Windows, and many Linux distributions. After setting up your development environment
you can test the generated binary by standing up a virtual machine of any supported
platform, to do that, you will need to install [Vagrant](https://www.vagrantup.com/) and [VirtualBox](https://www.virtualbox.org/wiki/Downloads) on your workstation.

To start a supported host, run:
```
$ make vagrant-windows-up  # Stand up a Windows 10 VM
$ make vagrant-macos-up    # Stand up a Macos Sierra VM
$ make vagrant-linux-up    # Stand up a Ubuntu 18.04 VM
```

To access the VM, run:
```
$ make vagrant-windows-login  # Access the Windows 10 VM via WinRM/Powershell
$ make vagrant-macos-login    # Access the Macos Sierra VM via SSH
$ make vagrant-linux-login    # Access the Ubuntu 18.04 VM via SSH
```
__NOTE: When accessing a Windows VM from a Linux or MacOS system, you will need
to use the VirtualBox GUI rather than your terminal.__

To destroy the VM, run:
```
$ make vagrant-windows-destroy  # Destroy the Windows 10 VM
$ make vagrant-macos-destroy    # Destroy the Macos Sierra VM
$ make vagrant-linux-destroy    # Destroy the Ubuntu 18.04 VM
```

JIRA: https://lacework.atlassian.net/browse/ALLY-571

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>