### PR TITLE
test(windows): fix TestQueryUpdateFromIDEditor

### DIFF
--- a/integration/lql_update_unix_test.go
+++ b/integration/lql_update_unix_test.go
@@ -1,0 +1,78 @@
+//go:build query && !windows
+
+// Author:: Salim Afiune Maya (<afiune@lacework.net>)
+// Copyright:: Copyright 2022, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package integration
+
+import (
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/Netflix/go-expect"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestQueryUpdateFromIDEditor(t *testing.T) {
+	// get temp file
+	file, err := createTemporaryFile(
+		"TestQueryUpdateFromIDEditor",
+		fmt.Sprintf(queryJSONTemplate, evaluatorID, queryID, queryUpdateText),
+	)
+	if err != nil {
+		t.FailNow()
+	}
+	defer os.Remove(file.Name())
+
+	dir := createTOMLConfigFromCIvars()
+	defer os.RemoveAll(dir)
+
+	// setup
+	LaceworkCLIWithHome(dir, "query", "create", "-u", queryURL)
+	// teardown
+	defer LaceworkCLIWithHome(dir, "query", "delete", queryID)
+
+	_ = runFakeTerminalTestFromDir(t, dir,
+		func(c *expect.Console) {
+			expectString(t, c, "Update query")
+			c.SendLine("")
+			time.Sleep(time.Millisecond)
+			// Move to line number 4 and add comment "--- Updated from CLI Editor"
+			c.Send("4Go--- Updated from CLI Editor\x1b")
+			c.SendLine(":wq!") // save and close
+			time.Sleep(time.Millisecond)
+			expectString(t, c,
+				fmt.Sprintf("The query %s was updated.", queryID))
+		},
+		"query", "update", queryID,
+	)
+
+	t.Run("verify query editions", func(t *testing.T) {
+		stdout, stderr, exitcode := LaceworkCLIWithHome(dir, "query", "show", queryID)
+		assert.Empty(t,
+			stderr.String(),
+			"STDERR should be empty")
+		assert.Contains(t,
+			stdout.String(),
+			"--- Updated from CLI Editor",
+			"the query was not editted correctly")
+		assert.Equal(t, 0, exitcode,
+			"EXITCODE is not the expected one")
+	})
+}


### PR DESCRIPTION

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/lacework/go-sdk) and create your branch from `main`
  2. Run `make prepare` in the repository root
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`make test`)
  5. Format your code (`make fmt`)
  6. Make sure your code lints (`make lint`)
  7. If you are updating the Lacework CLI, make sure it compiles (`make build-cli-cross-platform`)
  8. Follow the commit message standard (`type(scope): subject`) documented in [DEVELOPER_GUIDELINES.md](https://github.com/lacework/go-sdk/blob/main/DEVELOPER_GUIDELINES.md#commit-message-standard)
  9. If you haven't already, configure signed commits by [telling git about your signing key](https://docs.github.com/en/github/authenticating-to-github/managing-commit-signature-verification/telling-git-about-your-signing-key) and [signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)

  Learn more about contributing: https://github.com/lacework/go-sdk/blob/main/CONTRIBUTING.md
-->

## Summary

Our Windows CI pipeline is broken, this fixes the following error:
```
=== FAIL: integration TestQueryUpdateFromIDEditor (1.37s)
panic: unsupported [recovered]
        panic: unsupported
```

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>


## How did you test this change?

Will run the Windows pipeline.

## Issue
N/A