### PR TITLE
feat(cli): Add breadcrumb for "query show-source"

### DIFF
--- a/cli/cmd/lql_sources.go
+++ b/cli/cmd/lql_sources.go
@@ -126,5 +126,6 @@ func showQuerySource(_ *cobra.Command, args []string) error {
 			getShowQuerySourceTable(datasourceResponse.Data.ResultSchema),
 		),
 	)
+	cli.OutputHuman("\nUse 'lacework query preview-source <datasource_id>' to see an actual result from the data source.\n")
 	return nil
 }

--- a/integration/lql_sources_test.go
+++ b/integration/lql_sources_test.go
@@ -79,6 +79,7 @@ func TestQueryShowSourceTable(t *testing.T) {
 	out, err, exitcode := LaceworkCLIWithTOMLConfig("query", "describe", "CloudTrailRawEvents")
 	assert.Contains(t, out.String(), "FIELD NAME")
 	assert.Contains(t, out.String(), "INSERT_ID")
+	assert.Contains(t, out.String(), "preview-source")
 	assert.Empty(t, err.String(), "STDERR should be empty")
 	assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
 }


### PR DESCRIPTION
## Summary
As a Lacework user, I would like show-source to communicate that there is another step in the “journey” (preview-source)…

## How did you test this change?
Automated integration test added

## Issue
https://lacework.atlassian.net/browse/ALLY-898

```
❯ lacework-dev query show-source LW_HE_CONTAINERS
     DATASOURCE               DESCRIPTION            
-------------------+---------------------------------
  LW_HE_CONTAINERS   Detail about each host          
                     container                       

       FIELD NAME        DATA TYPE            DESCRIPTION            
-----------------------+-----------+---------------------------------
  BATCH_START_TIME       Timestamp   Beginning of time interval      
...
  PROPS_ENV              JSON        Container environment settings  

Use 'lacework query preview-source <datasource_id>' to see an actual result from the data source.
```