### PR TITLE
fix(cli): delete listed twice on help

### DIFF
--- a/cli/cmd/policy.go
+++ b/cli/cmd/policy.go
@@ -132,7 +132,6 @@ func init() {
 	policyCmd.AddCommand(policyListCmd)
 	policyCmd.AddCommand(policyListTagsCmd)
 	policyCmd.AddCommand(policyShowCmd)
-	policyCmd.AddCommand(policyDeleteCmd)
 
 	// policy list specific flags
 	policyListCmd.Flags().StringVar(


### PR DESCRIPTION
## Summary
Policies (LQL): Delete registered twice resulting in strange help output

```
lacework policy --help
Available Commands:
  create      Create a policy
  delete      Delete a policy
  delete      Delete a policy
  list        List policies
  list-tags   List policy tags
  show        Show policy
  update      Update a policy
```

## How did you test this change?
Manually

## Issue
https://lacework.atlassian.net/browse/ALLY-900
