### PR TITLE
feat(cli): display compliance status of cloud accounts/projects/subscriptions

### DIFF
--- a/cli/cmd/cli_state.go
+++ b/cli/cmd/cli_state.go
@@ -270,6 +270,12 @@ func (c *cliState) NonInteractive() {
 	c.nonInteractive = true
 }
 
+// Interactive turns on interactive mode, that is, progress bars and spinners
+func (c *cliState) Interactive() {
+	c.Log.Info("turning on interactive mode")
+	c.nonInteractive = false
+}
+
 // NoCache turns off the Lacework CLI caching mechanism, so nothing will be cached
 func (c *cliState) NoCache() {
 	c.Log.Info("turning off caching mechanism")

--- a/cli/cmd/compliance_aws.go
+++ b/cli/cmd/compliance_aws.go
@@ -34,12 +34,12 @@ var (
 	// complianceAwsListAccountsCmd represents the list-accounts inside the aws command
 	complianceAwsListAccountsCmd = &cobra.Command{
 		Use:     "list-accounts",
-		Aliases: []string{"list"},
+		Aliases: []string{"list", "ls"},
 		Short:   "List all AWS accounts configured",
 		Long:    `List all AWS accounts configured in your account.`,
 		Args:    cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
-			cli.StartProgress(" Fetching compliance information...")
+			cli.StartProgress("Fetching list of configured AWS accounts...")
 			awsIntegrations, err := cli.LwApi.Integrations.ListAwsCfg()
 			cli.StopProgress()
 			if err != nil {
@@ -105,7 +105,7 @@ To run an ad-hoc compliance assessment of an AWS account:
 					cli.Account, time.Now().Format("20060102150405"),
 				)
 
-				cli.StartProgress(" Downloading compliance report...")
+				cli.StartProgress("Downloading compliance report...")
 				err := cli.LwApi.Compliance.DownloadAwsReportPDF(pdfName, config)
 				cli.StopProgress()
 				if err != nil {
@@ -137,7 +137,7 @@ To run an ad-hoc compliance assessment of an AWS account:
 			)
 			expired := cli.ReadCachedAsset(cacheKey, &report)
 			if expired {
-				cli.StartProgress(" Getting compliance report...")
+				cli.StartProgress("Getting compliance report...")
 				response, err := cli.LwApi.Compliance.GetAwsReport(config)
 				cli.StopProgress()
 				if err != nil {

--- a/cli/cmd/compliance_aws_test.go
+++ b/cli/cmd/compliance_aws_test.go
@@ -1,0 +1,129 @@
+//
+// Author:: Salim Afiune Maya (<afiune@lacework.net>)
+// Copyright:: Copyright 2022, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cmd
+
+import (
+	"encoding/json"
+	"log"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/lacework/go-sdk/api"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCliListAwsAccountsWithNoAccounts(t *testing.T) {
+	cliOutput := captureOutput(func() {
+		assert.Nil(t, cliListAwsAccounts(new(api.AwsIntegrationsResponse)))
+	})
+	assert.Contains(t, cliOutput, "There are no AWS accounts configured in your account.")
+
+	t.Run("test JSON output", func(t *testing.T) {
+		cli.EnableJSONOutput()
+		defer cli.EnableHumanOutput()
+		cliJSONOutput := captureOutput(func() {
+			assert.Nil(t, cliListAwsAccounts(new(api.AwsIntegrationsResponse)))
+		})
+		expectedJSON := `{
+  "aws_accounts": []
+}
+`
+		assert.Equal(t, expectedJSON, cliJSONOutput)
+	})
+}
+
+func TestCliListAwsAccountsWithAccountsEnabled(t *testing.T) {
+	cliOutput := captureOutput(func() {
+		assert.Nil(t, cliListAwsAccounts(mockAwsIntegrationsResponse(1, 1)))
+	})
+	// NOTE (@afiune): We purposly leave trailing spaces in this table, we need them!
+	expectedTable := `
+  AWS ACCOUNT    STATUS   
+---------------+----------
+  123456789012   Enabled  
+  098765432109   Enabled  
+`
+	assert.Equal(t, strings.TrimPrefix(expectedTable, "\n"), cliOutput)
+}
+
+func TestCliListAwsAccountsWithAccountsDisabled(t *testing.T) {
+	cliOutput := captureOutput(func() {
+		assert.Nil(t, cliListAwsAccounts(mockAwsIntegrationsResponse(0, 0)))
+	})
+	// NOTE (@afiune): We purposly leave trailing spaces in this table, we need them!
+	expectedTable := `
+  AWS ACCOUNT     STATUS   
+---------------+-----------
+  123456789012   Disabled  
+  098765432109   Disabled  
+`
+	assert.Equal(t, strings.TrimPrefix(expectedTable, "\n"), cliOutput)
+}
+
+func mockAwsIntegrationsResponse(acc1Enabled, acc2Enabled int) *api.AwsIntegrationsResponse {
+	response := &api.AwsIntegrationsResponse{}
+	err := json.Unmarshal([]byte(`{
+  "data": [
+    {
+      "CREATED_OR_UPDATED_BY": "salim.afiunemaya@lacework.net",
+      "CREATED_OR_UPDATED_TIME": "2021-10-25T15:18:47.945Z",
+      "DATA": {
+        "AWS_ACCOUNT_ID": "123456789012"
+      },
+      "ENABLED": `+strconv.Itoa(acc1Enabled)+`,
+      "INTG_GUID": "MOCK_1233",
+      "IS_ORG": 0,
+      "NAME": "TF config",
+      "STATE": {
+        "lastSuccessfulTime": "2022-Jan-31 16:08:54 UTC",
+        "lastUpdatedTime": "2022-Jan-31 16:08:54 UTC",
+        "ok": true
+      },
+      "TYPE": "AWS_CFG",
+      "TYPE_NAME": "AWS Config"
+    },
+    {
+      "CREATED_OR_UPDATED_BY": "vatasha.white@lacework.net",
+      "CREATED_OR_UPDATED_TIME": "2022-01-13T20:32:59.954Z",
+      "DATA": {
+        "AWS_ACCOUNT_ID": "098765432109"
+      },
+      "ENABLED": `+strconv.Itoa(acc2Enabled)+`,
+      "INTG_GUID": "MOCK_1234",
+      "IS_ORG": 0,
+      "NAME": "TF config",
+      "STATE": {
+        "lastSuccessfulTime": "2022-Jan-31 16:47:04 UTC",
+        "lastUpdatedTime": "2022-Jan-31 16:47:04 UTC",
+        "ok": true
+      },
+      "TYPE": "AWS_CFG",
+      "TYPE_NAME": "AWS Config"
+    }
+  ],
+  "message": "SUCCESS",
+  "ok": true
+}
+`), response)
+	if err != nil {
+		log.Fatal(err)
+	}
+	return response
+}

--- a/cli/cmd/compliance_azure.go
+++ b/cli/cmd/compliance_azure.go
@@ -118,6 +118,10 @@ Use the following command to list all Azure Tenants configured in your account:
 		Long: `Get the latest Azure compliance assessment report, these reports run on a regular schedule,
 typically once a day. The available report formats are human-readable (default), json and pdf.
 
+To list all Azure tenants and subscriptions configured in your account:
+
+    lacework compliance azure list
+
 To run an ad-hoc compliance assessment use the command:
 
     lacework compliance azure run-assessment <tenant_id>
@@ -244,8 +248,12 @@ To run an ad-hoc compliance assessment use the command:
 		Use:     "run-assessment <tenant_id>",
 		Aliases: []string{"run"},
 		Short:   "Run a new Azure compliance assessment",
-		Long:    `Run a compliance assessment of the provided Azure tenant.`,
-		Args:    cobra.ExactArgs(1),
+		Long: `Run a compliance assessment of the provided Azure tenant.
+
+To list all Azure tenants and subscriptions configured in your account:
+
+    lacework compliance azure list`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
 			response, err := cli.LwApi.Compliance.RunAzureReport(args[0])
 			if err != nil {
@@ -425,7 +433,7 @@ func getAzureSubscriptions(tenantID, status string) []azureSubscription {
 	subsResponse, err := cli.LwApi.Compliance.ListAzureSubscriptions(tenantID)
 	cli.StopProgress()
 	if err != nil {
-		cli.Log.Warn("unable to list azure subscriptions", "tenant_id", tenantID, "error", err.Error())
+		cli.Log.Warnw("unable to list azure subscriptions", "tenant_id", tenantID, "error", err.Error())
 		return subs
 	}
 	for _, subsRes := range subsResponse.Data {

--- a/cli/cmd/compliance_azure.go
+++ b/cli/cmd/compliance_azure.go
@@ -78,13 +78,13 @@ Use the following command to list all Azure Tenants configured in your account:
 
 	// complianceAzureListTenantsCmd represents the list-tenants sub-command inside the azure command
 	complianceAzureListTenantsCmd = &cobra.Command{
-		Use:     "list-tenants",
-		Aliases: []string{"list", "ls"},
+		Use:     "list",
+		Aliases: []string{"list-tenants", "ls"},
 		Short:   "List Azure tenants and subscriptions",
 		Long:    `List all Azure tenants and subscriptions configured in your account.`,
 		Args:    cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
-			cli.StartProgress(" Fetching compliance information...")
+			cli.StartProgress("Fetching list of configured Azure tenants...")
 			azureIntegrations, err := cli.LwApi.Integrations.ListAzureCfg()
 			cli.StopProgress()
 			if err != nil {
@@ -145,7 +145,7 @@ To run an ad-hoc compliance assessment use the command:
 					cli.Account, time.Now().Format("20060102150405"),
 				)
 
-				cli.StartProgress(" Downloading compliance report...")
+				cli.StartProgress("Downloading compliance report...")
 				err := cli.LwApi.Compliance.DownloadAzureReportPDF(pdfName, config)
 				cli.StopProgress()
 				if err != nil {
@@ -178,7 +178,7 @@ To run an ad-hoc compliance assessment use the command:
 			)
 			expired := cli.ReadCachedAsset(cacheKey, &report)
 			if expired {
-				cli.StartProgress(" Getting compliance report...")
+				cli.StartProgress("Getting compliance report...")
 				response, err := cli.LwApi.Compliance.GetAzureReport(config)
 				cli.StopProgress()
 				if err != nil {
@@ -421,7 +421,7 @@ func extractAzureSubscriptions(response *api.AzureIntegrationsResponse) []azureS
 
 func getAzureSubscriptions(tenantID, status string) []azureSubscription {
 	var subs []azureSubscription
-	cli.StartProgress(fmt.Sprintf("Fetching compliance information about %s tenant...", tenantID))
+	cli.StartProgress(fmt.Sprintf("Fetching subscriptions from tenant (%s)...", tenantID))
 	subsResponse, err := cli.LwApi.Compliance.ListAzureSubscriptions(tenantID)
 	cli.StopProgress()
 	if err != nil {

--- a/cli/cmd/compliance_azure_test.go
+++ b/cli/cmd/compliance_azure_test.go
@@ -84,3 +84,84 @@ func TestSplitAzureSubscriptionsApiResponse(t *testing.T) {
 		})
 	}
 }
+
+func TestCliListAzureTenantsAndSubscriptionsWithoutData(t *testing.T) {
+	cliOutput := captureOutput(func() {
+		assert.Nil(t, cliListTenantsAndSubscriptions(new(api.AzureIntegrationsResponse)))
+	})
+	assert.Contains(t, cliOutput, "There are no Azure Tenants configured in your account.")
+
+	t.Run("test JSON output", func(t *testing.T) {
+		cli.EnableJSONOutput()
+		defer cli.EnableHumanOutput()
+		cliJSONOutput := captureOutput(func() {
+			assert.Nil(t, cliListTenantsAndSubscriptions(new(api.AzureIntegrationsResponse)))
+		})
+		expectedJSON := `{
+  "azure_subscriptions": []
+}
+`
+		assert.Equal(t, expectedJSON, cliJSONOutput)
+	})
+}
+
+/*
+func TestCliListAzureTenantsAndSubscriptionsWithDataEnabled(t *testing.T) {
+	cliOutput := captureOutput(func() {
+		assert.Nil(t, cliListTenantsAndSubscriptions(mockAzureIntegrationsResponse(1)))
+	})
+	// NOTE (@afiune): We purposly leave trailing spaces in this table, we need them!
+	expectedTable := `
+              AZURE TENANT                        AZURE SUBSCRIPTION            STATUS
+---------------------------------------+--------------------------------------+----------
+  abc123xy-1234-abcd-a1b2-09876zxy1234   ABC123XX-1234-ABCD-1234-ABCD1234XYZZ   Enabled
+`
+	assert.Equal(t, strings.TrimPrefix(expectedTable, "\n"), cliOutput)
+}
+
+func TestCliListAzureTenantsAndSubscriptionsWithDataDisabled(t *testing.T) {
+	cliOutput := captureOutput(func() {
+		assert.Nil(t, cliListTenantsAndSubscriptions(mockAzureIntegrationsResponse(0)))
+	})
+	// NOTE (@afiune): We purposly leave trailing spaces in this table, we need them!
+	expectedTable := `
+              AZURE TENANT                        AZURE SUBSCRIPTION            STATUS
+---------------------------------------+--------------------------------------+----------
+  abc123xy-1234-abcd-a1b2-09876zxy1234   ABC123XX-1234-ABCD-1234-ABCD1234XYZZ   Disabled
+`
+	assert.Equal(t, strings.TrimPrefix(expectedTable, "\n"), cliOutput)
+}
+
+func mockAzureIntegrationsResponse(enabled int) *api.AzureIntegrationsResponse {
+	response := &api.AzureIntegrationsResponse{}
+	err := json.Unmarshal([]byte(`{
+  "data": [
+	    {
+      "CREATED_OR_UPDATED_BY": "salim.afiune-maya@lacework.net",
+      "CREATED_OR_UPDATED_TIME": "2021-08-02T17:53:24.116Z",
+      "DATA": {
+        "TENANT_ID": "abc123xy-1234-abcd-a1b2-09876zxy1234"
+      },
+      "ENABLED": `+strconv.Itoa(enabled)+`,
+      "INTG_GUID": "MOCK_1234",
+      "IS_ORG": 0,
+      "NAME": "TF Config",
+      "STATE": {
+        "lastSuccessfulTime": "2021-Jun-04 09:40:39 UTC",
+        "lastUpdatedTime": "2022-Jan-31 11:49:09 UTC",
+        "ok": false
+      },
+      "TYPE": "AZURE_CFG",
+      "TYPE_NAME": "Azure Compliance"
+    }
+  ],
+  "message": "SUCCESS",
+  "ok": true
+}
+`), response)
+	if err != nil {
+		log.Fatal(err)
+	}
+	return response
+}
+*/

--- a/cli/cmd/compliance_azure_test.go
+++ b/cli/cmd/compliance_azure_test.go
@@ -19,12 +19,18 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
+	"log"
+	"net/http"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
 	"github.com/lacework/go-sdk/api"
+	"github.com/lacework/go-sdk/internal/lacework"
 )
 
 func TestSplitAzureSubscriptionsApiResponse(t *testing.T) {
@@ -105,34 +111,60 @@ func TestCliListAzureTenantsAndSubscriptionsWithoutData(t *testing.T) {
 	})
 }
 
-/*
-func TestCliListAzureTenantsAndSubscriptionsWithDataEnabled(t *testing.T) {
-	cliOutput := captureOutput(func() {
-		assert.Nil(t, cliListTenantsAndSubscriptions(mockAzureIntegrationsResponse(1)))
-	})
-	// NOTE (@afiune): We purposly leave trailing spaces in this table, we need them!
-	expectedTable := `
-              AZURE TENANT                        AZURE SUBSCRIPTION            STATUS
+func TestCliListAzureTenantsAndSubscriptionsWithData(t *testing.T) {
+	var (
+		fakeServer = lacework.MockServer()
+		tenantID   = "abc123xy-1234-abcd-a1b2-09876zxy1234"
+	)
+	fakeServer.MockToken("TOKEN")
+	fakeServer.MockAPI(
+		"external/compliance/azure/ListSubscriptionsForTenant",
+		func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprintf(w, mockAzureSubsResponse(tenantID))
+		})
+	defer fakeServer.Close()
+
+	c, err := api.NewClient("test",
+		api.WithToken("TOKEN"),
+		api.WithURL(fakeServer.URL()),
+	)
+	assert.Nil(t, err)
+
+	cli.LwApi = c
+	cli.NonInteractive()
+	defer func() {
+		cli.LwApi = nil
+		cli.Interactive()
+	}()
+
+	t.Run("enabled", func(t *testing.T) {
+		cliOutput := captureOutput(func() {
+			assert.Nil(t, cliListTenantsAndSubscriptions(mockAzureIntegrationsResponse(tenantID, 1)))
+		})
+		// NOTE (@afiune): We purposly leave trailing spaces in this table, we need them!
+		expectedTable := `
+              AZURE TENANT                        AZURE SUBSCRIPTION            STATUS   
 ---------------------------------------+--------------------------------------+----------
-  abc123xy-1234-abcd-a1b2-09876zxy1234   ABC123XX-1234-ABCD-1234-ABCD1234XYZZ   Enabled
+  abc123xy-1234-abcd-a1b2-09876zxy1234   ABC123XX-1234-ABCD-1234-ABCD1234XYZZ   Enabled  
 `
-	assert.Equal(t, strings.TrimPrefix(expectedTable, "\n"), cliOutput)
+		assert.Equal(t, strings.TrimPrefix(expectedTable, "\n"), cliOutput)
+	})
+
+	t.Run("disabled", func(t *testing.T) {
+		cliOutput := captureOutput(func() {
+			assert.Nil(t, cliListTenantsAndSubscriptions(mockAzureIntegrationsResponse(tenantID, 0)))
+		})
+		// NOTE (@afiune): We purposly leave trailing spaces in this table, we need them!
+		expectedTable := `
+              AZURE TENANT                        AZURE SUBSCRIPTION             STATUS   
+---------------------------------------+--------------------------------------+-----------
+  abc123xy-1234-abcd-a1b2-09876zxy1234   ABC123XX-1234-ABCD-1234-ABCD1234XYZZ   Disabled  
+`
+		assert.Equal(t, strings.TrimPrefix(expectedTable, "\n"), cliOutput)
+	})
 }
 
-func TestCliListAzureTenantsAndSubscriptionsWithDataDisabled(t *testing.T) {
-	cliOutput := captureOutput(func() {
-		assert.Nil(t, cliListTenantsAndSubscriptions(mockAzureIntegrationsResponse(0)))
-	})
-	// NOTE (@afiune): We purposly leave trailing spaces in this table, we need them!
-	expectedTable := `
-              AZURE TENANT                        AZURE SUBSCRIPTION            STATUS
----------------------------------------+--------------------------------------+----------
-  abc123xy-1234-abcd-a1b2-09876zxy1234   ABC123XX-1234-ABCD-1234-ABCD1234XYZZ   Disabled
-`
-	assert.Equal(t, strings.TrimPrefix(expectedTable, "\n"), cliOutput)
-}
-
-func mockAzureIntegrationsResponse(enabled int) *api.AzureIntegrationsResponse {
+func mockAzureIntegrationsResponse(tenantID string, enabled int) *api.AzureIntegrationsResponse {
 	response := &api.AzureIntegrationsResponse{}
 	err := json.Unmarshal([]byte(`{
   "data": [
@@ -140,7 +172,7 @@ func mockAzureIntegrationsResponse(enabled int) *api.AzureIntegrationsResponse {
       "CREATED_OR_UPDATED_BY": "salim.afiune-maya@lacework.net",
       "CREATED_OR_UPDATED_TIME": "2021-08-02T17:53:24.116Z",
       "DATA": {
-        "TENANT_ID": "abc123xy-1234-abcd-a1b2-09876zxy1234"
+        "TENANT_ID": "`+tenantID+`"
       },
       "ENABLED": `+strconv.Itoa(enabled)+`,
       "INTG_GUID": "MOCK_1234",
@@ -164,4 +196,18 @@ func mockAzureIntegrationsResponse(enabled int) *api.AzureIntegrationsResponse {
 	}
 	return response
 }
-*/
+
+func mockAzureSubsResponse(tenantID string) string {
+	return `{
+  "data": [
+    {
+      "subscriptions": [
+        "ABC123XX-1234-ABCD-1234-ABCD1234XYZZ (Default-account)"
+      ],
+      "tenant": "` + tenantID + ` (Default Directory)"
+    }
+  ],
+  "message": "SUCCESS",
+  "ok": true
+}`
+}

--- a/cli/cmd/compliance_gcp.go
+++ b/cli/cmd/compliance_gcp.go
@@ -35,11 +35,12 @@ import (
 var (
 	// complianceGcpListCmd represents the list sub-command inside the gcp command
 	complianceGcpListCmd = &cobra.Command{
-		Use:   "list",
-		Short: "List gcp projects and organizations",
-		Long:  `List all GCP projects and organization IDs.`,
+		Use:     "list",
+		Aliases: []string{"ls"},
+		Short:   "List gcp projects and organizations",
+		Long:    `List all GCP projects and organization IDs.`,
 		RunE: func(_ *cobra.Command, args []string) error {
-			cli.StartProgress(" Fetching compliance information...")
+			cli.StartProgress("Fetching list of configured GCP projects...")
 			response, err := cli.LwApi.Integrations.ListGcpCfg()
 			cli.StopProgress()
 			if err != nil {

--- a/cli/cmd/compliance_gcp.go
+++ b/cli/cmd/compliance_gcp.go
@@ -120,6 +120,10 @@ Then, select one GUID from an integration and visualize its details using the co
 		Long: `Get the latest compliance assessment report, these reports run on a regular schedule,
 typically once a day. The available report formats are human-readable (default), json and pdf.
 
+To list all GCP projects and organizations configured in your account:
+
+    lacework compliance gcp list
+
 To run an ad-hoc compliance assessment use the command:
 
     lacework compliance gcp run-assessment <project_id>
@@ -253,8 +257,12 @@ To run an ad-hoc compliance assessment use the command:
 		Use:     "run-assessment <org_or_project_id>",
 		Aliases: []string{"run"},
 		Short:   "Run a new GCP compliance assessment",
-		Long:    `Run a compliance assessment for the provided GCP organization or project.`,
-		Args:    cobra.ExactArgs(1),
+		Long: `Run a compliance assessment for the provided GCP organization or project.
+
+To list all GCP projects and organizations configured in your account:
+
+    lacework compliance gcp list`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
 			response, err := cli.LwApi.Compliance.RunGcpReport(args[0])
 			if err != nil {

--- a/cli/cmd/compliance_gcp_test.go
+++ b/cli/cmd/compliance_gcp_test.go
@@ -19,7 +19,11 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
+	"log"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -127,4 +131,126 @@ func TestDuplicateGcpAccountCheck(t *testing.T) {
 
 	assert.True(t, duplicate)
 	assert.False(t, different)
+}
+
+func TestCliListGcpListProjectsAndOrgsWithoutData(t *testing.T) {
+	cliOutput := captureOutput(func() {
+		assert.Nil(t, cliListGcpProjectsAndOrgs(new(api.GcpIntegrationsResponse)))
+	})
+	assert.Contains(t, cliOutput, "There are no GCP integrations configured in your account.")
+
+	t.Run("test JSON output", func(t *testing.T) {
+		cli.EnableJSONOutput()
+		defer cli.EnableHumanOutput()
+		cliJSONOutput := captureOutput(func() {
+			assert.Nil(t, cliListGcpProjectsAndOrgs(new(api.GcpIntegrationsResponse)))
+		})
+		expectedJSON := `{
+  "gcp_projects": []
+}
+`
+		assert.Equal(t, expectedJSON, cliJSONOutput)
+	})
+}
+
+func TestCliListGcpListProjectsAndOrgsWithDataEnabled(t *testing.T) {
+	cliOutput := captureOutput(func() {
+		assert.Nil(t, cliListGcpProjectsAndOrgs(mockGcpIntegrationsResponse(1, 1, 1)))
+	})
+	// NOTE (@afiune): We purposly leave trailing spaces in this table, we need them!
+	expectedTable := `
+  ORGANIZATION ID           PROJECT ID            STATUS   
+------------------+-----------------------------+----------
+  n/a               gcr-jenkins-sandbox-274317    Enabled  
+  n/a               techally-hipstershop-275821   Enabled  
+  n/a               techally-test                 Enabled  
+`
+	assert.Equal(t, strings.TrimPrefix(expectedTable, "\n"), cliOutput)
+}
+
+func TestCliListGcpListProjectsAndOrgsWithDataDisabled(t *testing.T) {
+	cliOutput := captureOutput(func() {
+		assert.Nil(t, cliListGcpProjectsAndOrgs(mockGcpIntegrationsResponse(0, 0, 1)))
+	})
+	// NOTE (@afiune): We purposly leave trailing spaces in this table, we need them!
+	expectedTable := `
+  ORGANIZATION ID           PROJECT ID             STATUS   
+------------------+-----------------------------+-----------
+  n/a               gcr-jenkins-sandbox-274317    Disabled  
+  n/a               techally-hipstershop-275821   Disabled  
+  n/a               techally-test                 Enabled   
+`
+	assert.Equal(t, strings.TrimPrefix(expectedTable, "\n"), cliOutput)
+}
+
+func mockGcpIntegrationsResponse(proj1Enabled, proj2Enabled, proj3Enabled int) *api.GcpIntegrationsResponse {
+	response := &api.GcpIntegrationsResponse{}
+	err := json.Unmarshal([]byte(`{
+  "data": [
+    {
+      "CREATED_OR_UPDATED_BY": "salim.afiunemaya@lacework.net",
+      "CREATED_OR_UPDATED_TIME": "2021-06-01T18:03:19.031Z",
+      "DATA": {
+        "ID": "techally-hipstershop-275821",
+        "ID_TYPE": "PROJECT"
+      },
+      "ENABLED": `+strconv.Itoa(proj1Enabled)+`,
+      "INTG_GUID": "MOCK_1232",
+      "IS_ORG": 0,
+      "NAME": "TF Hipstershop",
+      "STATE": {
+        "lastSuccessfulTime": "2022-Jan-31 14:24:56 UTC",
+        "lastUpdatedTime": "2022-Jan-31 14:24:56 UTC",
+        "ok": true
+      },
+      "TYPE": "GCP_CFG",
+      "TYPE_NAME": "GCP Compliance"
+    },
+    {
+      "CREATED_OR_UPDATED_BY": "salim.afiunemaya@lacework.net",
+      "CREATED_OR_UPDATED_TIME": "2020-09-17T17:13:48.393Z",
+      "DATA": {
+        "ID": "gcr-jenkins-sandbox-274317",
+        "ID_TYPE": "PROJECT"
+      },
+      "ENABLED": `+strconv.Itoa(proj2Enabled)+`,
+      "INTG_GUID": "MOCK_1233",
+      "IS_ORG": 0,
+      "NAME": "TF Sandbox",
+      "STATE": {
+        "lastSuccessfulTime": "2022-Jan-31 14:24:56 UTC",
+        "lastUpdatedTime": "2022-Jan-31 14:24:56 UTC",
+        "ok": true
+      },
+      "TYPE": "GCP_CFG",
+      "TYPE_NAME": "GCP Compliance"
+    },
+    {
+      "CREATED_OR_UPDATED_BY": "darren.murray@lacework.net",
+      "CREATED_OR_UPDATED_TIME": "2021-11-12T11:08:34.923Z",
+      "DATA": {
+        "ID": "techally-test",
+        "ID_TYPE": "PROJECT"
+      },
+      "ENABLED": `+strconv.Itoa(proj3Enabled)+`,
+      "INTG_GUID": "MOCK_1234",
+      "IS_ORG": 0,
+      "NAME": "techally-test-cfg",
+      "STATE": {
+        "lastSuccessfulTime": "2022-Jan-31 14:24:56 UTC",
+        "lastUpdatedTime": "2022-Jan-31 14:24:56 UTC",
+        "ok": true
+      },
+      "TYPE": "GCP_CFG",
+      "TYPE_NAME": "GCP Compliance"
+    }
+  ],
+  "message": "SUCCESS",
+  "ok": true
+}
+`), response)
+	if err != nil {
+		log.Fatal(err)
+	}
+	return response
 }

--- a/integration/compliance_aws_test.go
+++ b/integration/compliance_aws_test.go
@@ -25,6 +25,17 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestComplianceAwsList(t *testing.T) {
+	out, err, exitcode := LaceworkCLIWithTOMLConfig(
+		"compliance", "aws", "list",
+	)
+	assert.Empty(t, err.String(), "STDERR should be empty")
+
+	assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
+	assert.Contains(t, out.String(), "AWS ACCOUNT", "STDOUT changed, please check")
+	assert.Contains(t, out.String(), "STATUS", "STDOUT changed, please check")
+}
+
 func TestComplianceAwsGetReportFilter(t *testing.T) {
 	account := os.Getenv("LW_INT_TEST_AWS_ACC")
 	detailsOutput := "recommendations showing"

--- a/integration/compliance_gcp_test.go
+++ b/integration/compliance_gcp_test.go
@@ -49,4 +49,5 @@ func TestComplianceGoogleList(t *testing.T) {
 	assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
 	assert.Contains(t, out.String(), "PROJECT ID", "STDOUT changed, please check")
 	assert.Contains(t, out.String(), "ORGANIZATION ID", "STDOUT changed, please check")
+	assert.Contains(t, out.String(), "STATUS", "STDOUT changed, please check")
 }


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/lacework/go-sdk) and create your branch from `main`
  2. Run `make prepare` in the repository root
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`make test`)
  5. Format your code (`make fmt`)
  6. Make sure your code lints (`make lint`)
  7. If you are updating the Lacework CLI, make sure it compiles (`make build-cli-cross-platform`)
  8. Follow the commit message standard (`type(scope): subject`) documented in [DEVELOPER_GUIDELINES.md](https://github.com/lacework/go-sdk/blob/main/DEVELOPER_GUIDELINES.md#commit-message-standard)
  9. If you haven't already, configure signed commits by [telling git about your signing key](https://docs.github.com/en/github/authenticating-to-github/managing-commit-signature-verification/telling-git-about-your-signing-key) and [signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)

  Learn more about contributing: https://github.com/lacework/go-sdk/blob/main/CONTRIBUTING.md
-->

## Summary

When working with compliance reports, it is useful to include the status in the output of the **compliance list commands** for each cloud to enable the user to better understand what they are able to target from the Lacework CLI.

This PR is adding a new column `STATUS` to the following commands:

* `laceowrk compliance aws list`
* `lacework compliance gcp list`
* `lacework compliance azure list`

## How did you test this change?

Added unit tests and updated integration tests.

Ran `lacework compliance aws list` on test account:
```
  AWS ACCOUNT    STATUS
---------------+----------
  123456789012   Enabled
  123456789013   Enabled
```
Ran `lacework compliance gcp list` on test account:
```
  ORGANIZATION ID           PROJECT ID            STATUS
------------------+-----------------------------+----------
  n/a               gcr-jenkins-sandbox-274317    Enabled
```
Ran `lacework compliance az list` on test account:
```
              AZURE TENANT                        AZURE SUBSCRIPTION            STATUS
---------------------------------------+--------------------------------------+----------
  123abc-1234-abcd-11222-abcd1234xyzz1   123abc-1234-abcd-11222-abcd1234xyzz1   Enabled
```
## Issue
https://lacework.atlassian.net/browse/ALLY-712