### PR TITLE
fix(cli): remove text wrapping on list-sources output

### DIFF
--- a/cli/cmd/lql_sources.go
+++ b/cli/cmd/lql_sources.go
@@ -65,12 +65,6 @@ func getListQuerySourcesTable(datasources []api.Datasource) (out [][]string) {
 
 func listQuerySources(_ *cobra.Command, args []string) error {
 	cli.Log.Debugw("retrieving LQL data sources")
-
-	tableSettings := tableFunc(func(t *tablewriter.Table) {
-		t.SetAutoWrapText(false)
-		t.SetBorder(false)
-	})
-
 	lqlSourcesUnableMsg := "unable to retrieve LQL data sources"
 	datasourcesResponse, err := cli.LwApi.V2.Datasources.List()
 
@@ -87,7 +81,10 @@ func listQuerySources(_ *cobra.Command, args []string) error {
 		renderCustomTable(
 			[]string{"Datasource", "Description"},
 			getListQuerySourcesTable(datasourcesResponse.Data),
-			tableSettings,
+			tableFunc(func(t *tablewriter.Table) {
+				t.SetAutoWrapText(false)
+				t.SetBorder(false)
+			}),
 		),
 	)
 	cli.OutputHuman("\nUse 'lacework query show-source <datasource_id>' to show details about the data source.\n")

--- a/cli/cmd/lql_sources.go
+++ b/cli/cmd/lql_sources.go
@@ -19,6 +19,7 @@
 package cmd
 
 import (
+	"github.com/olekukonko/tablewriter"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
@@ -65,6 +66,11 @@ func getListQuerySourcesTable(datasources []api.Datasource) (out [][]string) {
 func listQuerySources(_ *cobra.Command, args []string) error {
 	cli.Log.Debugw("retrieving LQL data sources")
 
+	tableSettings := tableFunc(func(t *tablewriter.Table) {
+		t.SetAutoWrapText(false)
+		t.SetBorder(false)
+	})
+
 	lqlSourcesUnableMsg := "unable to retrieve LQL data sources"
 	datasourcesResponse, err := cli.LwApi.V2.Datasources.List()
 
@@ -78,9 +84,10 @@ func listQuerySources(_ *cobra.Command, args []string) error {
 		return yikes(lqlSourcesUnableMsg)
 	}
 	cli.OutputHuman(
-		renderSimpleTable(
+		renderCustomTable(
 			[]string{"Datasource", "Description"},
 			getListQuerySourcesTable(datasourcesResponse.Data),
+			tableSettings,
 		),
 	)
 	cli.OutputHuman("\nUse 'lacework query show-source <datasource_id>' to show details about the data source.\n")


### PR DESCRIPTION

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/lacework/go-sdk) and create your branch from `main`
  2. Run `make prepare` in the repository root
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`make test`)
  5. Format your code (`make fmt`)
  6. Make sure your code lints (`make lint`)
  7. If you are updating the Lacework CLI, make sure it compiles (`make build-cli-cross-platform`)
  8. Follow the commit message standard (`type(scope): subject`) documented in [DEVELOPER_GUIDELINES.md](https://github.com/lacework/go-sdk/blob/main/DEVELOPER_GUIDELINES.md#commit-message-standard)
  9. If you haven't already, configure signed commits by [telling git about your signing key](https://docs.github.com/en/github/authenticating-to-github/managing-commit-signature-verification/telling-git-about-your-signing-key) and [signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)

  Learn more about contributing: https://github.com/lacework/go-sdk/blob/main/CONTRIBUTING.md
-->

## Summary

Fix formatting on table output. Remove text wrapping.

## How did you test this change?

`lacework query list-sources`

## Issue
https://lacework.atlassian.net/browse/ALLY-863
