### PR TITLE
docs: improve pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,12 +1,38 @@
----
-name: Pull request template
-about: 'type(scope): Subject of the pull request '
----
+<!--
+  Thanks for submitting a pull request!
+  We appreciate you spending the time to work on these changes.
+  Please provide enough information so that others can review your pull request.
 
-***Issue***: Include link to the Jira/Github Issue
+  Before submitting a pull request, please make sure the following is done:
 
-***Description:***
-Provide a detailed description of the changes made by this pull request.
+  1. Fork [the repository](https://github.com/lacework/go-sdk) and create your branch from `main`.
+  2. Run `make prepare` in the repository root.
+  3. If you've fixed a bug or added code that should be tested, add tests!
+  4. Ensure the test suite passes (`make test`)
+  5. Format your code (`make fmt`).
+  6. Make sure your code lints (`make lint`)
+  7. If you are updating the Lacework CLI, make sure it compiles (`make build-cli-cross-platform`)
+  8. Follow the [commit message standard](#commit-message-standard) (`type(scope): subject`)
+  9. If you haven't already, configure signed commits by [telling git about your signing key](https://docs.github.com/en/github/authenticating-to-github/managing-commit-signature-verification/telling-git-about-your-signing-key) and [signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
 
-***Additional Info:***
-Include any other relevant information such as how to use the new fuctionality, screenshots, etc.
+  Learn more about contributing: https://github.com/lacework/go-sdk/blob/main/CONTRIBUTING.md
+-->
+
+## Summary
+
+<!--
+ Explain the **motivation** for making this change. What existing problem does the pull request solve?
+-->
+
+## How did you test this change?
+
+<!--
+  How exactly did you verify that your PR solves the issue you wanted to solve?
+  Include any other relevant information such as how to use the new fuctionality, screenshots, etc.
+-->
+
+## Issue
+
+<!--
+  Include the link to a Jira/Github issue
+-->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,14 +5,14 @@
 
   Before submitting a pull request, please make sure the following is done:
 
-  1. Fork [the repository](https://github.com/lacework/go-sdk) and create your branch from `main`.
-  2. Run `make prepare` in the repository root.
+  1. Fork [the repository](https://github.com/lacework/go-sdk) and create your branch from `main`
+  2. Run `make prepare` in the repository root
   3. If you've fixed a bug or added code that should be tested, add tests!
   4. Ensure the test suite passes (`make test`)
-  5. Format your code (`make fmt`).
+  5. Format your code (`make fmt`)
   6. Make sure your code lints (`make lint`)
   7. If you are updating the Lacework CLI, make sure it compiles (`make build-cli-cross-platform`)
-  8. Follow the [commit message standard](#commit-message-standard) (`type(scope): subject`)
+  8. Follow the commit message standard (`type(scope): subject`) documented in [DEVELOPER_GUIDELINES.md](https://github.com/lacework/go-sdk/blob/main/DEVELOPER_GUIDELINES.md#commit-message-standard)
   9. If you haven't already, configure signed commits by [telling git about your signing key](https://docs.github.com/en/github/authenticating-to-github/managing-commit-signature-verification/telling-git-about-your-signing-key) and [signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
 
   Learn more about contributing: https://github.com/lacework/go-sdk/blob/main/CONTRIBUTING.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ open a new [issue](https://github.com/lacework/go-sdk/issues/new)
 
 ### Pull Requests
 
-When submitting a pull request follow the [commit message standard](#commit-message-standard).
+When submitting a pull request follow the [commit message standard](DEVELOPER_GUIDELINES.md#commit-message-standard).
 Reduce the likelihood of pushing breaking changes by running the go-sdk unit and integration tests, 
 see [development documentation](https://github.com/lacework/go-sdk/tree/main/cli#development).
 

--- a/DEVELOPER_GUIDELINES.md
+++ b/DEVELOPER_GUIDELINES.md
@@ -1,11 +1,16 @@
-## Go-sdk Developer Guidelines
+## Developer Guidelines
+
+## Signed Commits
+Signed commits are required for any contribution to this project. Please see Github's documentation on configuring signed commits, [tell git about your signing key](https://docs.github.com/en/github/authenticating-to-github/managing-commit-signature-verification/telling-git-about-your-signing-key) and [signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
 
 ## Commit message standard
 
 The format is:
 ```
 type(scope): subject
+
 BODY
+
 FOOTER
 ```
 

--- a/DEVELOPER_GUIDELINES.md
+++ b/DEVELOPER_GUIDELINES.md
@@ -14,24 +14,38 @@ BODY
 FOOTER
 ```
 
-Each commit message consists of a header, body, and footer. The header is mandatory, the scope is optional, the type and subject are mandatory.
-When writing a commit message try and limit each line of the commit to a max of 100 hundred characters, so it can be read easily.
+Example commit message:
+```
+feat(cli): add --api_token global flag
+
+This new flag will replace the use of `api_key` and `api_secret` so that
+users can run the Lacework CLI only with an access token and their account:
+
+    lacework int list --api_token _secret123 -a mycompany
+
+Closes https://github.com/lacework/go-sdk/issues/282
+```
+
+Each commit message consists of a header, body, and footer. The header with the type and subject are mandatory, the scope is optional.
+When writing a commit message try and limit each line of the commit to a max of 80 characters, so it can be read easily.
 
 ### Type
 
-| Type | Description |
-| ----- | ----------- |
-| feat: | A new feature you're adding |
-| fix: |A bug fix|
-| style: | Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc) |
-| refactor: | A code change that neither fixes a bug nor adds a feature |
-| test: | Everything related to testing |
-| docs: | Everything related to documentation |
-| chore: | Regular code maintenance |
-| build: | Changes that affect the build |
-| ci: | Changes to our CI configuration files and scripts |
-| perf: | A code change that improves performance |
-| metric: | A change that provides better insights about the adoption of features and code statistics |
+Allowed `type` valued.
+
+| Type      | Description                                                                                            |
+| -----     | -----------                                                                                            |
+| feat:     | A new feature you're adding                                                                            |
+| fix:      | A bug fix                                                                                              |
+| style:    | Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc) |
+| refactor: | A code change that neither fixes a bug nor adds a feature                                              |
+| test:     | Everything related to testing                                                                          |
+| docs:     | Everything related to documentation                                                                    |
+| chore:    | Regular code maintenance                                                                               |
+| build:    | Changes that affect the build                                                                          |
+| ci:       | Changes to our CI configuration files and scripts                                                      |
+| perf:     | A code change that improves performance                                                                |
+| metric:   | A change that provides better insights about the adoption of features and code statistics              |
 
 ### Scope
 The optional scope refers to the section that this commit belongs to, for example, changing a specific component or service, a directive, pipes, etc.
@@ -39,13 +53,13 @@ Think about it as an indicator that will let the developers know at first glance
 
 A few good examples are:
 
-feat(client):
-docs(cli):
-chore(tests):
-ci(directive):
+* feat(client):
+* docs(cli):
+* chore(tests):
+* ci(directive):
 
 ### Subject
-The subject should contain a short description of the change, and written in present-tense, for example, use “add” and not “added”,  or “change” and not “changed”.
+The subject should contain a short description of the change, and written in present-tense, for example, use "add" and not "added",  or "change" and not "changed".
 I like to fill this sentence below to understand what should I put as my description of my change:
 
 If applied, this commit will ________________________________________.
@@ -55,4 +69,4 @@ The body should contain a longer description of the change, try not to repeat th
 Put as much context as you think it is needed, don’t be shy and explain your thought process, limitations, ideas for new features or fixes, etc.
 
 ### Footer
-The footer is used to reference issues, pull requests or breaking changes, for example, “Fixes ticket #123”.
+The footer is used to reference issues, pull requests or breaking changes, for example, "Fixes ticket #123".

--- a/Makefile
+++ b/Makefile
@@ -104,8 +104,8 @@ lint: ## Runs go linter
 
 .PHONY: fmt
 fmt: ## Runs and applies go formatting changes
-	@gofmt -w -l ./
-	@goimports -w -l ./
+	@gofmt -w -l $(shell go list -f {{.Dir}} ./...)
+	@goimports -w -l $(shell go list -f {{.Dir}} ./...)
 
 .PHONY: fmt-check
 fmt-check: ## Lists formatting issues


### PR DESCRIPTION
## Summary

Improve Pull Request template to render correctly and add useful information like,
add tests, how to run those tests, how to format code, run linter, built the CLI, etc.

Today, this templates look like this:
<img width="925" alt="Screen Shot 2021-10-04 at 11 00 15 AM" src="https://user-images.githubusercontent.com/5712253/135823296-ca8a5b51-153c-42cd-9ee3-2f785c4d63d2.png">

## How did you test this change?

I have not tested it 😂 since we need to merge first to see if Github renders it correctly 🤞🏽

## Issue

N/A
