### PR TITLE
feat(cli): add --cascade flag to delete policy and query

### DIFF
--- a/cli/cmd/policy.go
+++ b/cli/cmd/policy.go
@@ -26,11 +26,12 @@ import (
 	"strings"
 
 	"github.com/AlecAivazis/survey/v2"
-	"github.com/lacework/go-sdk/api"
-	"github.com/lacework/go-sdk/internal/array"
 	"github.com/olekukonko/tablewriter"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+
+	"github.com/lacework/go-sdk/api"
+	"github.com/lacework/go-sdk/internal/array"
 )
 
 var (
@@ -41,6 +42,7 @@ var (
 		Repo         bool
 		Severity     string
 		URL          string
+		ForceDelete  bool
 	}{}
 
 	policyTableHeaders = []string{
@@ -101,18 +103,6 @@ To view the LQL query associated with the policy, use the query id shown.
 		Long:    `Show details about a single policy.`,
 		Args:    cobra.ExactArgs(1),
 		RunE:    showPolicy,
-	}
-
-	// policyDeleteCmd represents the policy delete command
-	policyDeleteCmd = &cobra.Command{
-		Use:   "delete <policy_id>",
-		Short: "Delete a policy",
-		Long: `Delete a policy by providing the policy id.
-
-Use the command 'lacework policy list' to list the registered policies in
-your Lacework account.`,
-		Args: cobra.ExactArgs(1),
-		RunE: deletePolicy,
 	}
 )
 
@@ -333,24 +323,6 @@ func showPolicy(_ *cobra.Command, args []string) error {
 		renderSimpleTable(policyTableHeaders, policyTable([]api.Policy{policyResponse.Data})))
 	cli.OutputHuman("\n")
 	cli.OutputHuman(buildPolicyDetailsTable(policyResponse.Data))
-	return nil
-}
-
-func deletePolicy(_ *cobra.Command, args []string) error {
-	cli.Log.Debugw("deleting policy", "policyID", args[0])
-	cli.StartProgress(" Deleting policy...")
-	deleted, err := cli.LwApi.V2.Policy.Delete(args[0])
-	cli.StopProgress()
-	if err != nil {
-		return errors.Wrap(err, "unable to delete policy")
-	}
-
-	if cli.JSONOutput() {
-		return cli.OutputJSON(deleted)
-	}
-
-	cli.OutputHuman(
-		fmt.Sprintf("The policy %s was deleted.\n", args[0]))
 	return nil
 }
 

--- a/cli/cmd/policy.go
+++ b/cli/cmd/policy.go
@@ -36,13 +36,13 @@ import (
 
 var (
 	policyCmdState = struct {
-		AlertEnabled bool
-		Enabled      bool
-		File         string
-		Repo         bool
-		Severity     string
-		URL          string
-		ForceDelete  bool
+		AlertEnabled  bool
+		Enabled       bool
+		File          string
+		Repo          bool
+		Severity      string
+		URL           string
+		CascadeDelete bool
 	}{}
 
 	policyTableHeaders = []string{

--- a/cli/cmd/policy_delete.go
+++ b/cli/cmd/policy_delete.go
@@ -45,8 +45,8 @@ func init() {
 	policyCmd.AddCommand(policyDeleteCmd)
 
 	policyDeleteCmd.Flags().BoolVar(
-		&policyCmdState.ForceDelete,
-		"force", false, "delete policy and its associated query",
+		&policyCmdState.CascadeDelete,
+		"cascade", false, "delete policy and its associated query",
 	)
 }
 
@@ -57,7 +57,7 @@ func deletePolicy(_ *cobra.Command, args []string) error {
 		queryID     string
 	)
 
-	if policyCmdState.ForceDelete {
+	if policyCmdState.CascadeDelete {
 		cli.Log.Debugw("retrieving policy", "policyID", args[0])
 		cli.StartProgress(" Retrieving policy...")
 		getResponse, err = cli.LwApi.V2.Policy.Get(args[0])
@@ -81,7 +81,7 @@ func deletePolicy(_ *cobra.Command, args []string) error {
 		fmt.Sprintf("The policy %s was deleted.\n", args[0]),
 	)
 	// delete query
-	if policyCmdState.ForceDelete {
+	if policyCmdState.CascadeDelete {
 		cli.Log.Debugw("deleting query", "id", queryID)
 		cli.StartProgress(" Deleting query...")
 		_, err := cli.LwApi.V2.Query.Delete(queryID)

--- a/cli/cmd/policy_delete.go
+++ b/cli/cmd/policy_delete.go
@@ -1,0 +1,96 @@
+//
+// Author:: Salim Afiune Maya (<afiune@lacework.net>)
+// Copyright:: Copyright 2020, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
+	"github.com/lacework/go-sdk/api"
+)
+
+var (
+	// policyDeleteCmd represents the policy delete command
+	policyDeleteCmd = &cobra.Command{
+		Use:   "delete <policy_id>",
+		Short: "Delete a policy",
+		Long: `Delete a policy by providing the policy id.
+
+Use the command 'lacework policy list' to list the registered policies in
+your Lacework account.`,
+		Args: cobra.ExactArgs(1),
+		RunE: deletePolicy,
+	}
+)
+
+func init() {
+	// add sub-commands to the policy command
+	policyCmd.AddCommand(policyDeleteCmd)
+
+	policyDeleteCmd.Flags().BoolVar(
+		&policyCmdState.ForceDelete,
+		"force", false, "delete policy and its associated query",
+	)
+}
+
+func deletePolicy(_ *cobra.Command, args []string) error {
+	var (
+		getResponse api.PolicyResponse
+		err         error
+		queryID     string
+	)
+
+	if policyCmdState.ForceDelete {
+		cli.Log.Debugw("retrieving policy", "policyID", args[0])
+		cli.StartProgress(" Retrieving policy...")
+		getResponse, err = cli.LwApi.V2.Policy.Get(args[0])
+		cli.StopProgress()
+
+		if err != nil {
+			return errors.Wrap(err, "unable to retrieve policy")
+		}
+		queryID = getResponse.Data.QueryID
+	}
+
+	cli.Log.Debugw("deleting policy", "policyID", args[0])
+	cli.StartProgress(" Deleting policy...")
+	_, err = cli.LwApi.V2.Policy.Delete(args[0])
+	cli.StopProgress()
+
+	if err != nil {
+		return errors.Wrap(err, "unable to delete policy")
+	}
+	cli.OutputHuman(
+		fmt.Sprintf("The policy %s was deleted.\n", args[0]),
+	)
+	// delete query
+	if policyCmdState.ForceDelete {
+		cli.Log.Debugw("deleting query", "id", queryID)
+		cli.StartProgress(" Deleting query...")
+		_, err := cli.LwApi.V2.Query.Delete(queryID)
+		cli.StopProgress()
+
+		if err != nil {
+			return errors.Wrap(err, "unable to delete query")
+		}
+		cli.OutputHuman("The query %s was deleted.\n", queryID)
+	}
+	return nil
+}

--- a/integration/policy_test.go
+++ b/integration/policy_test.go
@@ -114,8 +114,6 @@ func TestPolicyCreateEditor(t *testing.T) {
 func TestPolicyCreateFile(t *testing.T) {
 	// setup
 	LaceworkCLIWithTOMLConfig("query", "create", "-u", queryURL)
-	// teardown
-	defer LaceworkCLIWithTOMLConfig("query", "delete", queryID)
 
 	// get temp file
 	file, err := createTemporaryFile("TestPolicyCreateFile", newPolicyYAML)
@@ -158,10 +156,12 @@ func TestPolicyCreateFile(t *testing.T) {
 	assert.Empty(t, stderr.String(), "STDERR should be empty")
 	assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
 
-	// delete
-	out, stderr, exitcode = LaceworkCLIWithTOMLConfig("policy", "delete", policyID)
+	// force delete
+	out, stderr, exitcode = LaceworkCLIWithTOMLConfig("policy", "delete", policyID, "--force")
 	assert.Contains(t, out.String(),
 		fmt.Sprintf("The policy %s was deleted.", policyID))
+	assert.Contains(t, out.String(),
+		fmt.Sprintf("The query %s was deleted.", queryID))
 	assert.Empty(t, stderr.String(), "STDERR should be empty")
 	assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
 }

--- a/integration/policy_test.go
+++ b/integration/policy_test.go
@@ -156,8 +156,8 @@ func TestPolicyCreateFile(t *testing.T) {
 	assert.Empty(t, stderr.String(), "STDERR should be empty")
 	assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
 
-	// force delete
-	out, stderr, exitcode = LaceworkCLIWithTOMLConfig("policy", "delete", policyID, "--force")
+	// cascade delete
+	out, stderr, exitcode = LaceworkCLIWithTOMLConfig("policy", "delete", policyID, "--cascade")
 	assert.Contains(t, out.String(),
 		fmt.Sprintf("The policy %s was deleted.", policyID))
 	assert.Contains(t, out.String(),


### PR DESCRIPTION
## Summary
As a Lacework user I want to be able to delete a policy and it’s associated query in “one go”.  If we implement a “force” flag for deletion we can attempt to delete the query associated with the policy.

```
lacework policy delete lwcustom-28 --cascade
```

## How did you test this change?
Integration testing added

## Issue
https://lacework.atlassian.net/browse/ALLY-852