### PR TITLE
feat: Filter vuln ctr list-assessments by registry

### DIFF
--- a/cli/cmd/vulnerability.go
+++ b/cli/cmd/vulnerability.go
@@ -82,6 +82,9 @@ var (
 
 		// filter assessments for specific repositories
 		Repositories []string
+
+		// filter assessments for specific registries
+		Registries []string
 	}{}
 
 	// vulnerability represents the vulnerability command that holds both, the host

--- a/integration/container_vulnerability_test.go
+++ b/integration/container_vulnerability_test.go
@@ -152,6 +152,21 @@ func TestContainerVulnerabilityCommandListAssessmentsJson(t *testing.T) {
 	})
 }
 
+func TestContainerVulnerabilityCommandListAssessmentsFilterRegistry(t *testing.T) {
+	out, err, exitcode := LaceworkCLIWithTOMLConfig("vulnerability", "container", "list-assessments", "--registry", "index.docker.io")
+	assert.Empty(t,
+		err.String(),
+		"STDERR should be empty")
+	assert.Equal(t, 0, exitcode,
+		"EXITCODE is not the expected one")
+
+	expected := "index.docker.io"
+	notExpected := "gcr.io"
+
+	assert.Contains(t, out.String(), expected, "STDOUT table does not contain the '"+expected+"' field")
+	assert.NotContains(t, out.String(), notExpected, "STDOUT table should not contain the '"+notExpected+"' field")
+}
+
 func TestContainerVulnerabilityCommandScanErrorRegistryNotFound(t *testing.T) {
 	out, err, exitcode := LaceworkCLIWithTOMLConfig(
 		"vulnerability", "container", "scan", "my.registry.example.com", "foo", "bar",


### PR DESCRIPTION
Signed-off-by: Darren Murray <darren.murray@lacework.net>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/lacework/go-sdk) and create your branch from `main`
  2. Run `make prepare` in the repository root
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`make test`)
  5. Format your code (`make fmt`)
  6. Make sure your code lints (`make lint`)
  7. If you are updating the Lacework CLI, make sure it compiles (`make build-cli-cross-platform`)
  8. Follow the commit message standard (`type(scope): subject`) documented in [DEVELOPER_GUIDELINES.md](https://github.com/lacework/go-sdk/blob/main/DEVELOPER_GUIDELINES.md#commit-message-standard)
  9. If you haven't already, configure signed commits by [telling git about your signing key](https://docs.github.com/en/github/authenticating-to-github/managing-commit-signature-verification/telling-git-about-your-signing-key) and [signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)

  Learn more about contributing: https://github.com/lacework/go-sdk/blob/main/CONTRIBUTING.md
-->

## Summary
Add a flag named --registry to filter by remote_scanner assessments.

## How did you test this change?
Run `lacework vuln ctr list --registry reg-name`

## Issue
https://lacework.atlassian.net/browse/ALLY-711
