### PR TITLE
fix(cli): Detect if running in cloudshell to output correct update command

### DIFF
--- a/cli/cmd/cli_unix.go
+++ b/cli/cmd/cli_unix.go
@@ -33,6 +33,13 @@ var promptIconsFunc = func(icons *survey.IconSet) {
 	icons.Question.Text = "▸"
 }
 
+// Env variables found in GCP, AWS and Azure cloudshell
+var (
+	gcpCloudEnv   = "CLOUD_SHELL"
+	awsCloudEnv   = "AWS_EXECUTION_ENV"
+	AzureCloudEnv = "POWERSHELL_DISTRIBUTION_CHANNEL"
+)
+
 // UpdateCommand returns the command that a user should run to update the cli
 // to the latest available version (unix specific command)
 func (c *cliState) UpdateCommand() string {
@@ -41,7 +48,17 @@ func (c *cliState) UpdateCommand() string {
   brew upgrade lacework-cli
 `
 	}
+
+	if isCloudshell() {
+		return `
+  curl https://raw.githubusercontent.com/lacework/go-sdk/main/cli/install.sh | bash -s -- -d $HOME/bin
+`
+	}
 	return `
   curl https://raw.githubusercontent.com/lacework/go-sdk/main/cli/install.sh | bash
 `
+}
+
+func isCloudshell() bool {
+	return os.Getenv(gcpCloudEnv) == "true" || os.Getenv(awsCloudEnv) == "Cloudshell" || os.Getenv(AzureCloudEnv) == "CloudShell"
 }

--- a/cli/cmd/cli_unix.go
+++ b/cli/cmd/cli_unix.go
@@ -33,8 +33,9 @@ var promptIconsFunc = func(icons *survey.IconSet) {
 	icons.Question.Text = "▸"
 }
 
-// Env variables found in GCP, AWS and Azure cloudshell
-var (
+// Env variables found in GCP, AWS and Azure cloudshell.
+// Used to determine if cli is running on cloudshell.
+const (
 	gcpCloudEnv   = "CLOUD_SHELL"
 	awsCloudEnv   = "AWS_EXECUTION_ENV"
 	AzureCloudEnv = "POWERSHELL_DISTRIBUTION_CHANNEL"
@@ -49,7 +50,7 @@ func (c *cliState) UpdateCommand() string {
 `
 	}
 
-	if isCloudshell() {
+	if isCloudShell() {
 		return `
   curl https://raw.githubusercontent.com/lacework/go-sdk/main/cli/install.sh | bash -s -- -d $HOME/bin
 `
@@ -59,6 +60,26 @@ func (c *cliState) UpdateCommand() string {
 `
 }
 
-func isCloudshell() bool {
-	return os.Getenv(gcpCloudEnv) == "true" || os.Getenv(awsCloudEnv) == "Cloudshell" || os.Getenv(AzureCloudEnv) == "CloudShell"
+// isCloudShell uses env variables specific to GCP, AWS and Azure
+// to determine if the Lacework CLI is running on cloudshell
+func isCloudShell() bool {
+	return isAwsCloudShell() || isGcpCloudShell() || isAzureCloudShell()
+}
+
+// isAzureCloudShell uses the native env variable POWERSHELL_DISTRIBUTION_CHANNEL="CloudShell"
+// to determine if the Lacework CLI is running on Azure cloudshell
+func isAzureCloudShell() bool {
+	return os.Getenv(AzureCloudEnv) == "CloudShell"
+}
+
+// isGcpCloudShell uses the native env variable CLOUD_SHELL=true
+// to determine if the Lacework CLI is running on GCP cloudshell
+func isGcpCloudShell() bool {
+	return os.Getenv(gcpCloudEnv) == "true"
+}
+
+// isAwsCloudShell uses the native env variable AWS_EXECUTION_ENV="CloudShell"
+// to determine if the Lacework CLI is running on AWS cloudshell
+func isAwsCloudShell() bool {
+	return os.Getenv(awsCloudEnv) == "Cloudshell"
 }

--- a/cli/cmd/cli_unix.go
+++ b/cli/cmd/cli_unix.go
@@ -78,7 +78,7 @@ func isGcpCloudShell() bool {
 	return os.Getenv(gcpCloudEnv) == "true"
 }
 
-// isAwsCloudShell uses the native env variable AWS_EXECUTION_ENV="CloudShell"
+// isAwsCloudShell uses the native env variable AWS_EXECUTION_ENV="Cloudshell"
 // to determine if the Lacework CLI is running on AWS cloudshell
 func isAwsCloudShell() bool {
 	return os.Getenv(awsCloudEnv) == "Cloudshell"

--- a/cli/cmd/cli_unix_test.go
+++ b/cli/cmd/cli_unix_test.go
@@ -38,19 +38,19 @@ func TestCliStateUpdateCommand(t *testing.T) {
 		assert.Contains(t, cli.UpdateCommand(), "brew upgrade lacework-cli")
 	})
 
-	t.Run("Homebrew installation", func(t *testing.T) {
+	t.Run("Gcp CloudShell Installation", func(t *testing.T) {
 		os.Setenv("CLOUD_SHELL", "true")
 		defer os.Setenv("CLOUD_SHELL", "")
 		assert.Contains(t, cli.UpdateCommand(), "curl https://raw.githubusercontent.com/lacework/go-sdk/main/cli/install.sh | bash -s -- -d $HOME/bin")
 	})
 
-	t.Run("Homebrew installation", func(t *testing.T) {
+	t.Run("Aws CloudShell Installation", func(t *testing.T) {
 		os.Setenv("AWS_EXECUTION_ENV", "Cloudshell")
 		defer os.Setenv("AWS_EXECUTION_ENV", "")
 		assert.Contains(t, cli.UpdateCommand(), "curl https://raw.githubusercontent.com/lacework/go-sdk/main/cli/install.sh | bash -s -- -d $HOME/bin")
 	})
 
-	t.Run("Homebrew installation", func(t *testing.T) {
+	t.Run("Azure CloudShell Installation", func(t *testing.T) {
 		os.Setenv("POWERSHELL_DISTRIBUTION_CHANNEL", "Cloudshell")
 		defer os.Setenv("POWERSHELL_DISTRIBUTION_CHANNEL", "")
 		assert.Contains(t, cli.UpdateCommand(), "curl https://raw.githubusercontent.com/lacework/go-sdk/main/cli/install.sh | bash -s -- -d $HOME/bin")

--- a/cli/cmd/cli_unix_test.go
+++ b/cli/cmd/cli_unix_test.go
@@ -51,7 +51,7 @@ func TestCliStateUpdateCommand(t *testing.T) {
 	})
 
 	t.Run("Azure CloudShell Installation", func(t *testing.T) {
-		os.Setenv("POWERSHELL_DISTRIBUTION_CHANNEL", "Cloudshell")
+		os.Setenv("POWERSHELL_DISTRIBUTION_CHANNEL", "CloudShell")
 		defer os.Setenv("POWERSHELL_DISTRIBUTION_CHANNEL", "")
 		assert.Contains(t, cli.UpdateCommand(), "curl https://raw.githubusercontent.com/lacework/go-sdk/main/cli/install.sh | bash -s -- -d $HOME/bin")
 	})

--- a/cli/cmd/cli_unix_test.go
+++ b/cli/cmd/cli_unix_test.go
@@ -37,4 +37,22 @@ func TestCliStateUpdateCommand(t *testing.T) {
 		defer os.Setenv("LW_HOMEBREW_INSTALL", "")
 		assert.Contains(t, cli.UpdateCommand(), "brew upgrade lacework-cli")
 	})
+
+	t.Run("Homebrew installation", func(t *testing.T) {
+		os.Setenv("CLOUD_SHELL", "true")
+		defer os.Setenv("CLOUD_SHELL", "")
+		assert.Contains(t, cli.UpdateCommand(), "curl https://raw.githubusercontent.com/lacework/go-sdk/main/cli/install.sh | bash -s -- -d $HOME/bin")
+	})
+
+	t.Run("Homebrew installation", func(t *testing.T) {
+		os.Setenv("AWS_EXECUTION_ENV", "Cloudshell")
+		defer os.Setenv("AWS_EXECUTION_ENV", "")
+		assert.Contains(t, cli.UpdateCommand(), "curl https://raw.githubusercontent.com/lacework/go-sdk/main/cli/install.sh | bash -s -- -d $HOME/bin")
+	})
+
+	t.Run("Homebrew installation", func(t *testing.T) {
+		os.Setenv("POWERSHELL_DISTRIBUTION_CHANNEL", "Cloudshell")
+		defer os.Setenv("POWERSHELL_DISTRIBUTION_CHANNEL", "")
+		assert.Contains(t, cli.UpdateCommand(), "curl https://raw.githubusercontent.com/lacework/go-sdk/main/cli/install.sh | bash -s -- -d $HOME/bin")
+	})
 }


### PR DESCRIPTION
issue: https://lacework.atlassian.net/browse/ALLY-567

When cli is running in cloudshell the update command should output:
`curl https://raw.githubusercontent.com/lacework/go-sdk/main/cli/install.sh | bash -s -- -d $HOME/bin
`

Signed-off-by: Darren Murray <darren.murray@lacework.net>