### PR TITLE
feat(cli): cache compliance reports for 30 minutes

### DIFF
--- a/cli/cmd/compliance.go
+++ b/cli/cmd/compliance.go
@@ -93,11 +93,11 @@ Use the following command to list all available integrations in your account:
 		Short:   "Compliance for Azure Cloud",
 		Long: `Manage compliance reports for Azure Cloud.
 
-To list all Azure Tenants configured in your account:
+To list all Azure tenants configured in your account:
 
     lacework compliance azure list-tenants
 
-To list all Azure Subscriptions from a Tenant, use the command:
+To list all Azure subscriptions from a tenant, use the command:
 
     lacework compliance azure list-subscriptions <tenant_id>
 
@@ -120,9 +120,9 @@ To run an ad-hoc compliance assessment use the command:
 		Short:   "Compliance for Google Cloud",
 		Long: `Manage compliance reports for Google Cloud.
 
-To list all Google Organizations and Projects configured in your account:
+To list all GCP organizations and projects configured in your account:
 
-    lacework compliance google list
+    lacework compliance gcp list
 
 To list all GCP projects from an organization, use the command:
 

--- a/cli/cmd/compliance.go
+++ b/cli/cmd/compliance.go
@@ -103,7 +103,7 @@ To list all Azure Subscriptions from a Tenant, use the command:
 
 To get the latest Azure compliance assessment report, use the command:
 
-    lacework compliance azure get-report <tenant_id> <subscriptions_id>
+    lacework compliance azure get-report <tenant_id> <subscription_id>
 
 These reports run on a regular schedule, typically once a day.
 
@@ -120,25 +120,19 @@ To run an ad-hoc compliance assessment use the command:
 		Short:   "Compliance for Google Cloud",
 		Long: `Manage compliance reports for Google Cloud.
 
+To list all Google Organizations and Projects configured in your account:
+
+    lacework compliance google list
+
+To list all GCP projects from an organization, use the command:
+
+    lacework compliance gcp list-projects <organization_id>
+
 To get the latest GCP compliance assessment report, use the command:
 
     lacework compliance gcp get-report <organization_id> <project_id>
 
 These reports run on a regular schedule, typically once a day.
-
-To find out which GCP organizations/projects are connected to your
-Lacework account, use the following command:
-
-    lacework integrations list --type GCP_CFG
-
-Then, choose one integration, copy the GUID and visualize its details
-using the command:
-
-    lacework integration show <int_guid>
-
-To list all GCP projects from an organization, use the command:
-
-    lacework compliance gcp list-projects <organization_id>
 
 To run an ad-hoc compliance assessment use the command:
 
@@ -355,13 +349,24 @@ func buildComplianceReportTable(detailsTable, summaryTable, recommendationsTable
 			mainReport.WriteString(filteredOutput)
 		}
 		mainReport.WriteString("\n")
-		mainReport.WriteString(
-			"Try using '--pdf' to download the report in PDF format.",
-		)
+
+		if compCmdState.Status == "" {
+			mainReport.WriteString(
+				"Try adding '--status non-compliant' to show only non-compliant recommendations.",
+			)
+		} else if compCmdState.Severity == "" {
+			mainReport.WriteString(
+				"Try adding '--severity high' to show only high and critical recommendations.",
+			)
+		} else {
+			mainReport.WriteString(
+				"Try using '--pdf' to download the entire report in PDF format.",
+			)
+		}
 		mainReport.WriteString("\n")
 	} else {
 		mainReport.WriteString(
-			"Try using '--details' to increase details shown about the compliance report.\n",
+			"Try adding '--details' to increase details shown about the compliance report.\n",
 		)
 	}
 	return mainReport.String()

--- a/cli/cmd/compliance_azure.go
+++ b/cli/cmd/compliance_azure.go
@@ -204,7 +204,7 @@ To run an ad-hoc compliance assessment use the command:
 
 			var (
 				report   api.ComplianceAzureReport
-				cacheKey = fmt.Sprintf("compliance/aws/%s/%s/%s",
+				cacheKey = fmt.Sprintf("compliance/azure/%s/%s/%s",
 					config.TenantID, config.SubscriptionID, config.Type)
 			)
 			expired := cli.ReadCachedAsset(cacheKey, &report)

--- a/cli/cmd/compliance_azure.go
+++ b/cli/cmd/compliance_azure.go
@@ -202,18 +202,29 @@ To run an ad-hoc compliance assessment use the command:
 				}
 			}
 
-			cli.StartProgress(" Getting compliance report...")
-			response, err := cli.LwApi.Compliance.GetAzureReport(config)
-			cli.StopProgress()
-			if err != nil {
-				return errors.Wrap(err, "unable to get azure compliance report")
+			var (
+				report   api.ComplianceAzureReport
+				cacheKey = fmt.Sprintf("compliance/aws/%s/%s/%s",
+					config.TenantID, config.SubscriptionID, config.Type)
+			)
+			expired := cli.ReadCachedAsset(cacheKey, &report)
+			if expired {
+				cli.StartProgress(" Getting compliance report...")
+				response, err := cli.LwApi.Compliance.GetAzureReport(config)
+				cli.StopProgress()
+				if err != nil {
+					return errors.Wrap(err, "unable to get azure compliance report")
+				}
+
+				if len(response.Data) == 0 {
+					return errors.New("no data found in the report")
+				}
+
+				report = response.Data[0]
+
+				cli.WriteAssetToCache(cacheKey, time.Now().Add(time.Minute*30), report)
 			}
 
-			if len(response.Data) == 0 {
-				return errors.New("there is no data found in the report")
-			}
-
-			report := response.Data[0]
 			filteredOutput := ""
 
 			if complianceFiltersEnabled() {
@@ -238,7 +249,9 @@ To run an ad-hoc compliance assessment use the command:
 				)
 
 				return cli.OutputCSV(
-					[]string{"Report_Type", "Report_Time", "Tenant", "Subscription", "Section", "ID", "Recommendation", "Status", "Severity", "Resource", "Region", "Reason"},
+					[]string{"Report_Type", "Report_Time", "Tenant",
+						"Subscription", "Section", "ID", "Recommendation",
+						"Status", "Severity", "Resource", "Region", "Reason"},
 					recommendations,
 				)
 			}


### PR DESCRIPTION

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/lacework/go-sdk) and create your branch from `main`
  2. Run `make prepare` in the repository root
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`make test`)
  5. Format your code (`make fmt`)
  6. Make sure your code lints (`make lint`)
  7. If you are updating the Lacework CLI, make sure it compiles (`make build-cli-cross-platform`)
  8. Follow the commit message standard (`type(scope): subject`) documented in [DEVELOPER_GUIDELINES.md](https://github.com/lacework/go-sdk/blob/main/DEVELOPER_GUIDELINES.md#commit-message-standard)
  9. If you haven't already, configure signed commits by [telling git about your signing key](https://docs.github.com/en/github/authenticating-to-github/managing-commit-signature-verification/telling-git-about-your-signing-key) and [signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)

  Learn more about contributing: https://github.com/lacework/go-sdk/blob/main/CONTRIBUTING.md
-->

## Summary

When a user is trying to visualize a compliance report via the CLI, we
shouldn’t ask the APIs for the same report on every command execution,
especially not since the report won’t change between two commands run
within a few minutes. We should be able to use the Caching mechanism
inside the Lacework CLI to cache compliance reports and let users
navigate them faster and reduce the load to our API server.

We have already done this for host vulnerability assessments.

## User Story
>As a Lacework CLI user,
I want to inspect compliance reports via the CLI multiple times without getting to API rate limits,
So I can create workflows internally and navigate my reports with additional flags and filters

>As a Lacework engineer,
I want tools and integrations to cache data as much as possible without compromising consistency,
So other services, such as the API server, don't get overwhelmed with the same API requests that are immutable

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>

## How did you test this change?

Ran a few commands in sequence against our test account.

![Screen Shot 2021-11-29 at 9 39 58 AM](https://user-images.githubusercontent.com/5712253/143916974-d357a590-3a2e-4c98-85f7-9c029260a313.png)

## Issue
https://lacework.atlassian.net/browse/ALLY-770