### PR TITLE
feat(cli): sort query and policy list output

### DIFF
--- a/cli/cmd/lql_list.go
+++ b/cli/cmd/lql_list.go
@@ -19,6 +19,8 @@
 package cmd
 
 import (
+	"sort"
+
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
@@ -50,6 +52,12 @@ func queryTable(queryData []api.Query) (out [][]string) {
 			query.LastUpdateUser,
 		})
 	}
+
+	// order by ID
+	sort.Slice(out, func(i, j int) bool {
+		return out[i][0] < out[j][0]
+	})
+
 	return
 }
 

--- a/cli/cmd/lql_sources.go
+++ b/cli/cmd/lql_sources.go
@@ -19,6 +19,8 @@
 package cmd
 
 import (
+	"sort"
+
 	"github.com/olekukonko/tablewriter"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -58,6 +60,12 @@ func getListQuerySourcesTable(datasources []api.Datasource) (out [][]string) {
 			source.Description,
 		})
 	}
+
+	// order by Name
+	sort.Slice(out, func(i, j int) bool {
+		return out[i][0] < out[j][0]
+	})
+
 	return
 }
 

--- a/cli/cmd/policy.go
+++ b/cli/cmd/policy.go
@@ -23,6 +23,9 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
+	"regexp"
+	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/AlecAivazis/survey/v2"
@@ -122,6 +125,7 @@ To view the LQL query associated with the policy, use the query id shown.
 		Args:    cobra.ExactArgs(1),
 		RunE:    showPolicy,
 	}
+	policyIDIntRE = regexp.MustCompile(`^(.*-)(\d+)$`)
 )
 
 func init() {
@@ -278,6 +282,27 @@ func policyTable(policies []api.Policy) (out [][]string) {
 			policy.QueryID,
 			strings.Join(policy.Tags, "\n"),
 		})
+
+		// order by ID (special handling for policy ID numbers)
+		sort.Slice(out, func(i, j int) bool {
+			iMatch := policyIDIntRE.FindStringSubmatch(out[i][0])
+			jMatch := policyIDIntRE.FindStringSubmatch(out[j][0])
+			// both regexes must match
+			// both regexes must have proper lengths since we'll be using...
+			// ...direct access from here on out
+			if iMatch == nil || jMatch == nil || len(iMatch) != 3 || len(jMatch) != 3 {
+				return out[i][0] < out[j][0]
+			}
+			// if string portions aren't the same
+			if iMatch[1] != jMatch[1] {
+				return out[i][0] < out[j][0]
+			}
+			// if string portions are the same; compare based on ints
+			// no error checking needed for Atoi since use regexp \d+
+			iNum, _ := strconv.Atoi(iMatch[2])
+			jNum, _ := strconv.Atoi(jMatch[2])
+			return iNum < jNum
+		})
 	}
 	return
 }
@@ -396,6 +421,12 @@ func policyTagsTable(pt []string) (out [][]string) {
 	for _, tag := range pt {
 		out = append(out, []string{tag})
 	}
+
+	// order by Tag
+	sort.Slice(out, func(i, j int) bool {
+		return out[i][0] < out[j][0]
+	})
+
 	return
 }
 

--- a/integration/lql_list_test.go
+++ b/integration/lql_list_test.go
@@ -20,6 +20,7 @@
 package integration
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/stretchr/testify/assert"

--- a/integration/lql_list_test.go
+++ b/integration/lql_list_test.go
@@ -38,12 +38,23 @@ func TestQueryList(t *testing.T) {
 	// teardown
 	defer LaceworkCLIWithTOMLConfig("query", "delete", queryID)
 
+	// list human
 	out, err, exitcode := LaceworkCLIWithTOMLConfig("query", "list")
 	assert.Contains(t, out.String(), "QUERY ID")
 	assert.Contains(t, out.String(), "LW_CLI_AWS_CTA_IntegrationTest")
 	assert.Empty(t, err.String(), "STDERR should be empty")
 	assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
 
+	// validate sort
+	aRE := regexp.MustCompile("LW_Global_AWS_CTA_AccessKeyDeleted")
+	aMatch := aRE.FindStringIndex(out.String())
+
+	zRE := regexp.MustCompile("LW_Global_AWS_CTA_NewCustomerMasterKey")
+	zMatch := zRE.FindStringIndex(out.String())
+
+	assert.Greater(t, zMatch[0], aMatch[0])
+
+	// list json
 	out, err, exitcode = LaceworkCLIWithTOMLConfig("query", "list", "--json")
 	assert.Contains(t, out.String(), `"LW_CLI_AWS_CTA_IntegrationTest"`)
 	assert.Empty(t, err.String(), "STDERR should be empty")

--- a/integration/lql_sources_test.go
+++ b/integration/lql_sources_test.go
@@ -45,6 +45,15 @@ func TestQueryListSourcesTable(t *testing.T) {
 	assert.Contains(t, out.String(), "CloudTrailRawEvents")
 	assert.Empty(t, err.String(), "STDERR should be empty")
 	assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
+
+	// validate sort
+	aRE := regexp.MustCompile("LW_CFG_AWS_EC2_DHCP_OPTIONS")
+	aMatch := aRE.FindStringIndex(out.String())
+
+	zRE := regexp.MustCompile("CloudTrailRawEvents")
+	zMatch := zRE.FindStringIndex(out.String())
+
+	assert.Greater(t, zMatch[0], aMatch[0])
 }
 
 func TestQueryListSourcesJSON(t *testing.T) {

--- a/integration/lql_sources_test.go
+++ b/integration/lql_sources_test.go
@@ -20,6 +20,7 @@
 package integration
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/stretchr/testify/assert"

--- a/integration/lql_sources_test.go
+++ b/integration/lql_sources_test.go
@@ -48,10 +48,10 @@ func TestQueryListSourcesTable(t *testing.T) {
 	assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
 
 	// validate sort
-	aRE := regexp.MustCompile("LW_CFG_AWS_EC2_DHCP_OPTIONS")
+	aRE := regexp.MustCompile("CloudTrailRawEvents")
 	aMatch := aRE.FindStringIndex(out.String())
 
-	zRE := regexp.MustCompile("CloudTrailRawEvents")
+	zRE := regexp.MustCompile("LW_CFG_AWS_EC2_DHCP_OPTIONS")
 	zMatch := zRE.FindStringIndex(out.String())
 
 	assert.Greater(t, zMatch[0], aMatch[0])

--- a/integration/policy_test.go
+++ b/integration/policy_test.go
@@ -313,6 +313,15 @@ func TestPolicyList(t *testing.T) {
 	assert.Empty(t, err.String(), "STDERR should be empty")
 	assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
 
+	// validate sort
+	aRE := regexp.MustCompile("lacework-global-3")
+	aMatch := aRE.FindStringIndex(out.String())
+
+	zRE := regexp.MustCompile("lacework-global-10")
+	zMatch := zRE.FindStringIndex(out.String())
+
+	assert.Greater(t, zMatch[0], aMatch[0])
+
 	// list (output json)
 	out, err, exitcode = LaceworkCLIWithTOMLConfig("policy", "list", "--json")
 	assert.Contains(t, out.String(), `"policyId"`)


### PR DESCRIPTION
## Summary
As a Lacework user, I would like the `lacework query ls`, `lacework query sources`, `lacework policy ls`, and `lacework policy list-tags` outputs to be sorted such that I can easily find items that I’m looking for

## How did you test this change?
Manually tested
Integration tested

## Issue
https://lacework.atlassian.net/browse/ALLY-910