### PR TITLE
test(integration): fix finding host id

### DIFF
--- a/integration/host_vulnerability_test.go
+++ b/integration/host_vulnerability_test.go
@@ -421,32 +421,26 @@ func machineIDExists(lw *api.Client) bool {
 }
 
 func setHostVulnTestMachineID(lw *api.Client) {
-	var cveId string
+	var cveID string
 	cveResp, err := lw.Vulnerabilities.Host.ListCves()
 	if err != nil {
 		log.Fatalf("Unable to list cves %s\n", err)
 	}
 
-	for _, cve := range cveResp.CVEs {
-		if cve.Summary.Severity.High == nil {
-			continue
-		}
-		if cve.Summary.Severity.High.Vulnerabilities > 0 {
-			cveId = cve.ID
-			break
-		} else {
-			log.Fatal("No Host CVE's found")
-		}
-	}
-
-	hostResp, err := lw.Vulnerabilities.Host.ListHostsWithCVE(cveId)
-	if err != nil {
-		log.Fatalf("Unable to get host for cveId %s %s\n", cveId, err)
-	}
-
-	if hostResp.Hosts[0].Details.MachineID != "" {
-		machineID = hostResp.Hosts[0].Details.MachineID
+	if len(cveResp.CVEs) > 0 {
+		cveID = cveResp.CVEs[0].ID
 	} else {
+		log.Fatal("No Host CVE's found")
+	}
+
+	hostResp, err := lw.Vulnerabilities.Host.ListHostsWithCVE(cveID)
+	if err != nil {
+		log.Fatalf("Unable to get host for cveID %s %s\n", cveID, err)
+	}
+
+	if len(hostResp.Hosts) == 0 || hostResp.Hosts[0].Details.MachineID == "" {
 		os.Setenv("CI_SKIP_HOST_VULN", "true")
+	} else {
+		machineID = hostResp.Hosts[0].Details.MachineID
 	}
 }


### PR DESCRIPTION

## Summary
Our QA tests are failing with:
```
=== FAIL: integration  (0.00s)                                                                                                                      
Setting up host tests                                                                                                                               
2022/03/08 03:25:44 Unable to get host for cveId                                                                                                    
  [GET] https://qa4.qa4.corp.lacework.net/api/v1/external/vulnerabilities/host/cveId/                                                               
  [404] HTTP 404 Not Found                                                                                                                          
FAIL    github.com/lacework/go-sdk/integration  4.368s     
```

## How did you test this change?

We are going to run the integration tests in prod and qa.

## Issue

N/A
