### PR TITLE
ci(cli): release CentOS end-of-life problem

### DIFF
--- a/cli/images/centos-8/Dockerfile
+++ b/cli/images/centos-8/Dockerfile
@@ -2,6 +2,11 @@ FROM  centos:8
 LABEL maintainer="tech-ally@lacework.net" \
       description="The Lacework CLI helps you manage the Lacework cloud security platform"
 
+# From December 2021 CentOS 8 Life was ended
+# (@afiune) Workaround: use a mirror
+RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-Linux-*
+RUN sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-Linux-*
+
 RUN yum update -y
 COPY ./LICENSE /
 RUN curl https://raw.githubusercontent.com/lacework/go-sdk/main/cli/install.sh | bash

--- a/scripts/release_container_manifest.sh
+++ b/scripts/release_container_manifest.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+#
+
+set -eou pipefail
+
+# The repository where we are hosting the lacework-cli containers
+readonly repository="lacework/lacework-cli"
+readonly project_name=lacework-cli
+
+log() {
+  echo "--> ${project_name}: $1"
+}
+
+# Enable docker experimental mode
+log "enabling experimental mode to use/upload docker manifest"
+_docker_config=$HOME/.docker/config.json
+mkdir -p ~/.docker
+[[ ! -f "$_docker_config" ]] && echo '{"experimental": "enabled"}' > "$_docker_config"
+
+# Authenticate to dockerhub if needed
+[[ "unset" != "${DOCKERHUB_PASS:-unset}" ]] && echo "$DOCKERHUB_PASS" | docker \
+  login -u "$DOCKERHUB_USERNAME" \
+  --password-stdin
+
+# when updating the distributions below, please make sure to update
+# the script 'release.sh' inside the 'script/' folder
+distros=(
+  scratch
+  ubi-8
+  centos-8
+  debian-10
+  ubuntu-1804
+  amazonlinux-2
+#  windows-nanoserver
+)
+
+for dist in "${distros[@]}"; do
+  log "pulling container for ${dist}"
+  docker pull "${repository}:${dist}"
+done
+
+log "creating docker manifest"
+docker manifest create   "${repository}:latest"      \
+                         "${repository}:scratch"     \
+                         "${repository}:ubi-8"       \
+                         "${repository}:centos-8"    \
+                         "${repository}:debian-10"   \
+                         "${repository}:ubuntu-1804" \
+                         "${repository}:amazonlinux-2" --amend
+
+log "pushing docker manifest"
+docker manifest push "${repository}:latest" --purge
+
+log "Docker manifest released! (https://hub.docker.com/repository/docker/${repository})"

--- a/scripts/release_containers.sh
+++ b/scripts/release_containers.sh
@@ -17,11 +17,6 @@ if [ ! -f "bin/lacework-cli-linux-amd64" ]; then
   make build-cli-cross-platform
 fi
 
-# Enable docker experimental mode
-log "enabling experimental mode to use/upload docker manifest"
-mkdir -p ~/.docker
-echo '{"experimental": "enabled"}' > ~/.docker/config.json
-
 # Authenticate to dockerhub
 echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
 
@@ -46,16 +41,6 @@ for dist in "${distros[@]}"; do
   docker push "${repository}:${dist}"
 done
 
-log "creating docker manifest"
-docker manifest create   "${repository}:latest"      \
-                         "${repository}:scratch"     \
-                         "${repository}:ubi-8"       \
-                         "${repository}:centos-8"    \
-                         "${repository}:debian-10"   \
-                         "${repository}:ubuntu-1804" \
-                         "${repository}:amazonlinux-2" --amend
-
-log "pushing docker manifest"
-docker manifest push "${repository}:latest" --purge
+scripts/release_container_manifest.sh
 
 log "All docker containers have been released! (https://hub.docker.com/repository/docker/${repository})"


### PR DESCRIPTION
## Summary

I think from December 2021 CentOS 8 Life was ended, we are applying a workaround which
is to use a mirror for now.

https://www.centos.org/news-and-events/1322-october-centos-dojo-videos/

We might have to stop releasing this container in the future.
## How did you test this change?

Released the CLI manually since our CI pipeline failed.

## Issue

https://lacework.atlassian.net/browse/ALLY-880