### PR TITLE
test: avoid running v1/v2 migration on every test

### DIFF
--- a/integration/framework_test.go
+++ b/integration/framework_test.go
@@ -162,6 +162,7 @@ func findLaceworkCLIBinary() string {
 
 func createTOMLConfigFromCIvars() string {
 	if os.Getenv("CI_ACCOUNT") == "" ||
+		os.Getenv("CI_V2_ACCOUNT") == "" ||
 		os.Getenv("CI_API_KEY") == "" ||
 		os.Getenv("CI_API_SECRET") == "" {
 		log.Fatal(missingCIEnvironmentVariables())
@@ -174,7 +175,8 @@ func createTOMLConfigFromCIvars() string {
 
 	configFile := filepath.Join(dir, ".lacework.toml")
 	c := []byte(`[default]
-account = '` + os.Getenv("CI_ACCOUNT") + `'
+account = '` + os.Getenv("CI_V2_ACCOUNT") + `'
+subaccount = '` + os.Getenv("CI_ACCOUNT") + `'
 api_key = '` + os.Getenv("CI_API_KEY") + `'
 api_secret = '` + os.Getenv("CI_API_SECRET") + `'
 version = 2
@@ -209,11 +211,13 @@ func createDummyTOMLConfig() string {
 account = 'dummy'
 api_key = 'DUMMY_1234567890abcdefg'
 api_secret = '_superdummysecret'
+version = 2
 
 [test]
 account = 'test.account'
 api_key = 'INTTEST_ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890AAABBBCCC00'
 api_secret = '_00000000000000000000000000000000'
+version = 2
 
 [v2]
 account = 'v2.config'
@@ -226,11 +230,13 @@ version = 2
 account = 'integration'
 api_key = 'INTEGRATION_3DF1234AABBCCDD5678XXYYZZ1234ABC8BEC6500DC70'
 api_secret = '_1234abdc00ff11vv22zz33xyz1234abc'
+version = 2
 
 [dev]
 account = 'dev.example'
 api_key = 'DEVDEV_ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890AAABBBCCC000'
 api_secret = '_11111111111111111111111111111111'
+version = 2
 `)
 	err = ioutil.WriteFile(configFile, c, 0644)
 	if err != nil {
@@ -260,11 +266,16 @@ func storeFileInCircleCI(f string) {
 
 func laceworkIntegrationTestClient() (*api.Client, error) {
 	fmt.Println("Setting up host tests")
-	account := os.Getenv("CI_ACCOUNT")
+	account := os.Getenv("CI_V2_ACCOUNT")
+	subaccount := os.Getenv("CI_ACCOUNT")
 	key := os.Getenv("CI_API_KEY")
 	secret := os.Getenv("CI_API_SECRET")
 
-	lacework, err := api.NewClient(account, api.WithApiV2(), api.WithApiKeys(key, secret))
+	lacework, err := api.NewClient(account,
+		api.WithApiKeys(key, secret),
+		api.WithSubaccount(subaccount),
+		api.WithApiV2(),
+	)
 	if err != nil {
 		fmt.Println(err)
 	}

--- a/integration/host_vulnerability_test.go
+++ b/integration/host_vulnerability_test.go
@@ -425,6 +425,9 @@ func setHostVulnTestMachineID(lw *api.Client) {
 	}
 
 	for _, cve := range cveResp.CVEs {
+		if cve.Summary.Severity.High == nil {
+			continue
+		}
 		if cve.Summary.Severity.High.Vulnerabilities > 0 {
 			cveId = cve.ID
 			break

--- a/integration/migration_test.go
+++ b/integration/migration_test.go
@@ -23,6 +23,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
+	"path/filepath"
 	"regexp"
 	"testing"
 
@@ -32,7 +33,20 @@ import (
 func TestV2MigrationWithConfigFile(t *testing.T) {
 	// create a temporal directory to use it as our home directory to test
 	// the version_cache mechanism
-	home := createTOMLConfigFromCIvars()
+	home, errDir := ioutil.TempDir("", "lacework-toml")
+	if errDir != nil {
+		panic(errDir)
+	}
+	configFile := filepath.Join(home, ".lacework.toml")
+	c := []byte(`[default]
+account = '` + os.Getenv("CI_ACCOUNT") + `'
+api_key = '` + os.Getenv("CI_API_KEY") + `'
+api_secret = '` + os.Getenv("CI_API_SECRET") + `'
+`)
+	errDir = ioutil.WriteFile(configFile, c, 0644)
+	if errDir != nil {
+		panic(errDir)
+	}
 	defer os.RemoveAll(home)
 
 	out, err, exitcode := LaceworkCLIWithHome(home, "agent", "token", "list")


### PR DESCRIPTION

## Summary

We were running migrations (on purpose) for every single integration
tests we run, this has caused our CI API key to get exhausted, but since
most customers are now running on v2 of the CLI configuration, we are
avoiding running so many migrations and instead, only test two times
such migration.

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>

## How did you test this change?

I ran integration tests locally with our Honeycomb Dev token and compared the number
migrations features ran with and without this change.

**NOTE: The orange line is the number of migrations ran.**

### Without this change
<img width="205" alt="Screen Shot 2022-01-10 at 10 25 50 AM" src="https://user-images.githubusercontent.com/5712253/148801200-b2970307-4d26-4717-a864-55f6a15300dd.png">

### With this change
<img width="345" alt="Screen Shot 2022-01-10 at 10 26 13 AM" src="https://user-images.githubusercontent.com/5712253/148801269-3caae83d-b8c8-4525-b864-5f2cd20ce1f7.png">

## Issue
https://lacework.atlassian.net/browse/ALLY-800
<!--
  Include the link to a Jira/Github issue
-->
