### PR TITLE
test: Fix failing alert rule test

### DIFF
--- a/integration/alert_rules_test.go
+++ b/integration/alert_rules_test.go
@@ -68,6 +68,12 @@ func TestAlertRuleRead(t *testing.T) {
 }
 
 func TestAlertRulesJsonOutput(t *testing.T) {
+	alertRule, createErr := createAlertRuleWithSlackAlertChannel()
+	if createErr != nil {
+		log.Fatal(createErr)
+	}
+	defer LaceworkCLIWithTOMLConfig("alert-rules", "delete", alertRule.Data.Guid)
+
 	out, err, exitcode := LaceworkCLIWithTOMLConfig("alert-rules", "list", "--json")
 
 	var rule api.AlertRulesResponse


### PR DESCRIPTION


## Summary

Alert Rule test requires at least 1 pre existing alert rule. Add create and delete of alert rule in test step.

