### PR TITLE
fix(cli): remove sub-account during reconfiguration

### DIFF
--- a/cli/cmd/configure.go
+++ b/cli/cmd/configure.go
@@ -193,10 +193,15 @@ func runConfigureSetup() error {
 		// before trying to detect if the account is organizational or not, and to
 		// check if there are sub-accounts, we need to update the CLI settings
 		cli.Log.Debug("storing interactive information into the cli state")
-		cli.Account = newProfile.Account
-		cli.Subaccount = newProfile.Subaccount
 		cli.Secret = newProfile.ApiSecret
 		cli.KeyID = newProfile.ApiKey
+		if cli.Account != newProfile.Account {
+			// if the account provided by the interactive prompt is different,
+			// we need to remove the previous sub-account since it's a reconfiguration
+			cli.Account = newProfile.Account
+			cli.Subaccount = ""
+			newProfile.Subaccount = ""
+		}
 
 		// generate a new API client to connect and check for sub-accounts
 		if err := cli.NewClient(); err != nil {

--- a/integration/alert_rules_test.go
+++ b/integration/alert_rules_test.go
@@ -79,9 +79,10 @@ func TestAlertRulesJsonOutput(t *testing.T) {
 	var rule api.AlertRulesResponse
 	jsonErr := json.Unmarshal(out.Bytes(), &rule)
 
-	assert.NoError(t, jsonErr)
-	assert.NotNil(t, rule.Data[0].Filter.Name)
-	assert.Empty(t, err.String(), "STDERR should be empty")
+	if assert.NoError(t, jsonErr) {
+		assert.NotNil(t, rule.Data[0].Filter.Name)
+		assert.Empty(t, err.String(), "STDERR should be empty")
+	}
 	assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
 }
 

--- a/integration/configure_test.go
+++ b/integration/configure_test.go
@@ -109,6 +109,12 @@ version = 2
 account = 'v1.example'
 api_key = 'V1CONFIG_KEY'
 api_secret = '_secret'
+
+[v2]
+account = 'v2.example'
+api_key = 'V2CONFIG_KEY'
+api_secret = '_secret'
+subaccount = 'sub-account'
 `)
 	err = ioutil.WriteFile(configFile, c, 0644)
 	if err != nil {

--- a/integration/configure_unix_test.go
+++ b/integration/configure_unix_test.go
@@ -385,7 +385,64 @@ func TestConfigureCommandWithExistingConfigAndMultiProfile(t *testing.T) {
   account = "v1.example"
   api_key = "V1CONFIG_KEY"
   api_secret = "_secret"
+
+[v2]
+  account = "v2.example"
+  subaccount = "sub-account"
+  api_key = "V2CONFIG_KEY"
+  api_secret = "_secret"
 `, laceworkTOML, "there is a problem with the generated config")
+
+	t.Run("Reconfigure", func(t *testing.T) {
+		_, laceworkTOML := runConfigureTestFromDir(t, dir,
+			func(c *expect.Console) {
+				c.ExpectString("Account:")
+				c.SendLine("new-account")
+				c.ExpectString("Access Key ID:")
+				c.SendLine("TEST_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")
+				c.ExpectString("Secret Access Key:")
+				c.SendLine("_oooooooooooooooooooooooooooooooo")
+				c.ExpectString("You are all set!")
+			},
+			"configure", "--profile", "v2",
+		)
+
+		assert.Equal(t, `[default]
+  account = "test.account"
+  api_key = "INTTEST_ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890AAABBBCCC00"
+  api_secret = "_00000000000000000000000000000000"
+  version = 2
+
+[dev]
+  account = "dev.example"
+  api_key = "DEVDEV_ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890AAABBBCCC000"
+  api_secret = "_11111111111111111111111111111111"
+  version = 2
+
+[integration]
+  account = "integration"
+  api_key = "INTEGRATION_3DF1234AABBCCDD5678XXYYZZ1234ABC8BEC6500DC70001"
+  api_secret = "_1234abdc00ff11vv22zz33xyz1234abc"
+  version = 2
+
+[new-profile]
+  account = "super-cool-profile"
+  api_key = "TEST_ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ"
+  api_secret = "_uuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuu"
+  version = 2
+
+[v1]
+  account = "v1.example"
+  api_key = "V1CONFIG_KEY"
+  api_secret = "_secret"
+
+[v2]
+  account = "new-account"
+  api_key = "TEST_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+  api_secret = "_oooooooooooooooooooooooooooooooo"
+  version = 2
+`, laceworkTOML, "there is a problem with the generated config")
+	})
 }
 
 func TestConfigureCommandErrors(t *testing.T) {


### PR DESCRIPTION

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/lacework/go-sdk) and create your branch from `main`
  2. Run `make prepare` in the repository root
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`make test`)
  5. Format your code (`make fmt`)
  6. Make sure your code lints (`make lint`)
  7. If you are updating the Lacework CLI, make sure it compiles (`make build-cli-cross-platform`)
  8. Follow the commit message standard (`type(scope): subject`) documented in [DEVELOPER_GUIDELINES.md](https://github.com/lacework/go-sdk/blob/main/DEVELOPER_GUIDELINES.md#commit-message-standard)
  9. If you haven't already, configure signed commits by [telling git about your signing key](https://docs.github.com/en/github/authenticating-to-github/managing-commit-signature-verification/telling-git-about-your-signing-key) and [signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)

  Learn more about contributing: https://github.com/lacework/go-sdk/blob/main/CONTRIBUTING.md
-->

## Summary

When running `lacework configure`, if a previous config has a sub-account
it is not removed that there is a sub account when reconfiguring to manage
a new account.

The `lacework.toml` becomes invalid.

This PR is fixing the above issue by removing the sub-account during
reconfiguration.

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>

## How did you test this change?

Manually, using an empty configuration as well as multiple profiles. 

## Issue
https://lacework.atlassian.net/browse/ALLY-687
<!--
  Include the link to a Jira/Github issue
-->
