### PR TITLE
feat(cli): unhiding query "sources" cmd

### DIFF
--- a/cli/cmd/lql_sources.go
+++ b/cli/cmd/lql_sources.go
@@ -27,7 +27,7 @@ import (
 
 var (
 	queryListSourcesCmd = &cobra.Command{
-		Hidden:  true, // api to be exposed for 4.31
+		Hidden:  false,
 		Aliases: []string{"sources"},
 		Use:     "list-sources",
 		Short:   "list Lacework query data sources",
@@ -37,7 +37,7 @@ var (
 	}
 
 	queryShowSourceCmd = &cobra.Command{
-		Hidden:  true, // api to be exposed for 4.31
+		Hidden:  false,
 		Aliases: []string{"describe"},
 		Use:     "show-source <datasource_id>",
 		Short:   "show Lacework query data source",

--- a/integration/lql_sources_test.go
+++ b/integration/lql_sources_test.go
@@ -1,3 +1,4 @@
+//go:build query
 // +build query
 
 // Author:: Salim Afiune Maya (<afiune@lacework.net>)
@@ -40,8 +41,6 @@ func TestQueryListSourcesAliases(t *testing.T) {
 }
 
 func TestQueryListSourcesTable(t *testing.T) {
-	t.Skip("skipping test due to unavailable api")
-
 	out, err, exitcode := LaceworkCLIWithTOMLConfig("query", "sources")
 	assert.Contains(t, out.String(), "DATASOURCE")
 	assert.Contains(t, out.String(), "CloudTrailRawEvents")
@@ -50,8 +49,6 @@ func TestQueryListSourcesTable(t *testing.T) {
 }
 
 func TestQueryListSourcesJSON(t *testing.T) {
-	t.Skip("skipping test due to unavailable api")
-
 	out, err, exitcode := LaceworkCLIWithTOMLConfig("query", "sources", "--json")
 	assert.Contains(t, out.String(), "[")
 	assert.Contains(t, out.String(), `"CloudTrailRawEvents"`)
@@ -80,8 +77,6 @@ func TestQueryShowSourceNoInput(t *testing.T) {
 }
 
 func TestQueryShowSourceTable(t *testing.T) {
-	t.Skip("skipping test due to unavailable api")
-
 	out, err, exitcode := LaceworkCLIWithTOMLConfig("query", "describe", "CloudTrailRawEvents")
 	assert.Contains(t, out.String(), "FIELD NAME")
 	assert.Contains(t, out.String(), "INSERT_ID")
@@ -90,8 +85,6 @@ func TestQueryShowSourceTable(t *testing.T) {
 }
 
 func TestQueryShowSourceJSON(t *testing.T) {
-	t.Skip("skipping test due to unavailable api")
-
 	out, err, exitcode := LaceworkCLIWithTOMLConfig("query", "describe", "CloudTrailRawEvents", "--json")
 	assert.Contains(t, out.String(), `"INSERT_ID"`)
 	assert.Empty(t, err.String(), "STDERR should be empty")

--- a/integration/lql_sources_test.go
+++ b/integration/lql_sources_test.go
@@ -1,4 +1,3 @@
-//go:build query
 // +build query
 
 // Author:: Salim Afiune Maya (<afiune@lacework.net>)


### PR DESCRIPTION
## Summary
Unhides lacework query list-sources
Unhides lacework query show-source
Enables integration testing

## How did you test this change?
Integration testing

## Issue
https://lacework.atlassian.net/browse/ALLY-704