### PR TITLE
fix: expiration time

### DIFF
--- a/api/vulnerability_exceptions.go
+++ b/api/vulnerability_exceptions.go
@@ -208,7 +208,9 @@ func NewVulnerabilityException(name string, exception VulnerabilityExceptionConf
 			Cve:      exception.Cve,
 			Fixable:  exception.FixableEnabled(),
 		},
-		ExpiryTime: exception.ExpiryTime.UTC().Format(lwtime.RFC3339Milli),
+	}
+	if !exception.ExpiryTime.IsZero() {
+		vulnException.ExpiryTime = exception.ExpiryTime.UTC().Format(lwtime.RFC3339Milli)
 	}
 	vulnException.setResourceScope(exception.ResourceScope)
 	return vulnException


### PR DESCRIPTION
Fix setting `expiration_time` when creating a new vulnerability exception