### PR TITLE
test: fix policy severity filter test

### DIFF
--- a/integration/policy_test.go
+++ b/integration/policy_test.go
@@ -339,7 +339,7 @@ func TestPolicyBadSeverity(t *testing.T) {
 func TestPolicySeverityCritical(t *testing.T) {
 	out, err, exitcode := LaceworkCLIWithTOMLConfig("policy", "list", "--severity", "critical")
 	assert.Contains(t, out.String(), "lacework-global-8")
-	assert.NotContains(t, out.String(), "lacework-global-1")
+	assert.NotContains(t, out.String(), "lacework-global-1 ")
 	assert.Empty(t, err.String(), "STDERR should be empty")
 	assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
 }


### PR DESCRIPTION
The filter output is expecting to only see 'critical'  severity. It expects result not to contain 'lacework-global-1' however it is matching 'lacework-global-1**' eg 'lacework-global-189'

Fixed by adding a space  to the expected output so we do not match lacework-global-189 etc