### PR TITLE
fix(cli): clarify container error message

### DIFF
--- a/cli/cmd/vuln_container.go
+++ b/cli/cmd/vuln_container.go
@@ -1063,7 +1063,7 @@ To integrate a new container registry use the command:
 		"Could not successfully send scan request to available integrations for given repo and label",
 	) {
 
-		msg := `container image '%s:%s' not found in registry '%s'.
+		msg := `container image '%s@%s' not found in registry '%s'.
 
 This error is likely due to a problem with the container registry integration 
 configured in your account. Verify that the integration was configured with 

--- a/cli/cmd/vuln_container_test.go
+++ b/cli/cmd/vuln_container_test.go
@@ -33,7 +33,7 @@ func TestUserFriendlyErrorFromOnDemandCtrVulnScanRepositoryNotFound(t *testing.T
 	if assert.NotNil(t, err) {
 		assert.Contains(t,
 			err.Error(),
-			"container image 'image:tag' not found in registry 'my-registry.example.com'")
+			"container image 'image@tag' not found in registry 'my-registry.example.com'")
 		assert.Contains(t,
 			err.Error(),
 			"To view all container registries configured in your account use the command:")

--- a/integration/container_vulnerability_test.go
+++ b/integration/container_vulnerability_test.go
@@ -193,7 +193,7 @@ func TestContainerVulnerabilityCommandScanErrorContainerImageNotFound(t *testing
 	assert.Empty(t, out.String(),
 		"STDOUT should be empty")
 	assert.Contains(t, err.String(),
-		fmt.Sprintf("container image 'foo:bar' not found in registry '%s'.", registry),
+		fmt.Sprintf("container image 'foo@bar' not found in registry '%s'.", registry),
 		"STDERR mismatch, please check")
 	assert.Contains(t, err.String(),
 		"To view all container registries configured in your account use the command",


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/lacework/go-sdk) and create your branch from `main`
  2. Run `make prepare` in the repository root
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`make test`)
  5. Format your code (`make fmt`)
  6. Make sure your code lints (`make lint`)
  7. If you are updating the Lacework CLI, make sure it compiles (`make build-cli-cross-platform`)
  8. Follow the commit message standard (`type(scope): subject`) documented in [DEVELOPER_GUIDELINES.md](https://github.com/lacework/go-sdk/blob/main/DEVELOPER_GUIDELINES.md#commit-message-standard)
  9. If you haven't already, configure signed commits by [telling git about your signing key](https://docs.github.com/en/github/authenticating-to-github/managing-commit-signature-verification/telling-git-about-your-signing-key) and [signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)

  Learn more about contributing: https://github.com/lacework/go-sdk/blob/main/CONTRIBUTING.md
-->

## Summary

An error like this is confusing:
```
ERROR container image '[image]:[tag]' not found in registry '[registry].
```
A better error message to reference an image and tag should be:
```
ERROR container image '[image]@[tag]' not found in registry '[registry].
```
## How did you test this change?

Ran a scan against an image that doesn't exist, also updated the tests.

## Issue

Via @alannix-lw 
