### PR TITLE
fix(cli): making evaluatorId optional

### DIFF
--- a/api/lql.go
+++ b/api/lql.go
@@ -28,7 +28,7 @@ import (
 type NewQuery struct {
 	QueryID     string `json:"queryId" yaml:"queryId"`
 	QueryText   string `json:"queryText" yaml:"queryText"`
-	EvaluatorID string `json:"evaluatorId" yaml:"evaluatorId"`
+	EvaluatorID string `json:"evaluatorId,omitempty" yaml:"evaluatorId"`
 }
 
 type UpdateQuery struct {

--- a/api/lql_execute.go
+++ b/api/lql_execute.go
@@ -29,7 +29,7 @@ import (
 
 type ExecuteQuery struct {
 	QueryText   string `json:"queryText"`
-	EvaluatorID string `json:"evaluatorId"`
+	EvaluatorID string `json:"evaluatorId,omitempty"`
 }
 
 type ExecuteQueryArgument struct {

--- a/api/lql_validate.go
+++ b/api/lql_validate.go
@@ -20,7 +20,7 @@ package api
 
 type ValidateQuery struct {
 	QueryText   string `json:"queryText"`
-	EvaluatorID string `json:"evaluatorId"`
+	EvaluatorID string `json:"evaluatorId,omitempty"`
 }
 
 func (svc *QueryService) Validate(vq ValidateQuery) (

--- a/api/policy.go
+++ b/api/policy.go
@@ -35,7 +35,7 @@ type PolicyService struct {
 var ValidPolicySeverities = []string{"critical", "high", "medium", "low", "info"}
 
 type NewPolicy struct {
-	EvaluatorID   string `json:"evaluatorId" yaml:"evaluatorId"`
+	EvaluatorID   string `json:"evaluatorId,omitempty" yaml:"evaluatorId"`
 	PolicyID      string `json:"policyId" yaml:"policyId" `
 	PolicyType    string `json:"policyType" yaml:"policyType"`
 	QueryID       string `json:"queryId" yaml:"queryId"`

--- a/integration/lql_constants.go
+++ b/integration/lql_constants.go
@@ -1,3 +1,4 @@
+//go:build query || policy
 // +build query policy
 
 // Author:: Salim Afiune Maya (<afiune@lacework.net>)
@@ -20,10 +21,14 @@
 package integration
 
 const (
-	evaluatorID       string = "Cloudtrail"
-	queryID           string = "LW_CLI_AWS_CTA_IntegrationTest"
-	queryText         string = "LW_CLI_AWS_CTA_IntegrationTest { source { CloudTrailRawEvents } return { INSERT_ID } }"
-	queryUpdateText   string = "LW_CLI_AWS_CTA_IntegrationTest { source { CloudTrailRawEvents } return { INSERT_ID, INSERT_TIME } }"
+	evaluatorID     string = "Cloudtrail"
+	queryID         string = "LW_CLI_AWS_CTA_IntegrationTest"
+	queryText       string = "LW_CLI_AWS_CTA_IntegrationTest { source { CloudTrailRawEvents } return { INSERT_ID } }"
+	queryUpdateText string = "LW_CLI_AWS_CTA_IntegrationTest { source { CloudTrailRawEvents } return { INSERT_ID, INSERT_TIME } }"
+
+	queryHostID   string = "LW_CLI_Host_File_IntegrationTest"
+	queryHostText string = "LW_CLI_Host_File_IntegrationTest { source { LW_HE_FILES } return { PATH } }"
+
 	queryJSONTemplate string = `{
 	"evaluatorID": "%s",
 	"queryID": "%s",

--- a/integration/lql_constants.go
+++ b/integration/lql_constants.go
@@ -1,4 +1,3 @@
-//go:build query || policy
 // +build query policy
 
 // Author:: Salim Afiune Maya (<afiune@lacework.net>)

--- a/integration/lql_constants.go
+++ b/integration/lql_constants.go
@@ -21,18 +21,16 @@
 package integration
 
 const (
-	evaluatorID     string = "Cloudtrail"
-	queryID         string = "LW_CLI_AWS_CTA_IntegrationTest"
-	queryText       string = "LW_CLI_AWS_CTA_IntegrationTest { source { CloudTrailRawEvents } return { INSERT_ID } }"
-	queryUpdateText string = "LW_CLI_AWS_CTA_IntegrationTest { source { CloudTrailRawEvents } return { INSERT_ID, INSERT_TIME } }"
-
-	queryHostID   string = "LW_CLI_Host_File_IntegrationTest"
-	queryHostText string = "LW_CLI_Host_File_IntegrationTest { source { LW_HE_FILES } return { PATH } }"
-
+	evaluatorID       string = "Cloudtrail"
+	queryID           string = "LW_CLI_AWS_CTA_IntegrationTest"
+	queryHostID       string = "LW_CLI_Host_Files_IntegrationTest"
+	queryText         string = "LW_CLI_AWS_CTA_IntegrationTest { source { CloudTrailRawEvents } return { INSERT_ID } }"
+	queryUpdateText   string = "LW_CLI_AWS_CTA_IntegrationTest { source { CloudTrailRawEvents } return { INSERT_ID, INSERT_TIME } }"
 	queryJSONTemplate string = `{
 	"evaluatorID": "%s",
 	"queryID": "%s",
 	"queryText": "%s"
 }`
-	queryURL string = "https://raw.githubusercontent.com/lacework/go-sdk/main/integration/test_resources/lql/LW_CLI_AWS_CTA_IntegrationTest.yaml"
+	queryURL     string = "https://raw.githubusercontent.com/lacework/go-sdk/main/integration/test_resources/lql/LW_CLI_AWS_CTA_IntegrationTest.yaml"
+	queryHostURL string = "https://raw.githubusercontent.com/lacework/go-sdk/main/integration/test_resources/lql/LW_CLI_Host_Files_IntegrationTest.yaml"
 )

--- a/integration/lql_validate_test.go
+++ b/integration/lql_validate_test.go
@@ -63,6 +63,24 @@ func TestQueryValidateFile(t *testing.T) {
 	assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
 }
 
+func TestQueryValidateHost(t *testing.T) {
+	// get temp file
+	file, err := createTemporaryFile(
+		"TestQueryValidateHost",
+		fmt.Sprintf(queryJSONTemplate, "", queryHostID, queryHostText))
+	if err != nil {
+		t.FailNow()
+	}
+	defer os.Remove(file.Name())
+
+	// validate_only
+	out, stderr, exitcode := LaceworkCLIWithTOMLConfig(
+		"query", "validate", "-f", file.Name())
+	assert.Contains(t, out.String(), "Query validated successfully.")
+	assert.Empty(t, stderr.String(), "STDERR should be empty")
+	assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
+}
+
 func TestQueryValidateURL(t *testing.T) {
 	// validate
 	out, err, exitcode := LaceworkCLIWithTOMLConfig("query", "validate", "-u", queryURL)

--- a/integration/lql_validate_test.go
+++ b/integration/lql_validate_test.go
@@ -63,24 +63,6 @@ func TestQueryValidateFile(t *testing.T) {
 	assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
 }
 
-func TestQueryValidateHost(t *testing.T) {
-	// get temp file
-	file, err := createTemporaryFile(
-		"TestQueryValidateHost",
-		fmt.Sprintf(queryJSONTemplate, "", queryHostID, queryHostText))
-	if err != nil {
-		t.FailNow()
-	}
-	defer os.Remove(file.Name())
-
-	// validate_only
-	out, stderr, exitcode := LaceworkCLIWithTOMLConfig(
-		"query", "validate", "-f", file.Name())
-	assert.Contains(t, out.String(), "Query validated successfully.")
-	assert.Empty(t, stderr.String(), "STDERR should be empty")
-	assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
-}
-
 func TestQueryValidateURL(t *testing.T) {
 	// validate
 	out, err, exitcode := LaceworkCLIWithTOMLConfig("query", "validate", "-u", queryURL)


### PR DESCRIPTION
## Summary
The Queries and Policies API will allow for a `null` or `unspecified` `evaluatorId` but not an `evaluatorId` of `""`.  From a go standpoint this means that we should omit if empty `evaluatorId` in our structs.

## How did you test this change?
Automated integration testing added

## Issue
https://lacework.atlassian.net/browse/ALLY-717