### PR TITLE
feat(lwdomain): export go package

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,35 @@ func main() {
 
 Look at the [lwconfig/](lwconfig/) folder for more information.
 
+## Lacework Domain ([`lwdomain`](lwdomain/))
+
+Go package to disseminate a domain URL into account, cluster and whether or not
+it is an internal account.
+
+### Basic Usage
+```go
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/lacework/go-sdk/lwdomain"
+)
+
+func main() {
+	domain, err := lwdomain.New("https://account.fra.lacework.net")
+	if err != nil {
+		fmt.Printf("Error %s\n", err)
+		os.Exit(1)
+	}
+
+	// Output: Lacework Account Name: account
+	fmt.Println("Lacework Account Name: %s", domain.Account)
+}
+```
+
+
 ## Release Process
 
 The release process of this repository is documented at the following [Wiki page](https://github.com/lacework/go-sdk/wiki/Release-Process).

--- a/api/account.go
+++ b/api/account.go
@@ -18,7 +18,7 @@
 
 package api
 
-import "github.com/lacework/go-sdk/internal/domain"
+import "github.com/lacework/go-sdk/lwdomain"
 
 // AccountService is a service that interacts with Account related
 // endpoints from the Lacework Server
@@ -44,6 +44,6 @@ type accountOrganizationInfoResponse struct {
 }
 
 func (r accountOrganizationInfoResponse) AccountName() string {
-	d, _ := domain.New(r.OrgAccountURL)
+	d, _ := lwdomain.New(r.OrgAccountURL)
 	return d.String()
 }

--- a/api/user_profile.go
+++ b/api/user_profile.go
@@ -21,7 +21,7 @@ package api
 import (
 	"strings"
 
-	"github.com/lacework/go-sdk/internal/domain"
+	"github.com/lacework/go-sdk/lwdomain"
 )
 
 // UserProfileService is the service that interacts with the UserProfile
@@ -49,7 +49,7 @@ type UserProfile struct {
 }
 
 func (p *UserProfile) OrgAccountName() string {
-	d, err := domain.New(p.URL)
+	d, err := lwdomain.New(p.URL)
 	if err != nil {
 		return p.URL
 	}

--- a/cli/cmd/configure.go
+++ b/cli/cmd/configure.go
@@ -30,9 +30,9 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
-	"github.com/lacework/go-sdk/internal/domain"
 	"github.com/lacework/go-sdk/internal/format"
 	"github.com/lacework/go-sdk/lwconfig"
+	"github.com/lacework/go-sdk/lwdomain"
 )
 
 var (
@@ -242,7 +242,7 @@ func promptConfigureSetup(newProfile *lwconfig.Profile) error {
 				answer, ok := ans.(string)
 				if ok && strings.Contains(answer, ".lacework.net") {
 
-					d, err := domain.New(answer)
+					d, err := lwdomain.New(answer)
 					if err != nil {
 						cli.Log.Warn(err)
 						return answer
@@ -365,7 +365,7 @@ func loadUIJsonFile(file string) error {
 	cli.Subaccount = strings.ToLower(auth.SubAccount)
 
 	if auth.Account != "" {
-		d, err := domain.New(auth.Account)
+		d, err := lwdomain.New(auth.Account)
 		if err != nil {
 			return err
 		}

--- a/lwdomain/README.md
+++ b/lwdomain/README.md
@@ -1,0 +1,44 @@
+# Lacework Domain
+
+Use this package to disseminate a domain URL into account, cluster and whether or not
+it is an internal account.
+
+## Usage
+
+Download the library into your `$GOPATH`:
+
+    $ go get github.com/lacework/go-sdk/lwdomain
+
+Import the library into your tool:
+
+```go
+import "github.com/lacework/go-sdk/lwdomain"
+```
+
+## Examples
+
+The following URL `https://account.fra.lacework.net` would be disseminated into:
+* `account` as the account name
+* `fra` as the cluster name
+
+```go
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/lacework/go-sdk/lwdomain"
+)
+
+func main() {
+	domain, err := lwdomain.New("https://account.fra.lacework.net")
+	if err != nil {
+		fmt.Printf("Error %s\n", err)
+		os.Exit(1)
+	}
+
+	// Output: Lacework Account Name: account
+	fmt.Println("Lacework Account Name: %s", domain.Account)
+}
+```

--- a/lwdomain/domain.go
+++ b/lwdomain/domain.go
@@ -16,7 +16,7 @@
 // limitations under the License.
 //
 
-package domain
+package lwdomain
 
 import (
 	"fmt"
@@ -39,9 +39,9 @@ type domain struct {
 //
 // For instance, the following URL:
 // ```
-// d := domain.New("https://account.fra.lacework.net")
+// d, err := lwdomain.New("https://account.fra.lacework.net")
 // ```
-// Would be dessiminated into:
+// Would be disseminated into:
 // * `account` as the account name
 // * `fra` as the cluster name
 func New(url string) (domain, error) {

--- a/lwdomain/domain_test.go
+++ b/lwdomain/domain_test.go
@@ -16,7 +16,7 @@
 // limitations under the License.
 //
 
-package domain_test
+package lwdomain_test
 
 import (
 	"fmt"
@@ -24,7 +24,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	subject "github.com/lacework/go-sdk/internal/domain"
+	subject "github.com/lacework/go-sdk/lwdomain"
 )
 
 func TestDomains(t *testing.T) {


### PR DESCRIPTION
Use this package to disseminate a domain URL into account, cluster, and whether or not
it is an internal account.

## Usage

Download the library into your `$GOPATH`:

    $ go get github.com/lacework/go-sdk/lwdomain

Import the library into your tool:

```go
import "github.com/lacework/go-sdk/lwdomain"
```

## Examples

The following URL `https://account.fra.lacework.net` would be disseminated into:
* `account` as the account name
* `fra` as the cluster name

```go
package main

import (
	"fmt"
	"os"

	"github.com/lacework/go-sdk/lwdomain"
)

func main() {
	domain, err := lwdomain.New("https://account.fra.lacework.net")
	if err != nil {
		fmt.Printf("Error %s\n", err)
		os.Exit(1)
	}

	// Output: Lacework Account Name: account
	fmt.Println("Lacework Account Name: %s", domain.Account)
}
```

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>