### PR TITLE
feat(api): Datadog Alert Channel API v2

### DIFF
--- a/api/alert_channel_datadog.go
+++ b/api/alert_channel_datadog.go
@@ -1,0 +1,47 @@
+//
+// Author:: Vatasha White (<vatasha.white@lacework.net>)
+// Copyright:: Copyright 2021, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package api
+
+// GetDatadog gets a single instance of a Datadog alert channel
+// with the corresponding integration guid
+func (svc *AlertChannelsService) GetDatadog(guid string) (response DatadogAlertChannelResponseV2, err error) {
+	err = svc.get(guid, &response)
+	return
+}
+
+// UpdateDatadog updates a single instance of a Datadog integration on the Lacework server
+func (svc *AlertChannelsService) UpdateDatadog(data AlertChannel) (response DatadogAlertChannelResponseV2, err error) {
+	err = svc.update(data.ID(), data, &response)
+	return
+}
+
+type DatadogDataV2 struct {
+	APIKey      string `json:"apiKey"`
+	DatadogSite string `json:"datadogSite,omitempty"`
+	DatadogType string `json:"datadogType,omitempty"`
+}
+
+type DatadogAlertChannelV2 struct {
+	v2CommonIntegrationData
+	Data DatadogDataV2 `json:"data"`
+}
+
+type DatadogAlertChannelResponseV2 struct {
+	Data DatadogAlertChannelV2 `json:"data"`
+}

--- a/api/alert_channel_datadog_test.go
+++ b/api/alert_channel_datadog_test.go
@@ -56,14 +56,15 @@ func TestAlertChannelsService_GetDatadog(t *testing.T) {
 	assert.Nil(t, err)
 
 	response, err := c.V2.AlertChannels.GetDatadog(intgGUID)
-	assert.Nil(t, err)
-	assert.NotNil(t, response)
-	assert.Equal(t, intgGUID, response.Data.IntgGuid)
-	assert.Equal(t, "integration_name", response.Data.Name)
-	assert.True(t, response.Data.State.Ok)
-	assert.Equal(t, APIKey, response.Data.Data.APIKey)
-	assert.Equal(t, DatadogSite, response.Data.Data.DatadogSite)
-	assert.Equal(t, DatadogType, response.Data.Data.DatadogType)
+	if assert.NoError(t, err) {
+		assert.NotNil(t, response)
+		assert.Equal(t, intgGUID, response.Data.IntgGuid)
+		assert.Equal(t, "integration_name", response.Data.Name)
+		assert.True(t, response.Data.State.Ok)
+		assert.Equal(t, APIKey, response.Data.Data.APIKey)
+		assert.Equal(t, DatadogSite, response.Data.Data.DatadogSite)
+		assert.Equal(t, DatadogType, response.Data.Data.DatadogType)
+	}
 }
 
 func TestAlertChannelsService_UpdateDatadog(t *testing.T) {
@@ -117,13 +118,14 @@ func TestAlertChannelsService_UpdateDatadog(t *testing.T) {
 	alertChannel.IntgGuid = intgGUID
 
 	response, err := c.V2.AlertChannels.UpdateDatadog(alertChannel)
-	assert.Nil(t, err)
-	assert.NotNil(t, response)
-	assert.Equal(t, intgGUID, response.Data.IntgGuid)
-	assert.True(t, response.Data.State.Ok)
-	assert.Equal(t, APIKey, response.Data.Data.APIKey)
-	assert.Equal(t, DatadogSite, response.Data.Data.DatadogSite)
-	assert.Equal(t, DatadogType, response.Data.Data.DatadogType)
+	if assert.NoError(t, err) {
+		assert.NotNil(t, response)
+		assert.Equal(t, intgGUID, response.Data.IntgGuid)
+		assert.True(t, response.Data.State.Ok)
+		assert.Equal(t, APIKey, response.Data.Data.APIKey)
+		assert.Equal(t, DatadogSite, response.Data.Data.DatadogSite)
+		assert.Equal(t, DatadogType, response.Data.Data.DatadogType)
+	}
 }
 
 func singleDatadogAlertChannel(id string) string {

--- a/api/alert_channel_datadog_test.go
+++ b/api/alert_channel_datadog_test.go
@@ -1,0 +1,154 @@
+//
+// Author:: Vatasha White (<vatasha.white@lacework.net>)
+// Copyright:: Copyright 2021, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package api_test
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/lacework/go-sdk/api"
+	"github.com/lacework/go-sdk/internal/intgguid"
+	"github.com/lacework/go-sdk/internal/lacework"
+)
+
+func TestAlertChannelsService_GetDatadog(t *testing.T) {
+	var (
+		intgGUID    = intgguid.New()
+		apiPath     = fmt.Sprintf("AlertChannels/%s", intgGUID)
+		fakeServer  = lacework.MockServer()
+		APIKey = "Im-a-fake-api-key"
+		DatadogSite = "com"
+		DatadogType = "Logs Detail"
+
+	)
+	fakeServer.UseApiV2()
+	fakeServer.MockToken("TOKEN")
+	defer fakeServer.Close()
+
+	fakeServer.MockAPI(apiPath, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method, "GetDatadog should be a GET method")
+		fmt.Fprintf(w, generateAlertChannelResponse(singleDatadogAlertChannel(intgGUID)))
+	})
+
+	c, err := api.NewClient("test",
+		api.WithApiV2(),
+		api.WithToken("TOKEN"),
+		api.WithURL(fakeServer.URL()),
+	)
+	assert.Nil(t, err)
+
+	response, err := c.V2.AlertChannels.GetDatadog(intgGUID)
+	assert.Nil(t, err)
+	assert.NotNil(t, response)
+	assert.Equal(t, intgGUID, response.Data.IntgGuid)
+	assert.Equal(t, "integration_name", response.Data.Name)
+	assert.True(t, response.Data.State.Ok)
+	assert.Equal(t, APIKey, response.Data.Data.APIKey)
+	assert.Equal(t, DatadogSite, response.Data.Data.DatadogSite)
+	assert.Equal(t, DatadogType, response.Data.Data.DatadogType)
+}
+
+func TestAlertChannelsService_UpdateDatadog(t *testing.T) {
+	var (
+		intgGUID    = intgguid.New()
+		apiPath     = fmt.Sprintf("AlertChannels/%s", intgGUID)
+		fakeServer  = lacework.MockServer()
+		APIKey = "Im-a-fake-api-key"
+		DatadogSite = "com"
+		DatadogType = "Logs Detail"
+	)
+	fakeServer.UseApiV2()
+	fakeServer.MockToken("TOKEN")
+	defer fakeServer.Close()
+
+	fakeServer.MockAPI(apiPath, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "PATCH", r.Method, "UpdateCloudwatchEb() should be a PATCH method")
+
+		if assert.NotNil(t, r.Body) {
+			body := httpBodySniffer(r)
+			assert.Contains(t, body, intgGUID, "INTG_GUID missing")
+			assert.Contains(t, body, "integration_name", "cloud account name is missing")
+			assert.Contains(t, body, "Datadog", "wrong cloud account type")
+			assert.Contains(t, body, APIKey, "missing API key")
+			assert.Contains(t, body, DatadogSite, "missing datadog site")
+			assert.Contains(t, body, DatadogType, "missing datadog type")
+			assert.Contains(t, body, "enabled\":1", "cloud account is not enabled")
+		}
+
+		fmt.Fprintf(w, generateAlertChannelResponse(singleDatadogAlertChannel(intgGUID)))
+	})
+
+	c, err := api.NewClient("test",
+		api.WithApiV2(),
+		api.WithToken("TOKEN"),
+		api.WithURL(fakeServer.URL()),
+	)
+	assert.Nil(t, err)
+
+	alertChannel := api.NewAlertChannel("integration_name",
+		api.DatadogAlertChannelType,
+		api.DatadogDataV2{
+			APIKey:      APIKey,
+			DatadogSite: DatadogSite,
+			DatadogType: DatadogType,
+		},
+	)
+	assert.Equal(t, "integration_name", alertChannel.Name)
+	assert.Equal(t, "Datadog", alertChannel.Type)
+	assert.Equal(t, 1, alertChannel.Enabled)
+	alertChannel.IntgGuid = intgGUID
+
+	response, err := c.V2.AlertChannels.UpdateDatadog(alertChannel)
+	assert.Nil(t, err)
+	assert.NotNil(t, response)
+	assert.Equal(t, intgGUID, response.Data.IntgGuid)
+	assert.True(t, response.Data.State.Ok)
+	assert.Equal(t, APIKey, response.Data.Data.APIKey)
+	assert.Equal(t, DatadogSite, response.Data.Data.DatadogSite)
+	assert.Equal(t, DatadogType, response.Data.Data.DatadogType)
+}
+
+func singleDatadogAlertChannel(id string) string {
+	return fmt.Sprintf(`
+	{
+		"createdOrUpdatedBy": "vatasha.white@lacework.net",
+		"createdOrUpdatedTime": "2021-09-29T117:55:47.277316",
+		"data": {
+			"apiKey": "Im-a-fake-api-key",
+			"datadogSite": "com",
+			"datadogType": "Logs Detail"
+		},
+		"enabled": 1,
+		"intgGuid": %q,
+		"isOrg": 0,
+		"name": "integration_name",
+		"state": {
+		"details": {},
+		"lastSuccessfulTime": 1632932665892,
+			"lastUpdatedTime": 1632932665892,
+			"ok": true
+	},
+		"type": "Datadog"
+	}
+	`, id)
+}
+

--- a/api/alert_channel_datadog_test.go
+++ b/api/alert_channel_datadog_test.go
@@ -35,10 +35,9 @@ func TestAlertChannelsService_GetDatadog(t *testing.T) {
 		intgGUID    = intgguid.New()
 		apiPath     = fmt.Sprintf("AlertChannels/%s", intgGUID)
 		fakeServer  = lacework.MockServer()
-		APIKey = "Im-a-fake-api-key"
+		APIKey      = "Im-a-fake-api-key"
 		DatadogSite = "com"
 		DatadogType = "Logs Detail"
-
 	)
 	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
@@ -72,7 +71,7 @@ func TestAlertChannelsService_UpdateDatadog(t *testing.T) {
 		intgGUID    = intgguid.New()
 		apiPath     = fmt.Sprintf("AlertChannels/%s", intgGUID)
 		fakeServer  = lacework.MockServer()
-		APIKey = "Im-a-fake-api-key"
+		APIKey      = "Im-a-fake-api-key"
 		DatadogSite = "com"
 		DatadogType = "Logs Detail"
 	)
@@ -151,4 +150,3 @@ func singleDatadogAlertChannel(id string) string {
 	}
 	`, id)
 }
-

--- a/api/alert_channels.go
+++ b/api/alert_channels.go
@@ -84,6 +84,7 @@ const (
 	SlackChannelAlertChannelType
 	AwsS3AlertChannelType
 	CloudwatchEbAlertChannelType
+	DatadogAlertChannelType
 )
 
 // AlertChannelTypeTypes is the list of available Alert Channel integration types
@@ -93,6 +94,7 @@ var AlertChannelTypes = map[alertChannelType]string{
 	SlackChannelAlertChannelType: "SlackChannel",
 	AwsS3AlertChannelType:        "AwsS3",
 	CloudwatchEbAlertChannelType: "CloudwatchEb",
+	DatadogAlertChannelType:      "Datadog",
 }
 
 // String returns the string representation of a Alert Channel integration type


### PR DESCRIPTION
---
name: Datadog Alert Channel API v2 Migration
about: feat(api): Datadog Alert Channel API v2
---

***Issue***: https://lacework.atlassian.net/browse/ALLY-639?atlOrigin=eyJpIjoiZTRiZWRiMWMxZDEzNGQ4N2FmYzhmZWE5MGRkOTMyMTgiLCJwIjoiaiJ9

***Description:***
Migrate datadog to use v2 of the API to create a new datadog alert channel

***Additional Info:***
Include any other relevant information such as how to use the new fuctionality, screenshots, etc.