### PR TITLE
feat(api): Add Non-OS Package Support for APIv1

### DIFF
--- a/api/integrations_ctr_reg.go
+++ b/api/integrations_ctr_reg.go
@@ -152,11 +152,12 @@ type ContainerRegData struct {
 
 	// for GCP_GCR integrations, the registry domain has to be one of:
 	// => [ "gcr.io", "us.gcr.io", "eu.gcr.io", "asia.gcr.io" ]
-	RegistryDomain string `json:"REGISTRY_DOMAIN" mapstructure:"REGISTRY_DOMAIN"`
-	LimitByTag     string `json:"LIMIT_BY_TAG" mapstructure:"LIMIT_BY_TAG"`
-	LimitByLabel   string `json:"LIMIT_BY_LABEL" mapstructure:"LIMIT_BY_LABEL"`
-	LimitByRep     string `json:"LIMIT_BY_REP,omitempty" mapstructure:"LIMIT_BY_REP"`
-	LimitNumImg    int    `json:"LIMIT_NUM_IMG,omitempty" mapstructure:"LIMIT_NUM_IMG"`
+	RegistryDomain   string `json:"REGISTRY_DOMAIN" mapstructure:"REGISTRY_DOMAIN"`
+	LimitByTag       string `json:"LIMIT_BY_TAG" mapstructure:"LIMIT_BY_TAG"`
+	LimitByLabel     string `json:"LIMIT_BY_LABEL" mapstructure:"LIMIT_BY_LABEL"`
+	LimitByRep       string `json:"LIMIT_BY_REP,omitempty" mapstructure:"LIMIT_BY_REP"`
+	LimitNumImg      int    `json:"LIMIT_NUM_IMG,omitempty" mapstructure:"LIMIT_NUM_IMG"`
+	NonOSPackageEval bool   `json:"NON_OS_PACKAGE_EVAL,omitempty" mapstructure:"NON_OS_PACKAGE_EVAL"`
 }
 
 type ContainerRegCreds struct {

--- a/api/integrations_ctr_reg_test.go
+++ b/api/integrations_ctr_reg_test.go
@@ -33,11 +33,12 @@ func TestIntegrationsNewContainerRegIntegration(t *testing.T) {
 				Username: "techally",
 				Password: "secret",
 			},
-			RegistryType:   api.DockerHubRegistry.String(),
-			RegistryDomain: "index.docker.io",
-			LimitByTag:     "*",
-			LimitByLabel:   "*",
-			LimitNumImg:    5,
+			RegistryType:     api.DockerHubRegistry.String(),
+			RegistryDomain:   "index.docker.io",
+			LimitByTag:       "*",
+			LimitByLabel:     "*",
+			LimitNumImg:      5,
+			NonOSPackageEval: true,
 		},
 	)
 	assert.Equal(t, api.ContainerRegistryIntegration.String(), subject.Type)


### PR DESCRIPTION
Add API support for Non-OS Package flag

https://support.lacework.com/hc/en-us/articles/4403668140691-August-2021-Releases

Signed-off-by: Andre Elizondo <andre@lacework.com>