### PR TITLE
fix(cli): scan-pkg-manifest returns valid JSON when no vulns are found

### DIFF
--- a/cli/cmd/vuln_host.go
+++ b/cli/cmd/vuln_host.go
@@ -887,7 +887,7 @@ func hostScanPackagesVulnToTable(scan *api.HostVulnScanPkgManifestResponse) stri
 }
 
 func filterHostScanPackagesVulnDetails(vulns []api.HostScanPackageVulnDetails) []api.HostScanPackageVulnDetails {
-	var out []api.HostScanPackageVulnDetails
+	out := make([]api.HostScanPackageVulnDetails, 0)
 
 	for _, vuln := range vulns {
 		if vulCmdState.Fixable && vuln.HasFix() {
@@ -1089,12 +1089,6 @@ func buildListCVEReports(cves []api.HostVulnCVE) error {
 
 // Build the cli output for vuln host scan-package-manifest
 func buildVulnHostScanPkgManifestReports(response api.HostVulnScanPkgManifestResponse) error {
-	if len(response.Vulns) == 0 {
-		// @afiune add a helpful message, possible things are:
-		cli.OutputHuman(fmt.Sprintf("There are no vulnerabilities found! Time for %s\n", randomEmoji()))
-		return nil
-	}
-
 	response.Vulns = filterHostScanPackagesVulnDetails(response.Vulns)
 
 	if cli.JSONOutput() {
@@ -1103,7 +1097,13 @@ func buildVulnHostScanPkgManifestReports(response api.HostVulnScanPkgManifestRes
 		}
 	} else {
 		cli.OutputHuman(hostScanPackagesVulnToTable(&response))
+		return nil
 	}
 
+	if len(response.Vulns) == 0 {
+		// @afiune add a helpful message, possible things are:
+		cli.OutputHuman(fmt.Sprintf("There are no vulnerabilities found! Time for %s\n", randomEmoji()))
+		return nil
+	}
 	return nil
 }

--- a/cli/cmd/vuln_host.go
+++ b/cli/cmd/vuln_host.go
@@ -162,7 +162,7 @@ To generate a package-manifest from the local host and scan it automatically:
 				return errors.Wrap(err, "unable to request an on-demand host vulnerability scan")
 			}
 
-			if err := buildVulnHostScanPkgManifestReports(response); err != nil {
+			if err := buildVulnHostScanPkgManifestReports(&response); err != nil {
 				return err
 			}
 
@@ -1088,22 +1088,18 @@ func buildListCVEReports(cves []api.HostVulnCVE) error {
 }
 
 // Build the cli output for vuln host scan-package-manifest
-func buildVulnHostScanPkgManifestReports(response api.HostVulnScanPkgManifestResponse) error {
+func buildVulnHostScanPkgManifestReports(response *api.HostVulnScanPkgManifestResponse) error {
 	response.Vulns = filterHostScanPackagesVulnDetails(response.Vulns)
 
 	if cli.JSONOutput() {
-		if err := cli.OutputJSON(response); err != nil {
-			return err
-		}
-	} else {
-		cli.OutputHuman(hostScanPackagesVulnToTable(&response))
-		return nil
+		return cli.OutputJSON(response)
 	}
 
 	if len(response.Vulns) == 0 {
-		// @afiune add a helpful message, possible things are:
 		cli.OutputHuman(fmt.Sprintf("There are no vulnerabilities found! Time for %s\n", randomEmoji()))
-		return nil
+	} else {
+		cli.OutputHuman(hostScanPackagesVulnToTable(response))
 	}
+
 	return nil
 }


### PR DESCRIPTION
` lacework vuln host scan-pkg-manifest --json ` command previously did not return anything
when 0 vulnerabilities were found. The command now returns a valid JSON response similar to:

```
❯ lacework vuln host scan-pkg-manifest --json
{
  "data": [],
  "message": "SUCCESS",
  "ok": true
}
```

Closes https://github.com/lacework/go-sdk/issues/491

JIRA: https://lacework.atlassian.net/browse/ALLY-592

Signed-off-by: Darren Murray <darren.murray@lacework.net>