### PR TITLE
feat(cli): make policyID optional for policy create

### DIFF
--- a/api/policy.go
+++ b/api/policy.go
@@ -35,8 +35,8 @@ type PolicyService struct {
 var ValidPolicySeverities = []string{"critical", "high", "medium", "low", "info"}
 
 type NewPolicy struct {
-	EvaluatorID   string `json:"evaluatorId,omitempty" yaml:"evaluatorId"`
-	PolicyID      string `json:"policyId" yaml:"policyId" `
+	EvaluatorID   string `json:"evaluatorId,omitempty" yaml:"evaluatorId,omitempty"`
+	PolicyID      string `json:"policyId,omitempty" yaml:"policyId,omitempty" `
 	PolicyType    string `json:"policyType" yaml:"policyType"`
 	QueryID       string `json:"queryId" yaml:"queryId"`
 	Title         string `json:"title" yaml:"title"`

--- a/cli/cmd/policy_create.go
+++ b/cli/cmd/policy_create.go
@@ -42,7 +42,6 @@ The following attributes are minimally required:
 
     ---
     evaluatorId: Cloudtrail
-    policyId: lacework-example-1
     policyType: Violation
     queryId: MyQuery
     title: My Policy

--- a/integration/policy_test.go
+++ b/integration/policy_test.go
@@ -65,7 +65,8 @@ policies:
 )
 
 var (
-	policyIDRE *regexp.Regexp = regexp.MustCompile(`([\w-]+-cli.*?test-1)`)
+	policyIDRE *regexp.Regexp = regexp.MustCompile(
+		`([\w-]+-(?:(?:cli.*?test-1)|(?:default-\d+)))`)
 )
 
 func getPolicyIdFromStdout(s string) (string, error) {

--- a/integration/policy_test.go
+++ b/integration/policy_test.go
@@ -46,7 +46,6 @@ alertProfile: LW_CloudTrail_Alerts
 `
 	newHostPolicyYAML string = `---
 evaluatorId:
-policyId: clihosttest-1
 policyType: Violation
 queryId: LW_CLI_Host_Files_IntegrationTest
 title: My Policy Title
@@ -55,7 +54,7 @@ description: My Policy Description
 remediation: Check yourself...
 severity: high
 alertEnabled: false
-alertProfile: LW_HE_Files.HE_File_NewViolation
+alertProfile: LW_HE_FILES_DEFAULT_PROFILE.HE_File_NewViolation
 `
 	// nested
 	updatePolicyYAML string = `---
@@ -247,7 +246,7 @@ func TestPolicyCreateStdin(t *testing.T) {
 	assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
 }
 
-func _TestPolicyCreateHost(t *testing.T) {
+func TestPolicyCreateHost(t *testing.T) {
 	// setup
 	LaceworkCLIWithTOMLConfig("query", "create", "-u", queryHostURL)
 	// teardown

--- a/integration/policy_test.go
+++ b/integration/policy_test.go
@@ -237,8 +237,7 @@ func TestPolicyCreateStdin(t *testing.T) {
 			fmt.Println(err)
 		}
 	}
-	assert.Contains(t, out.String(),
-		fmt.Sprintf("The policy %s was created.", policyID))
+	assert.Contains(t, out.String(), "was created.")
 	assert.Empty(t, stderr.String(), "STDERR should be empty")
 	assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
 

--- a/integration/policy_test.go
+++ b/integration/policy_test.go
@@ -130,7 +130,9 @@ func TestPolicyCreateFile(t *testing.T) {
 	assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
 
 	policyID, err := getPolicyIdFromStdout(out.String())
-	assert.Nil(t, err)
+	if err != nil {
+		assert.FailNow(t, err.Error())
+	}
 
 	// update-url (output human)
 	// ideally we wouldn't specify a policyID here since it's in policyURL
@@ -235,15 +237,16 @@ func TestPolicyCreateStdin(t *testing.T) {
 			fmt.Println(err)
 		}
 	}
-
-	policyID, err := getPolicyIdFromStdout(out.String())
-	assert.Nil(t, err)
-	defer LaceworkCLIWithTOMLConfig("policy", "delete", policyID)
-
 	assert.Contains(t, out.String(),
 		fmt.Sprintf("The policy %s was created.", policyID))
 	assert.Empty(t, stderr.String(), "STDERR should be empty")
 	assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
+
+	policyID, err := getPolicyIdFromStdout(out.String())
+	if err != nil {
+		assert.FailNow(t, err.Error())
+	}
+	defer LaceworkCLIWithTOMLConfig("policy", "delete", policyID)
 }
 
 func TestPolicyCreateHost(t *testing.T) {
@@ -261,14 +264,15 @@ func TestPolicyCreateHost(t *testing.T) {
 
 	// create (output json)
 	out, stderr, exitcode := LaceworkCLIWithTOMLConfig("policy", "create", "-f", file.Name(), "--json")
-
-	policyID, err := getPolicyIdFromStdout(out.String())
-	assert.Nil(t, err)
-	defer LaceworkCLIWithTOMLConfig("policy", "delete", policyID)
-
 	assert.Contains(t, out.String(), `"policyId"`)
 	assert.Empty(t, stderr.String(), "STDERR should be empty")
 	assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
+
+	policyID, err := getPolicyIdFromStdout(out.String())
+	if err != nil {
+		assert.FailNow(t, err.Error())
+	}
+	defer LaceworkCLIWithTOMLConfig("policy", "delete", policyID)
 }
 
 func TestPolicyListHelp(t *testing.T) {
@@ -384,8 +388,11 @@ func TestPolicyDelete(t *testing.T) {
 
 	// setup policy
 	out, _, _ := LaceworkCLIWithTOMLConfig("policy", "create", "-u", policyURL)
+
 	policyID, err := getPolicyIdFromStdout(out.String())
-	assert.Nil(t, err)
+	if err != nil {
+		assert.FailNow(t, err.Error())
+	}
 
 	// human delete tested by virtue of TestPolicyCreateFile
 


### PR DESCRIPTION
## Summary
We want to discourage users from defining their own policyId. Also, I learned that the policyId's format is invalid.

## How did you test this change?
Automated integration tests added

## Issue
https://lacework.atlassian.net/browse/ALLY-835