### PR TITLE
feat(policies): add tags support

### DIFF
--- a/api/lql_test.go
+++ b/api/lql_test.go
@@ -130,7 +130,7 @@ func TestQueryListMethod(t *testing.T) {
 	fakeServer.MockAPI(
 		"Queries",
 		func(w http.ResponseWriter, r *http.Request) {
-			assert.Equal(t, "GET", r.Method, "Get should be a GET method")
+			assert.Equal(t, "GET", r.Method, "List should be a GET method")
 			fmt.Fprint(w, "{}")
 		},
 	)

--- a/api/policy.go
+++ b/api/policy.go
@@ -35,19 +35,20 @@ type PolicyService struct {
 var ValidPolicySeverities = []string{"critical", "high", "medium", "low", "info"}
 
 type NewPolicy struct {
-	EvaluatorID   string `json:"evaluatorId,omitempty" yaml:"evaluatorId,omitempty"`
-	PolicyID      string `json:"policyId,omitempty" yaml:"policyId,omitempty" `
-	PolicyType    string `json:"policyType" yaml:"policyType"`
-	QueryID       string `json:"queryId" yaml:"queryId"`
-	Title         string `json:"title" yaml:"title"`
-	Enabled       bool   `json:"enabled" yaml:"enabled"`
-	Description   string `json:"description" yaml:"description"`
-	Remediation   string `json:"remediation" yaml:"remediation"`
-	Severity      string `json:"severity" yaml:"severity"`
-	Limit         int    `json:"limit,omitempty" yaml:"limit,omitempty"`
-	EvalFrequency string `json:"evalFrequency,omitempty" yaml:"evalFrequency,omitempty"`
-	AlertEnabled  bool   `json:"alertEnabled" yaml:"alertEnabled"`
-	AlertProfile  string `json:"alertProfile" yaml:"alertProfile"`
+	EvaluatorID   string   `json:"evaluatorId,omitempty" yaml:"evaluatorId,omitempty"`
+	PolicyID      string   `json:"policyId,omitempty" yaml:"policyId,omitempty" `
+	PolicyType    string   `json:"policyType" yaml:"policyType"`
+	QueryID       string   `json:"queryId" yaml:"queryId"`
+	Title         string   `json:"title" yaml:"title"`
+	Enabled       bool     `json:"enabled" yaml:"enabled"`
+	Description   string   `json:"description" yaml:"description"`
+	Remediation   string   `json:"remediation" yaml:"remediation"`
+	Severity      string   `json:"severity" yaml:"severity"`
+	Limit         int      `json:"limit,omitempty" yaml:"limit,omitempty"`
+	EvalFrequency string   `json:"evalFrequency,omitempty" yaml:"evalFrequency,omitempty"`
+	AlertEnabled  bool     `json:"alertEnabled" yaml:"alertEnabled"`
+	AlertProfile  string   `json:"alertProfile" yaml:"alertProfile"`
+	Tags          []string `json:"tags,omitempty" yaml:"tags,omitempty"`
 }
 
 /* In order to properly PATCH we need to omit items that aren't specified.
@@ -56,43 +57,59 @@ This would prevent someone from toggling something to disabled or 0 respectively
 As such we are using pointers instead of primitives for booleans and integers in this struct
 */
 type UpdatePolicy struct {
-	EvaluatorID   string `json:"evaluatorId,omitempty" yaml:"evaluatorId,omitempty"`
-	PolicyID      string `json:"policyId,omitempty" yaml:"policyId,omitempty"`
-	PolicyType    string `json:"policyType,omitempty" yaml:"policyType,omitempty"`
-	QueryID       string `json:"queryId,omitempty" yaml:"queryId,omitempty"`
-	Title         string `json:"title,omitempty" yaml:"title,omitempty"`
-	Enabled       *bool  `json:"enabled,omitempty" yaml:"enabled,omitempty"`
-	Description   string `json:"description,omitempty" yaml:"description,omitempty"`
-	Remediation   string `json:"remediation,omitempty" yaml:"remediation,omitempty"`
-	Severity      string `json:"severity,omitempty" yaml:"severity,omitempty"`
-	Limit         *int   `json:"limit,omitempty" yaml:"limit,omitempty"`
-	EvalFrequency string `json:"evalFrequency,omitempty" yaml:"evalFrequency,omitempty"`
-	AlertEnabled  *bool  `json:"alertEnabled,omitempty" yaml:"alertEnabled,omitempty"`
-	AlertProfile  string `json:"alertProfile,omitempty" yaml:"alertProfile,omitempty"`
+	EvaluatorID   string   `json:"evaluatorId,omitempty" yaml:"evaluatorId,omitempty"`
+	PolicyID      string   `json:"policyId,omitempty" yaml:"policyId,omitempty"`
+	PolicyType    string   `json:"policyType,omitempty" yaml:"policyType,omitempty"`
+	QueryID       string   `json:"queryId,omitempty" yaml:"queryId,omitempty"`
+	Title         string   `json:"title,omitempty" yaml:"title,omitempty"`
+	Enabled       *bool    `json:"enabled,omitempty" yaml:"enabled,omitempty"`
+	Description   string   `json:"description,omitempty" yaml:"description,omitempty"`
+	Remediation   string   `json:"remediation,omitempty" yaml:"remediation,omitempty"`
+	Severity      string   `json:"severity,omitempty" yaml:"severity,omitempty"`
+	Limit         *int     `json:"limit,omitempty" yaml:"limit,omitempty"`
+	EvalFrequency string   `json:"evalFrequency,omitempty" yaml:"evalFrequency,omitempty"`
+	AlertEnabled  *bool    `json:"alertEnabled,omitempty" yaml:"alertEnabled,omitempty"`
+	AlertProfile  string   `json:"alertProfile,omitempty" yaml:"alertProfile,omitempty"`
+	Tags          []string `json:"tags,omitempty" yaml:"tags,omitempty"`
 }
 
 type Policy struct {
-	EvaluatorID    string `json:"evaluatorId"`
-	PolicyID       string `json:"policyId"`
-	PolicyType     string `json:"policyType"`
-	QueryID        string `json:"queryId"`
-	Title          string `json:"title"`
-	Enabled        bool   `json:"enabled"`
-	Description    string `json:"description"`
-	Remediation    string `json:"remediation"`
-	Severity       string `json:"severity"`
-	Limit          int    `json:"limit"`
-	EvalFrequency  string `json:"evalFrequency"`
-	AlertEnabled   bool   `json:"alertEnabled"`
-	AlertProfile   string `json:"alertProfile"`
-	Owner          string `json:"owner"`
-	LastUpdateTime string `json:"lastUpdateTime"`
-	LastUpdateUser string `json:"lastUpdateUser"`
+	EvaluatorID    string   `json:"evaluatorId"`
+	PolicyID       string   `json:"policyId"`
+	PolicyType     string   `json:"policyType"`
+	QueryID        string   `json:"queryId"`
+	Title          string   `json:"title"`
+	Enabled        bool     `json:"enabled"`
+	Description    string   `json:"description"`
+	Remediation    string   `json:"remediation"`
+	Severity       string   `json:"severity"`
+	Limit          int      `json:"limit"`
+	EvalFrequency  string   `json:"evalFrequency"`
+	AlertEnabled   bool     `json:"alertEnabled"`
+	AlertProfile   string   `json:"alertProfile"`
+	Tags           []string `json:"tags"`
+	Owner          string   `json:"owner"`
+	LastUpdateTime string   `json:"lastUpdateTime"`
+	LastUpdateUser string   `json:"lastUpdateUser"`
+}
+
+func (p *Policy) HasTag(t string) bool {
+	for _, v := range p.Tags {
+		if t == v {
+			return true
+		}
+	}
+	return false
 }
 
 type PolicyResponse struct {
 	Data    Policy `json:"data"`
 	Message string `json:"message"`
+}
+
+type PolicyTagsResponse struct {
+	Data    []string `json:"data"`
+	Message string   `json:"message"`
 }
 
 type PoliciesResponse struct {
@@ -113,6 +130,19 @@ func (svc *PolicyService) List() (
 	err error,
 ) {
 	err = svc.client.RequestDecoder("GET", apiV2Policies, nil, &response)
+	return
+}
+
+func (svc *PolicyService) ListTags() (
+	response PolicyTagsResponse,
+	err error,
+) {
+	err = svc.client.RequestDecoder(
+		"GET",
+		fmt.Sprintf("%s/Tags", apiV2Policies),
+		nil,
+		&response,
+	)
 	return
 }
 

--- a/api/policy.go
+++ b/api/policy.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"net/url"
 
+	"github.com/lacework/go-sdk/internal/array"
 	"github.com/pkg/errors"
 )
 
@@ -94,12 +95,7 @@ type Policy struct {
 }
 
 func (p *Policy) HasTag(t string) bool {
-	for _, v := range p.Tags {
-		if t == v {
-			return true
-		}
-	}
-	return false
+	return array.ContainsStr(p.Tags, t)
 }
 
 type PolicyResponse struct {

--- a/api/policy_test.go
+++ b/api/policy_test.go
@@ -32,6 +32,9 @@ import (
 var (
 	policyURI = "Policies"
 	policyID  = "my-policy-1"
+	policy    = api.Policy{
+		Tags: []string{"fhqwhgads"},
+	}
 	newPolicy = api.NewPolicy{
 		EvaluatorID:   "Cloudtrail",
 		PolicyID:      policyID,
@@ -88,6 +91,11 @@ func mockPolicyDataResponse(data string) string {
 	"data": ` + data + `,
 	"message": "SUCCESS"
 }`
+}
+
+func TestPolicyHasTags(t *testing.T) {
+	assert.Equal(t, true, policy.HasTag("fhqwhgads"))
+	assert.Equal(t, false, policy.HasTag(""))
 }
 
 func TestPolicyCreateMethod(t *testing.T) {
@@ -230,6 +238,50 @@ func TestPolicyGetNotFound(t *testing.T) {
 
 	_, err = c.V2.Policy.Get("NoSuchPolicy")
 	assert.NotNil(t, err)
+}
+
+func TestPolicyListMethod(t *testing.T) {
+	fakeServer := lacework.MockServer()
+	fakeServer.UseApiV2()
+	fakeServer.MockAPI(
+		"Policies",
+		func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "GET", r.Method, "List should be a GET method")
+			fmt.Fprint(w, "{}")
+		},
+	)
+	defer fakeServer.Close()
+
+	c, err := api.NewClient("test",
+		api.WithToken("TOKEN"),
+		api.WithURL(fakeServer.URL()),
+	)
+	assert.Nil(t, err)
+
+	_, err = c.V2.Policy.List()
+	assert.Nil(t, err)
+}
+
+func TestPolicyListTagsMethod(t *testing.T) {
+	fakeServer := lacework.MockServer()
+	fakeServer.UseApiV2()
+	fakeServer.MockAPI(
+		"Policies/Tags",
+		func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "GET", r.Method, "ListTags should be a GET method")
+			fmt.Fprint(w, "{}")
+		},
+	)
+	defer fakeServer.Close()
+
+	c, err := api.NewClient("test",
+		api.WithToken("TOKEN"),
+		api.WithURL(fakeServer.URL()),
+	)
+	assert.Nil(t, err)
+
+	_, err = c.V2.Policy.ListTags()
+	assert.Nil(t, err)
 }
 
 func TestPolicyUpdateMethod(t *testing.T) {

--- a/integration/policy_test.go
+++ b/integration/policy_test.go
@@ -43,6 +43,8 @@ remediation: Check yourself...
 severity: high
 alertEnabled: false
 alertProfile: LW_CloudTrail_Alerts
+tags:
+  - fhqwhgads
 `
 	newHostPolicyYAML string = `---
 evaluatorId:
@@ -153,6 +155,24 @@ func TestPolicyCreateFile(t *testing.T) {
 	out, stderr, exitcode = LaceworkCLIWithTOMLConfig("policy", "list", "--alert_enabled")
 	assert.Contains(t, out.String(), "lacework-global-1")
 	assert.NotContains(t, out.String(), policyID)
+	assert.Empty(t, stderr.String(), "STDERR should be empty")
+	assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
+
+	// list tag match
+	out, stderr, exitcode = LaceworkCLIWithTOMLConfig("policy", "list", "--tag", "fhqwhgads")
+	assert.Contains(t, out.String(), policyID)
+	assert.Empty(t, stderr.String(), "STDERR should be empty")
+	assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
+
+	// list tag non-match
+	out, stderr, exitcode = LaceworkCLIWithTOMLConfig("policy", "list", "--tag", "nosuchtag")
+	assert.NotContains(t, out.String(), policyID)
+	assert.Empty(t, stderr.String(), "STDERR should be empty")
+	assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
+
+	// list-tags
+	out, stderr, exitcode = LaceworkCLIWithTOMLConfig("policy", "list-tags")
+	assert.Contains(t, out.String(), "fhqwhgads")
 	assert.Empty(t, stderr.String(), "STDERR should be empty")
 	assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
 


### PR DESCRIPTION

## Summary
As a Lacework user I want to use the CLI to interact (CRU) with policy tags

- Add list-tags command
- Add --tag filter for policy list
- Add tag to appropriate structs


## How did you test this change?
Automated unit and integration testing

## Issue
https://lacework.atlassian.net/browse/ALLY-878

## Examples
List policies with a specific tag
```
lacework policy list --tag control:1.1 
```

List all policy tags
```
lacework policy list-tags                         
```  

