### PR TITLE
refactor(cli): further deprecate evaluatorId

### DIFF
--- a/cli/cmd/lql.go
+++ b/cli/cmd/lql.go
@@ -314,7 +314,6 @@ It looks like you attempted to submit a query in JSON format.
 Please validate that the JSON is formatted properly and adheres to the following schema:
 
 {
-    "evaluatorId": "Cloudtrail",
     "queryId": "MyLQL",
     "queryText": "MyLQL { source { CloudTrailRawEvents } filter { EVENT_SOURCE = 's3.amazonaws.com' } return { INSERT_ID } }"
 }
@@ -326,7 +325,6 @@ Please validate that the JSON is formatted properly and adheres to the following
 It looks like you attempted to submit a query in YAML format.
 Please validate that the text adheres to the following schema:
 
-evaluatorId: Cloudtrail
 queryId: MyLQL
 queryText: |-
   MyLQL {

--- a/cli/cmd/lql_create.go
+++ b/cli/cmd/lql_create.go
@@ -48,7 +48,6 @@ To launch your default editor and create a new query.
 The following example comes from Lacework's implementation of a policy query:
 
     ---
-    evaluatorId: Cloudtrail
     queryId: LW_Global_AWS_CTA_AccessKeyDeleted
     queryText: |-
       LW_Global_AWS_CTA_AccessKeyDeleted {

--- a/cli/cmd/lql_internal_test.go
+++ b/cli/cmd/lql_internal_test.go
@@ -32,19 +32,16 @@ import (
 
 var (
 	newQuery = api.NewQuery{
-		EvaluatorID: "Cloudtrail",
-		QueryID:     "my_lql",
-		QueryText:   `my_lql { source { CloudTrailRawEvents } return { INSERT_ID } }`,
+		QueryID:   "my_lql",
+		QueryText: `my_lql { source { CloudTrailRawEvents } return { INSERT_ID } }`,
 	}
 	newQueryJSON = fmt.Sprintf(`{
-	"evaluatorId": "%s",
 	"queryId": "%s",
 	"queryText": "%s"
-	}`, newQuery.EvaluatorID, newQuery.QueryID, newQuery.QueryText)
+	}`, newQuery.QueryID, newQuery.QueryText)
 	newQueryYAML = fmt.Sprintf(`---
-evaluatorId: %s
 queryId: %s
-queryText: %s`, newQuery.EvaluatorID, newQuery.QueryID, newQuery.QueryText)
+queryText: %s`, newQuery.QueryID, newQuery.QueryText)
 )
 
 type parseQueryTest struct {

--- a/cli/cmd/lql_preview.go
+++ b/cli/cmd/lql_preview.go
@@ -71,9 +71,6 @@ func previewQuerySource(_ *cobra.Command, args []string) error {
 				queryPreviewSourceTemplate, args[0], strings.Join(returns, ",")),
 		},
 	}
-	if args[0] == "CloudTrailRawEvents" {
-		executeQuery.Query.EvaluatorID = "Cloudtrail"
-	}
 
 	// initialize time attempts
 	timeAttempts := []map[string]string{

--- a/cli/cmd/policy.go
+++ b/cli/cmd/policy.go
@@ -48,7 +48,6 @@ var (
 
 	policyTableHeaders = []string{
 		"Policy ID",
-		"Evaluator ID",
 		"Severity",
 		"Title",
 		"State",
@@ -269,7 +268,6 @@ func policyTable(policies []api.Policy) (out [][]string) {
 		}
 		out = append(out, []string{
 			policy.PolicyID,
-			policy.EvaluatorID,
 			policy.Severity,
 			policy.Title,
 			state,

--- a/cli/cmd/policy_create.go
+++ b/cli/cmd/policy_create.go
@@ -41,7 +41,6 @@ A policy is represented in either JSON or YAML format.
 The following attributes are minimally required:
 
     ---
-    evaluatorId: Cloudtrail
     policyType: Violation
     queryId: MyQuery
     title: My Policy

--- a/cli/cmd/policy_create_internal_test.go
+++ b/cli/cmd/policy_create_internal_test.go
@@ -30,7 +30,6 @@ import (
 
 var (
 	newPolicy = api.NewPolicy{
-		EvaluatorID:  "Cloudtrail",
 		PolicyID:     "lacework-clitest-1",
 		PolicyType:   "Violation",
 		QueryID:      "LW_CLI_AWS_CTA_IntegrationTest",
@@ -44,7 +43,6 @@ var (
 		AlertProfile: "LW_CloudTrail_Alerts",
 	}
 	newPolicyJSON = fmt.Sprintf(`{
-	"evaluatorId": "%s",
 	"policyId": "%s",
 	"policyType": "%s",
 	"queryId": "%s",
@@ -56,11 +54,10 @@ var (
 	"alertEnabled": %t,
 	"alertProfile": "%s",
 	}
-}`, newPolicy.EvaluatorID, newPolicy.PolicyID, newPolicy.PolicyType, newPolicy.QueryID, newPolicy.Title,
+}`, newPolicy.PolicyID, newPolicy.PolicyType, newPolicy.QueryID, newPolicy.Title,
 		newPolicy.Enabled, newPolicy.Description, newPolicy.Remediation, newPolicy.Severity, newPolicy.AlertEnabled,
 		newPolicy.AlertProfile)
 	newPolicyYAML = fmt.Sprintf(`---
-evaluatorId: %s
 policyId: %s
 policyType: %s
 queryId: %s
@@ -71,13 +68,12 @@ remediation: %s
 severity: %s
 alertEnabled: %t
 alertProfile: %s
-`, newPolicy.EvaluatorID, newPolicy.PolicyID, newPolicy.PolicyType, newPolicy.QueryID, newPolicy.Title,
+`, newPolicy.PolicyID, newPolicy.PolicyType, newPolicy.QueryID, newPolicy.Title,
 		newPolicy.Enabled, newPolicy.Description, newPolicy.Remediation, newPolicy.Severity, newPolicy.AlertEnabled,
 		newPolicy.AlertProfile)
 	newPolicyNestedYAML = fmt.Sprintf(`---
 policies:
-- evaluatorId: %s
-  policyId: %s
+- policyId: %s
   policyType: %s
   queryId: %s
   title: %s
@@ -87,7 +83,7 @@ policies:
   severity: %s
   alertEnabled: %t
   alertProfile: %s
-`, newPolicy.EvaluatorID, newPolicy.PolicyID, newPolicy.PolicyType, newPolicy.QueryID, newPolicy.Title,
+`, newPolicy.PolicyID, newPolicy.PolicyType, newPolicy.QueryID, newPolicy.Title,
 		newPolicy.Enabled, newPolicy.Description, newPolicy.Remediation, newPolicy.Severity, newPolicy.AlertEnabled,
 		newPolicy.AlertProfile)
 )

--- a/cli/cmd/policy_update_internal_test.go
+++ b/cli/cmd/policy_update_internal_test.go
@@ -31,7 +31,6 @@ import (
 var (
 	falsePtr         = false
 	updateTestPolicy = api.UpdatePolicy{
-		EvaluatorID:  "Cloudtrail",
 		PolicyType:   "Violation",
 		QueryID:      "LW_CLI_AWS_CTA_IntegrationTest",
 		Title:        "My Policy Title",
@@ -44,7 +43,6 @@ var (
 		AlertProfile: "LW_CloudTrail_Alerts",
 	}
 	updateTestPolicyJSON = fmt.Sprintf(`{
-	"evaluatorId": "%s",
 	"policyId": "%s",
 	"policyType": "%s",
 	"queryId": "%s",
@@ -55,11 +53,10 @@ var (
 	"severity": "%s",
 	"alertEnabled": %t,
 	"alertProfile": "%s"
-}`, updateTestPolicy.EvaluatorID, updateTestPolicy.PolicyID, updateTestPolicy.PolicyType, updateTestPolicy.QueryID, updateTestPolicy.Title,
+}`, updateTestPolicy.PolicyID, updateTestPolicy.PolicyType, updateTestPolicy.QueryID, updateTestPolicy.Title,
 		false, updateTestPolicy.Description, updateTestPolicy.Remediation, updateTestPolicy.Severity, false,
 		updateTestPolicy.AlertProfile)
 	updatePolicyYAML = fmt.Sprintf(`---
-evaluatorId: %s
 policyId: %s
 policyType: %s
 queryId: %s
@@ -70,13 +67,12 @@ remediation: %s
 severity: %s
 alertEnabled: %t
 alertProfile: %s
-`, updateTestPolicy.EvaluatorID, updateTestPolicy.PolicyID, updateTestPolicy.PolicyType, updateTestPolicy.QueryID, updateTestPolicy.Title,
+`, updateTestPolicy.PolicyID, updateTestPolicy.PolicyType, updateTestPolicy.QueryID, updateTestPolicy.Title,
 		false, updateTestPolicy.Description, updateTestPolicy.Remediation, updateTestPolicy.Severity, false,
 		updateTestPolicy.AlertProfile)
 	updatePolicyNestedYAML = fmt.Sprintf(`---
 policies:
-- evaluatorId: %s
-  policyId: %s
+- policyId: %s
   policyType: %s
   queryId: %s
   title: %s
@@ -86,7 +82,7 @@ policies:
   severity: %s
   alertEnabled: %t
   alertProfile: %s
-`, updateTestPolicy.EvaluatorID, updateTestPolicy.PolicyID, updateTestPolicy.PolicyType, updateTestPolicy.QueryID, updateTestPolicy.Title,
+`, updateTestPolicy.PolicyID, updateTestPolicy.PolicyType, updateTestPolicy.QueryID, updateTestPolicy.Title,
 		false, updateTestPolicy.Description, updateTestPolicy.Remediation, updateTestPolicy.Severity, false,
 		updateTestPolicy.AlertProfile)
 )

--- a/integration/lql_constants.go
+++ b/integration/lql_constants.go
@@ -26,7 +26,6 @@ const (
 	queryText         string = "LW_CLI_AWS_CTA_IntegrationTest { source { CloudTrailRawEvents } return { INSERT_ID } }"
 	queryUpdateText   string = "LW_CLI_AWS_CTA_IntegrationTest { source { CloudTrailRawEvents } return { INSERT_ID, INSERT_TIME } }"
 	queryJSONTemplate string = `{
-	"evaluatorID": "%s",
 	"queryID": "%s",
 	"queryText": "%s"
 }`

--- a/integration/lql_create_test.go
+++ b/integration/lql_create_test.go
@@ -48,7 +48,7 @@ func TestQueryCreateFile(t *testing.T) {
 	// get temp file
 	file, err := createTemporaryFile(
 		"TestQueryCreateFile",
-		fmt.Sprintf(queryJSONTemplate, evaluatorID, queryID, queryText),
+		fmt.Sprintf(queryJSONTemplate, queryID, queryText),
 	)
 	if err != nil {
 		t.FailNow()

--- a/integration/lql_test.go
+++ b/integration/lql_test.go
@@ -152,7 +152,7 @@ func TestQueryRunFile(t *testing.T) {
 	// get temp file
 	file, err := createTemporaryFile(
 		"TestQueryRunFile",
-		fmt.Sprintf(queryJSONTemplate, evaluatorID, queryID, queryText))
+		fmt.Sprintf(queryJSONTemplate, queryID, queryText))
 	if err != nil {
 		t.FailNow()
 	}

--- a/integration/lql_update_test.go
+++ b/integration/lql_update_test.go
@@ -48,7 +48,7 @@ func TestQueryUpdateFile(t *testing.T) {
 	// get temp file
 	file, err := createTemporaryFile(
 		"TestQueryUpdateFile",
-		fmt.Sprintf(queryJSONTemplate, evaluatorID, queryID, queryUpdateText),
+		fmt.Sprintf(queryJSONTemplate, queryID, queryUpdateText),
 	)
 	if err != nil {
 		t.FailNow()
@@ -76,7 +76,7 @@ func TestQueryUpdateURL(t *testing.T) {
 	// get temp file
 	file, err := createTemporaryFile(
 		"TestQueryUpdateFile",
-		fmt.Sprintf(queryJSONTemplate, evaluatorID, queryID, queryUpdateText),
+		fmt.Sprintf(queryJSONTemplate, queryID, queryUpdateText),
 	)
 	if err != nil {
 		t.FailNow()

--- a/integration/lql_update_test.go
+++ b/integration/lql_update_test.go
@@ -107,7 +107,7 @@ func TestQueryUpdateFromIDEditor(t *testing.T) {
 	// get temp file
 	file, err := createTemporaryFile(
 		"TestQueryUpdateFromIDEditor",
-		fmt.Sprintf(queryJSONTemplate, evaluatorID, queryID, queryUpdateText),
+		fmt.Sprintf(queryJSONTemplate, queryID, queryUpdateText),
 	)
 	if err != nil {
 		t.FailNow()

--- a/integration/lql_update_unix_test.go
+++ b/integration/lql_update_unix_test.go
@@ -33,7 +33,7 @@ func TestQueryUpdateFromIDEditor(t *testing.T) {
 	// get temp file
 	file, err := createTemporaryFile(
 		"TestQueryUpdateFromIDEditor",
-		fmt.Sprintf(queryJSONTemplate, evaluatorID, queryID, queryUpdateText),
+		fmt.Sprintf(queryJSONTemplate, queryID, queryUpdateText),
 	)
 	if err != nil {
 		t.FailNow()

--- a/integration/lql_validate_test.go
+++ b/integration/lql_validate_test.go
@@ -49,7 +49,7 @@ func TestQueryValidateFile(t *testing.T) {
 	// get temp file
 	file, err := createTemporaryFile(
 		"TestQueryValidateFile",
-		fmt.Sprintf(queryJSONTemplate, evaluatorID, queryID, queryText),
+		fmt.Sprintf(queryJSONTemplate, queryID, queryText),
 	)
 	if err != nil {
 		t.FailNow()
@@ -81,7 +81,7 @@ func TestQueryValidateStdin(t *testing.T) {
 	// get temp file
 	file, err := createTemporaryFile(
 		"TestQueryValidateFile",
-		fmt.Sprintf(queryJSONTemplate, evaluatorID, queryID, queryText),
+		fmt.Sprintf(queryJSONTemplate, queryID, queryText),
 	)
 	if err != nil {
 		t.FailNow()

--- a/integration/policy_test.go
+++ b/integration/policy_test.go
@@ -32,7 +32,6 @@ import (
 
 const (
 	newPolicyYAML string = `---
-evaluatorId: Cloudtrail
 policyId: clitest-1
 policyType: Violation
 queryId: LW_CLI_AWS_CTA_IntegrationTest

--- a/integration/test_resources/help/policy_create
+++ b/integration/test_resources/help/policy_create
@@ -5,7 +5,6 @@ A policy is represented in either JSON or YAML format.
 The following attributes are minimally required:
 
     ---
-    evaluatorId: Cloudtrail
     policyType: Violation
     queryId: MyQuery
     title: My Policy

--- a/integration/test_resources/help/query_create
+++ b/integration/test_resources/help/query_create
@@ -18,7 +18,6 @@ To launch your default editor and create a new query.
 The following example comes from Lacework's implementation of a policy query:
 
     ---
-    evaluatorId: Cloudtrail
     queryId: LW_Global_AWS_CTA_AccessKeyDeleted
     queryText: |-
       LW_Global_AWS_CTA_AccessKeyDeleted {


### PR DESCRIPTION
## Summary
Deprecate Evaluator ID from the Go-SDK and Lacework CLI

## How did you test this change?
Existing and updated integration testing

## Issue
https://lacework.atlassian.net/browse/ALLY-905