### PR TITLE
fix(install.ps1): verify if running as administrator

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,17 +24,17 @@ reports, external integrations, vulnerability scans, and other operations.
 
 #### Bash:
 ```
-$ curl https://raw.githubusercontent.com/lacework/go-sdk/main/cli/install.sh | bash
+curl https://raw.githubusercontent.com/lacework/go-sdk/main/cli/install.sh | bash
 ```
 
 #### Powershell:
 ```
-C:\> Set-ExecutionPolicy Bypass -Scope Process -Force
-C:\> iex ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/lacework/go-sdk/main/cli/install.ps1'))
+Set-ExecutionPolicy Bypass -Scope Process -Force;
+iex ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/lacework/go-sdk/main/cli/install.ps1'))
 ```
 #### Homebrew:
 ```
-$ brew install lacework/tap/lacework-cli
+brew install lacework/tap/lacework-cli
 ```
 For more details, see [Lacework Homebrew Tap](https://github.com/lacework/homebrew-tap).
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -19,8 +19,8 @@ curl https://raw.githubusercontent.com/lacework/go-sdk/main/cli/install.sh | bas
 ### Powershell:
 
 ```
-C:\> Set-ExecutionPolicy Bypass -Scope Process -Force
-C:\> iex ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/lacework/go-sdk/main/cli/install.ps1'))
+Set-ExecutionPolicy Bypass -Scope Process -Force;
+iex ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/lacework/go-sdk/main/cli/install.ps1'))
 ```
 
 ### Homebrew:
@@ -75,7 +75,7 @@ Then, when you run a command, you can specify a `--profile prod` and use the
 credentials and settings stored under that name.
 
 ```bash
-$ lacework integration list --profile prod
+lacework integration list --profile prod
 ```
 
 If there is no `--profile` option, the CLI will default to the `default` profile.
@@ -86,14 +86,14 @@ overriden by setting environment variables prefixed with `LW_`.
 
 To override the `account`, `api_key`, and `api_secret`  configurations:
 ```
-$ export LW_ACCOUNT="<YOUR_ACCOUNT>"
-$ export LW_API_KEY="<YOUR_API_KEY>"
-$ export LW_API_SECRET="<YOUR_API_SECRET>"
+export LW_ACCOUNT="<YOUR_ACCOUNT>"
+export LW_API_KEY="<YOUR_API_KEY>"
+export LW_API_SECRET="<YOUR_API_SECRET>"
 ```
 
 To override the profile to use:
 ```
-$ export LW_PROFILE=prod
+export LW_PROFILE=prod
 ```
 
 This is a list of all environment variables that can be used to modify the
@@ -118,20 +118,20 @@ A few basic commands are:
 
 1) List all integration in your account:
 ```bash
-$ lacework integrations list
+lacework integrations list
 ```
 2) List all events from the last 7 days in your account:
 ```bash
-$ lacework events list
+lacework events list
 ```
 3) Request an on-demand container vulnerability scan:
 ```bash
-$ lacework vulnerability container scan index.docker.io lacework/lacework-cli latest
+lacework vulnerability container scan index.docker.io lacework/lacework-cli latest
 ```
 4) Use the `api` command to access Lacework's RestfulAPI, for example,
 to look at the SCHEMA of the `WEBHOOK` integration:
 ```bash
-$ lacework api get /external/integrations/schema/WEBHOOK
+lacework api get /external/integrations/schema/WEBHOOK
 ```
 
 ## CLI Documentation
@@ -191,7 +191,7 @@ Server, for that reason, it requires a set of Lacework API keys. To run these te
 locally you need to setup the following environment variables and use the directive
 `make integration`, an example of the command you can use is:
 ```
-$ CI_ACCOUNT="<YOUR_ACCOUNT>" \
+CI_ACCOUNT="<YOUR_ACCOUNT>" \
   CI_V2_ACCOUNT="<YOUR_APIV2_PRIMARY_ACCOUNT>" \
   CI_API_KEY="<YOUR_API_KEY>" \
   CI_API_SECRET="<YOUR_API_SECRET>" \

--- a/cli/cmd/cli_unix.go
+++ b/cli/cmd/cli_unix.go
@@ -26,7 +26,7 @@ import (
 )
 
 // used by configure.go
-var configureListCmdSetProfileEnv = `$ export LW_PROFILE="my-profile"`
+var configureListCmdSetProfileEnv = `export LW_PROFILE="my-profile"`
 
 // promptIconsFuncs configures the prompt icons for Unix systems
 var promptIconsFunc = func(icons *survey.IconSet) {
@@ -38,10 +38,10 @@ var promptIconsFunc = func(icons *survey.IconSet) {
 func (c *cliState) UpdateCommand() string {
 	if os.Getenv(HomebrewInstall) != "" {
 		return `
-  $ brew upgrade lacework-cli
+  brew upgrade lacework-cli
 `
 	}
 	return `
-  $ curl https://raw.githubusercontent.com/lacework/go-sdk/main/cli/install.sh | bash
+  curl https://raw.githubusercontent.com/lacework/go-sdk/main/cli/install.sh | bash
 `
 }

--- a/cli/cmd/cli_windows.go
+++ b/cli/cmd/cli_windows.go
@@ -21,7 +21,7 @@ package cmd
 import "github.com/AlecAivazis/survey/v2"
 
 // used by configure.go
-var configureListCmdSetProfileEnv = `C:\> $env:LW_PROFILE = 'my-profile'`
+var configureListCmdSetProfileEnv = `$env:LW_PROFILE = 'my-profile'`
 
 // promptIconsFuncs configures the prompt icons for Windows systems
 var promptIconsFunc = func(icons *survey.IconSet) {
@@ -32,7 +32,7 @@ var promptIconsFunc = func(icons *survey.IconSet) {
 // to the latest available version (windows specific command)
 func (c *cliState) UpdateCommand() string {
 	return `
-  C:\> Set-ExecutionPolicy Bypass -Scope Process -Force
-  C:\> iex ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/lacework/go-sdk/main/cli/install.ps1'))
+  Set-ExecutionPolicy Bypass -Scope Process -Force;
+  iex ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/lacework/go-sdk/main/cli/install.ps1'))
 `
 }

--- a/cli/install.ps1
+++ b/cli/install.ps1
@@ -101,7 +101,18 @@ Function Install-Lacework-CLI {
     $env:PATH = New-PathString -StartingPath $env:PATH -Path $laceworkPath
     $machinePath = [System.Environment]::GetEnvironmentVariable("PATH", "Machine")
     $machinePath = New-PathString -StartingPath $machinePath -Path $laceworkPath
-    [System.Environment]::SetEnvironmentVariable("PATH", $machinePath, "Machine")
+
+    $isAdmin = False
+    try {
+        $currentPrincipal = New-Object Security.Principal.WindowsPrincipal([Security.Principal.WindowsIdentity]::GetCurrent())
+        $isAdmin = $currentPrincipal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+    } finally {
+        if ($isAdmin) {
+            [System.Environment]::SetEnvironmentVariable("PATH", $machinePath, "Machine")
+        } else {
+            [System.Environment]::SetEnvironmentVariable("PATH", $machinePath, "User")
+        }
+    }
 }
 
 Function New-PathString([string]$StartingPath, [string]$Path) {

--- a/integration/configure_unix_test.go
+++ b/integration/configure_unix_test.go
@@ -489,7 +489,7 @@ func TestConfigureListHelp(t *testing.T) {
 		"STDERR should be empty")
 	assert.Contains(t,
 		out.String(),
-		"$ export LW_PROFILE=\"my-profile\"",
+		"export LW_PROFILE=\"my-profile\"",
 		"STDOUT the environment variable in the help message is not correct")
 	assert.Equal(t, 0, exitcode,
 		"EXITCODE is not the expected one")


### PR DESCRIPTION
When trying to install the Lacework CLI using Power Shell without "run as administrator " option
the install error our with the following output:
 
![image](https://user-images.githubusercontent.com/5712253/128804994-a49a3b08-59f6-4117-a9f6-75090efceb2f.png)

This change is improving the `install.ps1` script to detect when the user runs the install
as an Administrator or not, if the script is run without "run as administrator" option, the
script will now configure the appropriate user-level environment variables rather than
the global machine-level environment variables.

JIRA: https://lacework.atlassian.net/browse/ALLY-516

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>