### PR TITLE
feat(api): Cloudwatch Alert Channel (v2)

### DIFF
--- a/api/alert_channels.go
+++ b/api/alert_channels.go
@@ -83,6 +83,7 @@ const (
 	EmailUserAlertChannelType
 	SlackChannelAlertChannelType
 	AwsS3AlertChannelType
+	CloudwatchEbAlertChannelType
 )
 
 // AlertChannelTypeTypes is the list of available Alert Channel integration types
@@ -91,6 +92,7 @@ var AlertChannelTypes = map[alertChannelType]string{
 	EmailUserAlertChannelType:    "EmailUser",
 	SlackChannelAlertChannelType: "SlackChannel",
 	AwsS3AlertChannelType:        "AwsS3",
+	CloudwatchEbAlertChannelType: "CloudwatchEb",
 }
 
 // String returns the string representation of a Alert Channel integration type

--- a/api/alert_channels_aws_cloudwatch.go
+++ b/api/alert_channels_aws_cloudwatch.go
@@ -1,0 +1,45 @@
+//
+// Author:: Vatasha White (<vatasha.white@lacework.net>)
+// Copyright:: Copyright 2021, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package api
+
+// GetCloudwatchEb gets a single instance of an AWS Cloudwatch alert channel
+// with the corresponding integration guid
+func (svc *AlertChannelsService) GetCloudwatchEb(guid string) (response CloudwatchEbAlertChannelResponseV2, err error) {
+	err = svc.get(guid, &response)
+	return
+}
+
+// UpdateCloudwatchEb Update AWSCloudWatch updates a single instance of an AWS cloudwatch integration on the Lacework server
+func (svc *AlertChannelsService) UpdateCloudwatchEb(data AlertChannel) (response CloudwatchEbAlertChannelResponseV2, err error) {
+	err = svc.update(data.ID(), data, &response)
+	return
+}
+
+type CloudwatchEbDataV2 struct {
+	EventBusArn string `json:"eventBusArn"`
+}
+
+type CloudwatchEbAlertChannelV2 struct {
+	v2CommonIntegrationData
+	Data CloudwatchEbDataV2 `json:"data"`
+}
+
+type CloudwatchEbAlertChannelResponseV2 struct {
+	Data CloudwatchEbAlertChannelV2 `json:"data"`
+}

--- a/api/alert_channels_aws_cloudwatch_test.go
+++ b/api/alert_channels_aws_cloudwatch_test.go
@@ -1,0 +1,135 @@
+//
+// Author:: Vatasha White (<vatasha.white@lacework.net>)
+// Copyright:: Copyright 2021, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package api_test
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/lacework/go-sdk/api"
+	"github.com/lacework/go-sdk/internal/intgguid"
+	"github.com/lacework/go-sdk/internal/lacework"
+)
+
+func TestAlertChannelsService_GetCloudwatchEb(t *testing.T) {
+	var (
+		intgGUID   = intgguid.New()
+		apiPath    = fmt.Sprintf("AlertChannels/%s", intgGUID)
+		fakeServer = lacework.MockServer()
+	)
+	fakeServer.UseApiV2()
+	fakeServer.MockToken("TOKEN")
+	defer fakeServer.Close()
+
+	fakeServer.MockAPI(apiPath, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method, "GetCloudwatchEb() should be a GET method")
+		fmt.Fprintf(w, generateAlertChannelResponse(singleAWSCloudwatchAlertChannel(intgGUID)))
+	})
+
+	c, err := api.NewClient("test",
+		api.WithApiV2(),
+		api.WithToken("TOKEN"),
+		api.WithURL(fakeServer.URL()),
+	)
+	assert.Nil(t, err)
+
+	response, err := c.V2.AlertChannels.GetCloudwatchEb(intgGUID)
+	assert.Nil(t, err)
+	assert.NotNil(t, response)
+	assert.Equal(t, intgGUID, response.Data.IntgGuid)
+	assert.Equal(t, "integration_name", response.Data.Name)
+	assert.True(t, response.Data.State.Ok)
+	assert.Equal(t, response.Data.Data.EventBusArn, "arn:aws:events:YourRegion:YourAccountID:event-bus/default")
+}
+
+func TestAlertChannelsService_UpdateCloudwatchEb(t *testing.T) {
+	var (
+		intgGUID    = intgguid.New()
+		apiPath     = fmt.Sprintf("AlertChannels/%s", intgGUID)
+		fakeServer  = lacework.MockServer()
+		eventBusArn = "arn:aws:events:YourRegion:YourAccountID:event-bus/default"
+	)
+	fakeServer.UseApiV2()
+	fakeServer.MockToken("TOKEN")
+	defer fakeServer.Close()
+
+	fakeServer.MockAPI(apiPath, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "PATCH", r.Method, "UpdateCloudwatchEb() should be a PATCH method")
+
+		if assert.NotNil(t, r.Body) {
+			body := httpBodySniffer(r)
+			assert.Contains(t, body, intgGUID, "INTG_GUID missing")
+			assert.Contains(t, body, "integration_name", "cloud account name is missing")
+			assert.Contains(t, body, "CloudwatchEb", "wrong cloud account type")
+			assert.Contains(t, body, eventBusArn, "missing event bus arn")
+			assert.Contains(t, body, "enabled\":1", "cloud account is not enabled")
+		}
+
+		fmt.Fprintf(w, generateAlertChannelResponse(singleAWSCloudwatchAlertChannel(intgGUID)))
+	})
+
+	c, err := api.NewClient("test",
+		api.WithApiV2(),
+		api.WithToken("TOKEN"),
+		api.WithURL(fakeServer.URL()),
+	)
+	assert.Nil(t, err)
+
+	emailAlertChan := api.NewAlertChannel("integration_name",
+		api.CloudwatchEbAlertChannelType,
+		api.CloudwatchEbDataV2{EventBusArn: eventBusArn},
+	)
+	assert.Equal(t, "integration_name", emailAlertChan.Name)
+	assert.Equal(t, "CloudwatchEb", emailAlertChan.Type)
+	assert.Equal(t, 1, emailAlertChan.Enabled)
+	emailAlertChan.IntgGuid = intgGUID
+
+	response, err := c.V2.AlertChannels.UpdateCloudwatchEb(emailAlertChan)
+	assert.Nil(t, err)
+	assert.NotNil(t, response)
+	assert.Equal(t, intgGUID, response.Data.IntgGuid)
+	assert.True(t, response.Data.State.Ok)
+	assert.Equal(t, eventBusArn, response.Data.Data.EventBusArn)
+}
+
+func singleAWSCloudwatchAlertChannel(id string) string {
+	return fmt.Sprintf(`
+	{
+		"createdOrUpdatedBy": "vatasha.white@lacework.net",
+		"createdOrUpdatedTime": "2021-09-29T117:55:47.277316",
+		"data": {
+			"eventBusArn": "arn:aws:events:YourRegion:YourAccountID:event-bus/default"
+		},
+		"enabled": 1,
+		"intgGuid": %q,
+		"isOrg": 0,
+		"name": "integration_name",
+		"state": {
+		"details": {},
+		"lastSuccessfulTime": 1632932665892,
+			"lastUpdatedTime": 1632932665892,
+			"ok": true
+	},
+		"type": "CloudwatchEb"
+	}
+	`, id)
+}

--- a/api/alert_channels_test.go
+++ b/api/alert_channels_test.go
@@ -44,6 +44,10 @@ func TestAlertChannelTypes(t *testing.T) {
 		"AwsS3", api.AwsS3AlertChannelType.String(),
 		"wrong alert channel type",
 	)
+	assert.Equal(t,
+		"CloudwatchEb", api.CloudwatchEbAlertChannelType.String(),
+		"wrong alert channel type",
+	)
 }
 
 func TestFindAlertChannelType(t *testing.T) {
@@ -56,9 +60,17 @@ func TestFindAlertChannelType(t *testing.T) {
 	assert.True(t, found, "alert channel type should exist")
 	assert.Equal(t, "EmailUser", alertFound.String(), "wrong alert channel type")
 
-	//alertFound, found = api.FindAlertChannelType("SlackChannel")
-	//assert.True(t, found, "alert channel type should exist")
-	//assert.Equal(t, "SlackChannel", alertFound.String(), "wrong alert channel type")
+	alertFound, found = api.FindAlertChannelType("SlackChannel")
+	assert.True(t, found, "alert channel type should exist")
+	assert.Equal(t, "SlackChannel", alertFound.String(), "wrong alert channel type")
+
+	alertFound, found = api.FindAlertChannelType("AwsS3")
+	assert.True(t, found, "alert channel type should exist")
+	assert.Equal(t, "AwsS3", alertFound.String(), "wrong alert channel type")
+
+	alertFound, found = api.FindAlertChannelType("CloudwatchEb")
+	assert.True(t, found, "alert channel type should exist")
+	assert.Equal(t, "CloudwatchEb", alertFound.String(), "wrong alert channel type")
 }
 
 func TestAlertChannelsGet(t *testing.T) {
@@ -195,9 +207,11 @@ func TestAlertChannelsList(t *testing.T) {
 		slackAlertChan = []string{
 			intgguid.New(), intgguid.New(), intgguid.New(), intgguid.New(),
 		}
-		allGUIDs    = append(awsS3AlertChan, append(slackAlertChan, emailAlertChan...)...)
-		expectedLen = len(allGUIDs)
-		fakeServer  = lacework.MockServer()
+		cloudwatchAlertChan = []string{intgguid.New(), intgguid.New()}
+		someGUIDs           = append(awsS3AlertChan, append(slackAlertChan, emailAlertChan...)...)
+		allGUIDs            = append(someGUIDs, cloudwatchAlertChan...)
+		expectedLen         = len(allGUIDs)
+		fakeServer          = lacework.MockServer()
 	)
 	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
@@ -208,6 +222,7 @@ func TestAlertChannelsList(t *testing.T) {
 				generateAlertChannels(emailAlertChan, "EmailUser"),
 				generateAlertChannels(slackAlertChan, "SlackChannel"),
 				generateAlertChannels(awsS3AlertChan, "AwsS3"),
+				generateAlertChannels(cloudwatchAlertChan, "CloudwatchEb"),
 			}
 			fmt.Fprintf(w,
 				generateAlertChannelsResponse(
@@ -244,6 +259,8 @@ func generateAlertChannels(guids []string, iType string) string {
 			alertChannels[i] = singleSlackChannelAlertChannel(guid)
 		case api.AwsS3AlertChannelType.String():
 			alertChannels[i] = singleAwsS3AlertChannel(guid)
+		case api.CloudwatchEbAlertChannelType.String():
+			alertChannels[i] = singleAWSCloudwatchAlertChannel(guid)
 		}
 	}
 	return strings.Join(alertChannels, ", ")

--- a/cli/install.ps1
+++ b/cli/install.ps1
@@ -102,7 +102,7 @@ Function Install-Lacework-CLI {
     $machinePath = [System.Environment]::GetEnvironmentVariable("PATH", "Machine")
     $machinePath = New-PathString -StartingPath $machinePath -Path $laceworkPath
 
-    $isAdmin = False
+    $isAdmin = $false
     try {
         $currentPrincipal = New-Object Security.Principal.WindowsPrincipal([Security.Principal.WindowsIdentity]::GetCurrent())
         $isAdmin = $currentPrincipal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)


### PR DESCRIPTION
## Migrating Cloudwatch Alert Channels To V2.


***Issue***: https://lacework.atlassian.net/browse/ALLY-637

***Description:***
The changes in this pull request are to migrate the cloudwatch alert channel to use the V2 API. This is needed for all remaining V1 alert channels to ultimately manage alert channels at the organization level. 
