### PR TITLE
feat(cli): show resources affected by a compliance recommendation

### DIFF
--- a/api/compliance.go
+++ b/api/compliance.go
@@ -26,6 +26,10 @@ type ComplianceService struct {
 	client *Client
 }
 
+type CloudComplianceReport interface {
+	GetComplianceRecommendations() []ComplianceRecommendation
+}
+
 func (svc *ComplianceService) ListGcpProjects(orgID string) (
 	response compGcpProjectsResponse,
 	err error,

--- a/api/compliance.go
+++ b/api/compliance.go
@@ -27,7 +27,7 @@ type ComplianceService struct {
 }
 
 type CloudComplianceReport interface {
-	GetComplianceRecommendations() []ComplianceRecommendation
+	GetComplianceRecommendation(recommendationID string) ComplianceRecommendation
 }
 
 func (svc *ComplianceService) ListGcpProjects(orgID string) (

--- a/api/compliance_aws.go
+++ b/api/compliance_aws.go
@@ -116,6 +116,11 @@ type ComplianceAwsReport struct {
 	Recommendations []ComplianceRecommendation `json:"recommendations"`
 }
 
-func (aws ComplianceAwsReport) GetComplianceRecommendations() []ComplianceRecommendation {
-	return aws.Recommendations
+func (aws ComplianceAwsReport) GetComplianceRecommendation(recommendationID string) ComplianceRecommendation {
+	for _, r := range aws.Recommendations {
+		if r.RecID == recommendationID {
+			return r
+		}
+	}
+	return ComplianceRecommendation{}
 }

--- a/api/compliance_aws.go
+++ b/api/compliance_aws.go
@@ -115,3 +115,7 @@ type ComplianceAwsReport struct {
 	Summary         []ComplianceSummary        `json:"summary"`
 	Recommendations []ComplianceRecommendation `json:"recommendations"`
 }
+
+func (aws ComplianceAwsReport) GetComplianceRecommendations() []ComplianceRecommendation {
+	return aws.Recommendations
+}

--- a/api/compliance_azure.go
+++ b/api/compliance_azure.go
@@ -157,3 +157,7 @@ type ComplianceAzureReport struct {
 	Summary          []ComplianceSummary        `json:"summary"`
 	Recommendations  []ComplianceRecommendation `json:"recommendations"`
 }
+
+func (az ComplianceAzureReport) GetComplianceRecommendations() []ComplianceRecommendation {
+	return az.Recommendations
+}

--- a/api/compliance_azure.go
+++ b/api/compliance_azure.go
@@ -158,6 +158,11 @@ type ComplianceAzureReport struct {
 	Recommendations  []ComplianceRecommendation `json:"recommendations"`
 }
 
-func (az ComplianceAzureReport) GetComplianceRecommendations() []ComplianceRecommendation {
-	return az.Recommendations
+func (az ComplianceAzureReport) GetComplianceRecommendation(recommendationID string) ComplianceRecommendation {
+	for _, r := range az.Recommendations {
+		if r.RecID == recommendationID {
+			return r
+		}
+	}
+	return ComplianceRecommendation{}
 }

--- a/api/compliance_gcp.go
+++ b/api/compliance_gcp.go
@@ -138,6 +138,11 @@ type ComplianceGcpReport struct {
 	Recommendations  []ComplianceRecommendation `json:"recommendations"`
 }
 
-func (gcp ComplianceGcpReport) GetComplianceRecommendations() []ComplianceRecommendation {
-	return gcp.Recommendations
+func (gcp ComplianceGcpReport) GetComplianceRecommendation(recommendationID string) ComplianceRecommendation {
+	for _, r := range gcp.Recommendations {
+		if r.RecID == recommendationID {
+			return r
+		}
+	}
+	return ComplianceRecommendation{}
 }

--- a/api/compliance_gcp.go
+++ b/api/compliance_gcp.go
@@ -137,3 +137,7 @@ type ComplianceGcpReport struct {
 	Summary          []ComplianceSummary        `json:"summary"`
 	Recommendations  []ComplianceRecommendation `json:"recommendations"`
 }
+
+func (gcp ComplianceGcpReport) GetComplianceRecommendations() []ComplianceRecommendation {
+	return gcp.Recommendations
+}

--- a/cli/cmd/compliance.go
+++ b/cli/cmd/compliance.go
@@ -442,16 +442,17 @@ func statusToProperTypes(status string) string {
 	}
 }
 
-func validateRecommendationID(s string) bool {
+func validRecommendationID(s string) bool {
 	match, _ := regexp.MatchString(RecommendationIDRegex, s)
 	return match
 }
 
 func outputResourcesByRecommendationID(report api.CloudComplianceReport) error {
-	violations := filterResourcesByRecommendationID(report, compCmdState.RecommendationID)
+	recommendation := report.GetComplianceRecommendation(compCmdState.RecommendationID)
+	violations := recommendation.Violations
 
 	if len(violations) == 0 {
-		cli.OutputHuman("\nNo resources found affected by '%s'\n", compCmdState.RecommendationID)
+		cli.OutputHuman("No resources found affected by '%s'\n", compCmdState.RecommendationID)
 		return nil
 	}
 
@@ -468,17 +469,8 @@ func outputResourcesByRecommendationID(report api.CloudComplianceReport) error {
 			violationsToTable(violations),
 		),
 	)
-	cli.OutputHuman("\n%d resources showing affected by `%s`\n", len(violations), compCmdState.RecommendationID)
+	cli.OutputHuman("\n%d resources showing affected by '%s'\n", len(violations), compCmdState.RecommendationID)
 	return nil
-}
-
-func filterResourcesByRecommendationID(report api.CloudComplianceReport, recID string) (violations []api.ComplianceViolation) {
-	for _, r := range report.GetComplianceRecommendations() {
-		if r.RecID == recID {
-			violations = append(violations, r.Violations...)
-		}
-	}
-	return
 }
 
 func violationsToTable(violations []api.ComplianceViolation) (resourceTable [][]string) {

--- a/cli/cmd/compliance.go
+++ b/cli/cmd/compliance.go
@@ -367,7 +367,7 @@ func buildComplianceReportTable(detailsTable, summaryTable, recommendationsTable
 			)
 		} else {
 			mainReport.WriteString(
-				"Try using '--pdf' to download the entire report in PDF format.",
+				"Try adding [recommendation_id] to show affected resources.",
 			)
 		}
 		mainReport.WriteString("\n")

--- a/cli/cmd/compliance.go
+++ b/cli/cmd/compliance.go
@@ -471,3 +471,19 @@ func outputResourcesByRecommendationID(report api.CloudComplianceReport) error {
 	cli.OutputHuman("\n%d resources showing affected by `%s`\n", len(violations), compCmdState.RecommendationID)
 	return nil
 }
+
+func filterResourcesByRecommendationID(report api.CloudComplianceReport, recID string) (violations []api.ComplianceViolation) {
+	for _, r := range report.GetComplianceRecommendations() {
+		if r.RecID == recID {
+			violations = append(violations, r.Violations...)
+		}
+	}
+	return
+}
+
+func violationsToTable(violations []api.ComplianceViolation) (resourceTable [][]string) {
+	for _, v := range violations {
+		resourceTable = append(resourceTable, []string{v.Resource, v.Region, strings.Join(v.Reasons, ",")})
+	}
+	return
+}

--- a/cli/cmd/compliance.go
+++ b/cli/cmd/compliance.go
@@ -458,25 +458,28 @@ func outputResourcesByRecommendationID(report api.CloudComplianceReport) error {
 	}
 
 	cli.OutputHuman(
-		renderCustomTable(
-			[]string{"Summary"},
-			[][]string{
-				{"Severity", recommendation.SeverityString()},
-				{"Service", recommendation.Service},
-				{"Category", recommendation.Category},
-				{"Status", recommendation.Status},
-				{"Assessed Resources", strconv.Itoa(recommendation.AssessedResourceCount)},
-				{"Affected Resources", strconv.Itoa(affectedResources)},
-			},
-			tableFunc(func(t *tablewriter.Table) {
+		renderOneLineCustomTable("RECOMMENDATION DETAILS",
+			renderCustomTable([]string{},
+				[][]string{
+					{"ID", compCmdState.RecommendationID},
+					{"SEVERITY", recommendation.SeverityString()},
+					{"SERVICE", recommendation.Service},
+					{"CATEGORY", recommendation.Category},
+					{"STATUS", recommendation.Status},
+					{"ASSESSED RESOURCES", strconv.Itoa(recommendation.AssessedResourceCount)},
+					{"AFFECTED RESOURCES", strconv.Itoa(affectedResources)},
+				},
+				tableFunc(func(t *tablewriter.Table) {
+					t.SetBorder(false)
+					t.SetColumnSeparator(" ")
+					t.SetAutoWrapText(false)
+					t.SetAlignment(tablewriter.ALIGN_LEFT)
+				}),
+			), tableFunc(func(t *tablewriter.Table) {
 				t.SetBorder(false)
-				t.SetColumnSeparator(" ")
 				t.SetAutoWrapText(false)
-				t.SetAlignment(tablewriter.ALIGN_LEFT)
-				t.SetCenterSeparator("")
 			}),
-		),
-	)
+		))
 
 	if affectedResources == 0 {
 		cli.OutputHuman("\nNo resources found affected by '%s'\n", compCmdState.RecommendationID)
@@ -485,7 +488,7 @@ func outputResourcesByRecommendationID(report api.CloudComplianceReport) error {
 
 	cli.OutputHuman(
 		renderSimpleTable(
-			[]string{"Resource", "Region", "Reasons"},
+			[]string{"AFFECTED RESOURCE", "REGION", "REASON"},
 			violationsToTable(violations),
 		),
 	)

--- a/cli/cmd/compliance.go
+++ b/cli/cmd/compliance.go
@@ -20,6 +20,7 @@ package cmd
 
 import (
 	"fmt"
+	"regexp"
 	"sort"
 	"strings"
 	"time"
@@ -57,7 +58,12 @@ var (
 
 		// Filter the recommendations table by status
 		Status string
+
+		// output resources affected by recommendationID
+		RecommendationID string
 	}{Type: "CIS"}
+
+	RecommendationIDRegex = "^[A-Z]+[A-Z_]*[0-9]*"
 
 	// complianceCmd represents the compliance command
 	complianceCmd = &cobra.Command{
@@ -434,4 +440,9 @@ func statusToProperTypes(status string) string {
 	default:
 		return "Unknown"
 	}
+}
+
+func validateRecommendationID(s string) bool {
+	match, _ := regexp.MatchString(RecommendationIDRegex, s)
+	return match
 }

--- a/cli/cmd/compliance.go
+++ b/cli/cmd/compliance.go
@@ -446,3 +446,28 @@ func validateRecommendationID(s string) bool {
 	match, _ := regexp.MatchString(RecommendationIDRegex, s)
 	return match
 }
+
+func outputResourcesByRecommendationID(report api.CloudComplianceReport) error {
+	violations := filterResourcesByRecommendationID(report, compCmdState.RecommendationID)
+
+	if len(violations) == 0 {
+		cli.OutputHuman("\nNo resources found affected by '%s'\n", compCmdState.RecommendationID)
+		return nil
+	}
+
+	if cli.JSONOutput() {
+		resourcesJsonOut := struct {
+			Violations []api.ComplianceViolation `json:"violations"`
+		}{violations}
+		return cli.OutputJSON(resourcesJsonOut)
+	}
+
+	cli.OutputHuman(
+		renderSimpleTable(
+			[]string{"Resource", "Region", "Reasons"},
+			violationsToTable(violations),
+		),
+	)
+	cli.OutputHuman("\n%d resources showing affected by `%s`\n", len(violations), compCmdState.RecommendationID)
+	return nil
+}

--- a/cli/cmd/compliance_aws.go
+++ b/cli/cmd/compliance_aws.go
@@ -245,22 +245,6 @@ To run an show recources affected by a violation:
 	}
 )
 
-func filterResourcesByRecommendationID(report api.CloudComplianceReport, recID string) (violations []api.ComplianceViolation) {
-	for _, r := range report.GetComplianceRecommendations() {
-		if r.RecID == recID {
-			violations = append(violations, r.Violations...)
-		}
-	}
-	return
-}
-
-func violationsToTable(violations []api.ComplianceViolation) (resourceTable [][]string) {
-	for _, v := range violations {
-		resourceTable = append(resourceTable, []string{v.Resource, v.Region, strings.Join(v.Reasons, ",")})
-	}
-	return
-}
-
 func init() {
 	// add sub-commands to the aws command
 	complianceAwsCmd.AddCommand(complianceAwsGetReportCmd)

--- a/cli/cmd/compliance_aws.go
+++ b/cli/cmd/compliance_aws.go
@@ -193,30 +193,9 @@ To run an show recources affected by a violation:
 				)
 			}
 
-			// if a second arg if provided, we assume it's a recommendation id
+			// If RecommendationID is provided, output resources matching that id
 			if compCmdState.RecommendationID != "" {
-				violations := filterResourcesByRecommendationID(report, compCmdState.RecommendationID)
-
-				if len(violations) == 0 {
-					cli.OutputHuman("\nNo resources found affected by '%s'\n", compCmdState.RecommendationID)
-					return nil
-				}
-
-				if cli.JSONOutput() {
-					resourcesJsonOut := struct {
-						Violations []api.ComplianceViolation `json:"violations"`
-					}{violations}
-					return cli.OutputJSON(resourcesJsonOut)
-				}
-
-				cli.OutputHuman(
-					renderSimpleTable(
-						[]string{"Resource", "Region", "Reasons"},
-						violationsToTable(violations),
-					),
-				)
-				cli.OutputHuman("\n%d resources showing affected by `%s`\n", len(violations), compCmdState.RecommendationID)
-				return nil
+				return outputResourcesByRecommendationID(report)
 			}
 
 			recommendations := complianceReportRecommendationsTable(report.Recommendations)
@@ -266,8 +245,8 @@ To run an show recources affected by a violation:
 	}
 )
 
-func filterResourcesByRecommendationID(report api.ComplianceAwsReport, recID string) (violations []api.ComplianceViolation) {
-	for _, r := range report.Recommendations {
+func filterResourcesByRecommendationID(report api.CloudComplianceReport, recID string) (violations []api.ComplianceViolation) {
+	for _, r := range report.GetComplianceRecommendations() {
 		if r.RecID == recID {
 			violations = append(violations, r.Violations...)
 		}

--- a/cli/cmd/compliance_aws.go
+++ b/cli/cmd/compliance_aws.go
@@ -61,7 +61,7 @@ var (
 
 			if len(args) > 1 {
 				compCmdState.RecommendationID = args[1]
-				if !validateRecommendationID(compCmdState.RecommendationID) {
+				if !validRecommendationID(compCmdState.RecommendationID) {
 					return errors.Errorf("\n'%s' is not a valid recommendation id\n", compCmdState.RecommendationID)
 				}
 			}
@@ -92,9 +92,9 @@ To run an ad-hoc compliance assessment of an AWS account:
 
     lacework compliance aws run-assessment <account_id>
 
-To run an show recources affected by a violation:
+To show resources affected by a violation:
 
-    lacework compliance aws get-report <account_id> <recommendation_id>
+    lacework compliance aws get-report <account_id> [recommendation_id]
 `,
 		Args: cobra.RangeArgs(1, 2),
 		RunE: func(_ *cobra.Command, args []string) error {

--- a/cli/cmd/compliance_aws.go
+++ b/cli/cmd/compliance_aws.go
@@ -92,7 +92,7 @@ To run an ad-hoc compliance assessment of an AWS account:
 
     lacework compliance aws run-assessment <account_id>
 
-To show resources affected by a violation:
+To show recommendation details and affected resources for a recommendation id:
 
     lacework compliance aws get-report <account_id> [recommendation_id]
 `,

--- a/cli/cmd/compliance_azure.go
+++ b/cli/cmd/compliance_azure.go
@@ -126,7 +126,7 @@ To run an ad-hoc compliance assessment use the command:
 
     lacework compliance azure run-assessment <tenant_id>
 `,
-		Args: cobra.ExactArgs(2),
+		Args: cobra.RangeArgs(2, 3),
 		RunE: func(_ *cobra.Command, args []string) error {
 			var (
 				// clean tenantID and subscriptionID if they were provided
@@ -204,7 +204,7 @@ To run an ad-hoc compliance assessment use the command:
 				report.Recommendations, filteredOutput = filterRecommendations(report.Recommendations)
 			}
 
-			if cli.JSONOutput() {
+			if cli.JSONOutput() && compCmdState.RecommendationID == "" {
 				return cli.OutputJSON(report)
 			}
 
@@ -227,6 +227,11 @@ To run an ad-hoc compliance assessment use the command:
 						"Status", "Severity", "Resource", "Region", "Reason"},
 					recommendations,
 				)
+			}
+
+			// If RecommendationID is provided, output resources matching that id
+			if compCmdState.RecommendationID != "" {
+				return outputResourcesByRecommendationID(report)
 			}
 
 			recommendations := complianceReportRecommendationsTable(report.Recommendations)

--- a/cli/cmd/compliance_azure.go
+++ b/cli/cmd/compliance_azure.go
@@ -99,9 +99,16 @@ Use the following command to list all Azure Tenants configured in your account:
 	complianceAzureGetReportCmd = &cobra.Command{
 		Use:     "get-report <tenant_id> <subscriptions_id>",
 		Aliases: []string{"get"},
-		PreRunE: func(_ *cobra.Command, _ []string) error {
+		PreRunE: func(_ *cobra.Command, args []string) error {
 			if compCmdState.Csv {
 				cli.EnableCSVOutput()
+			}
+
+			if len(args) > 2 {
+				compCmdState.RecommendationID = args[2]
+				if !validateRecommendationID(compCmdState.RecommendationID) {
+					return errors.Errorf("\n'%s' is not a valid recommendation id\n", compCmdState.RecommendationID)
+				}
 			}
 
 			switch compCmdState.Type {

--- a/cli/cmd/compliance_azure.go
+++ b/cli/cmd/compliance_azure.go
@@ -133,7 +133,7 @@ To run an ad-hoc compliance assessment use the command:
 
     lacework compliance azure run-assessment <tenant_id>
 
-To show resources affected by a violation:
+To show recommendation details and affected resources for a recommendation id:
 
     lacework compliance azure get-report <tenant_id> <subscriptions_id> [recommendation_id]
 `,

--- a/cli/cmd/compliance_azure.go
+++ b/cli/cmd/compliance_azure.go
@@ -106,7 +106,7 @@ Use the following command to list all Azure Tenants configured in your account:
 
 			if len(args) > 2 {
 				compCmdState.RecommendationID = args[2]
-				if !validateRecommendationID(compCmdState.RecommendationID) {
+				if !validRecommendationID(compCmdState.RecommendationID) {
 					return errors.Errorf("\n'%s' is not a valid recommendation id\n", compCmdState.RecommendationID)
 				}
 			}
@@ -132,6 +132,10 @@ To list all Azure tenants and subscriptions configured in your account:
 To run an ad-hoc compliance assessment use the command:
 
     lacework compliance azure run-assessment <tenant_id>
+
+To show resources affected by a violation:
+
+    lacework compliance azure get-report <tenant_id> <subscriptions_id> [recommendation_id]
 `,
 		Args: cobra.RangeArgs(2, 3),
 		RunE: func(_ *cobra.Command, args []string) error {

--- a/cli/cmd/compliance_gcp.go
+++ b/cli/cmd/compliance_gcp.go
@@ -135,7 +135,7 @@ To run an ad-hoc compliance assessment use the command:
 
     lacework compliance gcp run-assessment <project_id>
 
-To show resources affected by a violation:
+To show recommendation details and affected resources for a recommendation id:
 
     lacework compliance gcp get-report <organization_id> <project_id> [recommendation_id]
 `,

--- a/cli/cmd/compliance_gcp.go
+++ b/cli/cmd/compliance_gcp.go
@@ -106,8 +106,8 @@ Then, select one GUID from an integration and visualize its details using the co
 				cli.EnableCSVOutput()
 			}
 
-			if len(args) > 1 {
-				compCmdState.RecommendationID = args[1]
+			if len(args) > 2 {
+				compCmdState.RecommendationID = args[2]
 				if !validateRecommendationID(compCmdState.RecommendationID) {
 					return errors.Errorf("\n'%s' is not a valid recommendation id\n", compCmdState.RecommendationID)
 				}

--- a/cli/cmd/compliance_gcp.go
+++ b/cli/cmd/compliance_gcp.go
@@ -108,7 +108,7 @@ Then, select one GUID from an integration and visualize its details using the co
 
 			if len(args) > 2 {
 				compCmdState.RecommendationID = args[2]
-				if !validateRecommendationID(compCmdState.RecommendationID) {
+				if !validRecommendationID(compCmdState.RecommendationID) {
 					return errors.Errorf("\n'%s' is not a valid recommendation id\n", compCmdState.RecommendationID)
 				}
 			}
@@ -134,6 +134,10 @@ To list all GCP projects and organizations configured in your account:
 To run an ad-hoc compliance assessment use the command:
 
     lacework compliance gcp run-assessment <project_id>
+
+To show resources affected by a violation:
+
+    lacework compliance gcp get-report <organization_id> <project_id> [recommendation_id]
 `,
 		Args: cobra.RangeArgs(2, 3),
 		RunE: func(_ *cobra.Command, args []string) error {

--- a/cli/cmd/compliance_test.go
+++ b/cli/cmd/compliance_test.go
@@ -19,6 +19,7 @@
 package cmd
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -237,3 +238,26 @@ var (
 		Violations:            []api.ComplianceViolation{},
 	}
 )
+
+func TestRecommendationIDRegex(t *testing.T) {
+	regexTests := []struct {
+		input    string
+		message  string
+		expected bool
+	}{
+		{input: "invalid", message: "recommendation id must be uppercase", expected: false},
+		{input: "", message: "recommendation id cannot be empty string", expected: false},
+		{input: "44LW_AWS_ELASTICSEARCH_3", message: "recommendation id cannot be start with a number", expected: false},
+		{input: "_LW", message: "recommendation id cannot start with underscore", expected: false},
+		{input: "LW_AWS_ELASTICSEARCH_3", message: "recommendation id must start with uppercase letter, may contain underscores and numbers", expected: true},
+		{input: "LW_AWS_NETWORKING_46", message: "recommendation id must start with uppercase letter, may contain underscores and numbers", expected: true},
+		{input: "AWS_CIS_3_3", message: "recommendation id must start with uppercase letter, may contain underscores and numbers", expected: true},
+	}
+
+	for _, tests := range regexTests {
+		t.Run(tests.message, func(t *testing.T) {
+			result, _ := regexp.MatchString(RecommendationIDRegex, tests.input)
+			assert.Equal(t, tests.expected, result, tests.message)
+		})
+	}
+}

--- a/integration/compliance_aws_test.go
+++ b/integration/compliance_aws_test.go
@@ -145,16 +145,16 @@ func TestComplianceAwsGetReportRecommendationID(t *testing.T) {
 	assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
 	assert.Contains(t, out.String(), "SUMMARY",
 		"STDOUT table headers changed, please check")
-	assert.Contains(t, out.String(), "Severity",
+	assert.Contains(t, out.String(), "SEVERITY",
 		"STDOUT table headers changed, please check")
-	assert.Contains(t, out.String(), "Service",
+	assert.Contains(t, out.String(), "SERVICE",
 		"STDOUT table headers changed, please check")
-	assert.Contains(t, out.String(), "Category",
+	assert.Contains(t, out.String(), "CATEGORY",
 		"STDOUT table headers changed, please check")
-	assert.Contains(t, out.String(), "Status",
+	assert.Contains(t, out.String(), "STATUS",
 		"STDOUT table headers changed, please check")
-	assert.Contains(t, out.String(), "Assessed Resources ",
+	assert.Contains(t, out.String(), "ASSESSED RESOURCES ",
 		"STDOUT table headers changed, please check")
-	assert.Contains(t, out.String(), "Affected Resources",
+	assert.Contains(t, out.String(), "AFFECTED RESOURCES",
 		"STDOUT table headers changed, please check")
 }

--- a/integration/compliance_aws_test.go
+++ b/integration/compliance_aws_test.go
@@ -143,7 +143,7 @@ func TestComplianceAwsGetReportRecommendationID(t *testing.T) {
 
 	assert.Empty(t, err.String(), "STDERR should be empty")
 	assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
-	assert.Contains(t, out.String(), "SUMMARY",
+	assert.Contains(t, out.String(), "RECOMMENDATION DETAILS",
 		"STDOUT table headers changed, please check")
 	assert.Contains(t, out.String(), "SEVERITY",
 		"STDOUT table headers changed, please check")

--- a/integration/compliance_aws_test.go
+++ b/integration/compliance_aws_test.go
@@ -136,3 +136,25 @@ func TestComplianceAwsGetReportTypeAWS_SOC_Rev2(t *testing.T) {
 	assert.Contains(t, out.String(), account,
 		"Account ID in compliance report is not correct")
 }
+
+func TestComplianceAwsGetReportRecommendationID(t *testing.T) {
+	account := os.Getenv("LW_INT_TEST_AWS_ACC")
+	out, err, exitcode := LaceworkCLIWithTOMLConfig("compliance", "aws", "get-report", account, "AWS_CIS_2_5")
+
+	assert.Empty(t, err.String(), "STDERR should be empty")
+	assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
+	assert.Contains(t, out.String(), "SUMMARY",
+		"STDOUT table headers changed, please check")
+	assert.Contains(t, out.String(), "Severity",
+		"STDOUT table headers changed, please check")
+	assert.Contains(t, out.String(), "Service",
+		"STDOUT table headers changed, please check")
+	assert.Contains(t, out.String(), "Category",
+		"STDOUT table headers changed, please check")
+	assert.Contains(t, out.String(), "Status",
+		"STDOUT table headers changed, please check")
+	assert.Contains(t, out.String(), "Assessed Resources ",
+		"STDOUT table headers changed, please check")
+	assert.Contains(t, out.String(), "Affected Resources",
+		"STDOUT table headers changed, please check")
+}


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/lacework/go-sdk) and create your branch from `main`
  2. Run `make prepare` in the repository root
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`make test`)
  5. Format your code (`make fmt`)
  6. Make sure your code lints (`make lint`)
  7. If you are updating the Lacework CLI, make sure it compiles (`make build-cli-cross-platform`)
  8. Follow the commit message standard (`type(scope): subject`) documented in [DEVELOPER_GUIDELINES.md](https://github.com/lacework/go-sdk/blob/main/DEVELOPER_GUIDELINES.md#commit-message-standard)
  9. If you haven't already, configure signed commits by [telling git about your signing key](https://docs.github.com/en/github/authenticating-to-github/managing-commit-signature-verification/telling-git-about-your-signing-key) and [signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)

  Learn more about contributing: https://github.com/lacework/go-sdk/blob/main/CONTRIBUTING.md
-->

## Summary

The lacework compliance command can now return a list of resources affected by a recommendation ID.
`lacework comp aws get <account_id> <reccomendation_id>`
`lacework comp gcp get <organization_id> <project_id>`
`lacework comp az get <tenant_id> <subscriptions_id>`

## How did you test this change?

- Add unit test for regex validation `cli/cmd/compliance_test.go`
- Add integration tests  `integration/compliance_aws_test.go`
-  run `lacework comp aws get <account_id> <reccomendation_id>`
-  run `lacework comp gcp get <organization_id> <project_id>`
-  run `lacework comp az get <tenant_id> <subscriptions_id>`


<!--
  How exactly did you verify that your PR solves the issue you wanted to solve?
  Include any other relevant information such as how to use the new fuctionality, screenshots, etc.
-->

## Issue

https://lacework.atlassian.net/browse/ALLY-816


Usage:

```
// Output if no resources are affected

         RECOMMENDATION DETAILS          
-----------------------------------------
    ID                   AWS_CIS_2_5     
    SEVERITY             High            
    SERVICE              aws:config      
    CATEGORY             Logging         
    STATUS               NonCompliant    
    ASSESSED RESOURCES   0              
    AFFECTED RESOURCES   0              

No resources found affected by 'recommendationID'
```

```
// Output if 1 resource is affected

         RECOMMENDATION DETAILS          
-----------------------------------------
    ID                   'rec_id'     
    SEVERITY             High            
    SERVICE             'service'      
    CATEGORY             'category'         
    STATUS               NonCompliant    
    ASSESSED RESOURCES   1              
    AFFECTED RESOURCES   1              
                                         
  AFFECTED RESOURCE       REGION                   REASON              
--------------------+----------------+---------------------------------
     resource-name        region         reason      

```


