### PR TITLE
fix(cli): make sure progress bar starts with space

### DIFF
--- a/cli/cmd/cli_state.go
+++ b/cli/cmd/cli_state.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"reflect"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -291,7 +292,12 @@ func (c *cliState) StartProgress(suffix string) {
 		// make sure there is not a spinner already running
 		c.StopProgress()
 
-		c.Log.Debug("starting spinner")
+		// verify that the suffix starts with a space
+		if !strings.HasPrefix(suffix, " ") {
+			suffix = fmt.Sprintf(" %s", suffix)
+		}
+
+		c.Log.Debugw("starting spinner", "suffix", suffix)
 		c.spinner = spinner.New(spinner.CharSets[9], 100*time.Millisecond)
 		c.spinner.Suffix = suffix
 		c.spinner.Start()


### PR DESCRIPTION
## Summary

If we start a progress bar without a space, that is `cli.StartProgress("Generating foo...")` the progress message 
looks odd since there is no space in between. This PR is adding a space if the developer doesn't already add it.


## Issue

N/A
