### PR TITLE
fix: handle unsupported integration types

### DIFF
--- a/cli/cmd/integration.go
+++ b/cli/cmd/integration.go
@@ -105,19 +105,22 @@ var (
 				return errors.New(msg)
 			}
 
-			integrationType, _ := api.FindIntegrationType(integration.Data[0].Type)
-			var resp api.V2CommonIntegration
-			err = cli.LwApi.V2.Schemas.GetService(integrationType.Schema()).Get(args[0], &resp)
-
-			if err != nil {
-				cli.Log.Debugw("unable to get integration service", "error", err.Error())
-			}
-
-			if resp.Data.State != nil {
-				integration.Data[0].State.Details = resp.Data.State.Details
-			}
 			if cli.JSONOutput() {
 				return cli.OutputJSON(integration.Data[0])
+			}
+
+			integrationType, supported := api.FindIntegrationType(integration.Data[0].Type)
+			if supported {
+				var resp api.V2CommonIntegration
+				err = cli.LwApi.V2.Schemas.GetService(integrationType.Schema()).Get(args[0], &resp)
+
+				if err != nil {
+					cli.Log.Debugw("unable to get integration service", "error", err.Error())
+				}
+
+				if resp.Data.State != nil {
+					integration.Data[0].State.Details = resp.Data.State.Details
+				}
 			}
 
 			cli.OutputHuman(
@@ -126,6 +129,7 @@ var (
 					integrationsToTable(integration.Data),
 				),
 			)
+
 			cli.OutputHuman("\n")
 			cli.OutputHuman(buildIntDetailsTable(integration.Data))
 			return nil


### PR DESCRIPTION
Signed-off-by: Darren Murray <darren.murray@lacework.net>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/lacework/go-sdk) and create your branch from `main`
  2. Run `make prepare` in the repository root
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`make test`)
  5. Format your code (`make fmt`)
  6. Make sure your code lints (`make lint`)
  7. If you are updating the Lacework CLI, make sure it compiles (`make build-cli-cross-platform`)
  8. Follow the commit message standard (`type(scope): subject`) documented in [DEVELOPER_GUIDELINES.md](https://github.com/lacework/go-sdk/blob/main/DEVELOPER_GUIDELINES.md#commit-message-standard)
  9. If you haven't already, configure signed commits by [telling git about your signing key](https://docs.github.com/en/github/authenticating-to-github/managing-commit-signature-verification/telling-git-about-your-signing-key) and [signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)

  Learn more about contributing: https://github.com/lacework/go-sdk/blob/main/CONTRIBUTING.md
-->

## Summary

CLI panics when showing an unsupported integration type

The fix is to fetch and output the raw response using api v1 when a type is unsupported.

## How did you test this change?

run `lacework int show <id>` with id being an unsupported type eg. SAML_CFG

## Issue

https://lacework.atlassian.net/browse/ALLY-775
