### PR TITLE
feat(cli): new agent install --trust_host_key flag

### DIFF
--- a/cli/cmd/agent.go
+++ b/cli/cmd/agent.go
@@ -38,6 +38,7 @@ var (
 		InstallForce        bool
 		InstallSshUser      string
 		InstallAgentToken   string
+		InstallTrustHostKey bool
 		InstallPassword     string
 		InstallIdentityFile string
 	}{}
@@ -206,6 +207,9 @@ func init() {
 	)
 	agentInstallCmd.Flags().StringVar(&agentCmdState.InstallAgentToken,
 		"token", "", "agent access token",
+	)
+	agentInstallCmd.Flags().BoolVar(&agentCmdState.InstallTrustHostKey,
+		"trust_host_key", false, "automatically add host keys to the ~/.ssh/known_hosts file",
 	)
 }
 

--- a/cli/cmd/agent_install.go
+++ b/cli/cmd/agent_install.go
@@ -257,6 +257,11 @@ func verifyHostCallback(host string, remote net.Addr, key ssh.PublicKey) error {
 		return nil
 	}
 
+	if agentCmdState.InstallTrustHostKey {
+		// the user wants to add the new host to known hosts file automatically
+		return lwrunner.AddKnownHost(host, remote, key, "")
+	}
+
 	// ask user to check if he/she trust the host public key
 	if askIsHostTrusted(host, key) {
 		// add the new host to known hosts file.


### PR DESCRIPTION
We are adding a new flag named `--trust_host_key` that will tell the
Lacework CLI to automatically add host keys to the `~/.ssh/known_hosts`
file rather than interactively ask the user if he/she trust the host.

Note that, if the host key changes, the Lacework CLI will continue to
refuse to connect to the host to provide maximum protection against
trojan horse attacks.

JIRA: https://lacework.atlassian.net/browse/ALLY-544

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>