### PR TITLE
fix(cli): vuln host scan-pkg-manifest --local centos 6.10

### DIFF
--- a/cli/cmd/package_manifest.go
+++ b/cli/cmd/package_manifest.go
@@ -263,29 +263,21 @@ func (c *cliState) GetOSInfo() (*OS, error) {
 	if err == nil {
 		c.Log.Debugw("parsing os release file", "file", osReleaseFile)
 		osInfo, parseErr := openOsReleaseFile()
-		if parseErr != nil {
-			return osInfo, parseErr
-		}
+		return osInfo, parseErr
 	}
 
 	_, err = os.Stat(sysReleaseFile)
 	if err == nil {
 		c.Log.Debugw("parsing system release file", "file", sysReleaseFile)
 		osInfo, parseErr := openSystemReleaseFile()
-		if parseErr != nil {
-			return osInfo, parseErr
-		}
+		return osInfo, parseErr
 	}
 
-	if err != nil {
 		msg := `unsupported platform
 
 For more information about supported platforms, visit:
    https://support.lacework.com/hc/en-us/articles/360049666194-Host-Vulnerability-Assessment-Overview`
 		return osInfo, errors.Wrap(err, msg)
-	}
-
-	return osInfo, nil
 }
 
 func openSystemReleaseFile() (*OS, error) {

--- a/cli/cmd/package_manifest.go
+++ b/cli/cmd/package_manifest.go
@@ -304,7 +304,6 @@ func openOsReleaseFile(filename string) (*OS, error) {
 	osInfo := new(OS)
 
 	f, err := os.Open(filename)
-
 	if err != nil {
 		return osInfo, err
 	}

--- a/cli/cmd/package_manifest.go
+++ b/cli/cmd/package_manifest.go
@@ -42,10 +42,10 @@ type OS struct {
 }
 
 var (
-	osReleaseFile = "/etc/os-release"
+	osReleaseFile  = "/etc/os-release"
 	sysReleaseFile = "/etc/system-release"
-	rexNameFromID = regexp.MustCompile(`^ID=(.*)$`)
-	rexVersionID  = regexp.MustCompile(`^VERSION_ID=(.*)$`)
+	rexNameFromID  = regexp.MustCompile(`^ID=(.*)$`)
+	rexVersionID   = regexp.MustCompile(`^VERSION_ID=(.*)$`)
 )
 
 func (c *cliState) GeneratePackageManifest() (*api.PackageManifest, error) {
@@ -268,8 +268,8 @@ func (c *cliState) GetOSInfo() (*OS, error) {
 		}
 	}
 
-	 _, err = os.Stat(sysReleaseFile)
-	 if err == nil {
+	_, err = os.Stat(sysReleaseFile)
+	if err == nil {
 		c.Log.Debugw("parsing system release file", "file", sysReleaseFile)
 		osInfo, parseErr := openSystemReleaseFile()
 		if parseErr != nil {
@@ -312,7 +312,7 @@ func openSystemReleaseFile() (*OS, error) {
 	return osInfo, err
 }
 
-func openOsReleaseFile() (*OS, error){
+func openOsReleaseFile() (*OS, error) {
 	osInfo := new(OS)
 
 	f, err := os.Open(osReleaseFile)

--- a/cli/cmd/package_manifest.go
+++ b/cli/cmd/package_manifest.go
@@ -259,31 +259,27 @@ func (c *cliState) GetOSInfo() (*OS, error) {
 		"arch", runtime.GOARCH,
 	)
 
-	_, err := os.Stat(osReleaseFile)
-	if err == nil {
+	if fileExists(osReleaseFile) {
 		c.Log.Debugw("parsing os release file", "file", osReleaseFile)
-		osInfo, parseErr := openOsReleaseFile()
-		return osInfo, parseErr
+		return openOsReleaseFile(osReleaseFile)
 	}
 
-	_, err = os.Stat(sysReleaseFile)
-	if err == nil {
+	if fileExists(sysReleaseFile) {
 		c.Log.Debugw("parsing system release file", "file", sysReleaseFile)
-		osInfo, parseErr := openSystemReleaseFile()
-		return osInfo, parseErr
+		return openSystemReleaseFile(sysReleaseFile)
 	}
 
 	msg := `unsupported platform
 
 For more information about supported platforms, visit:
    https://support.lacework.com/hc/en-us/articles/360049666194-Host-Vulnerability-Assessment-Overview`
-	return osInfo, errors.Wrap(err, msg)
+	return osInfo, errors.New(msg)
 }
 
-func openSystemReleaseFile() (*OS, error) {
+func openSystemReleaseFile(filename string) (*OS, error) {
 	osInfo := new(OS)
 
-	f, err := os.Open(sysReleaseFile)
+	f, err := os.Open(filename)
 
 	if err != nil {
 		return osInfo, err
@@ -304,10 +300,10 @@ func openSystemReleaseFile() (*OS, error) {
 	return osInfo, err
 }
 
-func openOsReleaseFile() (*OS, error) {
+func openOsReleaseFile(filename string) (*OS, error) {
 	osInfo := new(OS)
 
-	f, err := os.Open(osReleaseFile)
+	f, err := os.Open(filename)
 
 	if err != nil {
 		return osInfo, err

--- a/cli/cmd/package_manifest.go
+++ b/cli/cmd/package_manifest.go
@@ -273,11 +273,11 @@ func (c *cliState) GetOSInfo() (*OS, error) {
 		return osInfo, parseErr
 	}
 
-		msg := `unsupported platform
+	msg := `unsupported platform
 
 For more information about supported platforms, visit:
    https://support.lacework.com/hc/en-us/articles/360049666194-Host-Vulnerability-Assessment-Overview`
-		return osInfo, errors.Wrap(err, msg)
+	return osInfo, errors.Wrap(err, msg)
 }
 
 func openSystemReleaseFile() (*OS, error) {

--- a/cli/cmd/package_manifest_test.go
+++ b/cli/cmd/package_manifest_test.go
@@ -234,6 +234,7 @@ func TestParseOsRelease(t *testing.T) {
 	defer os.Remove(file.Name())
 
 	os, err := openOsReleaseFile(file.Name())
+	assert.Nil(t, err)
 	assert.Equal(t, mockUbuntu.Name, os.Name)
 	assert.Equal(t, mockUbuntu.Version, os.Version)
 }
@@ -247,6 +248,7 @@ func TestParseSysRelease(t *testing.T) {
 	defer os.Remove(file.Name())
 
 	os, err := openSystemReleaseFile(file.Name())
+	assert.Nil(t, err)
 	assert.Equal(t, mockCentos.Name, os.Name)
 	assert.Equal(t, mockCentos.Version, os.Version)
 }
@@ -267,12 +269,5 @@ BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
 PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
 VERSION_CODENAME=bionic
 UBUNTU_CODENAME=bionic
-`
-	mockAlpineOSReleaseFile = `NAME="Alpine Linux"
-ID=alpine
-VERSION_ID=3.7.0
-PRETTY_NAME="Alpine Linux v3.7"
-HOME_URL="http://alpinelinux.org"
-BUG_REPORT_URL="http://bugs.alpinelinux.org"
 `
 )

--- a/cli/cmd/package_manifest_test.go
+++ b/cli/cmd/package_manifest_test.go
@@ -259,9 +259,9 @@ func TestParseSysRelease(t *testing.T) {
 }
 
 var (
-	mockCentos = OS{Name: "centos", Version: "6.10"}
-	mockUbuntu = OS{Name: "ubuntu", Version: "18.04"}
-	mockCentosSystemFile = "CentOS release 6.10 (Final)"
+	mockCentos              = OS{Name: "centos", Version: "6.10"}
+	mockUbuntu              = OS{Name: "ubuntu", Version: "18.04"}
+	mockCentosSystemFile    = "CentOS release 6.10 (Final)"
 	mockUbuntuOSReleaseFile = `NAME="Ubuntu"
 VERSION="18.04.5 LTS (Bionic Beaver)"
 ID=ubuntu
@@ -276,6 +276,3 @@ VERSION_CODENAME=bionic
 UBUNTU_CODENAME=bionic
 `
 )
-
-
-

--- a/cli/cmd/package_manifest_test.go
+++ b/cli/cmd/package_manifest_test.go
@@ -225,13 +225,6 @@ func TestMergeHostVulnScanPkgManifestResponses(t *testing.T) {
 	}
 }
 
-func TestGetOsInfoUnsupported(t *testing.T) {
-	_, err := cli.GetOSInfo()
-	assert.Contains(t, err.Error(),
-		"unsupported platform",
-	)
-}
-
 func TestParseOsRelease(t *testing.T) {
 	file, err := ioutil.TempFile("", "os-release")
 	assert.Nil(t, err)
@@ -274,5 +267,12 @@ BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
 PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
 VERSION_CODENAME=bionic
 UBUNTU_CODENAME=bionic
+`
+	mockAlpineOSReleaseFile = `NAME="Alpine Linux"
+ID=alpine
+VERSION_ID=3.7.0
+PRETTY_NAME="Alpine Linux v3.7"
+HOME_URL="http://alpinelinux.org"
+BUG_REPORT_URL="http://bugs.alpinelinux.org"
 `
 )

--- a/cli/cmd/package_manifest_test.go
+++ b/cli/cmd/package_manifest_test.go
@@ -20,6 +20,8 @@ package cmd
 
 import (
 	"fmt"
+	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -222,3 +224,58 @@ func TestMergeHostVulnScanPkgManifestResponses(t *testing.T) {
 		})
 	}
 }
+
+func TestGetOsInfoUnsupported(t *testing.T) {
+	_, err := cli.GetOSInfo()
+	assert.Contains(t, err.Error(),
+		"unsupported platform", // intentional error since we are mocking the api token
+	)
+}
+
+func TestParseOsRelease(t *testing.T) {
+	file, err := ioutil.TempFile("", "os-release")
+	assert.Nil(t, err)
+	_, err = file.WriteString(mockUbuntuOSReleaseFile)
+	assert.Nil(t, err)
+
+	defer os.Remove(file.Name())
+
+	os, err := openOsReleaseFile(file.Name())
+	assert.Equal(t, mockUbuntu.Name, os.Name)
+	assert.Equal(t, mockUbuntu.Version, os.Version)
+}
+
+func TestParseSysRelease(t *testing.T) {
+	file, err := ioutil.TempFile("", "system-release")
+	assert.Nil(t, err)
+	_, err = file.WriteString(mockCentosSystemFile)
+	assert.Nil(t, err)
+
+	defer os.Remove(file.Name())
+
+	os, err := openSystemReleaseFile(file.Name())
+	assert.Equal(t, mockCentos.Name, os.Name)
+	assert.Equal(t, mockCentos.Version, os.Version)
+}
+
+var (
+	mockCentos = OS{Name: "centos", Version: "6.10"}
+	mockUbuntu = OS{Name: "ubuntu", Version: "18.04"}
+	mockCentosSystemFile = "CentOS release 6.10 (Final)"
+	mockUbuntuOSReleaseFile = `NAME="Ubuntu"
+VERSION="18.04.5 LTS (Bionic Beaver)"
+ID=ubuntu
+ID_LIKE=debian
+PRETTY_NAME="Ubuntu 18.04.5 LTS"
+VERSION_ID="18.04"
+HOME_URL="https://www.ubuntu.com/"
+SUPPORT_URL="https://help.ubuntu.com/"
+BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
+PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
+VERSION_CODENAME=bionic
+UBUNTU_CODENAME=bionic
+`
+)
+
+
+

--- a/cli/cmd/package_manifest_test.go
+++ b/cli/cmd/package_manifest_test.go
@@ -228,7 +228,7 @@ func TestMergeHostVulnScanPkgManifestResponses(t *testing.T) {
 func TestGetOsInfoUnsupported(t *testing.T) {
 	_, err := cli.GetOSInfo()
 	assert.Contains(t, err.Error(),
-		"unsupported platform", // intentional error since we are mocking the api token
+		"unsupported platform",
 	)
 }
 

--- a/cli/vagrant/centos-6.10/Vagrantfile
+++ b/cli/vagrant/centos-6.10/Vagrantfile
@@ -1,0 +1,6 @@
+Vagrant.configure("2") do |config|
+  config.vm.box = "bento/centos-6.10"
+  config.vm.synced_folder "../../../bin", "/devcli"
+  config.vm.provision "shell", inline: "ln -s /devcli/lacework-cli-linux-amd64 /home/vagrant/lacework"
+end
+


### PR DESCRIPTION
Issue: https://lacework.atlassian.net/browse/ALLY-591

centos < 6.10 does not have /etc/os-release check for existence of system-releases if os-releases not found. 

Signed-off-by: Darren Murray <darren.murray@lacework.net>