### PR TITLE
fix(cli): avoid panic when assessment has NO vulns

### DIFF
--- a/cli/cmd/capture_output_from_test.go
+++ b/cli/cmd/capture_output_from_test.go
@@ -1,0 +1,62 @@
+//
+// Author:: Salim Afiune Maya (<afiune@lacework.net>)
+// Copyright:: Copyright 2021, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cmd
+
+import (
+	"bytes"
+	"io"
+	"os"
+
+	"github.com/fatih/color"
+)
+
+// captureOutput executes a function and captures the STDOUT and STDERR,
+// useful to test logging messages or human readable output
+func captureOutput(f func()) string {
+	r, w, err := os.Pipe()
+	if err != nil {
+		panic(err)
+	}
+
+	stdout := os.Stdout
+	os.Stdout = w
+	defer func() {
+		os.Stdout = stdout
+	}()
+
+	colorOut := color.Output
+	color.Output = w
+	defer func() {
+		color.Output = colorOut
+	}()
+
+	stderr := os.Stderr
+	os.Stderr = w
+	defer func() {
+		os.Stderr = stderr
+	}()
+
+	f()
+	w.Close()
+
+	var buf bytes.Buffer
+	io.Copy(&buf, r)
+
+	return buf.String()
+}

--- a/cli/cmd/vuln_container.go
+++ b/cli/cmd/vuln_container.go
@@ -575,10 +575,6 @@ func buildVulnerabilityDetailsReportTable(details vulnerabilityDetailsReport) st
 }
 
 func buildVulnerabilitySummaryReportTable(assessment *api.VulnContainerAssessment) string {
-	if assessment.TotalVulnerabilities == 0 {
-		return fmt.Sprintf("Great news! This container image has no vulnerabilities... (time for %s)\n", randomEmoji())
-	}
-
 	mainReport := &strings.Builder{}
 	mainReport.WriteString(
 		renderCustomTable(

--- a/cli/cmd/vulnerability.go
+++ b/cli/cmd/vulnerability.go
@@ -331,22 +331,34 @@ func pollScanStatus(requestID string) error {
 
 // Build the cli output for vuln ctr 'scan-status', 'scan' and 'show-assessment' commands
 func buildVulnContainerAssessmentReports(assessment *api.VulnContainerAssessment) error {
-	var (
-		summaryReport = buildVulnerabilitySummaryReportTable(assessment)
-		details       = vulnerabilityDetailsReport{
-			VulnerabilityDetails: filterVulContainerImageLayers(assessment.Image),
-			Packages:             filterVulnContainerImagePackages(assessment.Image),
+	if assessment.TotalVulnerabilities == 0 {
+		if cli.JSONOutput() {
+			return cli.OutputJSON(assessment)
 		}
-		detailsReport      = buildVulnerabilityDetailsReportTable(details)
-		filteredAssessment = assessment
-	)
-	filteredAssessment.Image.ImageLayers = details.VulnerabilityDetails.ImageLayers
+		cli.OutputHuman("Great news! This container image has no vulnerabilities... (time for %s)\n", randomEmoji())
+		return nil
+	}
+
+	// check if the image pointer is nil, if so, we can't render a report
+	if assessment.Image == nil {
+		cli.Log.Debugw("image details not found", "assessment", assessment)
+		return errors.Errorf("unable to build container vulnerability report. (image information not found)")
+	}
+
+	details := vulnerabilityDetailsReport{
+		VulnerabilityDetails: filterVulContainerImageLayers(assessment.Image),
+		Packages:             filterVulnContainerImagePackages(assessment.Image),
+	}
 
 	if cli.JSONOutput() {
+		filteredAssessment := assessment
+		filteredAssessment.Image.ImageLayers = details.VulnerabilityDetails.ImageLayers
 		if err := cli.OutputJSON(filteredAssessment); err != nil {
 			return err
 		}
 	} else {
+		summaryReport := buildVulnerabilitySummaryReportTable(assessment)
+		detailsReport := buildVulnerabilityDetailsReportTable(details)
 		cli.OutputHuman(buildVulnContainerAssessmentReportTable(summaryReport, detailsReport))
 	}
 

--- a/cli/cmd/vulnerability_test.go
+++ b/cli/cmd/vulnerability_test.go
@@ -1,0 +1,341 @@
+//
+// Author:: Salim Afiune Maya (<afiune@lacework.net>)
+// Copyright:: Copyright 2021, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cmd
+
+import (
+	"encoding/json"
+	"log"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/lacework/go-sdk/api"
+)
+
+func TestBuildVulnContainerAssessmentReportsNoVulnerabilities(t *testing.T) {
+	cliOutput := captureOutput(func() {
+		assert.Nil(t, buildVulnContainerAssessmentReports(new(api.VulnContainerAssessment)))
+	})
+	assert.Contains(t, cliOutput, "Great news! This container image has no vulnerabilities...")
+
+	t.Run("test JSON output", func(t *testing.T) {
+		cli.EnableJSONOutput()
+		defer cli.EnableHumanOutput()
+		cliJSONOutput := captureOutput(func() {
+			assert.Nil(t, buildVulnContainerAssessmentReports(new(api.VulnContainerAssessment)))
+		})
+		expectedJSON := `{
+  "critical_vulnerabilities": 0,
+  "fixable_vulnerabilities": 0,
+  "high_vulnerabilities": 0,
+  "info_vulnerabilities": 0,
+  "low_vulnerabilities": 0,
+  "medium_vulnerabilities": 0,
+  "total_vulnerabilities": 0
+}
+`
+		assert.Equal(t, expectedJSON, cliJSONOutput)
+	})
+}
+
+func TestBuildVulnContainerAssessmentReportsWithVulnerabilitiesButNoImageInformation(t *testing.T) {
+	cliOutput := captureOutput(func() {
+		err := buildVulnContainerAssessmentReports(&api.VulnContainerAssessment{TotalVulnerabilities: 10})
+		if assert.NotNil(t, err, "we would panic, please check this error") {
+			assert.Equal(t, "unable to build container vulnerability report. (image information not found)", err.Error())
+		}
+	})
+	assert.Empty(t, cliOutput)
+}
+
+func TestBuildVulnContainerAssessmentReportsWithVulnerabilitiesAndNoFilters(t *testing.T) {
+	cliOutput := captureOutput(func() {
+		assert.Nil(t, buildVulnContainerAssessmentReports(mockVulnerabilityAssessment()))
+	})
+	// NOTE (@afiune): We purposly leave trailing spaces in this table, we need them!
+	expectedTable := `
+                                  CONTAINER IMAGE DETAILS                                          VULNERABILITIES          
+------------------------------------------------------------------------------------------+---------------------------------
+    ID          sha256:6446ea57df7b5badfcbdb47cf2d05d7831a33d36a97835b2c061cd1b4cc33deb       SEVERITY   COUNT   FIXABLE    
+    Digest      sha256:c933030694d7c95a266f8ba1236711595065b10531dd0df655852bccce96a66e     -----------+-------+----------  
+    Registry    index.docker.io                                                               Critical       1         1    
+    Repository  techallylw/test-cli-clean                                                     High           2         2    
+    Size        2.7 MB                                                                        Medium         1         1    
+    Created At  2020-05-29T21:19:46.363Z                                                      Low            0         0    
+    Tags        latest                                                                        Info           0         0    
+                                                                                                                            
+  CVE COUNT   SEVERITY    PACKAGE    CURRENT VERSION   FIX VERSION  
+------------+----------+-----------+-----------------+--------------
+  1           Critical   apk-tools   2.10.5-r1         2.10.7-r0    
+  1           High       apk-tools   2.10.5-r1         2.10.6-r0    
+  1           High       busybox     1.31.1-r16        1.31.1-r20   
+  1           Medium     musl        1.1.24-r8         1.1.24-r10   
+`
+	assert.Equal(t, strings.TrimPrefix(expectedTable, "\n"), cliOutput)
+}
+
+func TestBuildVulnContainerAssessmentReportsWithVulnerabilitiesWithFilters(t *testing.T) {
+	vulCmdState.Severity = "critical"
+	defer func() {
+		vulCmdState.Severity = ""
+	}()
+
+	cliOutput := captureOutput(func() {
+		assert.Nil(t, buildVulnContainerAssessmentReports(mockVulnerabilityAssessment()))
+	})
+	// NOTE (@afiune): We purposly leave trailing spaces in this table, we need them!
+	expectedTable := `
+                                  CONTAINER IMAGE DETAILS                                          VULNERABILITIES          
+------------------------------------------------------------------------------------------+---------------------------------
+    ID          sha256:6446ea57df7b5badfcbdb47cf2d05d7831a33d36a97835b2c061cd1b4cc33deb       SEVERITY   COUNT   FIXABLE    
+    Digest      sha256:c933030694d7c95a266f8ba1236711595065b10531dd0df655852bccce96a66e     -----------+-------+----------  
+    Registry    index.docker.io                                                               Critical       1         1    
+    Repository  techallylw/test-cli-clean                                                     High           2         2    
+    Size        2.7 MB                                                                        Medium         1         1    
+    Created At  2020-05-29T21:19:46.363Z                                                      Low            0         0    
+    Tags        latest                                                                        Info           0         0    
+                                                                                                                            
+  CVE COUNT   SEVERITY    PACKAGE    CURRENT VERSION   FIX VERSION  
+------------+----------+-----------+-----------------+--------------
+  1           Critical   apk-tools   2.10.5-r1         2.10.7-r0    
+1 of 4 packages showing 
+`
+	assert.Equal(t, strings.TrimPrefix(expectedTable, "\n"), cliOutput)
+
+	t.Run("test JSON output", func(t *testing.T) {
+		cli.EnableJSONOutput()
+		defer cli.EnableHumanOutput()
+		cliJSONOutput := captureOutput(func() {
+			assert.Nil(t, buildVulnContainerAssessmentReports(mockVulnerabilityAssessment()))
+		})
+		expectedJSON := `{
+  "critical_vulnerabilities": 1,
+  "fixable_vulnerabilities": 4,
+  "high_vulnerabilities": 2,
+  "image": {
+    "image_info": {
+      "created_time": "2020-05-29T21:19:46.363Z",
+      "image_digest": "sha256:c933030694d7c95a266f8ba1236711595065b10531dd0df655852bccce96a66e",
+      "image_id": "sha256:6446ea57df7b5badfcbdb47cf2d05d7831a33d36a97835b2c061cd1b4cc33deb",
+      "registry": "index.docker.io",
+      "repository": "techallylw/test-cli-clean",
+      "size": 2797541,
+      "tags": [
+        "latest"
+      ]
+    },
+    "image_layers": [
+      {
+        "created_by": "ADD file:c92c248239f8c7b9b3c067650954815f391b7bcb09023f984972c082ace2a8d0 in / ",
+        "hash": "sha256:sha256:df20fa9351a15782c64e6dddb2d4a6f50bf6d3688060a34c4014b0d9a752eb4c",
+        "packages": [
+          {
+            "name": "apk-tools",
+            "namescape": "",
+            "version": "2.10.5-r1",
+            "vulnerabilities": [
+              {
+                "description": "",
+                "fix_version": "2.10.7-r0",
+                "link": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-36159",
+                "metadata": {
+                  "NVD": {
+                    "CVSSv2": {
+                      "PublishedDateTime": "2021-08-03T14:15Z",
+                      "Score": 6.4,
+                      "Vectors": "AV:N/AC:L/Au:N/C:P/I:N/A:P"
+                    },
+                    "CVSSv3": {
+                      "ExploitabilityScore": 3.9,
+                      "ImpactScore": 5.2,
+                      "Score": 9.1,
+                      "Vectors": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:H"
+                    }
+                  }
+                },
+                "name": "CVE-2021-36159",
+                "severity": "critical"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "info_vulnerabilities": 0,
+  "last_evaluation_time": "2021-11-05T12:47:03.886Z",
+  "low_vulnerabilities": 0,
+  "medium_vulnerabilities": 1,
+  "scan_status": "Success",
+  "total_vulnerabilities": 4
+}
+`
+		assert.Equal(t, expectedJSON, cliJSONOutput)
+	})
+}
+
+func mockVulnerabilityAssessment() *api.VulnContainerAssessment {
+	assessment := &api.VulnContainerAssessment{}
+	err := json.Unmarshal([]byte(`{
+  "critical_vulnerabilities": 1,
+  "fixable_vulnerabilities": 4,
+  "high_vulnerabilities": 2,
+  "image": {
+    "image_info": {
+      "created_time": "2020-05-29T21:19:46.363Z",
+      "image_digest": "sha256:c933030694d7c95a266f8ba1236711595065b10531dd0df655852bccce96a66e",
+      "image_id": "sha256:6446ea57df7b5badfcbdb47cf2d05d7831a33d36a97835b2c061cd1b4cc33deb",
+      "registry": "index.docker.io",
+      "repository": "techallylw/test-cli-clean",
+      "size": 2797541,
+      "tags": [
+        "latest"
+      ]
+    },
+    "image_layers": [
+      {
+        "created_by": "ADD file:c92c248239f8c7b9b3c067650954815f391b7bcb09023f984972c082ace2a8d0 in / ",
+        "hash": "sha256:sha256:df20fa9351a15782c64e6dddb2d4a6f50bf6d3688060a34c4014b0d9a752eb4c",
+        "packages": [
+          {
+            "name": "apk-tools",
+            "namescape": "",
+            "version": "2.10.5-r1",
+            "vulnerabilities": [
+              {
+                "description": "",
+                "fix_version": "2.10.6-r0",
+                "link": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-30139",
+                "metadata": {
+                  "NVD": {
+                    "CVSSv2": {
+                      "PublishedDateTime": "2021-04-21T16:15Z",
+                      "Score": 5,
+                      "Vectors": "AV:N/AC:L/Au:N/C:N/I:N/A:P"
+                    },
+                    "CVSSv3": {
+                      "ExploitabilityScore": 3.9,
+                      "ImpactScore": 3.6,
+                      "Score": 7.5,
+                      "Vectors": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+                    }
+                  }
+                },
+                "name": "CVE-2021-30139",
+                "severity": "high"
+              },
+              {
+                "description": "",
+                "fix_version": "2.10.7-r0",
+                "link": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-36159",
+                "metadata": {
+                  "NVD": {
+                    "CVSSv2": {
+                      "PublishedDateTime": "2021-08-03T14:15Z",
+                      "Score": 6.4,
+                      "Vectors": "AV:N/AC:L/Au:N/C:P/I:N/A:P"
+                    },
+                    "CVSSv3": {
+                      "ExploitabilityScore": 3.9,
+                      "ImpactScore": 5.2,
+                      "Score": 9.1,
+                      "Vectors": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:H"
+                    }
+                  }
+                },
+                "name": "CVE-2021-36159",
+                "severity": "critical"
+              }
+            ]
+          },
+          {
+            "name": "musl",
+            "namescape": "",
+            "version": "1.1.24-r8",
+            "vulnerabilities": [
+              {
+                "description": "",
+                "fix_version": "1.1.24-r10",
+                "link": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-28928",
+                "metadata": {
+                  "NVD": {
+                    "CVSSv2": {
+                      "PublishedDateTime": "2020-11-24T18:15Z",
+                      "Score": 2.1,
+                      "Vectors": "AV:L/AC:L/Au:N/C:N/I:N/A:P"
+                    },
+                    "CVSSv3": {
+                      "ExploitabilityScore": 1.8,
+                      "ImpactScore": 3.6,
+                      "Score": 5.5,
+                      "Vectors": "CVSS:3.0/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H"
+                    }
+                  }
+                },
+                "name": "CVE-2020-28928",
+                "severity": "medium"
+              }
+            ]
+          },
+          {
+            "name": "busybox",
+            "namescape": "",
+            "version": "1.31.1-r16",
+            "vulnerabilities": [
+              {
+                "description": "",
+                "fix_version": "1.31.1-r20",
+                "link": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-28831",
+                "metadata": {
+                  "NVD": {
+                    "CVSSv2": {
+                      "PublishedDateTime": "2021-03-19T05:15Z",
+                      "Score": 5,
+                      "Vectors": "AV:N/AC:L/Au:N/C:N/I:N/A:P"
+                    },
+                    "CVSSv3": {
+                      "ExploitabilityScore": 3.9,
+                      "ImpactScore": 3.6,
+                      "Score": 7.5,
+                      "Vectors": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+                    }
+                  }
+                },
+                "name": "CVE-2021-28831",
+                "severity": "high"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "info_vulnerabilities": 0,
+  "last_evaluation_time": "2021-11-05T12:47:03.886Z",
+  "low_vulnerabilities": 0,
+  "medium_vulnerabilities": 1,
+  "scan_status": "Success",
+  "total_vulnerabilities": 4
+}`), assessment)
+	if err != nil {
+		log.Fatal(err)
+	}
+	return assessment
+}


### PR DESCRIPTION

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/lacework/go-sdk) and create your branch from `main`
  2. Run `make prepare` in the repository root
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`make test`)
  5. Format your code (`make fmt`)
  6. Make sure your code lints (`make lint`)
  7. If you are updating the Lacework CLI, make sure it compiles (`make build-cli-cross-platform`)
  8. Follow the commit message standard (`type(scope): subject`) documented in [DEVELOPER_GUIDELINES.md](https://github.com/lacework/go-sdk/blob/main/DEVELOPER_GUIDELINES.md#commit-message-standard)
  9. If you haven't already, configure signed commits by [telling git about your signing key](https://docs.github.com/en/github/authenticating-to-github/managing-commit-signature-verification/telling-git-about-your-signing-key) and [signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)

  Learn more about contributing: https://github.com/lacework/go-sdk/blob/main/CONTRIBUTING.md
-->

## Summary

The Lacework CLI panics when trying to run a scan, check for a scan-status, or show
the results of a container image that has NO vulnerabilities.

```
$ lacework vulnerability container scan-status 36940f74-cad7-4007-ac3d-f702f01254ba
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x1612dc6]

goroutine 1 [running]:
[github.com/lacework/go-sdk/cli/cmd.buildVulnContainerAssessmentReports(0xc00061e100|http://github.com/lacework/go-sdk/cli/cmd.buildVulnContainerAssessmentReports(0xc00061e100], 0x24, 0xc00061e100)
	/codefresh/volume/go-sdk/cli/cmd/vulnerability.go:343 +0x1e6
[github.com/lacework/go-sdk/cli/cmd.checkOnDemandContainerVulnerabilityStatus|http://github.com/lacework/go-sdk/cli/cmd.checkOnDemandContainerVulnerabilityStatus](0x7ffeefbffbb5, 0x24, 0x11bec20, 0xc0001f9cb8)
	/codefresh/volume/go-sdk/cli/cmd/vuln_container.go:431 +0x1bb
[github.com/lacework/go-sdk/cli/cmd.glob..func37(0x1c1fa40|http://github.com/lacework/go-sdk/cli/cmd.glob..func37(0x1c1fa40], 0xc000192c70, 0x1, 0x1, 0x0, 0x0)
	/codefresh/volume/go-sdk/cli/cmd/vuln_container.go:82 +0x65
[github.com/spf13/cobra.(*Command).execute(0x1c1fa40|http://github.com/spf13/cobra.(*Command).execute(0x1c1fa40], 0xc000192c50, 0x1, 0x1, 0x1c1fa40, 0xc000192c50)
	/codefresh/volume/go-sdk/vendor/github.com/spf13/cobra/command.go:856 +0x472
[github.com/spf13/cobra.(*Command).ExecuteC(0x1c2abc0|http://github.com/spf13/cobra.(*Command).ExecuteC(0x1c2abc0], 0x2, 0x1006625, 0xc000078000)
	/codefresh/volume/go-sdk/vendor/github.com/spf13/cobra/command.go:974 +0x375
[github.com/spf13/cobra.(*Command).Execute(...)|http://github.com/spf13/cobra.(*Command).Execute(...)]
	/codefresh/volume/go-sdk/vendor/github.com/spf13/cobra/command.go:902
[github.com/lacework/go-sdk/cli/cmd.Execute|http://github.com/lacework/go-sdk/cli/cmd.Execute](0x0, 0x0)
	/codefresh/volume/go-sdk/cli/cmd/root.go:118 +0xa8
main.main()
	/codefresh/volume/go-sdk/cli/main.go:29 +0x26
```

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>

## How did you test this change?

Added a bunch of unit tests that should have been added on previous refactors. 

Additionally, I ran a scan against an image without vulnerabilities and it worked great, as well as showing an existing assessment without vulnerabilities, the result:
```
$ lacework vuln ctr show sha256:c838ee70a4aa2a13be872269746035faac7b5f7706d5faca9fd147615ac5db73
Great news! This container image has no vulnerabilities... (time for 🍺 )
```

## Issue
JIRA: https://lacework.atlassian.net/browse/ALLY-734

