### PR TITLE
feat(telemetry): send information about flags

### DIFF
--- a/cli/cmd/honeyvent.go
+++ b/cli/cmd/honeyvent.go
@@ -95,6 +95,7 @@ type Honeyvent struct {
 	Arch          string      `json:"arch"`
 	Command       string      `json:"command,omitempty"`
 	Args          []string    `json:"args,omitempty"`
+	Flags         []string    `json:"flags,omitempty"`
 	Account       string      `json:"account,omitempty"`
 	Subaccount    string      `json:"subaccount,omitempty"`
 	Profile       string      `json:"profile,omitempty"`
@@ -217,4 +218,19 @@ func installMethod() string {
 		return "HOMEBREW"
 	}
 	return ""
+}
+
+// parseFlags is a helper used to parse all the flags that the user provided
+func parseFlags(args []string) (flags []string) {
+	for len(args) > 0 {
+		arg := args[0]
+		args = args[1:]
+		if len(arg) == 0 || arg[0] != '-' || len(arg) == 1 {
+			// not a flag
+			continue
+		}
+
+		flags = append(flags, arg)
+	}
+	return
 }

--- a/cli/cmd/honeyvent.go
+++ b/cli/cmd/honeyvent.go
@@ -225,7 +225,7 @@ func parseFlags(args []string) (flags []string) {
 	for len(args) > 0 {
 		arg := args[0]
 		args = args[1:]
-		if len(arg) == 0 || arg[0] != '-' || len(arg) == 1 {
+		if len(arg) <= 1 || arg[0] != '-' {
 			// not a flag
 			continue
 		}

--- a/cli/cmd/honeyvent_test.go
+++ b/cli/cmd/honeyvent_test.go
@@ -19,6 +19,7 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
 	"runtime"
 	"testing"
@@ -132,4 +133,35 @@ func TestSendHoneyventAccountToLower(t *testing.T) {
 	// after submitting the honeyvent, the global
 	// event struct should be resetted
 	assert.Equal(t, "all-lower-or-all-upper", cli.Event.Account)
+}
+
+func TestParseFlags(t *testing.T) {
+	cases := []struct {
+		args          []string
+		expectedFlags []string
+	}{
+		{args: []string{},
+			expectedFlags: []string(nil)},
+		// no flags, just commands
+		{args: []string{"int", "list"},
+			expectedFlags: []string(nil)},
+		// only flags
+		{args: []string{"-a", "--foo", "-b", "--bar", "-l"},
+			expectedFlags: []string{"-a", "--foo", "-b", "--bar", "-l"}},
+		// mixing commands, flags
+		{args: []string{"agent", "token", "list", "--account", "myaccount", "--debug"},
+			expectedFlags: []string{"--account", "--debug"}},
+		// lots of things
+		{args: []string{"command", "--flag", "subcmd", "--debug", "arg1", "--json", "arg2", "--noninteractive"},
+			expectedFlags: []string{"--flag", "--debug", "--json", "--noninteractive"}},
+
+		// invalid flag
+		{args: []string{"-"},
+			expectedFlags: []string(nil)},
+	}
+	for i, kase := range cases {
+		t.Run(fmt.Sprintf("test case %d", i), func(t *testing.T) {
+			assert.Equal(t, kase.expectedFlags, parseFlags(kase.args))
+		})
+	}
 }

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -54,7 +54,7 @@ This will prompt you for your Lacework account and a set of API access keys.`,
 			cli.Log.Debugw("updating honeyvent", "dataset", HoneyDataset)
 			cli.Event.Command = cmd.CommandPath()
 			cli.Event.Args = args
-			// TODO @afiune how do we send flags?
+			cli.Event.Flags = parseFlags(os.Args[1:])
 			cli.SendHoneyvent()
 
 			switch cmd.Use {

--- a/integration/framework_test.go
+++ b/integration/framework_test.go
@@ -177,6 +177,7 @@ func createTOMLConfigFromCIvars() string {
 account = '` + os.Getenv("CI_ACCOUNT") + `'
 api_key = '` + os.Getenv("CI_API_KEY") + `'
 api_secret = '` + os.Getenv("CI_API_SECRET") + `'
+version = 2
 `)
 	err = ioutil.WriteFile(configFile, c, 0644)
 	if err != nil {


### PR DESCRIPTION
With this change we are now sending telemetry about the flags that the
user use on every command execution, this will help us understand how
the Lacework CLI is used, what are the most used flags, and more
information to discover.

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>