### PR TITLE
refactor(cli): Refactor generate & generate_aws

### DIFF
--- a/cli/cmd/generate.go
+++ b/cli/cmd/generate.go
@@ -5,12 +5,9 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
-	"strings"
 	"time"
 
 	"github.com/AlecAivazis/survey/v2"
-	"github.com/imdario/mergo"
-	"github.com/lacework/go-sdk/lwgenerate/aws"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -37,13 +34,6 @@ var (
 	QuestionRunTfPlan        = "Run Terraform plan now?"
 	QuestionUsePreviousCache = "Previous IaC generation detected, load cached values?"
 
-	GenerateAwsCommandState      = &aws.GenerateAwsTfConfigurationArgs{}
-	GenerateAwsExistingRoleState = &aws.ExistingIamRoleDetails{}
-	GenerateAwsCommandExtraState = &AwsGenerateCommandExtraState{}
-	ValidateSubAccountFlagRegex  = fmt.Sprintf(`%s:%s`, AwsProfileRegex, AwsRegionRegex)
-	CachedAwsAssetIacParams      = "iac-aws-generate-params"
-	CachedAssetAwsExtraState     = "iac-aws-extra-state"
-
 	// iac-generate command is used to create IaC code for various environments
 	generateTfCommand = &cobra.Command{
 		Use:     "iac-generate",
@@ -52,228 +42,6 @@ var (
 		Long:    "Create IaC content for various different cloud environments and configurations",
 	}
 
-	// aws command is used to generate TF code for aws
-	generateAwsTfCommand = &cobra.Command{
-		Use:   "aws",
-		Short: "Generate and/or execute Terraform code for AWS integration",
-		Long: `Use this command to generate Terraform code for deploying Lacework into an AWS environment.
-
-By default, this command will function interactively, prompting for the required information to setup the new cloud account. In interactive mode, this command will:
-
-* Prompt for the required information to setup the integration
-* Generate new Terraform code using the inputs
-* Optionally, run the generated Terraform code:
-  * If Terraform is already installed, the version will be confirmed suitable for use
-	* If Terraform is not installed, or the version installed is not suitable, a new version will be installed into a temporary location
-	* Once Terraform is detected or installed, Terraform plan will be executed
-	* The command will prompt with the outcome of the plan and allow to view more details or continue with Terraform apply
-	* If confirmed, Terraform apply will be run, completing the setup of the cloud account
-
-This command can also be run in noninteractive mode. See help output for more details on supplying required values for generation.
-`,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			// Generate TF Code
-			cli.StartProgress("Generating Terraform Code...")
-
-			// Explicitly set Lacework profile if it was passed in main args
-			if cli.Profile != "default" {
-				GenerateAwsCommandState.LaceworkProfile = cli.Profile
-			}
-
-			// Setup modifiers for NewTerraform constructor
-			mods := []aws.AwsTerraformModifier{
-				aws.WithAwsProfile(GenerateAwsCommandState.AwsProfile),
-				aws.WithLaceworkProfile(GenerateAwsCommandState.LaceworkProfile),
-				aws.ExistingCloudtrailBucketArn(GenerateAwsCommandState.ExistingCloudtrailBucketArn),
-				aws.ExistingSnsTopicArn(GenerateAwsCommandState.ExistingSnsTopicArn),
-				aws.WithSubaccounts(GenerateAwsCommandState.SubAccounts...),
-				aws.UseExistingIamRole(GenerateAwsCommandState.ExistingIamRole),
-			}
-
-			if GenerateAwsCommandState.ForceDestroyS3Bucket {
-				mods = append(mods, aws.EnableForceDestroyS3Bucket())
-			}
-
-			if GenerateAwsCommandState.ConsolidatedCloudtrail {
-				mods = append(mods, aws.UseConsolidatedCloudtrail())
-			}
-
-			// Create new struct
-			data := aws.NewTerraform(
-				GenerateAwsCommandState.AwsRegion,
-				GenerateAwsCommandState.Config,
-				GenerateAwsCommandState.Cloudtrail,
-				mods...)
-
-			// Generate
-			hcl, err := data.Generate()
-			cli.StopProgress()
-
-			if err != nil {
-				return errors.Wrap(err, "failed to generate terraform code")
-			}
-
-			// Write-out generated code to location specified
-			dirname, err := cmd.Flags().GetString("output")
-			if err != nil {
-				return errors.Wrap(err, "failed to parse output location")
-			}
-
-			ok, err := writeHclOutputPreCheck(dirname)
-			if err != nil {
-				return errors.Wrap(err, "failed to validate output location")
-			}
-
-			if !ok {
-				return errors.Wrap(err, "aborting to avoid overwriting existing terraform code")
-			}
-
-			location, err := writeHclOutput(hcl, dirname)
-			if err != nil {
-				return errors.Wrap(err, "failed to write terraform code to disk")
-			}
-
-			// Prompt to execute
-			err = SurveyQuestionInteractiveOnly(SurveyQuestionWithValidationArgs{
-				Prompt:   &survey.Confirm{Default: GenerateAwsCommandExtraState.TerraformApply, Message: QuestionRunTfPlan},
-				Response: &GenerateAwsCommandExtraState.TerraformApply,
-			})
-
-			if err != nil {
-				return errors.Wrap(err, "failed to prompt for terraform execution")
-			}
-
-			// Execute
-			locationDir := filepath.Dir(location)
-			if GenerateAwsCommandExtraState.TerraformApply {
-				// Execution pre-run check
-				ok, err = TerraformExecutePreRunCheck(dirname)
-				if err != nil {
-					return errors.Wrap(err, "failed to check for existing terraform state")
-				}
-
-				if !ok {
-					cli.OutputHuman(provideGuidanceAfterExit(false, false, locationDir, "terraform"))
-					return nil
-				}
-
-				if err := TerraformPlanAndExecute(locationDir); err != nil {
-					return errors.Wrap(err, "failed to run terraform apply")
-				}
-			}
-
-			// Output where code was generated
-			if !GenerateAwsCommandExtraState.TerraformApply {
-				cli.OutputHuman(provideGuidanceAfterExit(false, false, locationDir, "terraform"))
-			}
-
-			return nil
-		},
-		PreRunE: func(cmd *cobra.Command, _ []string) error {
-			// Validate output location is OK if supplied
-			dirname, err := cmd.Flags().GetString("output")
-			if err != nil {
-				return errors.Wrap(err, "failed to load command flags")
-			}
-			if err := validateOutputLocation(dirname); err != nil {
-				return err
-			}
-
-			// Validate aws profile, if passed
-			profile, err := cmd.Flags().GetString("aws_profile")
-			if err != nil {
-				return errors.Wrap(err, "failed to load command flags")
-			}
-			if err := validateAwsProfile(profile); profile != "" && err != nil {
-				return err
-			}
-
-			// Validate aws region, if passed
-			region, err := cmd.Flags().GetString("aws_region")
-			if err != nil {
-				return errors.Wrap(err, "failed to load command flags")
-			}
-			if err := validateAwsRegion(region); region != "" && err != nil {
-				return err
-			}
-
-			// Validate cloudtrail bucket arn, if passed
-			arn, err := cmd.Flags().GetString("existing_bucket_arn")
-			if err != nil {
-				return errors.Wrap(err, "failed to load command flags")
-			}
-			if err := validateAwsArnFormat(arn); arn != "" && err != nil {
-				return err
-			}
-
-			// Load any cached inputs if interactive
-			if cli.InteractiveMode() {
-				cachedOptions := &aws.GenerateAwsTfConfigurationArgs{}
-				iacParamsExpired := cli.ReadCachedAsset(CachedAwsAssetIacParams, &cachedOptions)
-				if iacParamsExpired {
-					cli.Log.Debug("loaded previously set values for AWS iac generation")
-				}
-
-				extraState := &AwsGenerateCommandExtraState{}
-				extraStateParamsExpired := cli.ReadCachedAsset(CachedAssetAwsExtraState, &extraState)
-				if extraStateParamsExpired {
-					cli.Log.Debug("loaded previously set values for AWS iac generation (extra state)")
-				}
-
-				// Determine if previously cached options exists; prompt user if they'd like to continue
-				answer := false
-				if !iacParamsExpired || !extraStateParamsExpired {
-					if err := SurveyQuestionInteractiveOnly(SurveyQuestionWithValidationArgs{
-						Prompt:   &survey.Confirm{Message: QuestionUsePreviousCache, Default: false},
-						Response: &answer,
-					}); err != nil {
-						return errors.Wrap(err, "failed to load saved options")
-					}
-				}
-
-				// If the user decides NOT to use the previous values; we won't load them.  However, every time the command runs
-				// we are going to write out new cached values, so if they run it - bail out - and run it again they'll get
-				// re-prompted.
-				if answer {
-					// Merge cached inputs to current options (current options win)
-					if err := mergo.Merge(GenerateAwsCommandState, cachedOptions); err != nil {
-						return errors.Wrap(err, "failed to load saved options")
-					}
-					if err := mergo.Merge(GenerateAwsCommandExtraState, extraState); err != nil {
-						return errors.Wrap(err, "failed to load saved options")
-					}
-				}
-			}
-
-			// Parse passed in subaccounts (if any)
-			if len(GenerateAwsCommandExtraState.AwsSubAccounts) > 0 {
-				// validate consolidated_cloudtrail is enabled - otherwise this flag cannot be used
-				if ok, _ := cmd.Flags().GetBool("consolidated_cloudtrail"); !ok {
-					return errors.New("aws subaccounts can only be supplied with consolidated cloudtrail enabled")
-				}
-
-				// validate the format of supplied values is correct
-				if err := validateAwsSubAccounts(GenerateAwsCommandExtraState.AwsSubAccounts); err != nil {
-					return err
-				}
-
-				awsSubAccounts := []aws.AwsSubAccount{}
-				for _, account := range GenerateAwsCommandExtraState.AwsSubAccounts {
-					accountDetails := strings.Split(account, ":")
-					awsSubAccounts = append(awsSubAccounts, aws.NewAwsSubAccount(accountDetails[0], accountDetails[1]))
-				}
-				GenerateAwsCommandState.SubAccounts = awsSubAccounts
-			}
-
-			// Collect and/or confirm parameters
-			err = promptAwsGenerate(GenerateAwsCommandState, GenerateAwsExistingRoleState, GenerateAwsCommandExtraState)
-			if err != nil {
-				return errors.Wrap(err, "collecting/confirming parameters")
-			}
-
-			return nil
-		},
-	}
 )
 
 func init() {
@@ -556,6 +324,51 @@ func validPathExists(val interface{}) error {
 	default:
 		// if the value passed is not a string
 		return errors.New("value must be a string")
+	}
+
+	return nil
+}
+
+// writeGeneratedCodeToLocation Write-out generated code to location specified
+func writeGeneratedCodeToLocation(cmd *cobra.Command, hcl string) (string, string, error) {
+	//dirname, ok, location := "", false, ""
+	// Write-out generated code to location specified
+	dirname, err := cmd.Flags().GetString("output")
+	if err != nil {
+		return dirname, "", errors.Wrap(err, "failed to parse output location")
+	}
+
+	ok, err := writeHclOutputPreCheck(dirname)
+	if err != nil {
+		return dirname, "", errors.Wrap(err, "failed to validate output location")
+	}
+
+	if !ok {
+		return dirname, "", errors.Wrap(err, "aborting to avoid overwriting existing terraform code")
+	}
+
+	location, err := writeHclOutput(hcl, dirname)
+	if err != nil {
+		return dirname, location, errors.Wrap(err, "failed to write terraform code to disk")
+	}
+
+	return dirname, location, nil
+}
+
+// executionPreRunChecks Execution pre-run check
+func executionPreRunChecks(dirname string, locationDir string) error {
+	ok, err := TerraformExecutePreRunCheck(dirname)
+	if err != nil {
+		return errors.Wrap(err, "failed to check for existing terraform state")
+	}
+
+	if !ok {
+		cli.OutputHuman(provideGuidanceAfterExit(false, false, locationDir, "terraform"))
+		return nil
+	}
+
+	if err := TerraformPlanAndExecute(locationDir); err != nil {
+		return errors.Wrap(err, "failed to run terraform apply")
 	}
 
 	return nil

--- a/cli/cmd/generate.go
+++ b/cli/cmd/generate.go
@@ -41,7 +41,6 @@ var (
 		Short:   "Create IaC code",
 		Long:    "Create IaC content for various different cloud environments and configurations",
 	}
-
 )
 
 func init() {

--- a/cli/cmd/generate_aws.go
+++ b/cli/cmd/generate_aws.go
@@ -2,8 +2,12 @@ package cmd
 
 import (
 	"fmt"
+	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/imdario/mergo"
+	"github.com/spf13/cobra"
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/lacework/go-sdk/lwgenerate/aws"
@@ -43,6 +47,213 @@ var (
 	// AwsRegionRegex regex used for validating region input; note intentionally does not match gov cloud
 	AwsRegionRegex  = `(us|ap|ca|cn|eu|sa)-(central|(north|south)?(east|west)?)-\d`
 	AwsProfileRegex = `([A-Za-z_0-9-]+)`
+
+	GenerateAwsCommandState      = &aws.GenerateAwsTfConfigurationArgs{}
+	GenerateAwsExistingRoleState = &aws.ExistingIamRoleDetails{}
+	GenerateAwsCommandExtraState = &AwsGenerateCommandExtraState{}
+	ValidateSubAccountFlagRegex  = fmt.Sprintf(`%s:%s`, AwsProfileRegex, AwsRegionRegex)
+	CachedAwsAssetIacParams      = "iac-aws-generate-params"
+	CachedAssetAwsExtraState     = "iac-aws-extra-state"
+
+	// aws command is used to generate TF code for aws
+	generateAwsTfCommand = &cobra.Command{
+		Use:   "aws",
+		Short: "Generate and/or execute Terraform code for AWS integration",
+		Long: `Use this command to generate Terraform code for deploying Lacework into an AWS environment.
+
+By default, this command will function interactively, prompting for the required information to setup the new cloud account. In interactive mode, this command will:
+
+* Prompt for the required information to setup the integration
+* Generate new Terraform code using the inputs
+* Optionally, run the generated Terraform code:
+  * If Terraform is already installed, the version will be confirmed suitable for use
+	* If Terraform is not installed, or the version installed is not suitable, a new version will be installed into a temporary location
+	* Once Terraform is detected or installed, Terraform plan will be executed
+	* The command will prompt with the outcome of the plan and allow to view more details or continue with Terraform apply
+	* If confirmed, Terraform apply will be run, completing the setup of the cloud account
+
+This command can also be run in noninteractive mode. See help output for more details on supplying required values for generation.
+`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// Generate TF Code
+			cli.StartProgress("Generating Terraform Code...")
+
+			// Explicitly set Lacework profile if it was passed in main args
+			if cli.Profile != "default" {
+				GenerateAwsCommandState.LaceworkProfile = cli.Profile
+			}
+
+			// Setup modifiers for NewTerraform constructor
+			mods := []aws.AwsTerraformModifier{
+				aws.WithAwsProfile(GenerateAwsCommandState.AwsProfile),
+				aws.WithLaceworkProfile(GenerateAwsCommandState.LaceworkProfile),
+				aws.ExistingCloudtrailBucketArn(GenerateAwsCommandState.ExistingCloudtrailBucketArn),
+				aws.ExistingSnsTopicArn(GenerateAwsCommandState.ExistingSnsTopicArn),
+				aws.WithSubaccounts(GenerateAwsCommandState.SubAccounts...),
+				aws.UseExistingIamRole(GenerateAwsCommandState.ExistingIamRole),
+			}
+
+			if GenerateAwsCommandState.ForceDestroyS3Bucket {
+				mods = append(mods, aws.EnableForceDestroyS3Bucket())
+			}
+
+			if GenerateAwsCommandState.ConsolidatedCloudtrail {
+				mods = append(mods, aws.UseConsolidatedCloudtrail())
+			}
+
+			// Create new struct
+			data := aws.NewTerraform(
+				GenerateAwsCommandState.AwsRegion,
+				GenerateAwsCommandState.Config,
+				GenerateAwsCommandState.Cloudtrail,
+				mods...)
+
+			// Generate
+			hcl, err := data.Generate()
+			cli.StopProgress()
+
+			if err != nil {
+				return errors.Wrap(err, "failed to generate terraform code")
+			}
+
+			// Write-out generated code to location specified
+			dirname, location, err := writeGeneratedCodeToLocation(cmd, hcl)
+			if err != nil {
+				return err
+			}
+
+			// Prompt to execute
+			err = SurveyQuestionInteractiveOnly(SurveyQuestionWithValidationArgs{
+				Prompt:   &survey.Confirm{Default: GenerateAwsCommandExtraState.TerraformApply, Message: QuestionRunTfPlan},
+				Response: &GenerateAwsCommandExtraState.TerraformApply,
+			})
+
+			if err != nil {
+				return errors.Wrap(err, "failed to prompt for terraform execution")
+			}
+
+			// Execute
+			locationDir := filepath.Dir(location)
+			if GenerateAwsCommandExtraState.TerraformApply {
+				// Execution pre-run check
+				err := executionPreRunChecks(dirname, locationDir)
+				if err != nil {
+					return err
+				}
+			}
+
+			// Output where code was generated
+			if !GenerateAwsCommandExtraState.TerraformApply {
+				cli.OutputHuman(provideGuidanceAfterExit(false, false, locationDir, "terraform"))
+			}
+
+			return nil
+		},
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
+			// Validate output location is OK if supplied
+			dirname, err := cmd.Flags().GetString("output")
+			if err != nil {
+				return errors.Wrap(err, "failed to load command flags")
+			}
+			if err := validateOutputLocation(dirname); err != nil {
+				return err
+			}
+
+			// Validate aws profile, if passed
+			profile, err := cmd.Flags().GetString("aws_profile")
+			if err != nil {
+				return errors.Wrap(err, "failed to load command flags")
+			}
+			if err := validateAwsProfile(profile); profile != "" && err != nil {
+				return err
+			}
+
+			// Validate aws region, if passed
+			region, err := cmd.Flags().GetString("aws_region")
+			if err != nil {
+				return errors.Wrap(err, "failed to load command flags")
+			}
+			if err := validateAwsRegion(region); region != "" && err != nil {
+				return err
+			}
+
+			// Validate cloudtrail bucket arn, if passed
+			arn, err := cmd.Flags().GetString("existing_bucket_arn")
+			if err != nil {
+				return errors.Wrap(err, "failed to load command flags")
+			}
+			if err := validateAwsArnFormat(arn); arn != "" && err != nil {
+				return err
+			}
+
+			// Load any cached inputs if interactive
+			if cli.InteractiveMode() {
+				cachedOptions := &aws.GenerateAwsTfConfigurationArgs{}
+				iacParamsExpired := cli.ReadCachedAsset(CachedAwsAssetIacParams, &cachedOptions)
+				if iacParamsExpired {
+					cli.Log.Debug("loaded previously set values for AWS iac generation")
+				}
+
+				extraState := &AwsGenerateCommandExtraState{}
+				extraStateParamsExpired := cli.ReadCachedAsset(CachedAssetAwsExtraState, &extraState)
+				if extraStateParamsExpired {
+					cli.Log.Debug("loaded previously set values for AWS iac generation (extra state)")
+				}
+
+				// Determine if previously cached options exists; prompt user if they'd like to continue
+				answer := false
+				if !iacParamsExpired || !extraStateParamsExpired {
+					if err := SurveyQuestionInteractiveOnly(SurveyQuestionWithValidationArgs{
+						Prompt:   &survey.Confirm{Message: QuestionUsePreviousCache, Default: false},
+						Response: &answer,
+					}); err != nil {
+						return errors.Wrap(err, "failed to load saved options")
+					}
+				}
+
+				// If the user decides NOT to use the previous values; we won't load them.  However, every time the command runs
+				// we are going to write out new cached values, so if they run it - bail out - and run it again they'll get
+				// re-prompted.
+				if answer {
+					// Merge cached inputs to current options (current options win)
+					if err := mergo.Merge(GenerateAwsCommandState, cachedOptions); err != nil {
+						return errors.Wrap(err, "failed to load saved options")
+					}
+					if err := mergo.Merge(GenerateAwsCommandExtraState, extraState); err != nil {
+						return errors.Wrap(err, "failed to load saved options")
+					}
+				}
+			}
+
+			// Parse passed in subaccounts (if any)
+			if len(GenerateAwsCommandExtraState.AwsSubAccounts) > 0 {
+				// validate consolidated_cloudtrail is enabled - otherwise this flag cannot be used
+				if ok, _ := cmd.Flags().GetBool("consolidated_cloudtrail"); !ok {
+					return errors.New("aws subaccounts can only be supplied with consolidated cloudtrail enabled")
+				}
+
+				// validate the format of supplied values is correct
+				if err := validateAwsSubAccounts(GenerateAwsCommandExtraState.AwsSubAccounts); err != nil {
+					return err
+				}
+
+				awsSubAccounts := []aws.AwsSubAccount{}
+				for _, account := range GenerateAwsCommandExtraState.AwsSubAccounts {
+					accountDetails := strings.Split(account, ":")
+					awsSubAccounts = append(awsSubAccounts, aws.NewAwsSubAccount(accountDetails[0], accountDetails[1]))
+				}
+				GenerateAwsCommandState.SubAccounts = awsSubAccounts
+			}
+
+			// Collect and/or confirm parameters
+			err = promptAwsGenerate(GenerateAwsCommandState, GenerateAwsExistingRoleState, GenerateAwsCommandExtraState)
+			if err != nil {
+				return errors.Wrap(err, "collecting/confirming parameters")
+			}
+
+			return nil
+		},
+	}
 )
 
 // survey.Validator for aws ARNs


### PR DESCRIPTION
Signed-off-by: Ross <ross.moles@lacework.net>

## Summary

The generate.go & generate_aws.go files are geared towards AWS only.

This PR aims to refactor `generate.go` to be more generic to work with GCP & Azure. 
This PR also moves AWS specific vars to the `generate_aws.go` file
## How did you test this change?

make test ✅ 
make fmt ✅ 

## Issue

https://lacework.atlassian.net/browse/ALLY-865