### PR TITLE
feat(cli): add support for policy create from library

### DIFF
--- a/cli/cmd/lql_create.go
+++ b/cli/cmd/lql_create.go
@@ -139,6 +139,7 @@ func createQuery(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return errors.Wrap(err, msg)
 		}
+		cli.Log.Debugw("creating query", "query", queryString)
 		// parse query
 		newQuery, err = api.ParseNewQuery(queryString)
 	}
@@ -147,7 +148,6 @@ func createQuery(cmd *cobra.Command, args []string) error {
 		return errors.Wrap(queryErrorCrumbs(queryString), msg)
 	}
 
-	cli.Log.Debugw("creating query", "query", queryString)
 	cli.StartProgress(" Creating query...")
 	create, err := cli.LwApi.V2.Query.Create(newQuery)
 	cli.StopProgress()

--- a/cli/cmd/policy.go
+++ b/cli/cmd/policy.go
@@ -35,14 +35,15 @@ import (
 
 var (
 	policyCmdState = struct {
-		AlertEnabled    bool
-		Enabled         bool
-		File            string
-		Repo            bool
-		Severity        string
-		URL             string
-		ListFromLibrary bool
-		ShowFromLibrary bool
+		AlertEnabled      bool
+		Enabled           bool
+		File              string
+		Repo              bool
+		Severity          string
+		URL               string
+		ListFromLibrary   bool
+		ShowFromLibrary   bool
+		CreateFromLibrary string
 	}{}
 
 	policyTableHeaders = []string{


### PR DESCRIPTION
## Summary
feat(cli): add support for policy create from library
```
lacework policy create --library lwcustom-26
```

## How did you test this change?
Integration testing to be added
Manual testing performed

## Issue
https://lacework.atlassian.net/browse/ALLY-849
