### PR TITLE
fix(cli): disable cache mechanism in install.sh

### DIFF
--- a/cli/install.sh
+++ b/cli/install.sh
@@ -214,7 +214,7 @@ install_cli() {
 
 print_cli_version() {
   log "Verifying installed Lacework CLI version"
-  LW_TELEMETRY_DISABLE=1 LW_UPDATES_DISABLE=1 "${installation_dir}/${binary_name}" version
+  LW_NOCACHE=1 LW_TELEMETRY_DISABLE=1 LW_UPDATES_DISABLE=1 "${installation_dir}/${binary_name}" version
 }
 
 download_file() {


### PR DESCRIPTION
***Issue***: N/A

***Description:***
I spotted in Honeycomb that customers are experiencing these errors:
```
open /Users/afiune/.config/lacework/version_cache: permission denied
```

This might be happening when users use `sudo` to install the Lacework CLI and these files are
created by `root`. The solution here is to disable the caching mechanism during install.