### PR TITLE
feat(api): Implement AwsEksAudit CloudAccount interface

### DIFF
--- a/api/_examples/cloud-accounts/aws-eks-audit/main.go
+++ b/api/_examples/cloud-accounts/aws-eks-audit/main.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/lacework/go-sdk/api"
+)
+
+func main() {
+	// TODO @afiune maybe think about a way to inject CI credentials and
+	// run these examples as part of our CI pipelines
+	lacework, err := api.NewClient(os.Getenv("LW_ACCOUNT"),
+		api.WithSubaccount(os.Getenv("LW_SUBACCOUNT")),
+		api.WithApiKeys(os.Getenv("LW_API_KEY"), os.Getenv("LW_API_SECRET")),
+		api.WithApiV2(),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	res, err := lacework.V2.CloudAccounts.List()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	for _, account := range res.Data {
+		support := "Unsupported"
+		switch account.Type {
+		case api.AwsEksAuditCloudAccount.String():
+			support = "Supported"
+		}
+
+		// Output: INTEGRATION-GUID:INTEGRATION-TYPE:[Supported|Unsupported]
+		fmt.Printf("%s:%s:%s\n", account.IntgGuid, account.Type, support)
+	}
+
+	awsEksAuditData := api.AwsEksAuditData{
+		Credentials: api.AwsEksAuditCredentials{
+			RoleArn:    "arn:aws:iam::123456789000:role/lw-iam-b8c91298",
+			ExternalID: "abc123",
+		},
+		SnsArn: "arn:aws:sns:us-west-2:0123456789:foo-lacework-eks:00777777-ab77-1234-a123-a12ab1d12c1d",
+	}
+
+	awsEksAuditCloudAccount := api.NewCloudAccount(
+		"cloud-from-golang",
+		api.AwsEksAuditCloudAccount,
+		awsEksAuditData,
+	)
+
+	awsEksAuditResponse, err := lacework.V2.CloudAccounts.Create(awsEksAuditCloudAccount)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Output: AwsEksAudit Cloud Account created: THE-INTEGRATION-GUID
+	fmt.Printf("Cloud Account created: %s", awsEksAuditResponse.Data.IntgGuid)
+}

--- a/api/_examples/cloud-accounts/aws-eks-ct-sqs/main.go
+++ b/api/_examples/cloud-accounts/aws-eks-ct-sqs/main.go
@@ -29,11 +29,6 @@ func main() {
 		support := "Unsupported"
 		switch account.Type {
 		case api.AwsCtSqsCloudAccount.String():
-			//case api.AwsCfgCloudAccount:
-			//case api.GcpCfgCloudAccount:
-			//case api.GcpAtSesCloudAccount:
-			support = "Supported"
-		case api.AwsEksAuditCloudAccount.String():
 			support = "Supported"
 		}
 
@@ -87,26 +82,4 @@ func main() {
 
 	// Output: AwsCtSqs Cloud Account created: THE-INTEGRATION-GUID
 	fmt.Printf("Cloud Account created: %s", awsCtSqsResponse.Data.IntgGuid)
-
-	awsEksAuditData := api.AwsEksAuditData{
-		Credentials: api.AwsEksAuditCredentials{
-			RoleArn:    "arn:aws:iam::123456789000:role/lw-iam-b8c91298",
-			ExternalID: "abc123",
-		},
-		SnsArn: "arn:aws:sns:us-west-2:0123456789:foo-lacework-eks:00777777-ab77-1234-a123-a12ab1d12c1d",
-	}
-
-	awsEksAuditCloudAccount := api.NewCloudAccount(
-		"cloud-from-golang",
-		api.AwsEksAuditCloudAccount,
-		awsEksAuditData,
-	)
-
-	awsEksAuditResponse, err := orgLwClient.V2.CloudAccounts.Create(awsEksAuditCloudAccount)
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	// Output: AwsEksAudit Cloud Account created: THE-INTEGRATION-GUID
-	fmt.Printf("Cloud Account created: %s", awsEksAuditResponse.Data.IntgGuid)
 }

--- a/api/_examples/cloud-accouts/main.go
+++ b/api/_examples/cloud-accouts/main.go
@@ -33,6 +33,8 @@ func main() {
 			//case api.GcpCfgCloudAccount:
 			//case api.GcpAtSesCloudAccount:
 			support = "Supported"
+		case api.AwsEksAuditCloudAccount.String():
+			support = "Supported"
 		}
 
 		// Output: INTEGRATION-GUID:INTEGRATION-TYPE:[Supported|Unsupported]
@@ -63,7 +65,7 @@ func main() {
                               }
                             }`))
 
-	myCloudAccount := api.NewCloudAccount(
+	awsCtSqsCloudAccount := api.NewCloudAccount(
 		"cloud-from-golang",
 		api.AwsCtSqsCloudAccount,
 		awsCtSqsData,
@@ -78,11 +80,33 @@ func main() {
 		log.Fatal(err)
 	}
 
-	response, err := orgLwClient.V2.CloudAccounts.Create(myCloudAccount)
+	awsCtSqsResponse, err := orgLwClient.V2.CloudAccounts.Create(awsCtSqsCloudAccount)
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	// Output: Cloud Account created: THE-INTEGRATION-GUID
-	fmt.Printf("Cloud Account created: %s", response.Data.IntgGuid)
+	// Output: AwsCtSqs Cloud Account created: THE-INTEGRATION-GUID
+	fmt.Printf("Cloud Account created: %s", awsCtSqsResponse.Data.IntgGuid)
+
+	awsEksAuditData := api.AwsEksAuditData{
+		Credentials: api.AwsEksAuditCredentials{
+			RoleArn:    "arn:aws:iam::123456789000:role/lw-iam-b8c91298",
+			ExternalID: "abc123",
+		},
+		SnsArn: "arn:aws:sns:us-west-2:0123456789:foo-lacework-eks:00777777-ab77-1234-a123-a12ab1d12c1d",
+	}
+
+	awsEksAuditCloudAccount := api.NewCloudAccount(
+		"cloud-from-golang",
+		api.AwsEksAuditCloudAccount,
+		awsEksAuditData,
+	)
+
+	awsEksAuditResponse, err := orgLwClient.V2.CloudAccounts.Create(awsEksAuditCloudAccount)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Output: AwsEksAudit Cloud Account created: THE-INTEGRATION-GUID
+	fmt.Printf("Cloud Account created: %s", awsEksAuditResponse.Data.IntgGuid)
 }

--- a/api/cloud_accounts.go
+++ b/api/cloud_accounts.go
@@ -85,12 +85,14 @@ const (
 	// type that defines a non-existing Cloud Account integration
 	NoneCloudAccount cloudAccountType = iota
 	AwsCtSqsCloudAccount
+	AwsEksAuditCloudAccount
 )
 
 // CloudAccountTypes is the list of available Cloud Account integration types
 var CloudAccountTypes = map[cloudAccountType]string{
-	NoneCloudAccount:     "None",
-	AwsCtSqsCloudAccount: "AwsCtSqs",
+	NoneCloudAccount:        "None",
+	AwsCtSqsCloudAccount:    "AwsCtSqs",
+	AwsEksAuditCloudAccount: "AwsEksAudit",
 }
 
 // String returns the string representation of a Cloud Account integration type

--- a/api/cloud_accounts_aws_eks_audit.go
+++ b/api/cloud_accounts_aws_eks_audit.go
@@ -1,0 +1,56 @@
+//
+// Author:: Salim Afiune Maya (<afiune@lacework.net>)
+// Copyright:: Copyright 2021, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package api
+
+// GetAwsEksAudit gets a single AwsEksAudit integration matching the provided integration guid
+func (svc *CloudAccountsService) GetAwsEksAudit(guid string) (
+	response AwsEksAuditIntegrationResponse,
+	err error,
+) {
+	err = svc.get(guid, &response)
+	return
+}
+
+// UpdateAwsEksAudit updates a single AwsEksAudit integration on the Lacework Server
+func (svc *CloudAccountsService) UpdateAwsEksAudit(data CloudAccount) (
+	response AwsEksAuditIntegrationResponse,
+	err error,
+) {
+	err = svc.update(data.ID(), data, &response)
+	return
+}
+
+type AwsEksAuditIntegrationResponse struct {
+	Data AwsEksAuditIntegration `json:"data"`
+}
+
+type AwsEksAuditIntegration struct {
+	v2CommonIntegrationData
+	Data AwsEksAuditData `json:"data"`
+}
+
+type AwsEksAuditData struct {
+	Credentials AwsEksAuditCredentials `json:"crossAccountCredentials"`
+	SnsArn      string                 `json:"snsArn"`
+}
+
+type AwsEksAuditCredentials struct {
+	RoleArn    string `json:"roleArn"`
+	ExternalID string `json:"externalId"`
+}

--- a/api/cloud_accounts_aws_eks_audit_test.go
+++ b/api/cloud_accounts_aws_eks_audit_test.go
@@ -1,0 +1,212 @@
+//
+// Author:: Salim Afiune Maya (<afiune@lacework.net>)
+// Copyright:: Copyright 2021, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package api_test
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/lacework/go-sdk/api"
+	"github.com/lacework/go-sdk/internal/intgguid"
+	"github.com/lacework/go-sdk/internal/lacework"
+)
+
+func TestCloudAccountsNewAwsEksAuditWithCustomTemplateFile(t *testing.T) {
+	accountMappingJSON := []byte(`{
+    "defaultLaceworkAccountAws": "lw_account_1",
+    "integration_mappings": {
+      "lw_account_2": {
+        "aws_accounts": [
+          "234556677",
+          "774564564"
+        ]
+      },
+      "lw_account_3": {
+        "aws_accounts": [
+          "553453453",
+          "934534535"
+        ]
+      }
+    }
+  }`)
+	awsCtSqsData := api.AwsCtSqsData{
+		QueueUrl: "https://sqs.us-west-2.amazonaws.com/123456789000/lw",
+		Credentials: api.AwsCtSqsCredentials{
+			RoleArn:    "arn:foo:bar",
+			ExternalID: "0123456789",
+		},
+	}
+	awsCtSqsData.EncodeAccountMappingFile(accountMappingJSON)
+
+	subject := api.NewCloudAccount("integration_name", api.AwsCtSqsCloudAccount, awsCtSqsData)
+	assert.Equal(t, api.AwsCtSqsCloudAccount.String(), subject.Type)
+
+	// casting the data interface{} to type AwsCtSqsData
+	subjectData := subject.Data.(api.AwsCtSqsData)
+
+	assert.Contains(t,
+		subjectData.AccountMappingFile,
+		"data:application/json;name=i.json;base64,",
+		"check the custom_template_file encoder",
+	)
+	accountMapping, err := subjectData.DecodeAccountMappingFile()
+	assert.Nil(t, err)
+	assert.Equal(t, accountMappingJSON, accountMapping)
+
+	// When there is no custom account mapping file, this function should
+	// return an empty string to match the pattern
+	subjectData.AccountMappingFile = ""
+	accountMapping, err = subjectData.DecodeAccountMappingFile()
+	assert.Nil(t, err)
+	assert.Empty(t, accountMapping)
+}
+
+func TestCloudAccountsAwsEksAuditGet(t *testing.T) {
+	var (
+		intgGUID   = intgguid.New()
+		apiPath    = fmt.Sprintf("CloudAccounts/%s", intgGUID)
+		fakeServer = lacework.MockServer()
+	)
+	fakeServer.UseApiV2()
+	fakeServer.MockToken("TOKEN")
+	defer fakeServer.Close()
+
+	fakeServer.MockAPI(apiPath, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method, "GetAwsEksAudit() should be a GET method")
+		fmt.Fprintf(w, generateCloudAccountResponse(singleAwsEksAuditCloudAccount(intgGUID)))
+	})
+
+	c, err := api.NewClient("test",
+		api.WithApiV2(),
+		api.WithToken("TOKEN"),
+		api.WithURL(fakeServer.URL()),
+	)
+	assert.Nil(t, err)
+
+	response, err := c.V2.CloudAccounts.GetAwsEksAudit(intgGUID)
+	assert.Nil(t, err)
+	assert.NotNil(t, response)
+	assert.Equal(t, intgGUID, response.Data.IntgGuid)
+	assert.Equal(t, "integration_name", response.Data.Name)
+	assert.True(t, response.Data.State.Ok)
+	assert.Equal(t, "arn:foo:bar", response.Data.Data.Credentials.RoleArn)
+	assert.Equal(t, "0123456789", response.Data.Data.Credentials.ExternalID)
+	assert.Equal(
+		t,
+		"arn:aws:sns:us-west-2:0123456789:foo-lacework-eks:00777777-ab77-1234-a123-a12ab1d12c1d",
+		response.Data.Data.SnsArn,
+	)
+}
+
+func TestCloudAccountsAwsEksAuditUpdate(t *testing.T) {
+	var (
+		intgGUID   = intgguid.New()
+		apiPath    = fmt.Sprintf("CloudAccounts/%s", intgGUID)
+		fakeServer = lacework.MockServer()
+	)
+	fakeServer.UseApiV2()
+	fakeServer.MockToken("TOKEN")
+	defer fakeServer.Close()
+
+	fakeServer.MockAPI(apiPath, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "PATCH", r.Method, "UpdateAwsEksAudit() should be a PATCH method")
+
+		if assert.NotNil(t, r.Body) {
+			body := httpBodySniffer(r)
+			assert.Contains(t, body, intgGUID, "INTG_GUID missing")
+			assert.Contains(t, body, "integration_name", "cloud account name is missing")
+			assert.Contains(t, body, "AwsEksAudit", "wrong cloud account type")
+			assert.Contains(t, body, "arn:bubu:lubu", "wrong role arn")
+			assert.Contains(t, body, "abc123", "wrong external ID")
+			assert.Contains(
+				t,
+				body,
+				"arn:aws:sns:us-west-2:0123456789:foo-lacework-eks:00777777-ab77-1234-a123-a12ab1d12c1d",
+				"wrong sns arn")
+			assert.Contains(t, body, "enabled\":1", "cloud account is not enabled")
+		}
+
+		fmt.Fprintf(w, generateCloudAccountResponse(singleAwsEksAuditCloudAccount(intgGUID)))
+	})
+
+	c, err := api.NewClient("test",
+		api.WithApiV2(),
+		api.WithToken("TOKEN"),
+		api.WithURL(fakeServer.URL()),
+	)
+	assert.Nil(t, err)
+
+	cloudAccount := api.NewCloudAccount("integration_name",
+		api.AwsEksAuditCloudAccount,
+		api.AwsEksAuditData{
+			SnsArn: "arn:aws:sns:us-west-2:0123456789:foo-lacework-eks:00777777-ab77-1234-a123-a12ab1d12c1d",
+			Credentials: api.AwsEksAuditCredentials{
+				RoleArn:    "arn:bubu:lubu",
+				ExternalID: "abc123",
+			},
+		},
+	)
+	assert.Equal(t, "integration_name", cloudAccount.Name, "AwsEksAudit cloud account name mismatch")
+	assert.Equal(t, "AwsEksAudit", cloudAccount.Type, "a new AwsEksAudit cloud account should match its type")
+	assert.Equal(t, 1, cloudAccount.Enabled, "a new AwsEksAudit cloud account should be enabled")
+	cloudAccount.IntgGuid = intgGUID
+
+	response, err := c.V2.CloudAccounts.UpdateAwsEksAudit(cloudAccount)
+	assert.Nil(t, err)
+	assert.NotNil(t, response)
+	assert.Equal(t, intgGUID, response.Data.IntgGuid)
+	assert.Equal(t,
+		"arn:aws:sns:us-west-2:0123456789:foo-lacework-eks:00777777-ab77-1234-a123-a12ab1d12c1d",
+		response.Data.Data.SnsArn)
+}
+
+func singleAwsEksAuditCloudAccount(id string) string {
+	return `
+  {
+    "createdOrUpdatedBy": "salim.afiunemaya@lacework.net",
+    "createdOrUpdatedTime": "2021-06-01T19:28:00.092Z",
+	"enabled": 1,
+    "intgGuid": "` + id + `",
+    "isOrg": 0,
+    "name": "integration_name",
+    "state": {
+      "details": {
+        "complianceOpsDeniedAccess": [
+          "GetBucketAcl",
+          "GetBucketLogging"
+        ]
+      },
+      "lastSuccessfulTime": 1624456896915,
+      "lastUpdatedTime": 1624456896915,
+      "ok": true
+    },
+	"type": "AwsEksAudit",
+    "data": {
+      "snsArn": "arn:aws:sns:us-west-2:0123456789:foo-lacework-eks:00777777-ab77-1234-a123-a12ab1d12c1d",
+      "crossAccountCredentials": {
+        "externalId": "0123456789",
+        "roleArn": "arn:foo:bar"
+      }
+    }
+  }
+  `
+}

--- a/api/cloud_accounts_aws_eks_audit_test.go
+++ b/api/cloud_accounts_aws_eks_audit_test.go
@@ -30,56 +30,6 @@ import (
 	"github.com/lacework/go-sdk/internal/lacework"
 )
 
-func TestCloudAccountsNewAwsEksAuditWithCustomTemplateFile(t *testing.T) {
-	accountMappingJSON := []byte(`{
-    "defaultLaceworkAccountAws": "lw_account_1",
-    "integration_mappings": {
-      "lw_account_2": {
-        "aws_accounts": [
-          "234556677",
-          "774564564"
-        ]
-      },
-      "lw_account_3": {
-        "aws_accounts": [
-          "553453453",
-          "934534535"
-        ]
-      }
-    }
-  }`)
-	awsCtSqsData := api.AwsCtSqsData{
-		QueueUrl: "https://sqs.us-west-2.amazonaws.com/123456789000/lw",
-		Credentials: api.AwsCtSqsCredentials{
-			RoleArn:    "arn:foo:bar",
-			ExternalID: "0123456789",
-		},
-	}
-	awsCtSqsData.EncodeAccountMappingFile(accountMappingJSON)
-
-	subject := api.NewCloudAccount("integration_name", api.AwsCtSqsCloudAccount, awsCtSqsData)
-	assert.Equal(t, api.AwsCtSqsCloudAccount.String(), subject.Type)
-
-	// casting the data interface{} to type AwsCtSqsData
-	subjectData := subject.Data.(api.AwsCtSqsData)
-
-	assert.Contains(t,
-		subjectData.AccountMappingFile,
-		"data:application/json;name=i.json;base64,",
-		"check the custom_template_file encoder",
-	)
-	accountMapping, err := subjectData.DecodeAccountMappingFile()
-	assert.Nil(t, err)
-	assert.Equal(t, accountMappingJSON, accountMapping)
-
-	// When there is no custom account mapping file, this function should
-	// return an empty string to match the pattern
-	subjectData.AccountMappingFile = ""
-	accountMapping, err = subjectData.DecodeAccountMappingFile()
-	assert.Nil(t, err)
-	assert.Empty(t, accountMapping)
-}
-
 func TestCloudAccountsAwsEksAuditGet(t *testing.T) {
 	var (
 		intgGUID   = intgguid.New()


### PR DESCRIPTION
Signed-off-by: Ross <ross.moles@lacework.net>

## Summary

In order to facilitate the creation of the EKS Audit Log Terraform Module, we need to add support for the AwsEksAudit cloud account integration

## How did you test this change?

make fmt ✅ 
make test ✅ 

## Issue

https://lacework.atlassian.net/browse/ALLY-945
