### PR TITLE
feat(api): Migrate Ibm QRadar alert channel to API v2

### DIFF
--- a/api/_examples/qradar-alert-channel/main.go
+++ b/api/_examples/qradar-alert-channel/main.go
@@ -3,29 +3,32 @@ package main
 import (
 	"fmt"
 	"log"
+	"os"
 
 	"github.com/lacework/go-sdk/api"
 )
 
 func main() {
-	lacework, err := api.NewClient("account", api.WithApiKeys("KEY", "SECRET"))
+	lacework, err := api.NewClient(os.Getenv("LW_ACCOUNT"), api.WithApiV2(),
+		api.WithApiKeys(os.Getenv("LW_API_KEY"), os.Getenv("LW_API_SECRET")))
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	myQRadarChannel := api.NewQRadarAlertChannel("qradar-alert-from-golang",
-		api.QRadarChannelData{
-			HostURL:           "https://qradar-lacework.com",
-			HostPort:          8080,
-			CommunicationType: api.QRadarCommHttps,
+	myQRadarChannel := api.NewAlertChannel("qradar-alert-from-golang",
+		api.IbmQRadarAlertChannelType,
+		api.IbmQRadarDataV2{
+			HostURL:        "https://qradar-lacework.com",
+			HostPort:       8080,
+			QRadarCommType: api.QRadarCommHttps,
 		},
 	)
 
-	response, err := lacework.Integrations.CreateQRadarAlertChannel(myQRadarChannel)
+	response, err := lacework.V2.AlertChannels.Create(myQRadarChannel)
 	if err != nil {
 		log.Fatal(err)
 	}
 
 	// Output: QRadar alert channel created: THE-INTEGRATION-GUID
-	fmt.Printf("QRadar alert channel created: %s", response.Data[0].IntgGuid)
+	fmt.Printf("QRadar alert channel created: %s", response.Data.IntgGuid)
 }

--- a/api/alert_channels.go
+++ b/api/alert_channels.go
@@ -91,6 +91,7 @@ const (
 	MicrosoftTeamsAlertChannelType
 	SplunkHecAlertChannelType
 	ServiceNowRestAlertChannelType
+	IbmQRadarAlertChannelType
 )
 
 // AlertChannelTypeTypes is the list of available Alert Channel integration types
@@ -107,6 +108,7 @@ var AlertChannelTypes = map[alertChannelType]string{
 	MicrosoftTeamsAlertChannelType:    "MicrosoftTeams",
 	SplunkHecAlertChannelType:         "SplunkHec",
 	ServiceNowRestAlertChannelType:    "ServiceNowRest",
+	IbmQRadarAlertChannelType:         "IbmQradar",
 }
 
 // String returns the string representation of a Alert Channel integration type

--- a/api/alert_channels_ibm_qradar.go
+++ b/api/alert_channels_ibm_qradar.go
@@ -1,0 +1,53 @@
+//
+// Author:: Darren Murray (<darren.murray@lacework.net>)
+// Copyright:: Copyright 2021, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package api
+
+// GetIbmQRadar gets a single IbmQRadar alert channel matching the
+// provided integration guid
+func (svc *AlertChannelsService) GetIbmQRadar(guid string) (
+	response IbmQRadarAlertChannelResponseV2,
+	err error,
+) {
+	err = svc.get(guid, &response)
+	return
+}
+
+// UpdateIbmQRadar updates a single IbmQRadar integration on the Lacework Server
+func (svc *AlertChannelsService) UpdateIbmQRadar(data AlertChannel) (
+	response IbmQRadarAlertChannelResponseV2,
+	err error,
+) {
+	err = svc.update(data.ID(), data, &response)
+	return
+}
+
+type IbmQRadarAlertChannelResponseV2 struct {
+	Data IbmQRadarAlertChannelV2 `json:"data"`
+}
+
+type IbmQRadarAlertChannelV2 struct {
+	v2CommonIntegrationData
+	Data IbmQRadarDataV2 `json:"data"`
+}
+
+type IbmQRadarDataV2 struct {
+	QRadarCommType qradarComm `json:"qradarCommType"`
+	HostURL        string     `json:"qradarHostUrl"`
+	HostPort       int        `json:"qradarHostPort,omitempty"`
+}

--- a/api/alert_channels_ibm_qradar_test.go
+++ b/api/alert_channels_ibm_qradar_test.go
@@ -1,0 +1,147 @@
+//
+// Author:: Darren Murray (<darren.murray@lacework.net>)
+// Copyright:: Copyright 2021, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package api_test
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/lacework/go-sdk/api"
+	"github.com/lacework/go-sdk/internal/intgguid"
+	"github.com/lacework/go-sdk/internal/lacework"
+)
+
+func TestAlertChannelsGetIbmQRadar(t *testing.T) {
+	var (
+		intgGUID   = intgguid.New()
+		apiPath    = fmt.Sprintf("AlertChannels/%s", intgGUID)
+		fakeServer = lacework.MockServer()
+	)
+	fakeServer.UseApiV2()
+	fakeServer.MockToken("TOKEN")
+	defer fakeServer.Close()
+
+	fakeServer.MockAPI(apiPath, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method, "GetIbmQRadar() should be a GET method")
+		fmt.Fprintf(w, generateAlertChannelResponse(singleIbmQRadarAlertChannel(intgGUID)))
+	})
+
+	c, err := api.NewClient("test",
+		api.WithApiV2(),
+		api.WithToken("TOKEN"),
+		api.WithURL(fakeServer.URL()),
+	)
+	assert.Nil(t, err)
+
+	response, err := c.V2.AlertChannels.GetIbmQRadar(intgGUID)
+	if assert.NoError(t, err) {
+		assert.NotNil(t, response)
+		assert.Equal(t, intgGUID, response.Data.IntgGuid)
+		assert.Equal(t, "integration_name", response.Data.Name)
+		assert.True(t, response.Data.State.Ok)
+		assert.Equal(t, response.Data.Data.HostURL, "https://qradar-lacework.com")
+		assert.Equal(t, response.Data.Data.HostPort, 443)
+		assert.Equal(t, response.Data.Data.QRadarCommType, api.QRadarCommHttps)
+	}
+}
+
+func TestAlertChannelIbmQRadarUpdate(t *testing.T) {
+	var (
+		intgGUID   = intgguid.New()
+		apiPath    = fmt.Sprintf("AlertChannels/%s", intgGUID)
+		fakeServer = lacework.MockServer()
+	)
+	fakeServer.UseApiV2()
+	fakeServer.MockToken("TOKEN")
+	defer fakeServer.Close()
+
+	fakeServer.MockAPI(apiPath, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "PATCH", r.Method, "UpdateIbmQRadar() should be a PATCH method")
+
+		if assert.NotNil(t, r.Body) {
+			body := httpBodySniffer(r)
+			assert.Contains(t, body, intgGUID, "INTG_GUID missing")
+			assert.Contains(t, body, "integration_name", "alert channel name is missing")
+			assert.Contains(t, body, "IbmQradar", "wrong alert channel type")
+			assert.Contains(t, body, "https://qradar-lacework.com", "missing host url")
+			assert.Contains(t, body, "443", "missing host port")
+			assert.Contains(t, body, "HTTPS", "missing comm type")
+		}
+
+		fmt.Fprintf(w, generateAlertChannelResponse(singleIbmQRadarAlertChannel(intgGUID)))
+	})
+
+	c, err := api.NewClient("test",
+		api.WithApiV2(),
+		api.WithToken("TOKEN"),
+		api.WithURL(fakeServer.URL()),
+	)
+	assert.Nil(t, err)
+
+	qradarAlertChan := api.NewAlertChannel("integration_name",
+		api.IbmQRadarAlertChannelType,
+		api.IbmQRadarDataV2{
+			HostURL:        "https://qradar-lacework.com",
+			HostPort:       443,
+			QRadarCommType: "HTTPS",
+		},
+	)
+	assert.Equal(t, "integration_name", qradarAlertChan.Name, "IbmQRadar alert channel name mismatch")
+	assert.Equal(t, "IbmQradar", qradarAlertChan.Type, "a new IbmQRadar alert channel should match its type")
+	assert.Equal(t, 1, qradarAlertChan.Enabled, "a new IbmQRadar alert channel should be enabled")
+	qradarAlertChan.IntgGuid = intgGUID
+
+	response, err := c.V2.AlertChannels.UpdateIbmQRadar(qradarAlertChan)
+	if assert.NoError(t, err) {
+		assert.NotNil(t, response)
+		assert.Equal(t, intgGUID, response.Data.IntgGuid)
+		assert.True(t, response.Data.State.Ok)
+		assert.Equal(t, response.Data.Data.QRadarCommType, api.QRadarCommHttps)
+		assert.Equal(t, response.Data.Data.HostPort, 443)
+		assert.Equal(t, response.Data.Data.HostURL, "https://qradar-lacework.com")
+	}
+}
+
+func singleIbmQRadarAlertChannel(id string) string {
+	return `
+{
+    "createdOrUpdatedBy": "salim.afiunemaya@lacework.net",
+    "createdOrUpdatedTime": "2021-06-01T18:10:40.745Z",
+    "data": {
+	  "qradarHostUrl": "https://qradar-lacework.com",
+	  "qradarHostPort": 443,
+	  "qradarCommType": "HTTPS"
+    },
+    "enabled": 1,
+    "intgGuid": "` + id + `",
+    "isOrg": 0,
+    "name": "integration_name",
+    "state": {
+      "details": {},
+      "lastSuccessfulTime": 1627895573122,
+      "lastUpdatedTime": 1627895573122,
+      "ok": true
+    },
+    "type": "IbmQradar"
+}
+  `
+}

--- a/api/alert_channels_test.go
+++ b/api/alert_channels_test.go
@@ -72,6 +72,10 @@ func TestAlertChannelTypes(t *testing.T) {
 		"ServiceNowRest", api.ServiceNowRestAlertChannelType.String(),
 		"wrong alert channel type",
 	)
+	assert.Equal(t,
+		"IbmQradar", api.IbmQRadarAlertChannelType.String(),
+		"wrong alert channel type",
+	)
 }
 
 func TestFindAlertChannelType(t *testing.T) {
@@ -123,6 +127,10 @@ func TestFindAlertChannelType(t *testing.T) {
 	alertFound, found = api.FindAlertChannelType("ServiceNowRest")
 	assert.True(t, found, "alert channel type should exist")
 	assert.Equal(t, "ServiceNowRest", alertFound.String(), "wrong alert channel type")
+
+	alertFound, found = api.FindAlertChannelType("IbmQradar")
+	assert.True(t, found, "alert channel type should exist")
+	assert.Equal(t, "IbmQradar", alertFound.String(), "wrong alert channel type")
 }
 
 func TestAlertChannelsGet(t *testing.T) {
@@ -264,8 +272,9 @@ func TestAlertChannelsList(t *testing.T) {
 		victorOpsAlertChan         = generateGuids(&allGUIDs, 2)
 		ciscoSparkWebhookAlertChan = generateGuids(&allGUIDs, 2)
 		microsoftTeamsAlertChan    = generateGuids(&allGUIDs, 2)
-		splunkHecOpsAlertChan      = generateGuids(&allGUIDs, 2)
-		serviceNowRestOpsAlertChan = generateGuids(&allGUIDs, 2)
+		splunkHecAlertChan         = generateGuids(&allGUIDs, 2)
+		serviceNowRestAlertChan    = generateGuids(&allGUIDs, 2)
+		ibmQradarAlertChan         = generateGuids(&allGUIDs, 2)
 		expectedLen                = len(allGUIDs)
 		fakeServer                 = lacework.MockServer()
 	)
@@ -285,8 +294,9 @@ func TestAlertChannelsList(t *testing.T) {
 				generateAlertChannels(victorOpsAlertChan, "VictorOps"),
 				generateAlertChannels(ciscoSparkWebhookAlertChan, "CiscoSparkWebhook"),
 				generateAlertChannels(microsoftTeamsAlertChan, "MicrosoftTeams"),
-				generateAlertChannels(splunkHecOpsAlertChan, "SplunkHec"),
-				generateAlertChannels(serviceNowRestOpsAlertChan, "ServiceNowRest"),
+				generateAlertChannels(splunkHecAlertChan, "SplunkHec"),
+				generateAlertChannels(serviceNowRestAlertChan, "ServiceNowRest"),
+				generateAlertChannels(ibmQradarAlertChan, "IbmQradar"),
 			}
 			fmt.Fprintf(w,
 				generateAlertChannelsResponse(
@@ -350,6 +360,8 @@ func generateAlertChannels(guids []string, iType string) string {
 			alertChannels[i] = singleSplunkAlertChannel(guid)
 		case api.ServiceNowRestAlertChannelType.String():
 			alertChannels[i] = singleServiceNowRestAlertChannel(guid)
+		case api.IbmQRadarAlertChannelType.String():
+			alertChannels[i] = singleIbmQRadarAlertChannel(guid)
 		}
 	}
 	return strings.Join(alertChannels, ", ")

--- a/cli/cmd/integration_qradar_channel.go
+++ b/cli/cmd/integration_qradar_channel.go
@@ -69,16 +69,17 @@ func createQRadarAlertChannelIntegration() error {
 		return err
 	}
 
-	qradar := api.NewQRadarAlertChannel(answers.Name,
-		api.QRadarChannelData{
-			HostURL:           answers.HostURL,
-			HostPort:          answers.HostPort,
-			CommunicationType: commType,
+	qradar := api.NewAlertChannel(answers.Name,
+		api.IbmQRadarAlertChannelType,
+		api.IbmQRadarDataV2{
+			HostURL:        answers.HostURL,
+			HostPort:       answers.HostPort,
+			QRadarCommType: commType,
 		},
 	)
 
 	cli.StartProgress(" Creating integration...")
-	_, err = cli.LwApi.Integrations.CreateQRadarAlertChannel(qradar)
+	_, err = cli.LwApi.V2.AlertChannels.Create(qradar)
 	cli.StopProgress()
 	return err
 }


### PR DESCRIPTION
Signed-off-by: Darren Murray <darren.murray@lacework.net>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/lacework/go-sdk) and create your branch from `main`
  2. Run `make prepare` in the repository root
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`make test`)
  5. Format your code (`make fmt`)
  6. Make sure your code lints (`make lint`)
  7. If you are updating the Lacework CLI, make sure it compiles (`make build-cli-cross-platform`)
  8. Follow the commit message standard (`type(scope): subject`) documented in [DEVELOPER_GUIDELINES.md](https://github.com/lacework/go-sdk/blob/main/DEVELOPER_GUIDELINES.md#commit-message-standard)
  9. If you haven't already, configure signed commits by [telling git about your signing key](https://docs.github.com/en/github/authenticating-to-github/managing-commit-signature-verification/telling-git-about-your-signing-key) and [signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)

  Learn more about contributing: https://github.com/lacework/go-sdk/blob/main/CONTRIBUTING.md
-->

## Summary

Migrate Ibm QRadar alert channel integration to use api v2.

## How did you test this change?

New Unit tests added to:
```
alert_channels_test.go
alert_channel_ibm_qradar_test.go
```
Manually run lacework int create `IbmQradar`

## Issue

https://lacework.atlassian.net/browse/ALLY-646
