### PR TITLE
refactor(cli): Create cloud specific TF file

### DIFF
--- a/cli/cmd/generate.go
+++ b/cli/cmd/generate.go
@@ -196,7 +196,7 @@ func determineOutputDirPath(location string) (string, error) {
 }
 
 // writeHclOutputPreCheck Prompt for confirmation if main.tf already exists; return true to continue
-func writeHclOutputPreCheck(outputLocation string, cloud string) (bool, error) {
+func writeHclOutputPreCheck(outputLocation string, filename string) (bool, error) {
 	// If noninteractive, continue
 	if !cli.InteractiveMode() {
 		return true, nil
@@ -207,12 +207,11 @@ func writeHclOutputPreCheck(outputLocation string, cloud string) (bool, error) {
 		return false, err
 	}
 
-	fileName := cloud
-	if fileName == "" {
-		fileName = "main"
+	if filename == "" {
+		filename = "main"
 	}
 
-	hclPath := filepath.FromSlash(fmt.Sprintf("%s/%s.tf", outputDir, fileName))
+	hclPath := filepath.FromSlash(fmt.Sprintf("%s/%s.tf", outputDir, filename))
 
 	// If the file doesn't exist, carry on
 	if _, err := os.Stat(hclPath); os.IsNotExist(err) {
@@ -232,7 +231,7 @@ func writeHclOutputPreCheck(outputLocation string, cloud string) (bool, error) {
 }
 
 // writeHclOutput Write HCL output
-func writeHclOutput(hcl string, location string, cloud string) (string, error) {
+func writeHclOutput(hcl string, location string, filename string) (string, error) {
 	// Determine write location
 	dirname, err := determineOutputDirPath(location)
 	if err != nil {
@@ -250,13 +249,12 @@ func writeHclOutput(hcl string, location string, cloud string) (string, error) {
 		}
 	}
 
-	fileName := cloud
-	if fileName == "" {
-		fileName = "main"
+	if filename == "" {
+		filename = "main"
 	}
 
 	// Create HCL file
-	outputLocation := filepath.FromSlash(fmt.Sprintf("%s/%s.tf", dirname, fileName))
+	outputLocation := filepath.FromSlash(fmt.Sprintf("%s/%s.tf", dirname, filename))
 	err = os.WriteFile(
 		filepath.FromSlash(outputLocation),
 		[]byte(hcl),

--- a/cli/cmd/generate.go
+++ b/cli/cmd/generate.go
@@ -365,7 +365,7 @@ func writeGeneratedCodeToLocation(cmd *cobra.Command, hcl string, cloud string) 
 }
 
 // executionPreRunChecks Execution pre-run check
-func executionPreRunChecks(dirname string, locationDir string, cloud string) error {
+func executionPreRunChecks(dirname string, locationDir string) error {
 	ok, err := TerraformExecutePreRunCheck(dirname)
 	if err != nil {
 		return errors.Wrap(err, "failed to check for existing terraform state")

--- a/cli/cmd/generate.go
+++ b/cli/cmd/generate.go
@@ -196,7 +196,7 @@ func determineOutputDirPath(location string) (string, error) {
 }
 
 // writeHclOutputPreCheck Prompt for confirmation if main.tf already exists; return true to continue
-func writeHclOutputPreCheck(outputLocation string) (bool, error) {
+func writeHclOutputPreCheck(outputLocation string, cloud string) (bool, error) {
 	// If noninteractive, continue
 	if !cli.InteractiveMode() {
 		return true, nil
@@ -207,7 +207,12 @@ func writeHclOutputPreCheck(outputLocation string) (bool, error) {
 		return false, err
 	}
 
-	hclPath := filepath.FromSlash(fmt.Sprintf("%s/main.tf", outputDir))
+	fileName := cloud
+	if fileName == "" {
+		fileName = "main"
+	}
+
+	hclPath := filepath.FromSlash(fmt.Sprintf("%s/%s.tf", outputDir, fileName))
 
 	// If the file doesn't exist, carry on
 	if _, err := os.Stat(hclPath); os.IsNotExist(err) {
@@ -227,7 +232,7 @@ func writeHclOutputPreCheck(outputLocation string) (bool, error) {
 }
 
 // writeHclOutput Write HCL output
-func writeHclOutput(hcl string, location string) (string, error) {
+func writeHclOutput(hcl string, location string, cloud string) (string, error) {
 	// Determine write location
 	dirname, err := determineOutputDirPath(location)
 	if err != nil {
@@ -245,8 +250,13 @@ func writeHclOutput(hcl string, location string) (string, error) {
 		}
 	}
 
+	fileName := cloud
+	if fileName == "" {
+		fileName = "main"
+	}
+
 	// Create HCL file
-	outputLocation := filepath.FromSlash(fmt.Sprintf("%s/main.tf", dirname))
+	outputLocation := filepath.FromSlash(fmt.Sprintf("%s/%s.tf", dirname, fileName))
 	err = os.WriteFile(
 		filepath.FromSlash(outputLocation),
 		[]byte(hcl),
@@ -329,7 +339,7 @@ func validPathExists(val interface{}) error {
 }
 
 // writeGeneratedCodeToLocation Write-out generated code to location specified
-func writeGeneratedCodeToLocation(cmd *cobra.Command, hcl string) (string, string, error) {
+func writeGeneratedCodeToLocation(cmd *cobra.Command, hcl string, cloud string) (string, string, error) {
 	//dirname, ok, location := "", false, ""
 	// Write-out generated code to location specified
 	dirname, err := cmd.Flags().GetString("output")
@@ -337,7 +347,7 @@ func writeGeneratedCodeToLocation(cmd *cobra.Command, hcl string) (string, strin
 		return dirname, "", errors.Wrap(err, "failed to parse output location")
 	}
 
-	ok, err := writeHclOutputPreCheck(dirname)
+	ok, err := writeHclOutputPreCheck(dirname, cloud)
 	if err != nil {
 		return dirname, "", errors.Wrap(err, "failed to validate output location")
 	}
@@ -346,7 +356,7 @@ func writeGeneratedCodeToLocation(cmd *cobra.Command, hcl string) (string, strin
 		return dirname, "", errors.Wrap(err, "aborting to avoid overwriting existing terraform code")
 	}
 
-	location, err := writeHclOutput(hcl, dirname)
+	location, err := writeHclOutput(hcl, dirname, cloud)
 	if err != nil {
 		return dirname, location, errors.Wrap(err, "failed to write terraform code to disk")
 	}
@@ -355,7 +365,7 @@ func writeGeneratedCodeToLocation(cmd *cobra.Command, hcl string) (string, strin
 }
 
 // executionPreRunChecks Execution pre-run check
-func executionPreRunChecks(dirname string, locationDir string) error {
+func executionPreRunChecks(dirname string, locationDir string, cloud string) error {
 	ok, err := TerraformExecutePreRunCheck(dirname)
 	if err != nil {
 		return errors.Wrap(err, "failed to check for existing terraform state")

--- a/cli/cmd/generate_aws.go
+++ b/cli/cmd/generate_aws.go
@@ -136,7 +136,7 @@ This command can also be run in noninteractive mode. See help output for more de
 			locationDir := filepath.Dir(location)
 			if GenerateAwsCommandExtraState.TerraformApply {
 				// Execution pre-run check
-				err := executionPreRunChecks(dirname, locationDir, "aws")
+				err := executionPreRunChecks(dirname, locationDir)
 				if err != nil {
 					return err
 				}

--- a/cli/cmd/generate_aws.go
+++ b/cli/cmd/generate_aws.go
@@ -117,7 +117,7 @@ This command can also be run in noninteractive mode. See help output for more de
 			}
 
 			// Write-out generated code to location specified
-			dirname, location, err := writeGeneratedCodeToLocation(cmd, hcl)
+			dirname, location, err := writeGeneratedCodeToLocation(cmd, hcl, "aws")
 			if err != nil {
 				return err
 			}
@@ -136,7 +136,7 @@ This command can also be run in noninteractive mode. See help output for more de
 			locationDir := filepath.Dir(location)
 			if GenerateAwsCommandExtraState.TerraformApply {
 				// Execution pre-run check
-				err := executionPreRunChecks(dirname, locationDir)
+				err := executionPreRunChecks(dirname, locationDir, "aws")
 				if err != nil {
 					return err
 				}

--- a/cli/cmd/generate_execute.go
+++ b/cli/cmd/generate_execute.go
@@ -40,7 +40,7 @@ func newTf(workingDir string, execPath string) (*tfexec.Terraform, error) {
 	return tf, nil
 }
 
-// Determine if terraform is installed, if that version is new enough, and if not install a new ephemeral binary of the
+// LocateOrInstallTerraform Determine if terraform is installed, if that version is new enough, and if not install a new ephemeral binary of the
 // correct version into tmp location
 //
 // forceInstall: if set always install ephemeral binary
@@ -187,7 +187,7 @@ func buildHumanReadablePlannedActions(workingDir string, execPath string, data [
 	return outputString.String()
 }
 
-// used to display the results of a plan
+// DisplayTerraformPlanChanges used to display the results of a plan
 //
 // returns true if apply should run, false to exit
 func DisplayTerraformPlanChanges(tf *tfexec.Terraform, data TfPlanChangesSummary) (bool, error) {
@@ -277,7 +277,7 @@ func TerraformInit(tf *tfexec.Terraform) error {
 	return nil
 }
 
-// Run terraform plan using the workingDir from *tfexec.Terraform
+// TerraformExecPlan Run terraform plan using the workingDir from *tfexec.Terraform
 //
 // - Run plan
 // - Get plan file details (returned)
@@ -294,7 +294,7 @@ func TerraformExecPlan(tf *tfexec.Terraform) (*TfPlanChangesSummary, error) {
 	return processTfPlanChangesSummary(tf)
 }
 
-// Run terraform apply using the workingDir from *tfexec.Terraform
+// TerraformExecApply Run terraform apply using the workingDir from *tfexec.Terraform
 //
 // - Run plan
 // - Get plan file details (returned)

--- a/integration/aws_generation_test.go
+++ b/integration/aws_generation_test.go
@@ -134,7 +134,7 @@ func TestGenerationCustomizedOutputLocation(t *testing.T) {
 	assert.Contains(t, final, "Terraform code saved in")
 
 	// Get result
-	result, _ := ioutil.ReadFile(filepath.FromSlash(fmt.Sprintf("%s/main.tf", dir)))
+	result, _ := ioutil.ReadFile(filepath.FromSlash(fmt.Sprintf("%s/aws.tf", dir)))
 
 	// Create the TF directly with lwgenerate and validate same result via CLI
 	buildTf, _ := aws.NewTerraform(region, true, true, aws.WithAwsProfile("default")).Generate()
@@ -506,7 +506,7 @@ func TestGenerationAdvancedOptsUseExistingIAM(t *testing.T) {
 	assert.Equal(t, buildTf, tfResult)
 }
 
-// Test existing main.tf prompt
+// Test existing aws.tf prompt
 func TestGenerationWithExistingTerraform(t *testing.T) {
 	os.Setenv("LW_NOCACHE", "true")
 	defer os.Setenv("LW_NOCACHE", "")
@@ -520,8 +520,8 @@ func TestGenerationWithExistingTerraform(t *testing.T) {
 	}
 	defer os.RemoveAll(dir)
 
-	// Create fake main.tf
-	if err := os.WriteFile(filepath.FromSlash(fmt.Sprintf("%s/main.tf", dir)), []byte{}, 0644); err != nil {
+	// Create fake aws.tf
+	if err := os.WriteFile(filepath.FromSlash(fmt.Sprintf("%s/aws.tf", dir)), []byte{}, 0644); err != nil {
 		panic(err)
 	}
 
@@ -543,7 +543,7 @@ func TestGenerationWithExistingTerraform(t *testing.T) {
 			c.SendLine(dir)
 			expectString(c, cmd.QuestionAwsAnotherAdvancedOpt, &runError)
 			c.SendLine("n")
-			expectString(c, fmt.Sprintf("%s/main.tf already exists, overwrite?", dir), &runError)
+			expectString(c, fmt.Sprintf("%s/aws.tf already exists, overwrite?", dir), &runError)
 			c.SendLine("n")
 		},
 		"cloud",
@@ -552,7 +552,7 @@ func TestGenerationWithExistingTerraform(t *testing.T) {
 	)
 
 	// Ensure CLI ran correctly
-	data, err := os.ReadFile(fmt.Sprintf("%s/main.tf", dir))
+	data, err := os.ReadFile(fmt.Sprintf("%s/aws.tf", dir))
 	if err != nil {
 		panic(err)
 	}
@@ -571,7 +571,7 @@ func runGenerateTest(t *testing.T, conditions func(*expect.Console), args ...str
 	defer os.RemoveAll(dir)
 
 	runGenerationTestFromDir(t, dir, conditions, args...)
-	out, err := ioutil.ReadFile(filepath.FromSlash(fmt.Sprintf("%s/lacework/main.tf", dir)))
+	out, err := ioutil.ReadFile(filepath.FromSlash(fmt.Sprintf("%s/lacework/aws.tf", dir)))
 	if err != nil {
 		// Assume couldn't be found
 		return ""


### PR DESCRIPTION
Signed-off-by: Ross <ross.moles@lacework.net>

## Summary
Currently, the default output location for the Terraform generation is `~/lacework/main.tf`
We should create a file for each cloud to ensure we don't override TF from another cloud.

With this change, we can pass any filename to the output location
eg. 
```
~/lacework/aws.tf
~/lacework/azure.tf
~/lacework/gcp.tf
```

## How did you test this change?
make test ✅ 
run dev version of CLI and confirmed output location ✅ 
make fmt ✅ 

## Issue
https://lacework.atlassian.net/browse/ALLY-890
