### PR TITLE
feat(cli): switch-profile command

### DIFF
--- a/cli/cmd/configure.go
+++ b/cli/cmd/configure.go
@@ -73,10 +73,9 @@ the Lacework CLI will create it for you.`,
 		Args:  cobra.NoArgs,
 		Long: `List all profiles configured into the config file ~/.lacework.toml
 
-To switch to a different profile permanently in your current terminal,
-export the environment variable:
+To switch profiles permanently erminal use the command.
 
-    ` + configureListCmdSetProfileEnv,
+    lacework configure switch-profile profile2`,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			profiles, err := cli.LoadProfiles()
 			if err != nil {
@@ -89,6 +88,8 @@ export the environment variable:
 					buildProfilesTableContent(cli.Profile, profiles),
 				),
 			)
+
+			cli.OutputHuman("\nTo switch profiles use 'lacework configure switch-profile <profile>'\n")
 			return nil
 		},
 	}
@@ -105,6 +106,7 @@ The available configuration keys are:
 
 * profile
 * account
+* subaccount
 * api_secret
 * api_key
 
@@ -115,7 +117,8 @@ To show the configuration from a different profile, use the flag --profile.
 			data, ok := showConfigurationDataFromKey(args[0])
 			if !ok {
 				// TODO change this to be dynamic
-				return errors.New("unknown configuration key. (available: profile, account, subaccount, api_secret, api_key, version)")
+				return errors.New(
+					"unknown configuration key. (available: profile, account, subaccount, api_secret, api_key, version)")
 			}
 
 			if data != "" {

--- a/cli/cmd/configure.go
+++ b/cli/cmd/configure.go
@@ -68,12 +68,13 @@ the Lacework CLI will create it for you.`,
 	}
 
 	configureListCmd = &cobra.Command{
-		Use:   "list",
-		Short: "List all configured profiles at ~/.lacework.toml",
-		Args:  cobra.NoArgs,
+		Use:     "list",
+		Short:   "List all configured profiles at ~/.lacework.toml",
+		Aliases: []string{"ls"},
+		Args:    cobra.NoArgs,
 		Long: `List all profiles configured into the config file ~/.lacework.toml
 
-To switch profiles permanently erminal use the command.
+To switch profiles permanently use the command.
 
     lacework configure switch-profile profile2`,
 		RunE: func(_ *cobra.Command, _ []string) error {

--- a/cli/cmd/configure_switch_profile.go
+++ b/cli/cmd/configure_switch_profile.go
@@ -19,6 +19,8 @@
 package cmd
 
 import (
+	"os"
+
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -39,7 +41,9 @@ is to export the environment variable:
 			if args[0] == "default" {
 				cli.Log.Debug("removing global profile cache, going back to default")
 				if err := cli.Cache.Erase("global/profile"); err != nil {
-					return errors.Wrap(err, "unable to switch profile")
+					if !os.IsNotExist(err) {
+						return errors.Wrap(err, "unable to switch profile")
+					}
 				}
 				cli.OutputHuman("Profile switched back to default.\n")
 				return nil

--- a/cli/cmd/configure_switch_profile.go
+++ b/cli/cmd/configure_switch_profile.go
@@ -37,6 +37,7 @@ is to export the environment variable:
     ` + configureListCmdSetProfileEnv,
 		RunE: func(_ *cobra.Command, args []string) error {
 			if args[0] == "default" {
+				cli.Log.Debug("removing global profile cache, going back to default")
 				if err := cli.Cache.Erase("global/profile"); err != nil {
 					return errors.Wrap(err, "unable to switch profile")
 				}
@@ -50,6 +51,10 @@ is to export the environment variable:
 			}
 
 			if _, ok := profiles[args[0]]; ok {
+				cli.Log.Debugw("storing global profile cache",
+					"current_profile", cli.Profile,
+					"new_profile", args[0],
+				)
 				if err := cli.Cache.Write("global/profile", []byte(args[0])); err != nil {
 					return errors.Wrap(err, "unable to switch profile")
 				}

--- a/cli/cmd/configure_switch_profile.go
+++ b/cli/cmd/configure_switch_profile.go
@@ -58,7 +58,7 @@ is to export the environment variable:
 				if err := cli.Cache.Write("global/profile", []byte(args[0])); err != nil {
 					return errors.Wrap(err, "unable to switch profile")
 				}
-				cli.OutputHuman("Profile switched to '%s' (no more --profile)\n", args[0])
+				cli.OutputHuman("Profile switched to '%s'.\n", args[0])
 				return nil
 			}
 

--- a/cli/cmd/configure_switch_profile.go
+++ b/cli/cmd/configure_switch_profile.go
@@ -1,0 +1,70 @@
+//
+// Author:: Salim Afiune Maya (<afiune@lacework.net>)
+// Copyright:: Copyright 2022, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cmd
+
+import (
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+var (
+	configureSwitchProfileCmd = &cobra.Command{
+		Use:     "switch-profile <profile>",
+		Aliases: []string{"switch", "use"},
+		Args:    cobra.ExactArgs(1),
+		Short:   "Switch between configured profiles",
+		Long: `Switch between profiles configured into the config file ~/.lacework.toml
+
+An alternative to temporarily switch to a different profile in your current terminal
+is to export the environment variable:
+
+    ` + configureListCmdSetProfileEnv,
+		RunE: func(_ *cobra.Command, args []string) error {
+			if args[0] == "default" {
+				if err := cli.Cache.Erase("global/profile"); err != nil {
+					return errors.Wrap(err, "unable to switch profile")
+				}
+				cli.OutputHuman("Profile switched back to default.\n")
+				return nil
+			}
+
+			profiles, err := cli.LoadProfiles()
+			if err != nil {
+				return err
+			}
+
+			if _, ok := profiles[args[0]]; ok {
+				if err := cli.Cache.Write("global/profile", []byte(args[0])); err != nil {
+					return errors.Wrap(err, "unable to switch profile")
+				}
+				cli.OutputHuman("Profile switched to '%s' (no more --profile)\n", args[0])
+				return nil
+			}
+
+			return errors.Errorf(
+				"Profile '%s' not found. Try 'lacework configure list' to see all configured profiles.",
+				args[0],
+			)
+		},
+	}
+)
+
+func init() {
+	configureCmd.AddCommand(configureSwitchProfileCmd)
+}

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -242,6 +242,7 @@ func initConfig() {
 	if p := viper.GetString("profile"); len(p) != 0 {
 		err = cli.SetProfile(p)
 	} else if p, cacheErr := cli.Cache.Read("global/profile"); cacheErr == nil {
+		cli.Log.Debugw("loading profile from cache", "profile", string(p))
 		err = cli.SetProfile(string(p))
 	} else {
 		err = cli.LoadState()

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -233,11 +233,16 @@ func initConfig() {
 		)
 	}
 
+	// initialize cli cache library
+	cli.InitCache()
+
 	// get the profile passed as a parameter or environment variable
 	// if any, set it into the CLI state, that will trigger to load the
 	// state, if no profile was specified just load the default state
 	if p := viper.GetString("profile"); len(p) != 0 {
 		err = cli.SetProfile(p)
+	} else if p, cacheErr := cli.Cache.Read("global/profile"); cacheErr == nil {
+		err = cli.SetProfile(string(p))
 	} else {
 		err = cli.LoadState()
 	}
@@ -254,9 +259,6 @@ func initConfig() {
 			exitwith(err)
 		}
 	}
-
-	// initialize cli cache library
-	cli.InitCache()
 }
 
 // isCommand checks the overall arguments passed to the lacework cli

--- a/integration/configure_switch_profile_test.go
+++ b/integration/configure_switch_profile_test.go
@@ -1,0 +1,140 @@
+//go:build configure
+
+// Author:: Salim Afiune Maya (<afiune@lacework.net>)
+// Copyright:: Copyright 2022, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package integration
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConfigureSwitchProfileNoConfigFails(t *testing.T) {
+	out, err, exitcode := LaceworkCLI("configure", "switch-profile", "foo")
+	assert.Empty(t,
+		out.String(),
+		"STDOUT should be empty")
+	assert.Contains(t,
+		err.String(),
+		"ERROR unable to load profiles. No configuration file found.",
+		"STDERR message is not correct")
+	assert.Equal(t, 1, exitcode,
+		"EXITCODE is not the expected one")
+}
+
+func TestConfigureSwitchProfileNotFound(t *testing.T) {
+	out, err, exitcode := LaceworkCLIWithDummyConfig("configure", "switch-profile", "bar")
+	assert.Empty(t,
+		out.String(),
+		"STDOUT should be empty")
+	assert.Contains(t,
+		err.String(),
+		"ERROR Profile 'bar' not found. Try 'lacework configure list' to see all configured profiles.",
+		"STDERR message is not correct")
+	assert.Equal(t, 1, exitcode,
+		"EXITCODE is not the expected one")
+}
+
+func TestConfigureSwitchProfileWithConfig(t *testing.T) {
+	// @afiune we store the temp directory since we need to run more
+	// commands after switching a profile
+	dir := createDummyTOMLConfig()
+	defer os.RemoveAll(dir)
+
+	out, err, exitcode := LaceworkCLIWithHome(dir, "configure", "switch-profile", "dev")
+	assert.Empty(t,
+		err.String(),
+		"STDERR should be empty")
+	assert.Contains(t,
+		out.String(), "Profile switched to 'dev'.",
+		"STDOUT message is not correct")
+	assert.Equal(t, 0, exitcode,
+		"EXITCODE is not the expected one")
+
+	out, err, exitcode = LaceworkCLIWithHome(dir, "configure", "show", "account")
+	assert.Empty(t,
+		err.String(),
+		"STDERR should be empty")
+	assert.Contains(t,
+		out.String(), "dev.example",
+		"STDOUT message is not correct")
+	assert.Equal(t, 0, exitcode,
+		"EXITCODE is not the expected one")
+
+	t.Run("re-running should pass", func(t *testing.T) {
+		out, err, exitcode := LaceworkCLIWithDummyConfig("configure", "switch-profile", "dev")
+		assert.Empty(t,
+			err.String(),
+			"STDERR should be empty")
+		assert.Contains(t,
+			out.String(), "Profile switched to 'dev'.",
+			"STDOUT message is not correct")
+		assert.Equal(t, 0, exitcode,
+			"EXITCODE is not the expected one")
+
+		out, err, exitcode = LaceworkCLIWithHome(dir, "configure", "show", "account")
+		assert.Contains(t, out.String(), "dev.example", "STDOUT message is not correct")
+		assert.Empty(t,
+			err.String(),
+			"STDERR should be empty")
+		assert.Equal(t, 0, exitcode,
+			"EXITCODE is not the expected one")
+	})
+
+	t.Run("switch back to the default profile", func(t *testing.T) {
+		out, err, exitcode := LaceworkCLIWithHome(dir, "configure", "switch-profile", "default")
+		assert.Empty(t,
+			err.String(),
+			"STDERR should be empty")
+		assert.Contains(t,
+			out.String(), "Profile switched back to default.",
+			"STDOUT message is not correct")
+		assert.Equal(t, 0, exitcode,
+			"EXITCODE is not the expected one")
+
+		out, err, exitcode = LaceworkCLIWithHome(dir, "configure", "show", "account")
+		assert.Contains(t, out.String(), "dummy", "STDOUT message is not correct")
+		assert.Empty(t,
+			err.String(),
+			"STDERR should be empty")
+		assert.Equal(t, 0, exitcode,
+			"EXITCODE is not the expected one")
+
+		t.Run("re-run should pass", func(t *testing.T) {
+			out, err, exitcode := LaceworkCLIWithHome(dir, "configure", "switch-profile", "default")
+			assert.Empty(t,
+				err.String(),
+				"STDERR should be empty")
+			assert.Contains(t,
+				out.String(), "Profile switched back to default.",
+				"STDOUT message is not correct")
+			assert.Equal(t, 0, exitcode,
+				"EXITCODE is not the expected one")
+
+			out, err, exitcode = LaceworkCLIWithHome(dir, "configure", "show", "account")
+			assert.Contains(t, out.String(), "dummy", "STDOUT message is not correct")
+			assert.Empty(t,
+				err.String(),
+				"STDERR should be empty")
+			assert.Equal(t, 0, exitcode,
+				"EXITCODE is not the expected one")
+		})
+	})
+}

--- a/integration/configure_test.go
+++ b/integration/configure_test.go
@@ -29,6 +29,23 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestConfigureListHelp(t *testing.T) {
+	out, err, exitcode := LaceworkCLI("configure", "list", "--help")
+	assert.Empty(t,
+		err.String(),
+		"STDERR should be empty")
+	assert.Contains(t,
+		out.String(),
+		"To switch profiles permanently use the command.",
+		"STDOUT help message is not correct")
+	assert.Contains(t,
+		out.String(),
+		"lacework configure switch-profile profile2",
+		"STDOUT help message is not correct")
+	assert.Equal(t, 0, exitcode,
+		"EXITCODE is not the expected one")
+}
+
 func TestConfigureCommandNonInteractive(t *testing.T) {
 	// create a temporal directory where we will check that the
 	// configuration file is deployed (.lacework.toml)

--- a/integration/configure_unix_test.go
+++ b/integration/configure_unix_test.go
@@ -539,8 +539,8 @@ func TestConfigureCommandWithJSONFileFlagError(t *testing.T) {
 		"EXITCODE is not the expected one")
 }
 
-func TestConfigureListHelp(t *testing.T) {
-	out, err, exitcode := LaceworkCLI("configure", "list", "--help")
+func TestConfigureSwitchProfileHelp(t *testing.T) {
+	out, err, exitcode := LaceworkCLI("configure", "switch-profile", "--help")
 	assert.Empty(t,
 		err.String(),
 		"STDERR should be empty")

--- a/integration/configure_windows_test.go
+++ b/integration/configure_windows_test.go
@@ -38,8 +38,8 @@ func TestConfigureCommandWithJSONFileFlagError(t *testing.T) {
 		"EXITCODE is not the expected one")
 }
 
-func TestConfigureListHelp(t *testing.T) {
-	out, err, exitcode := LaceworkCLI("configure", "list", "--help")
+func TestConfigureSwitchProfileHelp(t *testing.T) {
+	out, err, exitcode := LaceworkCLI("configure", "switch-profile", "--help")
 	assert.Empty(t,
 		err.String(),
 		"STDERR should be empty")

--- a/integration/help_test.go
+++ b/integration/help_test.go
@@ -65,8 +65,9 @@ Usage:
   lacework configure [command]
 
 Available Commands:
-  list        List all configured profiles at ~/.lacework.toml
-  show        Show current configuration data
+  list           List all configured profiles at ~/.lacework.toml
+  show           Show current configuration data
+  switch-profile Switch between configured profiles
 
 Flags:
   -h, --help               help for configure


### PR DESCRIPTION

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/lacework/go-sdk) and create your branch from `main`
  2. Run `make prepare` in the repository root
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`make test`)
  5. Format your code (`make fmt`)
  6. Make sure your code lints (`make lint`)
  7. If you are updating the Lacework CLI, make sure it compiles (`make build-cli-cross-platform`)
  8. Follow the commit message standard (`type(scope): subject`) documented in [DEVELOPER_GUIDELINES.md](https://github.com/lacework/go-sdk/blob/main/DEVELOPER_GUIDELINES.md#commit-message-standard)
  9. If you haven't already, configure signed commits by [telling git about your signing key](https://docs.github.com/en/github/authenticating-to-github/managing-commit-signature-verification/telling-git-about-your-signing-key) and [signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)

  Learn more about contributing: https://github.com/lacework/go-sdk/blob/main/CONTRIBUTING.md
-->

## Summary

As a Lacework CLI user,
I would like to switch between my configured profiles
without using an interactive prompt, env var or editing the
`lacework.toml` config file directly.

**New Command**
```
$ lacework configure switch-profile profile2
Profile switched to 'profile2' (no more --profile)
```

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>

## How did you test this change?
Ran commands locally and added tests.

## Issue
https://lacework.atlassian.net/browse/ALLY-797
