### PR TITLE
fix: comp [aws | gcp | az] list json output

### DIFF
--- a/cli/cmd/compliance_aws.go
+++ b/cli/cmd/compliance_aws.go
@@ -66,7 +66,10 @@ Then navigate to Settings > Integrations > Cloud Accounts.
 			}
 
 			if cli.JSONOutput() {
-				return cli.OutputJSON(awsAccounts)
+				jsonOut := struct {
+					Accounts []string `json:"aws_accounts"`
+				}{Accounts: awsAccounts}
+				return cli.OutputJSON(jsonOut)
 			}
 
 			rows := [][]string{}

--- a/cli/cmd/compliance_azure.go
+++ b/cli/cmd/compliance_azure.go
@@ -110,7 +110,10 @@ Then navigate to Settings > Integrations > Cloud Accounts.
 			}
 
 			if cli.JSONOutput() {
-				return cli.OutputJSON(azureTenants)
+				jsonOut := struct {
+					Tenants []string `json:"azure_tenants"`
+				}{Tenants: azureTenants}
+				return cli.OutputJSON(jsonOut)
 			}
 
 			var rows [][]string

--- a/cli/cmd/compliance_gcp.go
+++ b/cli/cmd/compliance_gcp.go
@@ -48,6 +48,23 @@ var (
 				return errors.Wrap(err, "unable to list gcp projects/organizations")
 			}
 
+			if len(response.Data) == 0 {
+				msg := `There are no GCP integrations configured in your account.
+
+Get started by integrating your GCP to analyze configuration compliance using the command:
+
+    $ lacework integration create
+
+If you prefer to configure the integration via the WebUI, log in to your account at:
+
+    https://%s.lacework.net
+
+Then navigate to Settings > Integrations > Cloud Accounts.
+`
+				cli.OutputHuman(fmt.Sprintf(msg, cli.Account))
+				return nil
+			}
+
 			gcpAccounts := extractGcpAccounts(response)
 
 			for _, gcp := range gcpAccounts {
@@ -55,7 +72,10 @@ var (
 			}
 
 			if cli.JSONOutput() {
-				return cli.OutputJSON(gcpAccounts)
+				jsonOut := struct {
+					Accounts []gcpAccount `json:"gcp_accounts"`
+				}{Accounts: gcpAccounts}
+				return cli.OutputJSON(jsonOut)
 			}
 
 			cli.OutputHuman(renderSimpleTable([]string{"Organization ID", "Project ID"}, rows))

--- a/cli/cmd/compliance_gcp.go
+++ b/cli/cmd/compliance_gcp.go
@@ -65,16 +65,16 @@ Then navigate to Settings > Integrations > Cloud Accounts.
 				return nil
 			}
 
-			gcpAccounts := extractGcpAccounts(response)
+			gcpProjects := extractGcpProjects(response)
 
-			for _, gcp := range gcpAccounts {
+			for _, gcp := range gcpProjects {
 				rows = append(rows, []string{gcp.OrganizationID, gcp.ProjectID})
 			}
 
 			if cli.JSONOutput() {
 				jsonOut := struct {
 					Projects []gcpProject `json:"gcp_projects"`
-				}{Projects: gcpAccounts}
+				}{Projects: gcpProjects}
 				return cli.OutputJSON(jsonOut)
 			}
 
@@ -410,7 +410,7 @@ type gcpProject struct {
 	OrganizationID string `json:"organization_id"`
 }
 
-func extractGcpAccounts(response api.GcpIntegrationsResponse) []gcpProject {
+func extractGcpProjects(response api.GcpIntegrationsResponse) []gcpProject {
 	var gcpAccounts []gcpProject
 
 	for _, gcp := range response.Data {

--- a/cli/cmd/compliance_gcp_test.go
+++ b/cli/cmd/compliance_gcp_test.go
@@ -117,10 +117,10 @@ func TestSplitGcpProjectsApiResponse(t *testing.T) {
 }
 
 func TestDuplicateGcpAccountCheck(t *testing.T) {
-	gcpOne := gcpAccount{OrganizationID: "n/a", ProjectID: "1"}
-	gcpTwo := gcpAccount{OrganizationID: "n/a", ProjectID: "2"}
-	gcpThree := gcpAccount{OrganizationID: "n/a", ProjectID: "3"}
-	mockGcpAccounts := []gcpAccount{gcpOne, gcpTwo, gcpThree}
+	gcpOne := gcpProject{OrganizationID: "n/a", ProjectID: "1"}
+	gcpTwo := gcpProject{OrganizationID: "n/a", ProjectID: "2"}
+	gcpThree := gcpProject{OrganizationID: "n/a", ProjectID: "3"}
+	mockGcpAccounts := []gcpProject{gcpOne, gcpTwo, gcpThree}
 
 	duplicate := containsDuplicateProjectID(mockGcpAccounts, "1")
 	different := containsDuplicateProjectID(mockGcpAccounts, "4")


### PR DESCRIPTION
Improve json output for `lacework comp [aws | gcp | az] list` cmd

https://lacework.atlassian.net/browse/ALLY-575

```
❯ lacework comp aws list --json    
{
  "aws_accounts": [
    "123456789101",
    "123456789101",
    "123456789101",
    "123456789101",
    "123456789101"
  ]
}
```

```
❯ lacework comp az list --json
{
  "azure_tenants": [
    "12345678-1234-1235-1235-123456789101",
    "12345678-1234-1235-1235-123456789101",
    "12345678-1234-1235-1235-123456789101",
    "12345678-1234-1235-1235-123456789101"
  ]
}
```

```
❯ lacework comp gcp list --json
{
  "gcp_projects": [
    {
      "organization_id": "n/a",
      "project_id": "project-123456"
    },
    {
      "organization_id": "12345678",
      "project_id": "project-54321"
    }
  ]
}
```




Signed-off-by: Darren Murray <darren.murray@lacework.net>