### PR TITLE
fix(cli): install.ps1 to not fail for False boolean

### DIFF
--- a/cli/install.ps1
+++ b/cli/install.ps1
@@ -102,7 +102,7 @@ Function Install-Lacework-CLI {
     $machinePath = [System.Environment]::GetEnvironmentVariable("PATH", "Machine")
     $machinePath = New-PathString -StartingPath $machinePath -Path $laceworkPath
 
-    $isAdmin = False
+    $isAdmin = $false
     try {
         $currentPrincipal = New-Object Security.Principal.WindowsPrincipal([Security.Principal.WindowsIdentity]::GetCurrent())
         $isAdmin = $currentPrincipal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)


### PR DESCRIPTION
Update False to that script runs correctly in Windows.

---
name: Pull request template
about: 'type(scope): Subject of the pull request '
---

***Issue***: Include link to the Jira/Github Issue
Discussed here. Ran into this issue today during PoV. Making this edit worked and allowed customer install to proceed successfully. https://lacework.slack.com/archives/GLSRUQ11A/p1632417635037800

***Description:***
Change "False" to "$false"

***Additional Info:***
Include any other relevant information such as how to use the new fuctionality, screenshots, etc.