### PR TITLE
feat(cli): new --api_token global flag

### DIFF
--- a/cli/cmd/cache.go
+++ b/cli/cmd/cache.go
@@ -151,7 +151,7 @@ func (c *cliState) WriteCachedToken() error {
 		return nil
 	}
 
-	if c.tokenCache.Token == "" {
+	if c.Token == "" {
 		response, err := c.LwApi.GenerateToken()
 		if err != nil {
 			return err

--- a/cli/cmd/cli_state.go
+++ b/cli/cmd/cli_state.go
@@ -137,7 +137,7 @@ func (c *cliState) LoadState() error {
 		}
 	}
 
-	c.Token = c.extractValueString("token")
+	c.Token = c.extractValueString("api_token")
 	c.KeyID = c.extractValueString("api_key")
 	c.Secret = c.extractValueString("api_secret")
 	c.Account = c.extractValueString("account")
@@ -148,7 +148,7 @@ func (c *cliState) LoadState() error {
 		"profile", c.Profile,
 		"account", c.Account,
 		"subaccount", c.Subaccount,
-		"token", format.Secret(4, c.Token),
+		"api_token", format.Secret(4, c.Token),
 		"api_key", c.KeyID,
 		"api_secret", format.Secret(4, c.Secret),
 		"config_version", c.CfgVersion,
@@ -350,9 +350,9 @@ func (c *cliState) CSVOutput() bool {
 // loadStateFromViper loads parameters and environment variables
 // coming from viper into the CLI state
 func (c *cliState) loadStateFromViper() {
-	if v := viper.GetString("token"); v != "" {
+	if v := viper.GetString("api_token"); v != "" {
 		c.Token = v
-		c.Log.Debugw("state updated", "token", format.Secret(4, c.Token))
+		c.Log.Debugw("state updated", "api_token", format.Secret(4, c.Token))
 	}
 
 	if v := viper.GetString("api_key"); v != "" {

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -146,11 +146,11 @@ func init() {
 	rootCmd.PersistentFlags().StringP("api_secret", "s", "",
 		"secret access key",
 	)
+	rootCmd.PersistentFlags().String("api_token", "",
+		"access token (replaces the use of api_key and api_secret)",
+	)
 	rootCmd.PersistentFlags().StringP("account", "a", "",
 		"account subdomain of URL (i.e. <ACCOUNT>.lacework.net)",
-	)
-	rootCmd.PersistentFlags().String("token", "",
-		"access token (replaces the use of api_key and api_secret)",
 	)
 	rootCmd.PersistentFlags().String("subaccount", "",
 		"sub-account name inside your organization (org admins only)",
@@ -168,7 +168,7 @@ func init() {
 	errcheckWARN(viper.BindPFlag("account", rootCmd.PersistentFlags().Lookup("account")))
 	errcheckWARN(viper.BindPFlag("api_key", rootCmd.PersistentFlags().Lookup("api_key")))
 	errcheckWARN(viper.BindPFlag("api_secret", rootCmd.PersistentFlags().Lookup("api_secret")))
-	errcheckWARN(viper.BindPFlag("token", rootCmd.PersistentFlags().Lookup("token")))
+	errcheckWARN(viper.BindPFlag("api_token", rootCmd.PersistentFlags().Lookup("api_token")))
 	errcheckWARN(viper.BindPFlag("subaccount", rootCmd.PersistentFlags().Lookup("subaccount")))
 	errcheckWARN(viper.BindPFlag("organization", rootCmd.PersistentFlags().Lookup("organization")))
 }

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -149,6 +149,9 @@ func init() {
 	rootCmd.PersistentFlags().StringP("account", "a", "",
 		"account subdomain of URL (i.e. <ACCOUNT>.lacework.net)",
 	)
+	rootCmd.PersistentFlags().String("token", "",
+		"access token (replaces the use of api_key and api_secret)",
+	)
 	rootCmd.PersistentFlags().String("subaccount", "",
 		"sub-account name inside your organization (org admins only)",
 	)
@@ -165,6 +168,7 @@ func init() {
 	errcheckWARN(viper.BindPFlag("account", rootCmd.PersistentFlags().Lookup("account")))
 	errcheckWARN(viper.BindPFlag("api_key", rootCmd.PersistentFlags().Lookup("api_key")))
 	errcheckWARN(viper.BindPFlag("api_secret", rootCmd.PersistentFlags().Lookup("api_secret")))
+	errcheckWARN(viper.BindPFlag("token", rootCmd.PersistentFlags().Lookup("token")))
 	errcheckWARN(viper.BindPFlag("subaccount", rootCmd.PersistentFlags().Lookup("subaccount")))
 	errcheckWARN(viper.BindPFlag("organization", rootCmd.PersistentFlags().Lookup("organization")))
 }

--- a/integration/compliance_test.go
+++ b/integration/compliance_test.go
@@ -66,6 +66,7 @@ Global Flags:
   -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
+      --api_token string    access token (replaces the use of api_key and api_secret)
       --debug               turn on debug logging
       --json                switch commands output from human-readable to json format
       --nocache             turn off caching
@@ -74,7 +75,6 @@ Global Flags:
       --organization        access organization level data sets (org admins only)
   -p, --profile string      switch between profiles configured at ~/.lacework.toml
       --subaccount string   sub-account name inside your organization (org admins only)
-      --token string        access token (replaces the use of api_key and api_secret)
 
 Use "lacework compliance [command] --help" for more information about a command.
 `,

--- a/integration/compliance_test.go
+++ b/integration/compliance_test.go
@@ -74,6 +74,7 @@ Global Flags:
       --organization        access organization level data sets (org admins only)
   -p, --profile string      switch between profiles configured at ~/.lacework.toml
       --subaccount string   sub-account name inside your organization (org admins only)
+      --token string        access token (replaces the use of api_key and api_secret)
 
 Use "lacework compliance [command] --help" for more information about a command.
 `,

--- a/integration/global_flags_test.go
+++ b/integration/global_flags_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestGlobalFlagToken(t *testing.T) {
+func TestGlobalFlagApiToken(t *testing.T) {
 	// generating a token with toml config
 	token, err, exitcode := LaceworkCLIWithTOMLConfig("access-token")
 	assert.Contains(t, token.String(), "_", // @afiune tokens start with "_secret123"
@@ -39,7 +39,7 @@ func TestGlobalFlagToken(t *testing.T) {
 
 		// running the Lacework CLI without toml config but with the token flag
 		out, err, exitcode := LaceworkCLI("int", "list",
-			"--token", strings.Trim(token.String(), "\n"), "--account", os.Getenv("CI_ACCOUNT"))
+			"--api_token", strings.Trim(token.String(), "\n"), "--account", os.Getenv("CI_ACCOUNT"))
 		assert.Contains(t, out.String(), "INTEGRATION GUID")
 		assert.Empty(t, err.String(), "STDERR should be empty")
 		assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")

--- a/integration/global_flags_test.go
+++ b/integration/global_flags_test.go
@@ -1,0 +1,47 @@
+//
+// Author:: Salim Afiune Maya (<afiune@lacework.net>)
+// Copyright:: Copyright 2020, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package integration
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGlobalFlagToken(t *testing.T) {
+	// generating a token with toml config
+	token, err, exitcode := LaceworkCLIWithTOMLConfig("access-token")
+	assert.Contains(t, token.String(), "_", // @afiune tokens start with "_secret123"
+		"STDOUT table headers changed, please check")
+	assert.Empty(t,
+		err.String(),
+		"STDERR should be empty")
+	if assert.Equal(t, 0, exitcode,
+		"EXITCODE is not the expected one") {
+
+		// running the Lacework CLI without toml config but with the token flag
+		out, err, exitcode := LaceworkCLI("int", "list",
+			"--token", strings.Trim(token.String(), "\n"), "--account", os.Getenv("CI_ACCOUNT"))
+		assert.Contains(t, out.String(), "INTEGRATION GUID")
+		assert.Empty(t, err.String(), "STDERR should be empty")
+		assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
+	}
+}

--- a/integration/help_test.go
+++ b/integration/help_test.go
@@ -84,6 +84,7 @@ Global Flags:
       --organization        access organization level data sets (org admins only)
   -p, --profile string      switch between profiles configured at ~/.lacework.toml
       --subaccount string   sub-account name inside your organization (org admins only)
+      --token string        access token (replaces the use of api_key and api_secret)
 
 Use "lacework configure [command] --help" for more information about a command.
 `,
@@ -169,6 +170,7 @@ Flags:
       --organization        access organization level data sets (org admins only)
   -p, --profile string      switch between profiles configured at ~/.lacework.toml
       --subaccount string   sub-account name inside your organization (org admins only)
+      --token string        access token (replaces the use of api_key and api_secret)
 
 Use "lacework [command] --help" for more information about a command.
 `,

--- a/integration/help_test.go
+++ b/integration/help_test.go
@@ -76,6 +76,7 @@ Global Flags:
   -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
+      --api_token string    access token (replaces the use of api_key and api_secret)
       --debug               turn on debug logging
       --json                switch commands output from human-readable to json format
       --nocache             turn off caching
@@ -84,7 +85,6 @@ Global Flags:
       --organization        access organization level data sets (org admins only)
   -p, --profile string      switch between profiles configured at ~/.lacework.toml
       --subaccount string   sub-account name inside your organization (org admins only)
-      --token string        access token (replaces the use of api_key and api_secret)
 
 Use "lacework configure [command] --help" for more information about a command.
 `,
@@ -162,6 +162,7 @@ Flags:
   -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
+      --api_token string    access token (replaces the use of api_key and api_secret)
       --debug               turn on debug logging
       --json                switch commands output from human-readable to json format
       --nocache             turn off caching
@@ -170,7 +171,6 @@ Flags:
       --organization        access organization level data sets (org admins only)
   -p, --profile string      switch between profiles configured at ~/.lacework.toml
       --subaccount string   sub-account name inside your organization (org admins only)
-      --token string        access token (replaces the use of api_key and api_secret)
 
 Use "lacework [command] --help" for more information about a command.
 `,


### PR DESCRIPTION
This new flag will replace the use of `api_key` and `api_secret` so that
users can run the CLI only with an access token and their account:
```
lacework int list --api_token _secret123 -a mycompany
```

Closes https://github.com/lacework/go-sdk/issues/282
JIRA: https://lacework.atlassian.net/browse/ALLY-590

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>