### PR TITLE
refactor(cli): abstract shared funcs to internal package

### DIFF
--- a/cli/cmd/compliance_aws_test.go
+++ b/cli/cmd/compliance_aws_test.go
@@ -25,12 +25,14 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/lacework/go-sdk/api"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/lacework/go-sdk/api"
+	"github.com/lacework/go-sdk/internal/capturer"
 )
 
 func TestCliListAwsAccountsWithNoAccounts(t *testing.T) {
-	cliOutput := captureOutput(func() {
+	cliOutput := capturer.CaptureOutput(func() {
 		assert.Nil(t, cliListAwsAccounts(new(api.AwsIntegrationsResponse)))
 	})
 	assert.Contains(t, cliOutput, "There are no AWS accounts configured in your account.")
@@ -38,7 +40,7 @@ func TestCliListAwsAccountsWithNoAccounts(t *testing.T) {
 	t.Run("test JSON output", func(t *testing.T) {
 		cli.EnableJSONOutput()
 		defer cli.EnableHumanOutput()
-		cliJSONOutput := captureOutput(func() {
+		cliJSONOutput := capturer.CaptureOutput(func() {
 			assert.Nil(t, cliListAwsAccounts(new(api.AwsIntegrationsResponse)))
 		})
 		expectedJSON := `{
@@ -50,7 +52,7 @@ func TestCliListAwsAccountsWithNoAccounts(t *testing.T) {
 }
 
 func TestCliListAwsAccountsWithAccountsEnabled(t *testing.T) {
-	cliOutput := captureOutput(func() {
+	cliOutput := capturer.CaptureOutput(func() {
 		assert.Nil(t, cliListAwsAccounts(mockAwsIntegrationsResponse(1, 1)))
 	})
 	// NOTE (@afiune): We purposly leave trailing spaces in this table, we need them!
@@ -64,7 +66,7 @@ func TestCliListAwsAccountsWithAccountsEnabled(t *testing.T) {
 }
 
 func TestCliListAwsAccountsWithAccountsDisabled(t *testing.T) {
-	cliOutput := captureOutput(func() {
+	cliOutput := capturer.CaptureOutput(func() {
 		assert.Nil(t, cliListAwsAccounts(mockAwsIntegrationsResponse(0, 0)))
 	})
 	// NOTE (@afiune): We purposly leave trailing spaces in this table, we need them!

--- a/cli/cmd/compliance_azure_test.go
+++ b/cli/cmd/compliance_azure_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/lacework/go-sdk/api"
+	"github.com/lacework/go-sdk/internal/capturer"
 	"github.com/lacework/go-sdk/internal/lacework"
 )
 
@@ -92,7 +93,7 @@ func TestSplitAzureSubscriptionsApiResponse(t *testing.T) {
 }
 
 func TestCliListAzureTenantsAndSubscriptionsWithoutData(t *testing.T) {
-	cliOutput := captureOutput(func() {
+	cliOutput := capturer.CaptureOutput(func() {
 		assert.Nil(t, cliListTenantsAndSubscriptions(new(api.AzureIntegrationsResponse)))
 	})
 	assert.Contains(t, cliOutput, "There are no Azure Tenants configured in your account.")
@@ -100,7 +101,7 @@ func TestCliListAzureTenantsAndSubscriptionsWithoutData(t *testing.T) {
 	t.Run("test JSON output", func(t *testing.T) {
 		cli.EnableJSONOutput()
 		defer cli.EnableHumanOutput()
-		cliJSONOutput := captureOutput(func() {
+		cliJSONOutput := capturer.CaptureOutput(func() {
 			assert.Nil(t, cliListTenantsAndSubscriptions(new(api.AzureIntegrationsResponse)))
 		})
 		expectedJSON := `{
@@ -138,7 +139,7 @@ func TestCliListAzureTenantsAndSubscriptionsWithData(t *testing.T) {
 	}()
 
 	t.Run("enabled", func(t *testing.T) {
-		cliOutput := captureOutput(func() {
+		cliOutput := capturer.CaptureOutput(func() {
 			assert.Nil(t, cliListTenantsAndSubscriptions(mockAzureIntegrationsResponse(tenantID, 1)))
 		})
 		// NOTE (@afiune): We purposly leave trailing spaces in this table, we need them!
@@ -151,7 +152,7 @@ func TestCliListAzureTenantsAndSubscriptionsWithData(t *testing.T) {
 	})
 
 	t.Run("disabled", func(t *testing.T) {
-		cliOutput := captureOutput(func() {
+		cliOutput := capturer.CaptureOutput(func() {
 			assert.Nil(t, cliListTenantsAndSubscriptions(mockAzureIntegrationsResponse(tenantID, 0)))
 		})
 		// NOTE (@afiune): We purposly leave trailing spaces in this table, we need them!

--- a/cli/cmd/compliance_gcp_test.go
+++ b/cli/cmd/compliance_gcp_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/lacework/go-sdk/api"
+	"github.com/lacework/go-sdk/internal/capturer"
 )
 
 func TestSplitIDAndAlias(t *testing.T) {
@@ -134,7 +135,7 @@ func TestDuplicateGcpAccountCheck(t *testing.T) {
 }
 
 func TestCliListGcpListProjectsAndOrgsWithoutData(t *testing.T) {
-	cliOutput := captureOutput(func() {
+	cliOutput := capturer.CaptureOutput(func() {
 		assert.Nil(t, cliListGcpProjectsAndOrgs(new(api.GcpIntegrationsResponse)))
 	})
 	assert.Contains(t, cliOutput, "There are no GCP integrations configured in your account.")
@@ -142,7 +143,7 @@ func TestCliListGcpListProjectsAndOrgsWithoutData(t *testing.T) {
 	t.Run("test JSON output", func(t *testing.T) {
 		cli.EnableJSONOutput()
 		defer cli.EnableHumanOutput()
-		cliJSONOutput := captureOutput(func() {
+		cliJSONOutput := capturer.CaptureOutput(func() {
 			assert.Nil(t, cliListGcpProjectsAndOrgs(new(api.GcpIntegrationsResponse)))
 		})
 		expectedJSON := `{
@@ -154,7 +155,7 @@ func TestCliListGcpListProjectsAndOrgsWithoutData(t *testing.T) {
 }
 
 func TestCliListGcpListProjectsAndOrgsWithDataEnabled(t *testing.T) {
-	cliOutput := captureOutput(func() {
+	cliOutput := capturer.CaptureOutput(func() {
 		assert.Nil(t, cliListGcpProjectsAndOrgs(mockGcpIntegrationsResponse(1, 1, 1)))
 	})
 	// NOTE (@afiune): We purposly leave trailing spaces in this table, we need them!
@@ -169,7 +170,7 @@ func TestCliListGcpListProjectsAndOrgsWithDataEnabled(t *testing.T) {
 }
 
 func TestCliListGcpListProjectsAndOrgsWithDataDisabled(t *testing.T) {
-	cliOutput := captureOutput(func() {
+	cliOutput := capturer.CaptureOutput(func() {
 		assert.Nil(t, cliListGcpProjectsAndOrgs(mockGcpIntegrationsResponse(0, 0, 1)))
 	})
 	// NOTE (@afiune): We purposly leave trailing spaces in this table, we need them!


### PR DESCRIPTION
## Summary
Fix newly introduced tests to reference internal capturer package


## How did you test this change?
Unit testing

## Issue
https://lacework.atlassian.net/browse/ALLY-844
