### PR TITLE
chore(deps): Bump gotestsum version and use instead of go test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ integration-generation-only: ## Run integration tests
 	PATH=$(PWD)/bin:${PATH} go test -v github.com/lacework/go-sdk/integration -timeout 30m -run "^TestGeneration" -tags="generation"
 
 .PHONY: integration-only
-integration-only: ## Run integration tests
+integration-only: install-tools ## Run integration tests
 	PATH=$(PWD)/bin:${PATH} gotestsum -- -v github.com/lacework/go-sdk/integration -timeout 30m -tags="\
 		account \
 		agent_token \

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ ci: lint test fmt-check imports-check integration
 GOLANGCILINTVERSION?=1.23.8
 GOIMPORTSVERSION?=v0.1.2
 GOXVERSION?=v1.0.1
-GOTESTSUMVERSION?=v1.6.4
+GOTESTSUMVERSION?=v1.7.0
 
 CIARTIFACTS?=ci-artifacts
 COVERAGEOUT?=coverage.out
@@ -58,7 +58,7 @@ integration-generation-only: ## Run integration tests
 
 .PHONY: integration-only
 integration-only: ## Run integration tests
-	PATH=$(PWD)/bin:${PATH} go test -v github.com/lacework/go-sdk/integration -timeout 30m -tags="\
+	PATH=$(PWD)/bin:${PATH} gotestsum -- -v github.com/lacework/go-sdk/integration -timeout 30m -tags="\
 		account \
 		agent_token \
 		alert_rules \
@@ -79,14 +79,14 @@ integration-lql: build-cli-cross-platform integration-lql-only ## Build and run 
 
 .PHONY: integration-lql-only
 integration-lql-only: ## Run lql integration tests
-	PATH=$(PWD)/bin:${PATH} go test -v github.com/lacework/go-sdk/integration -timeout 30m -tags="query"
+	PATH=$(PWD)/bin:${PATH} gotestsum -- -v github.com/lacework/go-sdk/integration -timeout 30m -tags="query"
 
 .PHONY: integration-policy
 integration-policy: build-cli-cross-platform integration-policy-only ## Build and run lql policy tests
 
 .PHONY: integration-policy-only
 integration-policy-only: ## Run lql policy tests
-	PATH=$(PWD)/bin:${PATH} go test -v github.com/lacework/go-sdk/integration -timeout 30m -tags="policy"
+	PATH=$(PWD)/bin:${PATH} gotestsum -- -v github.com/lacework/go-sdk/integration -timeout 30m -tags="policy"
 
 .PHONY: coverage
 coverage: test ## Output coverage profile information for each function


### PR DESCRIPTION
Signed-off-by: Ross <ross.moles@lacework.net>

## Summary
Previously gotestsum was added to add some colorful output on test runs. It seems this hasn't been used across the make commands and therefore we have missed bumping this after the upgrade to Go 1.17

## How did you test this change?
make test ✅ 
make fmt ✅ 

## Issue
https://lacework.atlassian.net/browse/ALLY-791