### PR TITLE
chore(deps): Bump GoImports version to v0.1.8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ ci: lint test fmt-check imports-check integration
 
 # Tooling versions
 GOLANGCILINTVERSION?=1.23.8
-GOIMPORTSVERSION?=v0.1.2
+GOIMPORTSVERSION?=v0.1.8
 GOXVERSION?=v1.0.1
 GOTESTSUMVERSION?=v1.7.0
 


### PR DESCRIPTION
Signed-off-by: Ross <ross.moles@lacework.net>

## Summary
This was found when raising #632 and running `make fmt` I was getting a failure, due to a version of GoImports that doesn't work with Go 1.17

## How did you test this change?
make test ✅ 
make fmt ✅ 

## Issue
https://lacework.atlassian.net/browse/ALLY-792
