### PR TITLE
refactor(cli): Refactor generate & generate_aws

### DIFF
--- a/cli/cmd/generate.go
+++ b/cli/cmd/generate.go
@@ -527,7 +527,6 @@ func validateAwsSubAccounts(subaccounts []string) error {
 // create survey.Validator for string with regex
 func validateStringWithRegex(val interface{}, regex string, errorString string) error {
 	switch value := val.(type) {
-
 	case string:
 		// if value doesn't match regex, return invalid arn
 		ok, err := regexp.MatchString(regex, value)
@@ -538,11 +537,9 @@ func validateStringWithRegex(val interface{}, regex string, errorString string) 
 		if !ok {
 			return errors.New(errorString)
 		}
-
 	default:
 		// if the value passed is not a string
 		return errors.New("value must be a string")
-
 	}
 
 	return nil
@@ -551,17 +548,14 @@ func validateStringWithRegex(val interface{}, regex string, errorString string) 
 // Used to test if path supplied for output exists
 func validPathExists(val interface{}) error {
 	switch value := val.(type) {
-
 	case string:
 		// Test if supplied path exists
 		if err := validateOutputLocation(value); err != nil {
 			return err
 		}
-
 	default:
 		// if the value passed is not a string
 		return errors.New("value must be a string")
-
 	}
 
 	return nil

--- a/cli/cmd/generate_aws_test.go
+++ b/cli/cmd/generate_aws_test.go
@@ -123,7 +123,7 @@ func TestGenerationCache(t *testing.T) {
 
 		args := aws.GenerateAwsTfConfigurationArgs{AwsProfile: "default"} // Profile is set automatically by the CLI defaults
 		writeAwsGenerationArgsCache(&args)
-		assert.NoFileExists(t, filepath.FromSlash(fmt.Sprintf("%s/cache/standalone/%s", dir, CachedAssetIacParams)))
+		assert.NoFileExists(t, filepath.FromSlash(fmt.Sprintf("%s/cache/standalone/%s", dir, CachedAwsAssetIacParams)))
 	})
 	t.Run("iac params should be cached when not empty", func(t *testing.T) {
 		dir, err := ioutil.TempDir("", "lacework-cli-cache")
@@ -135,6 +135,6 @@ func TestGenerationCache(t *testing.T) {
 
 		args := aws.GenerateAwsTfConfigurationArgs{AwsProfile: "default", AwsRegion: "us-east-2"} // Profile is set automatically by the CLI defaults
 		writeAwsGenerationArgsCache(&args)
-		assert.FileExists(t, filepath.FromSlash(fmt.Sprintf("%s/cache/standalone/%s", dir, CachedAssetIacParams)))
+		assert.FileExists(t, filepath.FromSlash(fmt.Sprintf("%s/cache/standalone/%s", dir, CachedAwsAssetIacParams)))
 	})
 }

--- a/integration/aws_generation_test.go
+++ b/integration/aws_generation_test.go
@@ -35,7 +35,7 @@ func TestGenerationErrorOnNoSelection(t *testing.T) {
 	// Run CLI
 	runGenerateTest(t,
 		func(c *expect.Console) {
-			expectString(c, cmd.QuestionEnableConfig, &runError)
+			expectString(c, cmd.QuestionAwsEnableConfig, &runError)
 			c.SendLine("n")
 			expectString(c, cmd.QuestionEnableCloudtrail, &runError)
 			c.SendLine("n")
@@ -61,13 +61,13 @@ func TestGenerationSimple(t *testing.T) {
 	// Run CLI
 	tfResult := runGenerateTest(t,
 		func(c *expect.Console) {
-			expectString(c, cmd.QuestionEnableConfig, &runError)
+			expectString(c, cmd.QuestionAwsEnableConfig, &runError)
 			c.SendLine("y")
 			expectString(c, cmd.QuestionEnableCloudtrail, &runError)
 			c.SendLine("y")
 			expectString(c, cmd.QuestionAwsRegion, &runError)
 			c.SendLine(region)
-			expectString(c, cmd.QuestionConfigAdvanced, &runError)
+			expectString(c, cmd.QuestionAwsConfigAdvanced, &runError)
 			c.SendLine("n")
 			expectString(c, cmd.QuestionRunTfPlan, &runError)
 			c.SendLine("n")
@@ -105,20 +105,20 @@ func TestGenerationCustomizedOutputLocation(t *testing.T) {
 	// Run CLI
 	runGenerateTest(t,
 		func(c *expect.Console) {
-			expectString(c, cmd.QuestionEnableConfig, &runError)
+			expectString(c, cmd.QuestionAwsEnableConfig, &runError)
 			c.SendLine("y")
 			expectString(c, cmd.QuestionEnableCloudtrail, &runError)
 			c.SendLine("y")
 			expectString(c, cmd.QuestionAwsRegion, &runError)
 			c.SendLine(region)
-			expectString(c, cmd.QuestionConfigAdvanced, &runError)
+			expectString(c, cmd.QuestionAwsConfigAdvanced, &runError)
 			c.SendLine("y")
-			expectString(c, cmd.AdvancedOptDone, &runError)
+			expectString(c, cmd.AwsAdvancedOptDone, &runError)
 			c.Send("\x1B[B")
 			c.SendLine("\x1B[B")
-			expectString(c, cmd.QuestionCustomizeOutputLocation, &runError)
+			expectString(c, cmd.QuestionAwsCustomizeOutputLocation, &runError)
 			c.SendLine(dir)
-			expectString(c, cmd.QuestionAnotherAdvancedOpt, &runError)
+			expectString(c, cmd.QuestionAwsAnotherAdvancedOpt, &runError)
 			c.SendLine("n")
 			expectString(c, cmd.QuestionRunTfPlan, &runError)
 			c.SendLine("n")
@@ -152,13 +152,13 @@ func TestGenerationConfigOnly(t *testing.T) {
 	// Run CLI
 	tfResult := runGenerateTest(t,
 		func(c *expect.Console) {
-			expectString(c, cmd.QuestionEnableConfig, &runError)
+			expectString(c, cmd.QuestionAwsEnableConfig, &runError)
 			c.SendLine("y")
 			expectString(c, cmd.QuestionEnableCloudtrail, &runError)
 			c.SendLine("n")
 			expectString(c, cmd.QuestionAwsRegion, &runError)
 			c.SendLine(region)
-			expectString(c, cmd.QuestionConfigAdvanced, &runError)
+			expectString(c, cmd.QuestionAwsConfigAdvanced, &runError)
 			c.SendLine("n")
 			expectString(c, cmd.QuestionRunTfPlan, &runError)
 			c.SendLine("n")
@@ -189,15 +189,15 @@ func TestGenerationAdvancedOptsDone(t *testing.T) {
 	// Run CLI
 	tfResult := runGenerateTest(t,
 		func(c *expect.Console) {
-			expectString(c, cmd.QuestionEnableConfig, &runError)
+			expectString(c, cmd.QuestionAwsEnableConfig, &runError)
 			c.SendLine("y")
 			expectString(c, cmd.QuestionEnableCloudtrail, &runError)
 			c.SendLine("y")
 			expectString(c, cmd.QuestionAwsRegion, &runError)
 			c.SendLine(region)
-			expectString(c, cmd.QuestionConfigAdvanced, &runError)
+			expectString(c, cmd.QuestionAwsConfigAdvanced, &runError)
 			c.SendLine("y")
-			expectString(c, cmd.AdvancedOptDone, &runError)
+			expectString(c, cmd.AwsAdvancedOptDone, &runError)
 			c.Send("\x1B[B")
 			c.Send("\x1B[B")
 			c.SendLine("\x1B[B")
@@ -230,15 +230,15 @@ func TestGenerationAdvancedOptsConsolidatedAndForceDestroy(t *testing.T) {
 	// Run CLI
 	tfResult := runGenerateTest(t,
 		func(c *expect.Console) {
-			expectString(c, cmd.QuestionEnableConfig, &runError)
+			expectString(c, cmd.QuestionAwsEnableConfig, &runError)
 			c.SendLine("y")
 			expectString(c, cmd.QuestionEnableCloudtrail, &runError)
 			c.SendLine("y")
 			expectString(c, cmd.QuestionAwsRegion, &runError)
 			c.SendLine(region)
-			expectString(c, cmd.QuestionConfigAdvanced, &runError)
+			expectString(c, cmd.QuestionAwsConfigAdvanced, &runError)
 			c.SendLine("y")
-			expectString(c, cmd.AdvancedOptDone, &runError)
+			expectString(c, cmd.AwsAdvancedOptDone, &runError)
 			c.SendLine("")
 			expectString(c, cmd.QuestionConsolidatedCloudtrail, &runError)
 			c.SendLine("y")
@@ -246,7 +246,7 @@ func TestGenerationAdvancedOptsConsolidatedAndForceDestroy(t *testing.T) {
 			c.SendLine("n")
 			expectString(c, cmd.QuestionForceDestroyS3Bucket, &runError)
 			c.SendLine("y")
-			expectString(c, cmd.QuestionAnotherAdvancedOpt, &runError)
+			expectString(c, cmd.QuestionAwsAnotherAdvancedOpt, &runError)
 			c.SendLine("n")
 			expectString(c, cmd.QuestionRunTfPlan, &runError)
 			c.SendLine("n")
@@ -278,15 +278,15 @@ func TestGenerationAdvancedOptsUseExistingCloudtrail(t *testing.T) {
 	// Run CLI
 	tfResult := runGenerateTest(t,
 		func(c *expect.Console) {
-			expectString(c, cmd.QuestionEnableConfig, &runError)
+			expectString(c, cmd.QuestionAwsEnableConfig, &runError)
 			c.SendLine("y")
 			expectString(c, cmd.QuestionEnableCloudtrail, &runError)
 			c.SendLine("y")
 			expectString(c, cmd.QuestionAwsRegion, &runError)
 			c.SendLine(region)
-			expectString(c, cmd.QuestionConfigAdvanced, &runError)
+			expectString(c, cmd.QuestionAwsConfigAdvanced, &runError)
 			c.SendLine("y")
-			expectString(c, cmd.AdvancedOptDone, &runError)
+			expectString(c, cmd.AwsAdvancedOptDone, &runError)
 			c.SendLine("")
 			expectString(c, cmd.QuestionConsolidatedCloudtrail, &runError)
 			c.SendLine("n")
@@ -296,7 +296,7 @@ func TestGenerationAdvancedOptsUseExistingCloudtrail(t *testing.T) {
 			c.SendLine("notright") // test our validator is working
 			expectString(c, "invalid arn supplied", &runError)
 			c.SendLine("arn:aws:s3:::bucket_name")
-			expectString(c, cmd.QuestionAnotherAdvancedOpt, &runError)
+			expectString(c, cmd.QuestionAwsAnotherAdvancedOpt, &runError)
 			c.SendLine("n")
 			expectString(c, cmd.QuestionRunTfPlan, &runError)
 			c.SendLine("n")
@@ -328,15 +328,15 @@ func TestGenerationAdvancedOptsConsolidatedWithSubAccounts(t *testing.T) {
 	// Run CLI
 	tfResult := runGenerateTest(t,
 		func(c *expect.Console) {
-			expectString(c, cmd.QuestionEnableConfig, &runError)
+			expectString(c, cmd.QuestionAwsEnableConfig, &runError)
 			c.SendLine("y")
 			expectString(c, cmd.QuestionEnableCloudtrail, &runError)
 			c.SendLine("y")
 			expectString(c, cmd.QuestionAwsRegion, &runError)
 			c.SendLine(region)
-			expectString(c, cmd.QuestionConfigAdvanced, &runError)
+			expectString(c, cmd.QuestionAwsConfigAdvanced, &runError)
 			c.SendLine("y")
-			expectString(c, cmd.AdvancedOptDone, &runError)
+			expectString(c, cmd.AwsAdvancedOptDone, &runError)
 			c.SendLine("")
 			expectString(c, cmd.QuestionConsolidatedCloudtrail, &runError)
 			c.SendLine("y")
@@ -344,9 +344,9 @@ func TestGenerationAdvancedOptsConsolidatedWithSubAccounts(t *testing.T) {
 			c.SendLine("n")
 			expectString(c, cmd.QuestionForceDestroyS3Bucket, &runError)
 			c.SendLine("n")
-			expectString(c, cmd.QuestionAnotherAdvancedOpt, &runError)
+			expectString(c, cmd.QuestionAwsAnotherAdvancedOpt, &runError)
 			c.SendLine("y")
-			expectString(c, cmd.AdvancedOptDone, &runError)
+			expectString(c, cmd.AwsAdvancedOptDone, &runError)
 			c.Send("\x1B[B") // Down arrow twice and enter on the submenu to add subaccounts
 			c.SendLine("\x1B[B")
 			expectString(c, cmd.QuestionPrimaryAwsAccountProfile, &runError)
@@ -363,7 +363,7 @@ func TestGenerationAdvancedOptsConsolidatedWithSubAccounts(t *testing.T) {
 			c.SendLine("us-east-2")
 			expectString(c, cmd.QuestionSubAccountAddMore, &runError)
 			c.SendLine("n")
-			expectString(c, cmd.QuestionAnotherAdvancedOpt, &runError)
+			expectString(c, cmd.QuestionAwsAnotherAdvancedOpt, &runError)
 			c.SendLine("n")
 			expectString(c, cmd.QuestionRunTfPlan, &runError)
 			c.SendLine("n")
@@ -398,15 +398,15 @@ func TestGenerationAdvancedOptsConsolidatedWithSubAccountsPassedByFlag(t *testin
 	// Run CLI
 	tfResult := runGenerateTest(t,
 		func(c *expect.Console) {
-			expectString(c, cmd.QuestionEnableConfig, &runError)
+			expectString(c, cmd.QuestionAwsEnableConfig, &runError)
 			c.SendLine("y")
 			expectString(c, cmd.QuestionEnableCloudtrail, &runError)
 			c.SendLine("y")
 			expectString(c, cmd.QuestionAwsRegion, &runError)
 			c.SendLine(region)
-			expectString(c, cmd.QuestionConfigAdvanced, &runError)
+			expectString(c, cmd.QuestionAwsConfigAdvanced, &runError)
 			c.SendLine("y")
-			expectString(c, cmd.AdvancedOptDone, &runError)
+			expectString(c, cmd.AwsAdvancedOptDone, &runError)
 			c.Send("\x1B[B") // Down arrow twice and enter on the submenu to add subaccounts
 			c.SendLine("\x1B[B")
 			expectString(c, cmd.QuestionPrimaryAwsAccountProfile, &runError)
@@ -425,7 +425,7 @@ func TestGenerationAdvancedOptsConsolidatedWithSubAccountsPassedByFlag(t *testin
 			c.SendLine("us-east-2")
 			expectString(c, cmd.QuestionSubAccountAddMore, &runError)
 			c.SendLine("n")
-			expectString(c, cmd.QuestionAnotherAdvancedOpt, &runError)
+			expectString(c, cmd.QuestionAwsAnotherAdvancedOpt, &runError)
 			c.SendLine("n")
 			expectString(c, cmd.QuestionRunTfPlan, &runError)
 			c.SendLine("n")
@@ -468,15 +468,15 @@ func TestGenerationAdvancedOptsUseExistingIAM(t *testing.T) {
 	// Run CLI
 	tfResult := runGenerateTest(t,
 		func(c *expect.Console) {
-			expectString(c, cmd.QuestionEnableConfig, &runError)
+			expectString(c, cmd.QuestionAwsEnableConfig, &runError)
 			c.SendLine("y")
 			expectString(c, cmd.QuestionEnableCloudtrail, &runError)
 			c.SendLine("y")
 			expectString(c, cmd.QuestionAwsRegion, &runError)
 			c.SendLine(region)
-			expectString(c, cmd.QuestionConfigAdvanced, &runError)
+			expectString(c, cmd.QuestionAwsConfigAdvanced, &runError)
 			c.SendLine("y")
-			expectString(c, cmd.AdvancedOptDone, &runError)
+			expectString(c, cmd.AwsAdvancedOptDone, &runError)
 			c.SendLine("\x1B[B") // Down arrow once and return
 			expectString(c, cmd.QuestionExistingIamRoleName, &runError)
 			c.SendLine(roleName)
@@ -484,7 +484,7 @@ func TestGenerationAdvancedOptsUseExistingIAM(t *testing.T) {
 			c.SendLine(roleArn)
 			expectString(c, cmd.QuestionExistingIamRoleExtID, &runError)
 			c.SendLine(roleExtId)
-			expectString(c, cmd.QuestionAnotherAdvancedOpt, &runError)
+			expectString(c, cmd.QuestionAwsAnotherAdvancedOpt, &runError)
 			c.SendLine("n")
 			expectString(c, cmd.QuestionRunTfPlan, &runError)
 			c.SendLine("n")
@@ -528,20 +528,20 @@ func TestGenerationWithExistingTerraform(t *testing.T) {
 	// Run CLI
 	runGenerateTest(t,
 		func(c *expect.Console) {
-			expectString(c, cmd.QuestionEnableConfig, &runError)
+			expectString(c, cmd.QuestionAwsEnableConfig, &runError)
 			c.SendLine("y")
 			expectString(c, cmd.QuestionEnableCloudtrail, &runError)
 			c.SendLine("y")
 			expectString(c, cmd.QuestionAwsRegion, &runError)
 			c.SendLine(region)
-			expectString(c, cmd.QuestionConfigAdvanced, &runError)
+			expectString(c, cmd.QuestionAwsConfigAdvanced, &runError)
 			c.SendLine("y")
-			expectString(c, cmd.AdvancedOptDone, &runError)
+			expectString(c, cmd.AwsAdvancedOptDone, &runError)
 			c.Send("\x1B[B")
 			c.SendLine("\x1B[B")
-			expectString(c, cmd.QuestionCustomizeOutputLocation, &runError)
+			expectString(c, cmd.QuestionAwsCustomizeOutputLocation, &runError)
 			c.SendLine(dir)
-			expectString(c, cmd.QuestionAnotherAdvancedOpt, &runError)
+			expectString(c, cmd.QuestionAwsAnotherAdvancedOpt, &runError)
 			c.SendLine("n")
 			expectString(c, fmt.Sprintf("%s/main.tf already exists, overwrite?", dir), &runError)
 			c.SendLine("n")


### PR DESCRIPTION
Signed-off-by: Ross <ross.moles@lacework.net>

## Summary

The generate.go & generate_aws.go files are geared towards AWS only.

This PR aims to refactor `generate.go` to be more generic to work with GCP & Azure. 
This PR also refactors `generate_aws.go` to move out common functions and also rename vars to avoid clashes in the cmd package

## How did you test this change?

make test ✅ 
make fmt ✅ 

## Issue

https://lacework.atlassian.net/browse/ALLY-865