### PR TITLE
fix(api): Add issue grouping field to cloudwatch alert channel data

### DIFF
--- a/api/alert_channels_aws_cloudwatch.go
+++ b/api/alert_channels_aws_cloudwatch.go
@@ -32,7 +32,8 @@ func (svc *AlertChannelsService) UpdateCloudwatchEb(data AlertChannel) (response
 }
 
 type CloudwatchEbDataV2 struct {
-	EventBusArn string `json:"eventBusArn"`
+	EventBusArn   string `json:"eventBusArn"`
+	IssueGrouping string `json:"issueGrouping,omitempty"`
 }
 
 type CloudwatchEbAlertChannelV2 struct {

--- a/api/alert_channels_aws_cloudwatch_test.go
+++ b/api/alert_channels_aws_cloudwatch_test.go
@@ -32,9 +32,10 @@ import (
 
 func TestAlertChannelsService_GetCloudwatchEb(t *testing.T) {
 	var (
-		intgGUID   = intgguid.New()
-		apiPath    = fmt.Sprintf("AlertChannels/%s", intgGUID)
-		fakeServer = lacework.MockServer()
+		intgGUID    = intgguid.New()
+		apiPath     = fmt.Sprintf("AlertChannels/%s", intgGUID)
+		fakeServer  = lacework.MockServer()
+		eventBusArn = "arn:aws:events:YourRegion:YourAccountID:event-bus/default"
 	)
 	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
@@ -58,7 +59,8 @@ func TestAlertChannelsService_GetCloudwatchEb(t *testing.T) {
 	assert.Equal(t, intgGUID, response.Data.IntgGuid)
 	assert.Equal(t, "integration_name", response.Data.Name)
 	assert.True(t, response.Data.State.Ok)
-	assert.Equal(t, response.Data.Data.EventBusArn, "arn:aws:events:YourRegion:YourAccountID:event-bus/default")
+	assert.Equal(t, eventBusArn, response.Data.Data.EventBusArn)
+	assert.Equal(t, "Events", response.Data.Data.IssueGrouping)
 }
 
 func TestAlertChannelsService_UpdateCloudwatchEb(t *testing.T) {
@@ -109,6 +111,7 @@ func TestAlertChannelsService_UpdateCloudwatchEb(t *testing.T) {
 	assert.Equal(t, intgGUID, response.Data.IntgGuid)
 	assert.True(t, response.Data.State.Ok)
 	assert.Equal(t, eventBusArn, response.Data.Data.EventBusArn)
+	assert.Equal(t, "Events", response.Data.Data.IssueGrouping)
 }
 
 func singleAWSCloudwatchAlertChannel(id string) string {
@@ -117,7 +120,8 @@ func singleAWSCloudwatchAlertChannel(id string) string {
 		"createdOrUpdatedBy": "vatasha.white@lacework.net",
 		"createdOrUpdatedTime": "2021-09-29T117:55:47.277316",
 		"data": {
-			"eventBusArn": "arn:aws:events:YourRegion:YourAccountID:event-bus/default"
+			"eventBusArn": "arn:aws:events:YourRegion:YourAccountID:event-bus/default",
+			"issueGrouping": "Events"
 		},
 		"enabled": 1,
 		"intgGuid": %q,


### PR DESCRIPTION
---
 Add issue grouping field to the cloudwatcheb alert channel data
---

***Issue***: https://lacework.atlassian.net/jira/software/projects/ALLY/boards/58?selectedIssue=ALLY-637