### PR TITLE
fix(api): add 'description' field for Host Vulnerability

### DIFF
--- a/api/vulnerabilities_host.go
+++ b/api/vulnerabilities_host.go
@@ -149,6 +149,7 @@ type HostVulnPackage struct {
 	Version             string          `json:"version"`
 	HostCount           string          `json:"host_count"`
 	PackageStatus       string          `json:"package_status"`
+	Description         string          `json:"description"`
 	CveLink             string          `json:"cve_link"`
 	CvssScore           string          `json:"cvss_score"`
 	CvssV2Score         string          `json:"cvss_v_2_score"`

--- a/cli/cmd/vuln_host.go
+++ b/cli/cmd/vuln_host.go
@@ -782,15 +782,15 @@ func getNamespaceFromHostVuln(cves []api.HostVulnCVE) string {
 
 func hostVulnAssessmentToCountsTable(counts api.HostVulnCounts) [][]string {
 	return [][]string{
-		[]string{"Critical", fmt.Sprint(counts.Critical),
+		{"Critical", fmt.Sprint(counts.Critical),
 			fmt.Sprint(counts.CritFixable)},
-		[]string{"High", fmt.Sprint(counts.High),
+		{"High", fmt.Sprint(counts.High),
 			fmt.Sprint(counts.HighFixable)},
-		[]string{"Medium", fmt.Sprint(counts.Medium),
+		{"Medium", fmt.Sprint(counts.Medium),
 			fmt.Sprint(counts.MedFixable)},
-		[]string{"Low", fmt.Sprint(counts.Low),
+		{"Low", fmt.Sprint(counts.Low),
 			fmt.Sprint(counts.LowFixable)},
-		[]string{"Info", fmt.Sprint(counts.Info),
+		{"Info", fmt.Sprint(counts.Info),
 			fmt.Sprint(counts.InfoFixable)},
 	}
 }


### PR DESCRIPTION
Propagating the new field `description` introduced by https://lacework.atlassian.net/browse/RAIN-16614
into the Go client as well as into the Lacework CLI.

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>