### PR TITLE
test(policy): adds resource for dynamic accnt

### DIFF
--- a/integration/test_resources/policy/account-clitest-1.json
+++ b/integration/test_resources/policy/account-clitest-1.json
@@ -1,0 +1,13 @@
+{
+	"evaluatorId": "Cloudtrail",
+	"policyId": "$account-clitest-1",
+	"policyType": "Violation",
+	"queryId": "LW_CLI_AWS_CTA_IntegrationTest",
+	"title": "My Policy Title",
+	"enabled": false,
+	"description": "My Policy Description",
+	"remediation": "Check yourself...",
+	"severity": "high",
+	"alertEnabled": false,
+	"alertProfile": "LW_CloudTrail_Alerts"
+}


### PR DESCRIPTION
## Summary
This change introduces a test resource to facilitate modern testing policy creation via dynamic policyId

## How did you test this change?
This change introduces an integration test resources and is a noop to production code.  The resource itself will be used by updated integration testing in a subsequent PR.

## Issue
https://lacework.atlassian.net/browse/ALLY-743