### PR TITLE
fix: ResourceGroups lastUpdated time format

### DIFF
--- a/api/alert_channels_splunk_test.go
+++ b/api/alert_channels_splunk_test.go
@@ -19,9 +19,12 @@
 package api_test
 
 import (
+	"encoding/json"
 	"fmt"
+	"log"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -137,6 +140,21 @@ func TestAlertChannelSplunkUpdate(t *testing.T) {
 		assert.Contains(t, response.Data.Data.EventData.Source, "test-source")
 		assert.Contains(t, response.Data.Data.EventData.Index, "test-index")
 	}
+}
+
+func TestMarshallAlertChannelLastUpdatedTime(t *testing.T) {
+	var res api.SplunkHecAlertChannelResponseV2
+	err := json.Unmarshal([]byte(generateAlertChannelResponse(singleSplunkAlertChannel("test"))), &res)
+	if err != nil {
+		log.Fatal("Unable to unmarshall splunk string")
+	}
+	jsonString, err := json.Marshal(res)
+	if err != nil {
+		log.Fatal("Unable to marshall splunk string")
+	}
+
+	assert.Equal(t, res.Data.State.LastUpdatedTime.ToTime().UnixNano()/int64(time.Millisecond), int64(1627895573122))
+	assert.Contains(t, string(jsonString), "1627895573122")
 }
 
 func singleSplunkAlertChannel(id string) string {

--- a/api/resource_groups.go
+++ b/api/resource_groups.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/lacework/go-sdk/lwtime"
 	"github.com/pkg/errors"
 )
 
@@ -30,6 +31,16 @@ import (
 // the ResourceGroups schema from the Lacework APIv2 Server
 type ResourceGroupsService struct {
 	client *Client
+}
+
+type ResourceGroupProps interface {
+	GetBaseProps() ResourceGroupPropsBase
+}
+
+type ResourceGroupPropsBase struct {
+	Description string       `json:"description"`
+	UpdatedBy   string       `json:"updatedBy,omitempty"`
+	LastUpdated lwtime.Epoch `json:"lastUpdated,omitempty"`
 }
 
 type ResourceGroup interface {

--- a/api/resource_groups.go
+++ b/api/resource_groups.go
@@ -38,8 +38,8 @@ type ResourceGroupProps interface {
 }
 
 type ResourceGroupPropsBase struct {
-	Description string       `json:"description"`
-	UpdatedBy   string       `json:"updatedBy,omitempty"`
+	Description string        `json:"description"`
+	UpdatedBy   string        `json:"updatedBy,omitempty"`
 	LastUpdated *lwtime.Epoch `json:"lastUpdated,omitempty"`
 }
 

--- a/api/resource_groups.go
+++ b/api/resource_groups.go
@@ -23,8 +23,9 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/lacework/go-sdk/lwtime"
 	"github.com/pkg/errors"
+
+	"github.com/lacework/go-sdk/lwtime"
 )
 
 // ResourceGroupsService is the service that interacts with

--- a/api/resource_groups.go
+++ b/api/resource_groups.go
@@ -40,7 +40,7 @@ type ResourceGroupProps interface {
 type ResourceGroupPropsBase struct {
 	Description string       `json:"description"`
 	UpdatedBy   string       `json:"updatedBy,omitempty"`
-	LastUpdated lwtime.Epoch `json:"lastUpdated,omitempty"`
+	LastUpdated *lwtime.Epoch `json:"lastUpdated,omitempty"`
 }
 
 type ResourceGroup interface {

--- a/api/resource_groups_aws.go
+++ b/api/resource_groups_aws.go
@@ -134,3 +134,26 @@ type AwsResourceJsonStringGroupProps struct {
 	UpdatedBy   string       `json:"UPDATED_BY,omitempty"`
 	LastUpdated lwtime.Epoch `json:"LAST_UPDATED,omitempty"`
 }
+
+func (props AwsResourceGroupProps) GetBaseProps() ResourceGroupPropsBase {
+	return ResourceGroupPropsBase{
+		Description: props.Description,
+		UpdatedBy:   props.UpdatedBy,
+		LastUpdated: props.LastUpdated,
+	}
+}
+
+func (props AwsResourceGroupProps) MarshalJSON() ([]byte, error) {
+	res := struct {
+		Description string   `json:"description,omitempty"`
+		AccountIDs  []string `json:"accountIds"`
+		UpdatedBy   string   `json:"updatedBy,omitempty"`
+		LastUpdated string   `json:"lastUpdated,omitempty"`
+	}{
+		Description: props.Description,
+		AccountIDs:  props.AccountIDs,
+		UpdatedBy:   props.UpdatedBy,
+		LastUpdated: props.LastUpdated.String(),
+	}
+	return json.Marshal(&res)
+}

--- a/api/resource_groups_aws.go
+++ b/api/resource_groups_aws.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"strconv"
 
+	"github.com/lacework/go-sdk/lwtime"
 	"github.com/pkg/errors"
 )
 
@@ -120,16 +121,16 @@ type AwsResourceGroupData struct {
 }
 
 type AwsResourceGroupProps struct {
-	Description string   `json:"description,omitempty"`
-	AccountIDs  []string `json:"accountIds"`
-	UpdatedBy   string   `json:"updatedBy,omitempty"`
-	LastUpdated int      `json:"lastUpdated,omitempty"`
+	Description string       `json:"description,omitempty"`
+	AccountIDs  []string     `json:"accountIds"`
+	UpdatedBy   string       `json:"updatedBy,omitempty"`
+	LastUpdated lwtime.Epoch `json:"lastUpdated,omitempty"`
 }
 
 // Workaround for props being returned as a json string
 type AwsResourceJsonStringGroupProps struct {
-	Description string   `json:"DESCRIPTION,omitempty"`
-	AccountIDs  []string `json:"ACCOUNT_IDS"`
-	UpdatedBy   string   `json:"UPDATED_BY,omitempty"`
-	LastUpdated int      `json:"LAST_UPDATED,omitempty"`
+	Description string       `json:"DESCRIPTION,omitempty"`
+	AccountIDs  []string     `json:"ACCOUNT_IDS"`
+	UpdatedBy   string       `json:"UPDATED_BY,omitempty"`
+	LastUpdated lwtime.Epoch `json:"LAST_UPDATED,omitempty"`
 }

--- a/api/resource_groups_aws.go
+++ b/api/resource_groups_aws.go
@@ -121,17 +121,17 @@ type AwsResourceGroupData struct {
 }
 
 type AwsResourceGroupProps struct {
-	Description string       `json:"description,omitempty"`
-	AccountIDs  []string     `json:"accountIds"`
-	UpdatedBy   string       `json:"updatedBy,omitempty"`
+	Description string        `json:"description,omitempty"`
+	AccountIDs  []string      `json:"accountIds"`
+	UpdatedBy   string        `json:"updatedBy,omitempty"`
 	LastUpdated *lwtime.Epoch `json:"lastUpdated,omitempty"`
 }
 
 // Workaround for props being returned as a json string
 type AwsResourceJsonStringGroupProps struct {
-	Description string       `json:"DESCRIPTION,omitempty"`
-	AccountIDs  []string     `json:"ACCOUNT_IDS"`
-	UpdatedBy   string       `json:"UPDATED_BY,omitempty"`
+	Description string        `json:"DESCRIPTION,omitempty"`
+	AccountIDs  []string      `json:"ACCOUNT_IDS"`
+	UpdatedBy   string        `json:"UPDATED_BY,omitempty"`
 	LastUpdated *lwtime.Epoch `json:"LAST_UPDATED,omitempty"`
 }
 

--- a/api/resource_groups_aws.go
+++ b/api/resource_groups_aws.go
@@ -124,7 +124,7 @@ type AwsResourceGroupProps struct {
 	Description string       `json:"description,omitempty"`
 	AccountIDs  []string     `json:"accountIds"`
 	UpdatedBy   string       `json:"updatedBy,omitempty"`
-	LastUpdated lwtime.Epoch `json:"lastUpdated,omitempty"`
+	LastUpdated *lwtime.Epoch `json:"lastUpdated,omitempty"`
 }
 
 // Workaround for props being returned as a json string
@@ -132,7 +132,7 @@ type AwsResourceJsonStringGroupProps struct {
 	Description string       `json:"DESCRIPTION,omitempty"`
 	AccountIDs  []string     `json:"ACCOUNT_IDS"`
 	UpdatedBy   string       `json:"UPDATED_BY,omitempty"`
-	LastUpdated lwtime.Epoch `json:"LAST_UPDATED,omitempty"`
+	LastUpdated *lwtime.Epoch `json:"LAST_UPDATED,omitempty"`
 }
 
 func (props AwsResourceGroupProps) GetBaseProps() ResourceGroupPropsBase {

--- a/api/resource_groups_aws_test.go
+++ b/api/resource_groups_aws_test.go
@@ -19,9 +19,12 @@
 package api_test
 
 import (
+	"encoding/json"
 	"fmt"
+	"log"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -108,6 +111,21 @@ func TestResourceGroupsAwsUpdate(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, response)
 	assert.Equal(t, resourceGUID, response.Data.ResourceGuid)
+}
+
+func TestMarshallResourceGroupLastUpdatedTime(t *testing.T) {
+	var res api.AwsResourceGroupResponse
+	err := json.Unmarshal([]byte(generateResourceGroupResponse(singleAwsResourceGroupUpdateResponse("test"))), &res)
+	if err != nil {
+		log.Fatal("Unable to unmarshall aws resource group string")
+	}
+	jsonString, err := json.Marshal(res)
+	if err != nil {
+		log.Fatal("Unable to marshall aws resource group string")
+	}
+
+	assert.Equal(t, res.Data.Props.LastUpdated.ToTime().UnixNano()/int64(time.Millisecond), int64(1586453993470))
+	assert.Contains(t, string(jsonString), "2020-04-09T17:39:53Z")
 }
 
 func singleAwsResourceGroup(id string) string {

--- a/api/resource_groups_azure.go
+++ b/api/resource_groups_azure.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"strconv"
 
+	"github.com/lacework/go-sdk/lwtime"
 	"github.com/pkg/errors"
 )
 
@@ -124,18 +125,18 @@ type AzureResourceGroupData struct {
 }
 
 type AzureResourceGroupProps struct {
-	Description   string   `json:"description,omitempty"`
-	Tenant        string   `json:"tenant"`
-	Subscriptions []string `json:"subscriptions"`
-	UpdatedBy     string   `json:"updatedBy,omitempty"`
-	LastUpdated   int      `json:"lastUpdated,omitempty"`
+	Description   string       `json:"description,omitempty"`
+	Tenant        string       `json:"tenant"`
+	Subscriptions []string     `json:"subscriptions"`
+	UpdatedBy     string       `json:"updatedBy,omitempty"`
+	LastUpdated   lwtime.Epoch `json:"lastUpdated,omitempty"`
 }
 
 // Workaround for props being returned as a json string
 type AzureResourceJsonStringGroupProps struct {
-	Description   string   `json:"DESCRIPTION,omitempty"`
-	Tenant        string   `json:"TENANT"`
-	Subscriptions []string `json:"SUBSCRIPTIONS"`
-	UpdatedBy     string   `json:"UPDATED_BY,omitempty"`
-	LastUpdated   int      `json:"LAST_UPDATED,omitempty"`
+	Description   string       `json:"DESCRIPTION,omitempty"`
+	Tenant        string       `json:"TENANT"`
+	Subscriptions []string     `json:"SUBSCRIPTIONS"`
+	UpdatedBy     string       `json:"UPDATED_BY,omitempty"`
+	LastUpdated   lwtime.Epoch `json:"LAST_UPDATED,omitempty"`
 }

--- a/api/resource_groups_azure.go
+++ b/api/resource_groups_azure.go
@@ -129,7 +129,7 @@ type AzureResourceGroupProps struct {
 	Tenant        string       `json:"tenant"`
 	Subscriptions []string     `json:"subscriptions"`
 	UpdatedBy     string       `json:"updatedBy,omitempty"`
-	LastUpdated   lwtime.Epoch `json:"lastUpdated,omitempty"`
+	LastUpdated   *lwtime.Epoch `json:"lastUpdated,omitempty"`
 }
 
 // Workaround for props being returned as a json string
@@ -138,7 +138,7 @@ type AzureResourceJsonStringGroupProps struct {
 	Tenant        string       `json:"TENANT"`
 	Subscriptions []string     `json:"SUBSCRIPTIONS"`
 	UpdatedBy     string       `json:"UPDATED_BY,omitempty"`
-	LastUpdated   lwtime.Epoch `json:"LAST_UPDATED,omitempty"`
+	LastUpdated   *lwtime.Epoch `json:"LAST_UPDATED,omitempty"`
 }
 
 func (props AzureResourceGroupProps) GetBaseProps() ResourceGroupPropsBase {

--- a/api/resource_groups_azure.go
+++ b/api/resource_groups_azure.go
@@ -125,19 +125,19 @@ type AzureResourceGroupData struct {
 }
 
 type AzureResourceGroupProps struct {
-	Description   string       `json:"description,omitempty"`
-	Tenant        string       `json:"tenant"`
-	Subscriptions []string     `json:"subscriptions"`
-	UpdatedBy     string       `json:"updatedBy,omitempty"`
+	Description   string        `json:"description,omitempty"`
+	Tenant        string        `json:"tenant"`
+	Subscriptions []string      `json:"subscriptions"`
+	UpdatedBy     string        `json:"updatedBy,omitempty"`
 	LastUpdated   *lwtime.Epoch `json:"lastUpdated,omitempty"`
 }
 
 // Workaround for props being returned as a json string
 type AzureResourceJsonStringGroupProps struct {
-	Description   string       `json:"DESCRIPTION,omitempty"`
-	Tenant        string       `json:"TENANT"`
-	Subscriptions []string     `json:"SUBSCRIPTIONS"`
-	UpdatedBy     string       `json:"UPDATED_BY,omitempty"`
+	Description   string        `json:"DESCRIPTION,omitempty"`
+	Tenant        string        `json:"TENANT"`
+	Subscriptions []string      `json:"SUBSCRIPTIONS"`
+	UpdatedBy     string        `json:"UPDATED_BY,omitempty"`
 	LastUpdated   *lwtime.Epoch `json:"LAST_UPDATED,omitempty"`
 }
 

--- a/api/resource_groups_azure.go
+++ b/api/resource_groups_azure.go
@@ -140,3 +140,28 @@ type AzureResourceJsonStringGroupProps struct {
 	UpdatedBy     string       `json:"UPDATED_BY,omitempty"`
 	LastUpdated   lwtime.Epoch `json:"LAST_UPDATED,omitempty"`
 }
+
+func (props AzureResourceGroupProps) GetBaseProps() ResourceGroupPropsBase {
+	return ResourceGroupPropsBase{
+		Description: props.Description,
+		UpdatedBy:   props.UpdatedBy,
+		LastUpdated: props.LastUpdated,
+	}
+}
+
+func (props AzureResourceGroupProps) MarshalJSON() ([]byte, error) {
+	res := struct {
+		Description   string   `json:"description,omitempty"`
+		Tenant        string   `json:"tenant"`
+		Subscriptions []string `json:"subscriptions"`
+		UpdatedBy     string   `json:"updatedBy,omitempty"`
+		LastUpdated   string   `json:"lastUpdated,omitempty"`
+	}{
+		Description:   props.Description,
+		Tenant:        props.Tenant,
+		Subscriptions: props.Subscriptions,
+		UpdatedBy:     props.UpdatedBy,
+		LastUpdated:   props.LastUpdated.String(),
+	}
+	return json.Marshal(&res)
+}

--- a/api/resource_groups_container.go
+++ b/api/resource_groups_container.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"strconv"
 
+	"github.com/lacework/go-sdk/lwtime"
 	"github.com/pkg/errors"
 )
 
@@ -128,7 +129,7 @@ type ContainerResourceGroupProps struct {
 	ContainerLabels []map[string]string `json:"containerLabels"`
 	ContainerTags   []string            `json:"containerTags"`
 	UpdatedBy       string              `json:"updatedBy,omitempty"`
-	LastUpdated     int                 `json:"lastUpdated,omitempty"`
+	LastUpdated     lwtime.Epoch        `json:"lastUpdated,omitempty"`
 }
 
 // Workaround for props being returned as a json string
@@ -137,5 +138,5 @@ type ContainerResourceJsonStringGroupProps struct {
 	ContainerLabels []map[string]string `json:"CONTAINER_LABELS"`
 	ContainerTags   []string            `json:"CONTAINER_TAGS"`
 	UpdatedBy       string              `json:"UPDATED_BY,omitempty"`
-	LastUpdated     int                 `json:"LAST_UPDATED,omitempty"`
+	LastUpdated     lwtime.Epoch        `json:"LAST_UPDATED,omitempty"`
 }

--- a/api/resource_groups_container.go
+++ b/api/resource_groups_container.go
@@ -129,7 +129,7 @@ type ContainerResourceGroupProps struct {
 	ContainerLabels []map[string]string `json:"containerLabels"`
 	ContainerTags   []string            `json:"containerTags"`
 	UpdatedBy       string              `json:"updatedBy,omitempty"`
-	LastUpdated     *lwtime.Epoch        `json:"lastUpdated,omitempty"`
+	LastUpdated     *lwtime.Epoch       `json:"lastUpdated,omitempty"`
 }
 
 // Workaround for props being returned as a json string
@@ -138,7 +138,7 @@ type ContainerResourceJsonStringGroupProps struct {
 	ContainerLabels []map[string]string `json:"CONTAINER_LABELS"`
 	ContainerTags   []string            `json:"CONTAINER_TAGS"`
 	UpdatedBy       string              `json:"UPDATED_BY,omitempty"`
-	LastUpdated     *lwtime.Epoch        `json:"LAST_UPDATED,omitempty"`
+	LastUpdated     *lwtime.Epoch       `json:"LAST_UPDATED,omitempty"`
 }
 
 func (props ContainerResourceGroupProps) GetBaseProps() ResourceGroupPropsBase {

--- a/api/resource_groups_container.go
+++ b/api/resource_groups_container.go
@@ -129,7 +129,7 @@ type ContainerResourceGroupProps struct {
 	ContainerLabels []map[string]string `json:"containerLabels"`
 	ContainerTags   []string            `json:"containerTags"`
 	UpdatedBy       string              `json:"updatedBy,omitempty"`
-	LastUpdated     lwtime.Epoch        `json:"lastUpdated,omitempty"`
+	LastUpdated     *lwtime.Epoch        `json:"lastUpdated,omitempty"`
 }
 
 // Workaround for props being returned as a json string
@@ -138,7 +138,7 @@ type ContainerResourceJsonStringGroupProps struct {
 	ContainerLabels []map[string]string `json:"CONTAINER_LABELS"`
 	ContainerTags   []string            `json:"CONTAINER_TAGS"`
 	UpdatedBy       string              `json:"UPDATED_BY,omitempty"`
-	LastUpdated     lwtime.Epoch        `json:"LAST_UPDATED,omitempty"`
+	LastUpdated     *lwtime.Epoch        `json:"LAST_UPDATED,omitempty"`
 }
 
 func (props ContainerResourceGroupProps) GetBaseProps() ResourceGroupPropsBase {

--- a/api/resource_groups_container.go
+++ b/api/resource_groups_container.go
@@ -140,3 +140,28 @@ type ContainerResourceJsonStringGroupProps struct {
 	UpdatedBy       string              `json:"UPDATED_BY,omitempty"`
 	LastUpdated     lwtime.Epoch        `json:"LAST_UPDATED,omitempty"`
 }
+
+func (props ContainerResourceGroupProps) GetBaseProps() ResourceGroupPropsBase {
+	return ResourceGroupPropsBase{
+		Description: props.Description,
+		UpdatedBy:   props.UpdatedBy,
+		LastUpdated: props.LastUpdated,
+	}
+}
+
+func (props ContainerResourceGroupProps) MarshalJSON() ([]byte, error) {
+	res := struct {
+		Description     string              `json:"description,omitempty"`
+		ContainerLabels []map[string]string `json:"containerLabels"`
+		ContainerTags   []string            `json:"containerTags"`
+		UpdatedBy       string              `json:"updatedBy,omitempty"`
+		LastUpdated     string              `json:"lastUpdated,omitempty"`
+	}{
+		Description:     props.Description,
+		ContainerLabels: props.ContainerLabels,
+		ContainerTags:   props.ContainerTags,
+		UpdatedBy:       props.UpdatedBy,
+		LastUpdated:     props.LastUpdated.String(),
+	}
+	return json.Marshal(&res)
+}

--- a/api/resource_groups_gcp.go
+++ b/api/resource_groups_gcp.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"strconv"
 
+	"github.com/lacework/go-sdk/lwtime"
 	"github.com/pkg/errors"
 )
 
@@ -122,18 +123,18 @@ type GcpResourceGroupData struct {
 }
 
 type GcpResourceGroupProps struct {
-	Description  string   `json:"description,omitempty"`
-	Organization string   `json:"organization"`
-	Projects     []string `json:"projects"`
-	UpdatedBy    string   `json:"updatedBy,omitempty"`
-	LastUpdated  int      `json:"lastUpdated,omitempty"`
+	Description  string       `json:"description,omitempty"`
+	Organization string       `json:"organization"`
+	Projects     []string     `json:"projects"`
+	UpdatedBy    string       `json:"updatedBy,omitempty"`
+	LastUpdated  lwtime.Epoch `json:"lastUpdated,omitempty"`
 }
 
 // Workaround for props being returned as a json string
 type GcpResourceGroupJsonStringProps struct {
-	Description  string   `json:"DESCRIPTION,omitempty"`
-	Organization string   `json:"ORGANIZATION"`
-	Projects     []string `json:"PROJECTS"`
-	UpdatedBy    string   `json:"UPDATED_BY,omitempty"`
-	LastUpdated  int      `json:"LAST_UPDATED,omitempty"`
+	Description  string       `json:"DESCRIPTION,omitempty"`
+	Organization string       `json:"ORGANIZATION"`
+	Projects     []string     `json:"PROJECTS"`
+	UpdatedBy    string       `json:"UPDATED_BY,omitempty"`
+	LastUpdated  lwtime.Epoch `json:"LAST_UPDATED,omitempty"`
 }

--- a/api/resource_groups_gcp.go
+++ b/api/resource_groups_gcp.go
@@ -127,7 +127,7 @@ type GcpResourceGroupProps struct {
 	Organization string       `json:"organization"`
 	Projects     []string     `json:"projects"`
 	UpdatedBy    string       `json:"updatedBy,omitempty"`
-	LastUpdated  lwtime.Epoch `json:"lastUpdated,omitempty"`
+	LastUpdated  *lwtime.Epoch `json:"lastUpdated,omitempty"`
 }
 
 // Workaround for props being returned as a json string
@@ -136,7 +136,7 @@ type GcpResourceGroupJsonStringProps struct {
 	Organization string       `json:"ORGANIZATION"`
 	Projects     []string     `json:"PROJECTS"`
 	UpdatedBy    string       `json:"UPDATED_BY,omitempty"`
-	LastUpdated  lwtime.Epoch `json:"LAST_UPDATED,omitempty"`
+	LastUpdated  *lwtime.Epoch `json:"LAST_UPDATED,omitempty"`
 }
 
 func (props GcpResourceGroupProps) GetBaseProps() ResourceGroupPropsBase {

--- a/api/resource_groups_gcp.go
+++ b/api/resource_groups_gcp.go
@@ -138,3 +138,28 @@ type GcpResourceGroupJsonStringProps struct {
 	UpdatedBy    string       `json:"UPDATED_BY,omitempty"`
 	LastUpdated  lwtime.Epoch `json:"LAST_UPDATED,omitempty"`
 }
+
+func (props GcpResourceGroupProps) GetBaseProps() ResourceGroupPropsBase {
+	return ResourceGroupPropsBase{
+		Description: props.Description,
+		UpdatedBy:   props.UpdatedBy,
+		LastUpdated: props.LastUpdated,
+	}
+}
+
+func (props GcpResourceGroupProps) MarshalJSON() ([]byte, error) {
+	res := struct {
+		Description  string   `json:"description,omitempty"`
+		Organization string   `json:"organization"`
+		Projects     []string `json:"projects"`
+		UpdatedBy    string   `json:"updatedBy,omitempty"`
+		LastUpdated  string   `json:"lastUpdated,omitempty"`
+	}{
+		Description:  props.Description,
+		Organization: props.Organization,
+		Projects:     props.Projects,
+		UpdatedBy:    props.UpdatedBy,
+		LastUpdated:  props.LastUpdated.String(),
+	}
+	return json.Marshal(&res)
+}

--- a/api/resource_groups_gcp.go
+++ b/api/resource_groups_gcp.go
@@ -123,19 +123,19 @@ type GcpResourceGroupData struct {
 }
 
 type GcpResourceGroupProps struct {
-	Description  string       `json:"description,omitempty"`
-	Organization string       `json:"organization"`
-	Projects     []string     `json:"projects"`
-	UpdatedBy    string       `json:"updatedBy,omitempty"`
+	Description  string        `json:"description,omitempty"`
+	Organization string        `json:"organization"`
+	Projects     []string      `json:"projects"`
+	UpdatedBy    string        `json:"updatedBy,omitempty"`
 	LastUpdated  *lwtime.Epoch `json:"lastUpdated,omitempty"`
 }
 
 // Workaround for props being returned as a json string
 type GcpResourceGroupJsonStringProps struct {
-	Description  string       `json:"DESCRIPTION,omitempty"`
-	Organization string       `json:"ORGANIZATION"`
-	Projects     []string     `json:"PROJECTS"`
-	UpdatedBy    string       `json:"UPDATED_BY,omitempty"`
+	Description  string        `json:"DESCRIPTION,omitempty"`
+	Organization string        `json:"ORGANIZATION"`
+	Projects     []string      `json:"PROJECTS"`
+	UpdatedBy    string        `json:"UPDATED_BY,omitempty"`
 	LastUpdated  *lwtime.Epoch `json:"LAST_UPDATED,omitempty"`
 }
 

--- a/api/resource_groups_lw_account.go
+++ b/api/resource_groups_lw_account.go
@@ -136,3 +136,26 @@ type LwAccountResourceGroupJsonStringProps struct {
 	UpdatedBy   string       `json:"UPDATED_BY,omitempty"`
 	LastUpdated lwtime.Epoch `json:"LAST_UPDATED,omitempty"`
 }
+
+func (props LwAccountResourceGroupProps) GetBaseProps() ResourceGroupPropsBase {
+	return ResourceGroupPropsBase{
+		Description: props.Description,
+		UpdatedBy:   props.UpdatedBy,
+		LastUpdated: props.LastUpdated,
+	}
+}
+
+func (props LwAccountResourceGroupProps) MarshalJSON() ([]byte, error) {
+	res := struct {
+		Description string   `json:"description,omitempty"`
+		LwAccounts  []string `json:"lwAccounts"`
+		UpdatedBy   string   `json:"updatedBy,omitempty"`
+		LastUpdated string   `json:"lastUpdated,omitempty"`
+	}{
+		Description: props.Description,
+		LwAccounts:  props.LwAccounts,
+		UpdatedBy:   props.UpdatedBy,
+		LastUpdated: props.LastUpdated.String(),
+	}
+	return json.Marshal(&res)
+}

--- a/api/resource_groups_lw_account.go
+++ b/api/resource_groups_lw_account.go
@@ -123,17 +123,17 @@ type LwAccountResourceGroupData struct {
 }
 
 type LwAccountResourceGroupProps struct {
-	Description string       `json:"description,omitempty"`
-	LwAccounts  []string     `json:"lwAccounts"`
-	UpdatedBy   string       `json:"updatedBy,omitempty"`
+	Description string        `json:"description,omitempty"`
+	LwAccounts  []string      `json:"lwAccounts"`
+	UpdatedBy   string        `json:"updatedBy,omitempty"`
 	LastUpdated *lwtime.Epoch `json:"lastUpdated,omitempty"`
 }
 
 // Workaround for props being returned as a json string
 type LwAccountResourceGroupJsonStringProps struct {
-	Description string       `json:"DESCRIPTION,omitempty"`
-	LwAccounts  []string     `json:"LW_ACCOUNTS"`
-	UpdatedBy   string       `json:"UPDATED_BY,omitempty"`
+	Description string        `json:"DESCRIPTION,omitempty"`
+	LwAccounts  []string      `json:"LW_ACCOUNTS"`
+	UpdatedBy   string        `json:"UPDATED_BY,omitempty"`
 	LastUpdated *lwtime.Epoch `json:"LAST_UPDATED,omitempty"`
 }
 

--- a/api/resource_groups_lw_account.go
+++ b/api/resource_groups_lw_account.go
@@ -126,7 +126,7 @@ type LwAccountResourceGroupProps struct {
 	Description string       `json:"description,omitempty"`
 	LwAccounts  []string     `json:"lwAccounts"`
 	UpdatedBy   string       `json:"updatedBy,omitempty"`
-	LastUpdated lwtime.Epoch `json:"lastUpdated,omitempty"`
+	LastUpdated *lwtime.Epoch `json:"lastUpdated,omitempty"`
 }
 
 // Workaround for props being returned as a json string
@@ -134,7 +134,7 @@ type LwAccountResourceGroupJsonStringProps struct {
 	Description string       `json:"DESCRIPTION,omitempty"`
 	LwAccounts  []string     `json:"LW_ACCOUNTS"`
 	UpdatedBy   string       `json:"UPDATED_BY,omitempty"`
-	LastUpdated lwtime.Epoch `json:"LAST_UPDATED,omitempty"`
+	LastUpdated *lwtime.Epoch `json:"LAST_UPDATED,omitempty"`
 }
 
 func (props LwAccountResourceGroupProps) GetBaseProps() ResourceGroupPropsBase {

--- a/api/resource_groups_lw_account.go
+++ b/api/resource_groups_lw_account.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"strconv"
 
+	"github.com/lacework/go-sdk/lwtime"
 	"github.com/pkg/errors"
 )
 
@@ -122,16 +123,16 @@ type LwAccountResourceGroupData struct {
 }
 
 type LwAccountResourceGroupProps struct {
-	Description string   `json:"description,omitempty"`
-	LwAccounts  []string `json:"lwAccounts"`
-	UpdatedBy   string   `json:"updatedBy,omitempty"`
-	LastUpdated int      `json:"lastUpdated,omitempty"`
+	Description string       `json:"description,omitempty"`
+	LwAccounts  []string     `json:"lwAccounts"`
+	UpdatedBy   string       `json:"updatedBy,omitempty"`
+	LastUpdated lwtime.Epoch `json:"lastUpdated,omitempty"`
 }
 
 // Workaround for props being returned as a json string
 type LwAccountResourceGroupJsonStringProps struct {
-	Description string   `json:"DESCRIPTION,omitempty"`
-	LwAccounts  []string `json:"LW_ACCOUNTS"`
-	UpdatedBy   string   `json:"UPDATED_BY,omitempty"`
-	LastUpdated int      `json:"LAST_UPDATED,omitempty"`
+	Description string       `json:"DESCRIPTION,omitempty"`
+	LwAccounts  []string     `json:"LW_ACCOUNTS"`
+	UpdatedBy   string       `json:"UPDATED_BY,omitempty"`
+	LastUpdated lwtime.Epoch `json:"LAST_UPDATED,omitempty"`
 }

--- a/api/resource_groups_machine.go
+++ b/api/resource_groups_machine.go
@@ -126,7 +126,7 @@ type MachineResourceGroupProps struct {
 	Description string              `json:"description,omitempty"`
 	MachineTags []map[string]string `json:"machineTags"`
 	UpdatedBy   string              `json:"updatedBy,omitempty"`
-	LastUpdated lwtime.Epoch        `json:"lastUpdated,omitempty"`
+	LastUpdated *lwtime.Epoch        `json:"lastUpdated,omitempty"`
 }
 
 // Workaround for props being returned as a json string
@@ -134,7 +134,7 @@ type MachineResourceGroupJsonStringProps struct {
 	Description string              `json:"DESCRIPTION,omitempty"`
 	MachineTags []map[string]string `json:"MACHINE_TAGS"`
 	UpdatedBy   string              `json:"UPDATED_BY,omitempty"`
-	LastUpdated lwtime.Epoch        `json:"LAST_UPDATED,omitempty"`
+	LastUpdated *lwtime.Epoch        `json:"LAST_UPDATED,omitempty"`
 }
 
 func (props MachineResourceGroupProps) GetBaseProps() ResourceGroupPropsBase {

--- a/api/resource_groups_machine.go
+++ b/api/resource_groups_machine.go
@@ -126,7 +126,7 @@ type MachineResourceGroupProps struct {
 	Description string              `json:"description,omitempty"`
 	MachineTags []map[string]string `json:"machineTags"`
 	UpdatedBy   string              `json:"updatedBy,omitempty"`
-	LastUpdated *lwtime.Epoch        `json:"lastUpdated,omitempty"`
+	LastUpdated *lwtime.Epoch       `json:"lastUpdated,omitempty"`
 }
 
 // Workaround for props being returned as a json string
@@ -134,7 +134,7 @@ type MachineResourceGroupJsonStringProps struct {
 	Description string              `json:"DESCRIPTION,omitempty"`
 	MachineTags []map[string]string `json:"MACHINE_TAGS"`
 	UpdatedBy   string              `json:"UPDATED_BY,omitempty"`
-	LastUpdated *lwtime.Epoch        `json:"LAST_UPDATED,omitempty"`
+	LastUpdated *lwtime.Epoch       `json:"LAST_UPDATED,omitempty"`
 }
 
 func (props MachineResourceGroupProps) GetBaseProps() ResourceGroupPropsBase {

--- a/api/resource_groups_machine.go
+++ b/api/resource_groups_machine.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"strconv"
 
+	"github.com/lacework/go-sdk/lwtime"
 	"github.com/pkg/errors"
 )
 
@@ -125,7 +126,7 @@ type MachineResourceGroupProps struct {
 	Description string              `json:"description,omitempty"`
 	MachineTags []map[string]string `json:"machineTags"`
 	UpdatedBy   string              `json:"updatedBy,omitempty"`
-	LastUpdated int                 `json:"lastUpdated,omitempty"`
+	LastUpdated lwtime.Epoch        `json:"lastUpdated,omitempty"`
 }
 
 // Workaround for props being returned as a json string
@@ -133,5 +134,5 @@ type MachineResourceGroupJsonStringProps struct {
 	Description string              `json:"DESCRIPTION,omitempty"`
 	MachineTags []map[string]string `json:"MACHINE_TAGS"`
 	UpdatedBy   string              `json:"UPDATED_BY,omitempty"`
-	LastUpdated int                 `json:"LAST_UPDATED,omitempty"`
+	LastUpdated lwtime.Epoch        `json:"LAST_UPDATED,omitempty"`
 }

--- a/api/resource_groups_machine.go
+++ b/api/resource_groups_machine.go
@@ -136,3 +136,26 @@ type MachineResourceGroupJsonStringProps struct {
 	UpdatedBy   string              `json:"UPDATED_BY,omitempty"`
 	LastUpdated lwtime.Epoch        `json:"LAST_UPDATED,omitempty"`
 }
+
+func (props MachineResourceGroupProps) GetBaseProps() ResourceGroupPropsBase {
+	return ResourceGroupPropsBase{
+		Description: props.Description,
+		UpdatedBy:   props.UpdatedBy,
+		LastUpdated: props.LastUpdated,
+	}
+}
+
+func (props MachineResourceGroupProps) MarshalJSON() ([]byte, error) {
+	res := struct {
+		Description string              `json:"description,omitempty"`
+		MachineTags []map[string]string `json:"machineTags"`
+		UpdatedBy   string              `json:"updatedBy,omitempty"`
+		LastUpdated string              `json:"lastUpdated,omitempty"`
+	}{
+		Description: props.Description,
+		MachineTags: props.MachineTags,
+		UpdatedBy:   props.UpdatedBy,
+		LastUpdated: props.LastUpdated.String(),
+	}
+	return json.Marshal(&res)
+}

--- a/cli/cmd/resource_groups.go
+++ b/cli/cmd/resource_groups.go
@@ -21,7 +21,6 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
-	"time"
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/lacework/go-sdk/api"
@@ -294,7 +293,7 @@ func setBaseProps(props []byte) [][]string {
 
 	details = append(details, []string{"DESCRIPTION", baseProps.Description})
 	details = append(details, []string{"UPDATED BY", baseProps.UpdatedBy})
-	details = append(details, []string{"LAST UPDATED", baseProps.LastUpdated.UTC().Format(time.RFC3339)})
+	details = append(details, []string{"LAST UPDATED", baseProps.LastUpdated.String()})
 	return details
 }
 

--- a/cli/cmd/resource_groups.go
+++ b/cli/cmd/resource_groups.go
@@ -21,10 +21,11 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
-	"strconv"
+	"time"
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/lacework/go-sdk/api"
+	"github.com/lacework/go-sdk/lwtime"
 	"github.com/olekukonko/tablewriter"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -293,7 +294,7 @@ func setBaseProps(props []byte) [][]string {
 
 	details = append(details, []string{"DESCRIPTION", baseProps.Description})
 	details = append(details, []string{"UPDATED BY", baseProps.UpdatedBy})
-	details = append(details, []string{"LAST UPDATED", strconv.Itoa(baseProps.LastUpdated)})
+	details = append(details, []string{"LAST UPDATED", baseProps.LastUpdated.UTC().Format(time.RFC3339)})
 	return details
 }
 
@@ -326,7 +327,7 @@ type resourceGroup struct {
 }
 
 type resourceGroupPropsBase struct {
-	Description string `json:"description"`
-	UpdatedBy   string `json:"updatedBy,omitempty"`
-	LastUpdated int    `json:"lastUpdated,omitempty"`
+	Description string       `json:"description"`
+	UpdatedBy   string       `json:"updatedBy,omitempty"`
+	LastUpdated lwtime.Epoch `json:"lastUpdated,omitempty"`
 }

--- a/lwtime/epoch.go
+++ b/lwtime/epoch.go
@@ -18,7 +18,7 @@ func (epoch *Epoch) UnmarshalJSON(b []byte) error {
 }
 
 func (epoch Epoch) MarshalJSON() ([]byte, error) {
-	epochJson := fmt.Sprintf("%v", epoch.ToTime().UnixMilli())
+	epochJson := fmt.Sprintf("%v", epoch.ToTime().UnixNano() / int64(time.Millisecond))
 	return []byte(epochJson), nil
 }
 

--- a/lwtime/epoch.go
+++ b/lwtime/epoch.go
@@ -1,6 +1,7 @@
 package lwtime
 
 import (
+	"fmt"
 	"strconv"
 	"time"
 )
@@ -16,9 +17,9 @@ func (epoch *Epoch) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-func (epoch *Epoch) MarshalJSON() ([]byte, error) {
-	// @afiune we might have problems changing the location :(
-	return epoch.ToTime().UTC().MarshalJSON()
+func (epoch Epoch) MarshalJSON() ([]byte, error) {
+	epochJson := fmt.Sprintf("%v", epoch.ToTime().UnixMilli())
+	return []byte(epochJson), nil
 }
 
 // A few format functions for printing and manipulating the custom date
@@ -30,4 +31,8 @@ func (epoch Epoch) Format(s string) string {
 }
 func (epoch Epoch) UTC() time.Time {
 	return epoch.ToTime().UTC()
+}
+
+func (epoch *Epoch) String() string {
+	return epoch.UTC().Format(time.RFC3339)
 }

--- a/lwtime/epoch.go
+++ b/lwtime/epoch.go
@@ -18,7 +18,7 @@ func (epoch *Epoch) UnmarshalJSON(b []byte) error {
 }
 
 func (epoch Epoch) MarshalJSON() ([]byte, error) {
-	epochJson := fmt.Sprintf("%v", epoch.ToTime().UnixNano() / int64(time.Millisecond))
+	epochJson := fmt.Sprintf("%v", epoch.ToTime().UnixNano()/int64(time.Millisecond))
 	return []byte(epochJson), nil
 }
 

--- a/lwtime/epoch.go
+++ b/lwtime/epoch.go
@@ -34,5 +34,8 @@ func (epoch Epoch) UTC() time.Time {
 }
 
 func (epoch *Epoch) String() string {
-	return epoch.UTC().Format(time.RFC3339)
+	if epoch != nil {
+		return epoch.UTC().Format(time.RFC3339)
+	}
+	return ""
 }

--- a/lwtime/epoch_test.go
+++ b/lwtime/epoch_test.go
@@ -1,0 +1,25 @@
+package lwtime
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type mockLastUpdatedResponse struct {
+	LastUpdatedTime Epoch `json:"last_updated"`
+}
+
+type mockLastUpdatedIntResponse struct {
+	LastUpdatedTime int `json:"last_updated"`
+}
+
+func TestMarshallEpoch(t *testing.T) {
+	var res mockLastUpdatedResponse
+	lastUpdated := mockLastUpdatedIntResponse{LastUpdatedTime: 1635604492078}
+	lastUpdatedString, _ := json.Marshal(lastUpdated)
+	json.Unmarshal(lastUpdatedString, &res)
+	expected, _ := json.Marshal(lastUpdated)
+	assert.Equal(t, "{\"last_updated\":1635604492078}", string(expected))
+}


### PR DESCRIPTION
## Summary

The resourceGroups last updated type is now of type lacework.Epoch.
The cli table output for `resource group show <id>` lastUpdated is now RFC3339
The cli output for `resource group show <id> --json` &  `resource group list --json` now shows lastUpdated as RFC3339

## How did you test this change?
Manually run:
 `resource group show <id>`
 `resource group show <id> --json`
 `resource group list --json` 

## Issue
https://lacework.atlassian.net/browse/ALLY-659

## Usage:
Before
```
❯ lacework rg show <ID> --json
{
  "resource_group": {
  ...
      ],
      "lastUpdated": 1635519644365,
      "updatedBy": "salim.afiunemaya@lacework.net"
    }


❯ lacework rg show <ID>
                        RESOURCE ID                          TYPE               NAME                STATE    DEFAULT  
-----------------------------------------------------------+------+------------------------------+---------+----------
...
                RESOURCE GROUP PROPS                
----------------------------------------------------
    DESCRIPTION                                     
    UPDATED BY     salim.afiunemaya@lacework.net    
    LAST UPDATED   1635519644365                    
    ACCOUNT IDS    *         

```

After
```
❯ lacework rg show <ID> --json
{
  "resource_group": {
  ...
      ],
      "lastUpdated": "2021-10-29T15:00:44Z",
      "updatedBy": "salim.afiunemaya@lacework.net"
    },


❯ lacework rg show <ID>       
                        RESOURCE ID                          TYPE               NAME                STATE    DEFAULT  
-----------------------------------------------------------+------+------------------------------+---------+----------
  ...
                RESOURCE GROUP PROPS                
----------------------------------------------------
    DESCRIPTION                                     
    UPDATED BY     salim.afiunemaya@lacework.net    
    LAST UPDATED   2021-10-29T15:00:44Z             
    ACCOUNT IDS    *    

```
