### PR TITLE
feat(api): EmailUser Alert Channel (v2)

### DIFF
--- a/api/_examples/alert-channels-v2/main.go
+++ b/api/_examples/alert-channels-v2/main.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/lacework/go-sdk/api"
+)
+
+func main() {
+	lacework, err := api.NewClient(os.Getenv("LW_ACCOUNT"), api.WithApiV2(),
+		api.WithApiKeys(os.Getenv("LW_API_KEY"), os.Getenv("LW_API_SECRET")))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	alertChannel, err := lacework.V2.AlertChannels.GetEmailUser("CUSTOMER_8EB5E8092016A0B8CBD8CB591362344E3A87761B997ABA0")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Output: Alert channel: THE-INTEGRATION-GUID
+	fmt.Printf("Alert channel: %s", alertChannel.Data.Data.ChannelProps.Recipients[0])
+}

--- a/api/alert_channels.go
+++ b/api/alert_channels.go
@@ -1,0 +1,186 @@
+//
+// Author:: Salim Afiune Maya (<afiune@lacework.net>)
+// Copyright:: Copyright 2021, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package api
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+)
+
+// AlertChannelsService is the service that interacts with
+// the AlertChannels schema from the Lacework APIv2 Server
+type AlertChannelsService struct {
+	client *Client
+}
+
+// NewAlertChannel returns an instance of the AlertChannelRaw struct with the
+// provided Alert Channel integration type, name and raw data as an interface{}.
+//
+// NOTE: This function must be used by any Alert Channel type.
+//
+// Basic usage: Initialize a new EmailUserAlertChannel struct, then
+//              use the new instance to do CRUD operations
+//
+//   client, err := api.NewClient("account")
+//   if err != nil {
+//     return err
+//   }
+//
+//   emailAlertChan := api.NewAlertChannel("foo",
+//     api.EmailUserAlertChannel,
+//     api.EmailUserData{
+//       ChannelProps: api.EmailUserChannelProps{
+//         Recipients: []string{"name@example.com"},
+//       },
+//     },
+//   )
+//
+//   client.V2.AlertChannels.Creates(emailAlertChan)
+//
+func NewAlertChannel(name string, iType alertChannelType, data interface{}) AlertChannelRaw {
+	return AlertChannelRaw{
+		v2CommonIntegrationData: v2CommonIntegrationData{
+			Name:    name,
+			Type:    iType.String(),
+			Enabled: 1,
+		},
+		Data: data,
+	}
+}
+
+// AlertChannel is an interface that helps us implement a few functions
+// that any Alert Channel might use, there are some cases, like during
+// Update, where we need to get the ID of the Alert Channel and its type,
+// this will allow users to pass any Alert Channel that implements these
+// methods
+type AlertChannel interface {
+	ID() string
+	AlertChannelType() alertChannelType
+}
+
+type alertChannelType int
+
+const (
+	// type that defines a non-existing Alert Channel integration
+	NoneAlertChannel alertChannelType = iota
+	EmailUserAlertChannel
+)
+
+// AlertChannelTypes is the list of available Alert Channel integration types
+var AlertChannelTypes = map[alertChannelType]string{
+	NoneAlertChannel:      "None",
+	EmailUserAlertChannel: "EmailUser",
+}
+
+// String returns the string representation of a Alert Channel integration type
+func (i alertChannelType) String() string {
+	return AlertChannelTypes[i]
+}
+
+// FindAlertChannelType looks up inside the list of available alert channel types
+// the matching type from the provided string, if none, returns NoneAlertChannel
+func FindAlertChannelType(alertChannel string) (alertChannelType, bool) {
+	for cType, cStr := range AlertChannelTypes {
+		if cStr == alertChannel {
+			return cType, true
+		}
+	}
+	return NoneAlertChannel, false
+}
+
+// List returns a list of Alert Channel integrations
+func (svc *AlertChannelsService) List() (response AlertChannelsResponse, err error) {
+	err = svc.client.RequestDecoder("GET", apiV2AlertChannels, nil, &response)
+	return
+}
+
+// Create creates a single Alert Channel integration
+func (svc *AlertChannelsService) Create(integration AlertChannelRaw) (
+	response AlertChannelResponse,
+	err error,
+) {
+	err = svc.create(integration, &response)
+	return
+}
+
+// Delete deletes a Alert Channel integration that matches the provided guid
+func (svc *AlertChannelsService) Delete(guid string) error {
+	if guid == "" {
+		return errors.New("specify an intgGuid")
+	}
+
+	return svc.client.RequestDecoder(
+		"DELETE",
+		fmt.Sprintf(apiV2AlertChannelFromGUID, guid),
+		nil,
+		nil,
+	)
+}
+
+// Get returns a raw response of the Alert Channel with the matching integration guid.
+//
+// To return a more specific Go struct of a Alert Channel integration, use the proper
+// method such as GetEmailUser() where the function name is composed by:
+//
+//  Get<Type>(guid)
+//
+//    Where <Type> is the Alert Channel integration type.
+func (svc *AlertChannelsService) Get(guid string) (response AlertChannelResponse, err error) {
+	err = svc.get(guid, &response)
+	return
+}
+
+type AlertChannelRaw struct {
+	v2CommonIntegrationData
+	Data interface{} `json:"data,omitempty"`
+}
+
+func (alert AlertChannelRaw) AlertChannelType() alertChannelType {
+	t, _ := FindAlertChannelType(alert.Type)
+	return t
+}
+
+type AlertChannelResponse struct {
+	Data AlertChannelRaw `json:"data"`
+}
+
+type AlertChannelsResponse struct {
+	Data []AlertChannelRaw `json:"data"`
+}
+
+func (svc *AlertChannelsService) create(data interface{}, response interface{}) error {
+	return svc.client.RequestEncoderDecoder("POST", apiV2AlertChannels, data, response)
+}
+
+func (svc *AlertChannelsService) get(guid string, response interface{}) error {
+	if guid == "" {
+		return errors.New("specify an intgGuid")
+	}
+	apiPath := fmt.Sprintf(apiV2AlertChannelFromGUID, guid)
+	return svc.client.RequestDecoder("GET", apiPath, nil, response)
+}
+
+func (svc *AlertChannelsService) update(guid string, data interface{}, response interface{}) error {
+	if guid == "" {
+		return errors.New("specify an intgGuid")
+	}
+	apiPath := fmt.Sprintf(apiV2AlertChannelFromGUID, guid)
+	return svc.client.RequestEncoderDecoder("PATCH", apiPath, data, response)
+}

--- a/api/alert_channels_email_user.go
+++ b/api/alert_channels_email_user.go
@@ -1,0 +1,123 @@
+//
+// Author:: Salim Afiune Maya (<afiune@lacework.net>)
+// Copyright:: Copyright 2021, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package api
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+// GetEmailUser gets a single EmailUser alert channel matching the
+// provided integration guid
+func (svc *AlertChannelsService) GetEmailUser(guid string) (
+	response EmailUserAlertChannelResponse,
+	err error,
+) {
+
+	// by default, expect the correct response, if not, try the workaround
+	err = svc.get(guid, &response)
+	if err == nil {
+		return
+	}
+
+	// Workaround from APIv2
+	// Bug: https://lacework.atlassian.net/browse/RAIN-20070
+	//
+	// This means that the response.Data.Data.ChannelProps.Recipients is a 'string'
+	// instead of '[]string'. We will try to deserialize and cast to correct response
+	var getResponse emailUserGetAlertChannelResponse
+	err = svc.get(guid, &getResponse)
+	if err != nil {
+		return
+	}
+
+	// convert GET response to a consistent response
+	response, err = convertGetEmailUserAlertChannelResponse(getResponse)
+	return
+}
+
+// UpdateEmailUser updates a single EmailUser integration on the Lacework Server
+func (svc *AlertChannelsService) UpdateEmailUser(data AlertChannel) (
+	response EmailUserAlertChannelResponse,
+	err error,
+) {
+	err = svc.update(data.ID(), data, &response)
+	return
+}
+
+type EmailUserAlertChannelResponse struct {
+	Data EmailUserIntegration `json:"data"`
+}
+
+type EmailUserIntegration struct {
+	v2CommonIntegrationData
+	Data EmailUserData `json:"data"`
+}
+
+type EmailUserData struct {
+	ChannelProps      EmailUserChannelProps `json:"channelProps"`
+	NotificationTypes struct {
+		Properties interface{} `json:"properties,omitempty"`
+	} `json:"notificationTypes"`
+}
+
+type EmailUserChannelProps struct {
+	Recipients []string `json:"recipients"`
+}
+
+// Workaround from APIv2
+// Bug: https://lacework.atlassian.net/browse/RAIN-20070
+type emailUserGetData struct {
+	ChannelProps struct {
+		Recipients interface{} `json:"recipients"`
+	} `json:"channelProps"`
+	NotificationTypes struct {
+		Properties interface{} `json:"properties,omitempty"`
+	} `json:"notificationTypes"`
+}
+type emailUserGetIntegration struct {
+	v2CommonIntegrationData
+	Data emailUserGetData `json:"data"`
+}
+type emailUserGetAlertChannelResponse struct {
+	Data emailUserGetIntegration `json:"data"`
+}
+
+func convertGetEmailUserAlertChannelResponse(
+	res emailUserGetAlertChannelResponse) (EmailUserAlertChannelResponse, error) {
+
+	recipientsString, ok := res.Data.Data.ChannelProps.Recipients.(string)
+	if ok {
+		// deserialize string
+		res.Data.Data.ChannelProps.Recipients = strings.Split(recipientsString, ",")
+	}
+
+	return castEmailUserAlertChannelResponse(res)
+}
+
+func castEmailUserAlertChannelResponse(
+	res interface{}) (r EmailUserAlertChannelResponse, err error) {
+	var j []byte
+	j, err = json.Marshal(res)
+	if err != nil {
+		return
+	}
+	err = json.Unmarshal(j, &r)
+	return
+}

--- a/api/alert_channels_email_user_test.go
+++ b/api/alert_channels_email_user_test.go
@@ -1,0 +1,238 @@
+//
+// Author:: Salim Afiune Maya (<afiune@lacework.net>)
+// Copyright:: Copyright 2021, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package api_test
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/lacework/go-sdk/api"
+	"github.com/lacework/go-sdk/internal/intgguid"
+	"github.com/lacework/go-sdk/internal/lacework"
+)
+
+func TestAlertChannelsGetEmailUser(t *testing.T) {
+	var (
+		intgGUID   = intgguid.New()
+		apiPath    = fmt.Sprintf("AlertChannels/%s", intgGUID)
+		fakeServer = lacework.MockServer()
+	)
+	fakeServer.UseApiV2()
+	fakeServer.MockToken("TOKEN")
+	defer fakeServer.Close()
+
+	fakeServer.MockAPI(apiPath, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method, "GetEmailUser() should be a GET method")
+		fmt.Fprintf(w, generateAlertChannelResponse(singleEmailUserAlertChannel(intgGUID)))
+	})
+
+	c, err := api.NewClient("test",
+		api.WithApiV2(),
+		api.WithToken("TOKEN"),
+		api.WithURL(fakeServer.URL()),
+	)
+	assert.Nil(t, err)
+
+	response, err := c.V2.AlertChannels.GetEmailUser(intgGUID)
+	assert.Nil(t, err)
+	assert.NotNil(t, response)
+	assert.Equal(t, intgGUID, response.Data.IntgGuid)
+	assert.Equal(t, "integration_name", response.Data.Name)
+	assert.True(t, response.Data.State.Ok)
+	assert.Contains(t, response.Data.Data.ChannelProps.Recipients, "foo@lacework.net")
+	assert.Contains(t, response.Data.Data.ChannelProps.Recipients, "bar@lacework.net")
+}
+
+func TestAlertChannelsEmailUserUpdate(t *testing.T) {
+	var (
+		intgGUID   = intgguid.New()
+		apiPath    = fmt.Sprintf("AlertChannels/%s", intgGUID)
+		fakeServer = lacework.MockServer()
+	)
+	fakeServer.UseApiV2()
+	fakeServer.MockToken("TOKEN")
+	defer fakeServer.Close()
+
+	fakeServer.MockAPI(apiPath, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "PATCH", r.Method, "UpdateEmailUser() should be a PATCH method")
+
+		if assert.NotNil(t, r.Body) {
+			body := httpBodySniffer(r)
+			assert.Contains(t, body, intgGUID, "INTG_GUID missing")
+			assert.Contains(t, body, "integration_name", "cloud account name is missing")
+			assert.Contains(t, body, "EmailUser", "wrong cloud account type")
+			assert.Contains(t, body, "foo@example.com", "missing recipient")
+			assert.Contains(t, body, "bar@example.com", "missing recipient")
+			assert.Contains(t, body, "enabled\":1", "cloud account is not enabled")
+		}
+
+		fmt.Fprintf(w, generateAlertChannelResponse(singleEmailUserAlertChannel(intgGUID)))
+	})
+
+	c, err := api.NewClient("test",
+		api.WithApiV2(),
+		api.WithToken("TOKEN"),
+		api.WithURL(fakeServer.URL()),
+	)
+	assert.Nil(t, err)
+
+	emailAlertChan := api.NewAlertChannel("integration_name",
+		api.EmailUserAlertChannel,
+		api.EmailUserData{
+			ChannelProps: api.EmailUserChannelProps{
+				Recipients: []string{"foo@example.com", "bar@example.com"},
+			},
+		},
+	)
+	assert.Equal(t, "integration_name", emailAlertChan.Name, "EmailUser cloud account name mismatch")
+	assert.Equal(t, "EmailUser", emailAlertChan.Type, "a new EmailUser cloud account should match its type")
+	assert.Equal(t, 1, emailAlertChan.Enabled, "a new EmailUser cloud account should be enabled")
+	emailAlertChan.IntgGuid = intgGUID
+
+	response, err := c.V2.AlertChannels.UpdateEmailUser(emailAlertChan)
+	assert.Nil(t, err)
+	assert.NotNil(t, response)
+	assert.Equal(t, intgGUID, response.Data.IntgGuid)
+	assert.True(t, response.Data.State.Ok)
+	assert.Contains(t, response.Data.Data.ChannelProps.Recipients, "foo@lacework.net")
+	assert.Contains(t, response.Data.Data.ChannelProps.Recipients, "bar@lacework.net")
+}
+
+func singleEmailUserAlertChannel(id string) string {
+	return `
+{
+    "createdOrUpdatedBy": "Lacework",
+    "createdOrUpdatedTime": "2020-02-08T00:05:35.996Z",
+    "data": {
+      "channelProps": {
+        "recipients": ["foo@lacework.net","bar@lacework.net"]
+      },
+      "notificationTypes": {
+        "properties": {
+          "agentEvents": true,
+          "awsCisS3": false,
+          "awsCloudtrailEvents": true,
+          "awsComplianceEvents": true,
+          "azureCis": true,
+          "gcpCis": true,
+          "noEvents": false,
+          "time": "1200 (GMT)",
+          "trendReport": true
+        }
+      }
+    },
+    "enabled": 1,
+    "intgGuid": "` + id + `",
+    "isOrg": 0,
+    "name": "integration_name",
+    "props": {
+      "isDefault": 1
+    },
+    "state": {
+      "details": {
+        "message": "Unable to send email to channel with intg guid: foo"
+      },
+      "lastSuccessfulTime": 1617380198077,
+      "lastUpdatedTime": 1617380198077,
+      "ok": true
+    },
+    "type": "EmailUser"
+}
+  `
+}
+
+// Workaround from APIv2
+// Bug: https://lacework.atlassian.net/browse/RAIN-20070
+func TestAlertChannelsGetEmailUserBug(t *testing.T) {
+	var (
+		intgGUID   = intgguid.New()
+		apiPath    = fmt.Sprintf("AlertChannels/%s", intgGUID)
+		fakeServer = lacework.MockServer()
+	)
+	fakeServer.UseApiV2()
+	fakeServer.MockToken("TOKEN")
+	defer fakeServer.Close()
+
+	fakeServer.MockAPI(apiPath, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method, "GetEmailUser() should be a GET method")
+		fmt.Fprintf(w, generateAlertChannelResponse(bugGetEmailUserAlertChannel(intgGUID)))
+	})
+
+	c, err := api.NewClient("test",
+		api.WithApiV2(),
+		api.WithToken("TOKEN"),
+		api.WithURL(fakeServer.URL()),
+	)
+	assert.Nil(t, err)
+
+	response, err := c.V2.AlertChannels.GetEmailUser(intgGUID)
+	assert.Nil(t, err)
+	assert.NotNil(t, response)
+	assert.Equal(t, intgGUID, response.Data.IntgGuid)
+	assert.Equal(t, "integration_name", response.Data.Name)
+	assert.True(t, response.Data.State.Ok)
+	assert.Contains(t, response.Data.Data.ChannelProps.Recipients, "foo@lacework.net")
+	assert.Contains(t, response.Data.Data.ChannelProps.Recipients, "bar@lacework.net")
+}
+
+func bugGetEmailUserAlertChannel(id string) string {
+	return `
+{
+    "createdOrUpdatedBy": "Lacework",
+    "createdOrUpdatedTime": "2020-02-08T00:05:35.996Z",
+    "data": {
+      "channelProps": {
+        "recipients": "foo@lacework.net,bar@lacework.net"
+      },
+      "notificationTypes": {
+        "properties": {
+          "agentEvents": true,
+          "awsCisS3": false,
+          "awsCloudtrailEvents": true,
+          "awsComplianceEvents": true,
+          "azureCis": true,
+          "gcpCis": true,
+          "noEvents": false,
+          "time": "1200 (GMT)",
+          "trendReport": true
+        }
+      }
+    },
+    "enabled": 1,
+    "intgGuid": "` + id + `",
+    "isOrg": 0,
+    "name": "integration_name",
+    "props": {
+      "isDefault": 1
+    },
+    "state": {
+      "details": {
+        "message": "Unable to send email to channel with intg guid: foo"
+      },
+      "lastSuccessfulTime": 1617380198077,
+      "lastUpdatedTime": 1617380198077,
+      "ok": true
+    },
+    "type": "EmailUser"
+}
+  `
+}

--- a/api/alert_channels_test.go
+++ b/api/alert_channels_test.go
@@ -1,0 +1,279 @@
+//
+// Author:: Salim Afiune Maya (<afiune@lacework.net>)
+// Copyright:: Copyright 2021, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package api_test
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/lacework/go-sdk/api"
+	"github.com/lacework/go-sdk/internal/intgguid"
+	"github.com/lacework/go-sdk/internal/lacework"
+)
+
+func TestAlertChannelTypeEmailUser(t *testing.T) {
+	assert.Equal(t,
+		"EmailUser", api.EmailUserAlertChannel.String(),
+		"wrong alert channel type",
+	)
+}
+
+func TestFindAlertChannelType(t *testing.T) {
+	alertFound, found := api.FindAlertChannelType("SOME_NON_EXISTING_INTEGRATION")
+	assert.False(t, found, "alert channel type should not be found")
+	assert.Equal(t, 0, int(alertFound), "wrong alert channel type")
+	assert.Equal(t, "None", alertFound.String(), "wrong alert channel type")
+
+	alertFound, found = api.FindAlertChannelType("EmailUser")
+	assert.True(t, found, "alert channel type should exist")
+	assert.Equal(t, "EmailUser", alertFound.String(), "wrong alert channel type")
+
+	//alertFound, found = api.FindAlertChannelType("SlackChannel")
+	//assert.True(t, found, "alert channel type should exist")
+	//assert.Equal(t, "SlackChannel", alertFound.String(), "wrong alert channel type")
+}
+
+func TestAlertChannelsGet(t *testing.T) {
+	var (
+		intgGUID    = intgguid.New()
+		vanillaType = "VANILLA"
+		apiPath     = fmt.Sprintf("AlertChannels/%s", intgGUID)
+		vanillaInt  = singleVanillaAlertChannel(intgGUID, vanillaType, "")
+		fakeServer  = lacework.MockServer()
+	)
+	fakeServer.UseApiV2()
+	fakeServer.MockToken("TOKEN")
+	defer fakeServer.Close()
+
+	fakeServer.MockAPI(apiPath,
+		func(w http.ResponseWriter, r *http.Request) {
+			if assert.Equal(t, "GET", r.Method, "Get() should be a GET method") {
+				fmt.Fprintf(w, generateAlertChannelResponse(vanillaInt))
+			}
+		},
+	)
+
+	fakeServer.MockAPI("AlertChannels/UNKNOWN_INTG_GUID",
+		func(w http.ResponseWriter, r *http.Request) {
+			if assert.Equal(t, "GET", r.Method, "Get() should be a GET method") {
+				http.Error(w, "{ \"message\": \"Not Found\"}", 404)
+			}
+		},
+	)
+
+	c, err := api.NewClient("test",
+		api.WithApiV2(),
+		api.WithToken("TOKEN"),
+		api.WithURL(fakeServer.URL()),
+	)
+	assert.Nil(t, err)
+
+	t.Run("when alert channel exists", func(t *testing.T) {
+		response, err := c.V2.AlertChannels.Get(intgGUID)
+		assert.Nil(t, err)
+		if assert.NotNil(t, response) {
+			assert.Equal(t, intgGUID, response.Data.IntgGuid)
+			assert.Equal(t, "integration_name", response.Data.Name)
+			assert.Equal(t, "VANILLA", response.Data.Type)
+		}
+	})
+
+	t.Run("when alert channel does NOT exist", func(t *testing.T) {
+		response, err := c.V2.AlertChannels.Get("UNKNOWN_INTG_GUID")
+		assert.Empty(t, response)
+		if assert.NotNil(t, err) {
+			assert.Contains(t, err.Error(), "api/v2/AlertChannels/UNKNOWN_INTG_GUID")
+			assert.Contains(t, err.Error(), "[404] Not Found")
+		}
+	})
+}
+
+func TestAlertChannelsDelete(t *testing.T) {
+	var (
+		intgGUID    = intgguid.New()
+		vanillaType = "VANILLA"
+		apiPath     = fmt.Sprintf("AlertChannels/%s", intgGUID)
+		vanillaInt  = singleVanillaAlertChannel(intgGUID, vanillaType, "")
+		getResponse = generateAlertChannelResponse(vanillaInt)
+		fakeServer  = lacework.MockServer()
+	)
+	fakeServer.UseApiV2()
+	fakeServer.MockToken("TOKEN")
+	defer fakeServer.Close()
+
+	fakeServer.MockAPI(apiPath,
+		func(w http.ResponseWriter, r *http.Request) {
+			if getResponse != "" {
+				switch r.Method {
+				case "GET":
+					fmt.Fprintf(w, getResponse)
+				case "DELETE":
+					// once deleted, empty the getResponse so that
+					// further GET requests return 404s
+					getResponse = ""
+				}
+			} else {
+				http.Error(w, "{ \"message\": \"Not Found\"}", 404)
+			}
+		},
+	)
+
+	fakeServer.MockAPI("AlertChannels/UNKNOWN_INTG_GUID",
+		func(w http.ResponseWriter, r *http.Request) {
+			if assert.Equal(t, "GET", r.Method, "Get() should be a GET method") {
+				http.Error(w, "{ \"message\": \"Not Found\"}", 404)
+			}
+		},
+	)
+
+	c, err := api.NewClient("test",
+		api.WithApiV2(),
+		api.WithToken("TOKEN"),
+		api.WithURL(fakeServer.URL()),
+	)
+	assert.Nil(t, err)
+
+	t.Run("verify alert channel exists", func(t *testing.T) {
+		response, err := c.V2.AlertChannels.Get(intgGUID)
+		assert.Nil(t, err)
+		if assert.NotNil(t, response) {
+			assert.Equal(t, intgGUID, response.Data.IntgGuid)
+			assert.Equal(t, "integration_name", response.Data.Name)
+			assert.Equal(t, "VANILLA", response.Data.Type)
+		}
+	})
+
+	t.Run("when alert channel has been deleted", func(t *testing.T) {
+		err := c.V2.AlertChannels.Delete(intgGUID)
+		assert.Nil(t, err)
+
+		response, err := c.V2.AlertChannels.Get(intgGUID)
+		assert.Empty(t, response)
+		if assert.NotNil(t, err) {
+			assert.Contains(t, err.Error(), "api/v2/AlertChannels/MOCK_")
+			assert.Contains(t, err.Error(), "[404] Not Found")
+		}
+	})
+}
+
+func TestAlertChannelsList(t *testing.T) {
+	var (
+		emailAlertChan  = []string{intgguid.New(), intgguid.New(), intgguid.New()}
+		splunkAlertChan = []string{intgguid.New(), intgguid.New()}
+		slackAlertChan  = []string{
+			intgguid.New(), intgguid.New(), intgguid.New(), intgguid.New(),
+		}
+		allGUIDs    = append(splunkAlertChan, append(slackAlertChan, emailAlertChan...)...)
+		expectedLen = len(allGUIDs)
+		fakeServer  = lacework.MockServer()
+	)
+	fakeServer.UseApiV2()
+	fakeServer.MockToken("TOKEN")
+	fakeServer.MockAPI("AlertChannels",
+		func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "GET", r.Method, "List() should be a GET method")
+			alertChannels := []string{
+				generateAlertChannels(emailAlertChan, "EmailUser"),
+				// TODO @afiune come back here and update these Alert Channels types when they exist
+				generateAlertChannels(slackAlertChan, "EmailUser"),  // "SlackChannel"),
+				generateAlertChannels(splunkAlertChan, "EmailUser"), // "SplunkHec"),
+			}
+			fmt.Fprintf(w,
+				generateAlertChannelsResponse(
+					strings.Join(alertChannels, ", "),
+				),
+			)
+		},
+	)
+	defer fakeServer.Close()
+
+	c, err := api.NewClient("test",
+		api.WithApiV2(),
+		api.WithToken("TOKEN"),
+		api.WithURL(fakeServer.URL()),
+	)
+	assert.Nil(t, err)
+
+	response, err := c.V2.AlertChannels.List()
+	assert.Nil(t, err)
+	assert.NotNil(t, response)
+	assert.Equal(t, expectedLen, len(response.Data))
+	for _, d := range response.Data {
+		assert.Contains(t, allGUIDs, d.IntgGuid)
+	}
+}
+
+func generateAlertChannels(guids []string, iType string) string {
+	alertChannels := make([]string, len(guids))
+	for i, guid := range guids {
+		switch iType {
+		case api.EmailUserAlertChannel.String():
+			alertChannels[i] = singleEmailUserAlertChannel(guid)
+			// TODO @afiune come back here and update these Alert Channels types
+			// when they exist
+			//case api.SlackChannelAlertChannel.String():
+			//alertChannels[i] = singleSlackChannelAlertChannel(guid)
+		}
+	}
+	return strings.Join(alertChannels, ", ")
+}
+
+func generateAlertChannelsResponse(data string) string {
+	return `
+		{
+			"data": [` + data + `]
+		}
+	`
+}
+
+func generateAlertChannelResponse(data string) string {
+	return `
+		{
+			"data": ` + data + `
+		}
+	`
+}
+
+func singleVanillaAlertChannel(id string, iType string, data string) string {
+	if data == "" {
+		data = "{}"
+	}
+	return `
+    {
+      "createdOrUpdatedBy": "salim.afiunemaya@lacework.net",
+      "createdOrUpdatedTime": "2021-06-01T19:28:00.092Z",
+      "data": ` + data + `,
+      "enabled": 1,
+      "intgGuid": "` + id + `",
+      "isOrg": 0,
+      "name": "integration_name",
+      "state": {
+        "details": {},
+        "lastSuccessfulTime": 1624456896915,
+        "lastUpdatedTime": 1624456896915,
+        "ok": true
+      },
+      "type": "` + iType + `"
+    }
+	`
+}

--- a/api/api.go
+++ b/api/api.go
@@ -87,6 +87,9 @@ const (
 	// These endpoints only exist in APIv2 and therefore we prefix them with 'v2/'
 	apiV2UserProfile = "v2/UserProfile"
 
+	apiV2AlertChannels        = "v2/AlertChannels"
+	apiV2AlertChannelFromGUID = "v2/AlertChannels/%s"
+
 	apiV2CloudAccounts        = "v2/CloudAccounts"
 	apiV2CloudAccountFromGUID = "v2/CloudAccounts/%s"
 

--- a/api/v2.go
+++ b/api/v2.go
@@ -25,6 +25,7 @@ type V2Endpoints struct {
 
 	// Every schema must have its own service
 	UserProfile       *UserProfileService
+	AlertChannels     *AlertChannelsService
 	CloudAccounts     *CloudAccountsService
 	AgentAccessTokens *AgentAccessTokensService
 	Query             *QueryService
@@ -34,6 +35,7 @@ type V2Endpoints struct {
 func NewV2Endpoints(c *Client) *V2Endpoints {
 	return &V2Endpoints{c,
 		&UserProfileService{c},
+		&AlertChannelsService{c},
 		&CloudAccountsService{c},
 		&AgentAccessTokensService{c},
 		&QueryService{c},


### PR DESCRIPTION
`NewAlertChannel` returns an instance of the
AlertChannelRaw struct with the provided Alert Channel
integration type, name and raw data as an `interface{}`.

**NOTE: This function must be used by any Alert Channel type.**

Basic usage: Initialize a new `EmailUserAlertChannel`
             struct, then use the new instance to do
	     CRUD operations
```
  client, err := api.NewClient("account")
  if err != nil {
    return err
  }

  emailAlertChan := api.NewAlertChannel("foo",
    api.EmailUserAlertChannel,
    api.EmailUserData{
      ChannelProps: api.EmailUserChannelProps{
        Recipients: []string{"name@example.com"},
      },
    },
  )

  client.V2.AlertChannels.Create(emailAlertChan)
```

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>