### PR TITLE
ci: fix v1/v2 environment variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,10 +27,6 @@ GOFLAGS=-mod=vendor
 CGO_ENABLED?=0
 export GOFLAGS GO_LDFLAGS CGO_ENABLED
 
-# CI variables
-CI_V2_ACCOUNT?=customerdemo
-export CI_V2_ACCOUNT
-
 .PHONY: help
 help:
 	@echo "-------------------------------------------------------------------"

--- a/cli/README.md
+++ b/cli/README.md
@@ -192,7 +192,7 @@ locally you need to setup the following environment variables and use the direct
 `make integration`, an example of the command you can use is:
 ```
 CI_ACCOUNT="<YOUR_ACCOUNT>" \
-  CI_V2_ACCOUNT="<YOUR_APIV2_PRIMARY_ACCOUNT>" \
+  CI_SUBACCOUNT="<YOUR_SUBACCOUNT_IF_ANY>" \
   CI_API_KEY="<YOUR_API_KEY>" \
   CI_API_SECRET="<YOUR_API_SECRET>" \
   LW_INT_TEST_AWS_ACC="<YOUR_AWS_ACCOUNT>" make integration

--- a/integration/account_test.go
+++ b/integration/account_test.go
@@ -49,7 +49,7 @@ func TestAccountCommandList(t *testing.T) {
 		"STDOUT table headers changed, please check")
 	assert.Contains(t, out.String(), os.Getenv("CI_ACCOUNT"),
 		"STDOUT unable to find account, please check")
-	assert.Contains(t, out.String(), os.Getenv("CI_V2_ACCOUNT"),
+	assert.Contains(t, out.String(), os.Getenv("CI_SUBACCOUNT"),
 		"STDOUT unable to find account, please check")
 	assert.Contains(t, out.String(),
 		"Use '--subaccount <name>' to switch any command to a different account.",

--- a/integration/alert_rules_test.go
+++ b/integration/alert_rules_test.go
@@ -90,8 +90,8 @@ func TestAlertRulesJsonOutput(t *testing.T) {
 
 func createAlertRuleWithSlackAlertChannel() (alertRule api.AlertRuleResponse, err error) {
 	var slackChannel string
-	lacework, err := api.NewClient(os.Getenv("CI_V2_ACCOUNT"),
-		api.WithSubaccount(os.Getenv("CI_ACCOUNT")),
+	lacework, err := api.NewClient(os.Getenv("CI_ACCOUNT"),
+		api.WithSubaccount(os.Getenv("CI_SUBACCOUNT")),
 		api.WithApiKeys(os.Getenv("CI_API_KEY"), os.Getenv("CI_API_SECRET")),
 		api.WithApiV2(),
 	)

--- a/integration/configure_unix_test.go
+++ b/integration/configure_unix_test.go
@@ -90,7 +90,7 @@ func TestConfigureCommandForOrgAdmins(t *testing.T) {
 	_, laceworkTOML := runConfigureTest(t,
 		func(c *expect.Console) {
 			c.ExpectString("Account:")
-			c.SendLine(os.Getenv("CI_V2_ACCOUNT"))
+			c.SendLine(os.Getenv("CI_ACCOUNT"))
 			c.ExpectString("Access Key ID:")
 			c.SendLine(os.Getenv("CI_API_KEY"))
 			c.ExpectString("Secret Access Key:")
@@ -99,15 +99,15 @@ func TestConfigureCommandForOrgAdmins(t *testing.T) {
 			c.ExpectString("(Org Admins) Managing a sub-account?")
 			// @afiune this is needed just because we have two accounts that start exactly the same
 			// and so, we need to key in ARROW DOWN to chose the right one.
-			c.SendLine(fmt.Sprintf("%s\x1B[B", os.Getenv("CI_ACCOUNT")))
+			c.SendLine(fmt.Sprintf("%s\x1B[B", os.Getenv("CI_SUBACCOUNT")))
 			c.ExpectString("You are all set!")
 		},
 		"configure",
 	)
 
 	assert.Equal(t, `[default]
-  account = "`+os.Getenv("CI_V2_ACCOUNT")+`"
-  subaccount = "`+os.Getenv("CI_ACCOUNT")+`"
+  account = "`+os.Getenv("CI_ACCOUNT")+`"
+  subaccount = "`+os.Getenv("CI_SUBACCOUNT")+`"
   api_key = "`+os.Getenv("CI_API_KEY")+`"
   api_secret = "`+os.Getenv("CI_API_SECRET")+`"
   version = 2

--- a/integration/framework_test.go
+++ b/integration/framework_test.go
@@ -1,3 +1,4 @@
+//
 // Author:: Salim Afiune Maya (<afiune@lacework.net>)
 // Copyright:: Copyright 2020, Lacework Inc.
 // License:: Apache License, Version 2.0
@@ -162,7 +163,6 @@ func findLaceworkCLIBinary() string {
 
 func createTOMLConfigFromCIvars() string {
 	if os.Getenv("CI_ACCOUNT") == "" ||
-		os.Getenv("CI_V2_ACCOUNT") == "" ||
 		os.Getenv("CI_API_KEY") == "" ||
 		os.Getenv("CI_API_SECRET") == "" {
 		log.Fatal(missingCIEnvironmentVariables())
@@ -175,8 +175,8 @@ func createTOMLConfigFromCIvars() string {
 
 	configFile := filepath.Join(dir, ".lacework.toml")
 	c := []byte(`[default]
-account = '` + os.Getenv("CI_V2_ACCOUNT") + `'
-subaccount = '` + os.Getenv("CI_ACCOUNT") + `'
+account = '` + os.Getenv("CI_ACCOUNT") + `'
+subaccount = '` + os.Getenv("CI_SUBACCOUNT") + `'
 api_key = '` + os.Getenv("CI_API_KEY") + `'
 api_secret = '` + os.Getenv("CI_API_SECRET") + `'
 version = 2
@@ -266,8 +266,8 @@ func storeFileInCircleCI(f string) {
 
 func laceworkIntegrationTestClient() (*api.Client, error) {
 	fmt.Println("Setting up host tests")
-	account := os.Getenv("CI_V2_ACCOUNT")
-	subaccount := os.Getenv("CI_ACCOUNT")
+	account := os.Getenv("CI_ACCOUNT")
+	subaccount := os.Getenv("CI_SUBACCOUNT")
 	key := os.Getenv("CI_API_KEY")
 	secret := os.Getenv("CI_API_SECRET")
 

--- a/integration/global_flags_test.go
+++ b/integration/global_flags_test.go
@@ -27,6 +27,10 @@ import (
 )
 
 func _TestGlobalFlagApiToken(t *testing.T) {
+	if os.Getenv("CI_STANDALONE_ACCOUNT") != "" {
+		t.Skip("skipping organizational account test")
+	}
+
 	// generating a token with toml config
 	token, err, exitcode := LaceworkCLIWithTOMLConfig("access-token")
 	assert.Contains(t, token.String(), "_", // @afiune tokens start with "_secret123"
@@ -39,7 +43,7 @@ func _TestGlobalFlagApiToken(t *testing.T) {
 
 		// running the Lacework CLI without toml config but with the token flag
 		out, err, exitcode := LaceworkCLI("int", "list",
-			"--api_token", strings.Trim(token.String(), "\n"), "--account", os.Getenv("CI_ACCOUNT"))
+			"--api_token", strings.Trim(token.String(), "\n"), "--account", os.Getenv("CI_SUBACCOUNT"))
 		assert.Contains(t, out.String(), "INTEGRATION GUID")
 		assert.Empty(t, err.String(), "STDERR should be empty")
 		assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")

--- a/integration/migration_test.go
+++ b/integration/migration_test.go
@@ -31,6 +31,9 @@ import (
 )
 
 func TestV2MigrationWithConfigFile(t *testing.T) {
+	if os.Getenv("CI_STANDALONE_ACCOUNT") != "" || os.Getenv("CI_V1_ACCOUNT") == "" {
+		t.Skip("skipping organizational account test")
+	}
 	// create a temporal directory to use it as our home directory to test
 	// the version_cache mechanism
 	home, errDir := ioutil.TempDir("", "lacework-toml")
@@ -39,7 +42,7 @@ func TestV2MigrationWithConfigFile(t *testing.T) {
 	}
 	configFile := filepath.Join(home, ".lacework.toml")
 	c := []byte(`[default]
-account = '` + os.Getenv("CI_ACCOUNT") + `'
+account = '` + os.Getenv("CI_V1_ACCOUNT") + `'
 api_key = '` + os.Getenv("CI_API_KEY") + `'
 api_secret = '` + os.Getenv("CI_API_SECRET") + `'
 `)
@@ -82,7 +85,8 @@ api_secret = '` + os.Getenv("CI_API_SECRET") + `'
 			if assert.Nil(t, err) {
 				laceworkTOMLString := string(laceworkTOML)
 				assert.Contains(t, laceworkTOMLString, "account", "there is a problem with the v2 migrated config")
-				assert.Contains(t, laceworkTOMLString, "subaccount", "there is a problem with the v2 migrated config") // only for our tech-ally account
+				// only for our tech-ally account
+				assert.Contains(t, laceworkTOMLString, "subaccount", "there is a problem with the v2 migrated config")
 				assert.Contains(t, laceworkTOMLString, "api_key", "there is a problem with the v2 migrated config")
 				assert.Contains(t, laceworkTOMLString, "api_secret", "there is a problem with the v2 migrated config")
 				assert.Contains(t, laceworkTOMLString, "version = 2", "there is a problem with the v2 migrated config")
@@ -92,6 +96,9 @@ api_secret = '` + os.Getenv("CI_API_SECRET") + `'
 }
 
 func TestV2MigrationWithFlagsOrEnvVariables(t *testing.T) {
+	if os.Getenv("CI_STANDALONE_ACCOUNT") != "" || os.Getenv("CI_V1_ACCOUNT") == "" {
+		t.Skip("skipping organizational account test")
+	}
 	home, errDir := ioutil.TempDir("", "lacework-cli")
 	if errDir != nil {
 		panic(errDir)
@@ -99,7 +106,7 @@ func TestV2MigrationWithFlagsOrEnvVariables(t *testing.T) {
 	defer os.RemoveAll(home)
 
 	out, err, exitcode := LaceworkCLIWithHome(home, "agent", "token", "list",
-		"-a", os.Getenv("CI_ACCOUNT"), "-k", os.Getenv("CI_API_KEY"), "-s", os.Getenv("CI_API_SECRET"),
+		"-a", os.Getenv("CI_V1_ACCOUNT"), "-k", os.Getenv("CI_API_KEY"), "-s", os.Getenv("CI_API_SECRET"),
 	)
 	assert.Equal(t, 0, exitcode,
 		"EXITCODE is not the expected one")


### PR DESCRIPTION

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/lacework/go-sdk) and create your branch from `main`
  2. Run `make prepare` in the repository root
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`make test`)
  5. Format your code (`make fmt`)
  6. Make sure your code lints (`make lint`)
  7. If you are updating the Lacework CLI, make sure it compiles (`make build-cli-cross-platform`)
  8. Follow the commit message standard (`type(scope): subject`) documented in [DEVELOPER_GUIDELINES.md](https://github.com/lacework/go-sdk/blob/main/DEVELOPER_GUIDELINES.md#commit-message-standard)
  9. If you haven't already, configure signed commits by [telling git about your signing key](https://docs.github.com/en/github/authenticating-to-github/managing-commit-signature-verification/telling-git-about-your-signing-key) and [signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)

  Learn more about contributing: https://github.com/lacework/go-sdk/blob/main/CONTRIBUTING.md
-->

## Summary

This PR is fixing our CI environment variables to use the proper name for v1 account and v2
account/subaccount.

## How did you test this change?

Updated the pipeline to use these new environment variable names.

## Issue

N/A