### PR TITLE
fix(api): callbacks panic when response is nil

### DIFF
--- a/api/callbacks_test.go
+++ b/api/callbacks_test.go
@@ -1,0 +1,86 @@
+//
+// Author:: Salim Afiune Maya (<afiune@lacework.net>)
+// Copyright:: Copyright 2021, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package api_test
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/lacework/go-sdk/api"
+	"github.com/lacework/go-sdk/internal/lacework"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCallbacks(t *testing.T) {
+	fakeServer := lacework.MockServer()
+	fakeServer.UseApiV2()
+	fakeServer.MockToken("TOKEN")
+	fakeServer.MockAPI(
+		"foo",
+		func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, "", http.StatusBadRequest)
+		},
+	)
+	defer fakeServer.Close()
+
+	c, _ := api.NewClient("foo",
+		api.WithApiV2(),
+		api.WithURL(fakeServer.URL()),
+		api.WithToken("TOKEN"),
+		api.WithLifecycleCallbacks(api.LifecycleCallbacks{
+			RequestCallback: func(httpCode int, _ http.Header) error {
+				assert.Equal(t, http.StatusBadRequest, httpCode)
+				return nil
+			},
+		}),
+	)
+	request, _ := c.NewRequest("GET", "foo", nil)
+
+	_, err := c.Do(request)
+	assert.Nil(t, err)
+}
+
+func TestCallbacksOnRequestError(t *testing.T) {
+	fakeServer := lacework.MockServer()
+	fakeServer.UseApiV2()
+	fakeServer.MockToken("TOKEN")
+	fakeServer.MockAPI(
+		"foo",
+		func(w http.ResponseWriter, r *http.Request) {
+			time.Sleep(time.Duration(10))
+		},
+	)
+	defer fakeServer.Close()
+
+	c, _ := api.NewClient("foo",
+		api.WithApiV2(),
+		api.WithURL(fakeServer.URL()),
+		api.WithTimeout(time.Duration(1)),
+		api.WithToken("TOKEN"),
+		api.WithLifecycleCallbacks(api.LifecycleCallbacks{
+			RequestCallback: func(httpCode int, _ http.Header) error {
+				return nil
+			},
+		}),
+	)
+	request, _ := c.NewRequest("GET", "foo", nil)
+	_, err := c.Do(request)
+	assert.NotNil(t, err)
+}

--- a/api/http.go
+++ b/api/http.go
@@ -175,7 +175,7 @@ func (c *Client) Do(req *http.Request) (*http.Response, error) {
 	}
 
 	// run request callback
-	if call := c.callbacks.RequestCallback; call != nil {
+	if call := c.callbacks.RequestCallback; call != nil && response != nil {
 		if err := call(response.StatusCode, response.Header); err != nil {
 			c.log.Info("request callback failure", zap.String("error", err.Error()))
 		}


### PR DESCRIPTION
I have spotted a panic during the execution of CLI commands, the problem
is that we never checked if the `response` comes back as a `nil` pointer
and we try to access it anyway:

```
=== FAIL: api TestCallbacksOnRequestError (0.00s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x131c784]

goroutine 132 [running]:
testing.tRunner.func1.2(0x1404500, 0x1703d50)
	/usr/local/go/src/testing/testing.go:1143 +0x332
testing.tRunner.func1(0xc0003f4f00)
	/usr/local/go/src/testing/testing.go:1146 +0x4b6
panic(0x1404500, 0x1703d50)
	/usr/local/go/src/runtime/panic.go:965 +0x1b9
github.com/lacework/go-sdk/api.(*Client).Do(0xc00013a340, 0xc000076100, 0x3, 0x14749dc, 0x3)
	/Users/salimmaya/go/src/github.com/lacework/go-sdk/api/http.go:179 +0xe4
github.com/lacework/go-sdk/api_test.TestCallbacksOnRequestError(0xc0003f4f00)
	/Users/salimmaya/go/src/github.com/lacework/go-sdk/api/callbacks_test.go:85 +0x3af
testing.tRunner(0xc0003f4f00, 0x149c520)
	/usr/local/go/src/testing/testing.go:1193 +0xef
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:1238 +0x2b3

DONE 338 tests, 1 failure in 2.649s
make: *** [test] Error 1
```

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>