### PR TITLE
feat(cli): pass-through used profile in recommendations

### DIFF
--- a/cli/cmd/agent.go
+++ b/cli/cmd/agent.go
@@ -330,7 +330,10 @@ func listAgentTokens(_ *cobra.Command, _ []string) error {
 	}
 
 	if len(response.Data) == 0 {
-		cli.OutputHuman("There are no agent access tokens. Try creating one with 'lacework agent token create'\n")
+		cli.OutputHuman(
+			"There are no agent access tokens. Try creating one with 'lacework agent token create%s'\n",
+			cli.OutputNonDefaultProfileFlag(),
+		)
 		return nil
 	}
 

--- a/cli/cmd/outputs.go
+++ b/cli/cmd/outputs.go
@@ -108,3 +108,10 @@ func (c *cliState) OutputCSV(headers []string, data [][]string) error {
 	fmt.Fprint(os.Stdout, csv)
 	return nil
 }
+
+func (c *cliState) OutputNonDefaultProfileFlag() string {
+	if c.Profile != "default" {
+		return fmt.Sprintf(" --profile %s", c.Profile)
+	}
+	return ""
+}

--- a/cli/cmd/outputs_test.go
+++ b/cli/cmd/outputs_test.go
@@ -73,3 +73,16 @@ func TestCSVDataCleanup(t *testing.T) {
 	data := csvCleanData([]string{"KEY\n HEADER\n VALUE", "VALUE,TEST\n"})
 	assert.NotContains(t, strings.Join(data, ""), "\n", "data is not being cleaned up properly")
 }
+
+func TestOutputNonDefaultProfileFlag(t *testing.T) {
+	// test with the default profile
+	assert.Equal(t, "", cli.OutputNonDefaultProfileFlag())
+
+	// test with a test profile
+	cli.Profile = "my-test"
+	defer func() {
+		cli.Profile = "default"
+	}()
+
+	assert.Equal(t, " --profile my-test", cli.OutputNonDefaultProfileFlag())
+}

--- a/cli/cmd/vuln_container.go
+++ b/cli/cmd/vuln_container.go
@@ -396,7 +396,11 @@ func requestOnDemandContainerVulnerabilityScan(args []string) error {
 	}
 
 	cli.OutputHuman("To track the progress of the scan, use the command:\n")
-	cli.OutputHuman("  $ lacework vulnerability container scan-status %s\n", scan.Data.RequestID)
+	cli.OutputHuman(
+		"  $ lacework vulnerability container scan-status %s%s\n",
+		scan.Data.RequestID,
+		cli.OutputNonDefaultProfileFlag(),
+	)
 	return nil
 }
 


### PR DESCRIPTION
***Issue***
Closes https://github.com/lacework/go-sdk/issues/540
JIRA: https://lacework.atlassian.net/browse/ALLY-634

***Description:***
Pass through the currently used profile in command recommendations.

***Additional Info:***

<img width="1638" alt="Screen Shot 2021-09-21 at 5 12 49 PM" src="https://user-images.githubusercontent.com/5712253/134197777-ada036b1-bf8b-4237-9eaa-b10147860681.png">



