### PR TITLE
fix(cli): affected resource count in compliance reports

### DIFF
--- a/cli/cmd/compliance.go
+++ b/cli/cmd/compliance.go
@@ -185,11 +185,11 @@ func complianceReportSummaryTable(summaries []api.ComplianceSummary) [][]string 
 	}
 	summary := summaries[0]
 	return [][]string{
-		[]string{"Critical", fmt.Sprint(summary.NumSeverity1NonCompliance)},
-		[]string{"High", fmt.Sprint(summary.NumSeverity2NonCompliance)},
-		[]string{"Medium", fmt.Sprint(summary.NumSeverity3NonCompliance)},
-		[]string{"Low", fmt.Sprint(summary.NumSeverity4NonCompliance)},
-		[]string{"Info", fmt.Sprint(summary.NumSeverity5NonCompliance)},
+		{"Critical", fmt.Sprint(summary.NumSeverity1NonCompliance)},
+		{"High", fmt.Sprint(summary.NumSeverity2NonCompliance)},
+		{"Medium", fmt.Sprint(summary.NumSeverity3NonCompliance)},
+		{"Low", fmt.Sprint(summary.NumSeverity4NonCompliance)},
+		{"Info", fmt.Sprint(summary.NumSeverity5NonCompliance)},
 	}
 }
 
@@ -202,7 +202,7 @@ func complianceReportRecommendationsTable(recommendations []api.ComplianceRecomm
 			recommend.Status,
 			recommend.SeverityString(),
 			recommend.Service,
-			fmt.Sprint(recommend.ResourceCount),
+			fmt.Sprint(len(recommend.Violations)),
 			fmt.Sprint(recommend.AssessedResourceCount),
 		})
 	}


### PR DESCRIPTION

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/lacework/go-sdk) and create your branch from `main`
  2. Run `make prepare` in the repository root
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`make test`)
  5. Format your code (`make fmt`)
  6. Make sure your code lints (`make lint`)
  7. If you are updating the Lacework CLI, make sure it compiles (`make build-cli-cross-platform`)
  8. Follow the commit message standard (`type(scope): subject`) documented in [DEVELOPER_GUIDELINES.md](https://github.com/lacework/go-sdk/blob/main/DEVELOPER_GUIDELINES.md#commit-message-standard)
  9. If you haven't already, configure signed commits by [telling git about your signing key](https://docs.github.com/en/github/authenticating-to-github/managing-commit-signature-verification/telling-git-about-your-signing-key) and [signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)

  Learn more about contributing: https://github.com/lacework/go-sdk/blob/main/CONTRIBUTING.md
-->

## Summary

For some reason, APIv1 is returning the same number for both fields,
`assessed_resource_count`, and `resource_count` which before they were
different. APIv1 won’t be fixed so we will fix this issue by counting
the violations from the JSON response.

Maybe new endpoints in API v2 will have a field like
`affected_resource_count` or something like that.

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>


## How did you test this change?
Manually ran:
```
$ lacework comp aws get <MY_AWS_ACCOUNT> --details
```
And saw that the AFFECTED column matches with the Lacework UI.

<img width="1133" alt="Screen Shot 2021-10-26 at 2 56 34 AM" src="https://user-images.githubusercontent.com/5712253/138790759-3d5986a5-71fa-4402-ae7d-2b8e2f99ee8e.png">

<!--
  How exactly did you verify that your PR solves the issue you wanted to solve?
  Include any other relevant information such as how to use the new fuctionality, screenshots, etc.
-->

## Issue
https://lacework.atlassian.net/browse/ALLY-686

<!--
  Include the link to a Jira/Github issue
-->
