### PR TITLE
feat(lql): more suitable default for lql run

### DIFF
--- a/cli/cmd/lql.go
+++ b/cli/cmd/lql.go
@@ -142,7 +142,7 @@ func init() {
 	// start time flag
 	queryRunCmd.Flags().StringVarP(
 		&queryCmdState.Start,
-		"start", "", "@d",
+		"start", "", "-24h",
 		"start time for query",
 	)
 	// end time flag

--- a/integration/lql_test.go
+++ b/integration/lql_test.go
@@ -42,7 +42,7 @@ func cleanAndCreateQuery(id string, args ...string) (bytes.Buffer, bytes.Buffer,
 
 func TestQueryAliases(t *testing.T) {
 	// lacework query
-	out, err, exitcode := LaceworkCLI("help", "query")
+	out, err, exitcode := LaceworkCLI("help", "queries")
 	assert.Contains(t, out.String(), "lacework query [command]")
 	assert.Empty(t, err.String(), "STDERR should be empty")
 	assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
@@ -58,28 +58,14 @@ func TestQueryBase(t *testing.T) {
 	out, err, exitcode := LaceworkCLI("query")
 	assert.Contains(t, out.String(), "create")
 	assert.Contains(t, out.String(), "delete")
-	//assert.Contains(t, out.String(), "describe")
 	assert.Contains(t, out.String(), "list")
-	//assert.Contains(t, out.String(), "list-sources")
+	assert.Contains(t, out.String(), "list-sources")
+	assert.Contains(t, out.String(), "preview-source")
 	assert.Contains(t, out.String(), "run")
 	assert.Contains(t, out.String(), "show")
+	assert.Contains(t, out.String(), "show-source")
 	assert.Contains(t, out.String(), "update")
 	assert.Contains(t, out.String(), "validate")
-	assert.Empty(t, err.String(), "STDERR should be empty")
-	assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
-}
-
-func TestQueryRunHelp(t *testing.T) {
-	out, err, exitcode := LaceworkCLI("help", "query", "run")
-	assert.Contains(t, out.String(), "lacework query run [query_id] [flags]")
-	assert.Contains(t, out.String(), "--end string")
-	assert.Contains(t, out.String(), `end time for query (default "now")`)
-	assert.Contains(t, out.String(), "-f, --file string")
-	assert.Contains(t, out.String(), "--start string")
-	assert.Contains(t, out.String(), `start time for query (default "@d")`)
-	assert.Contains(t, out.String(), "--range string")
-	assert.Contains(t, out.String(), "-u, --url string")
-	assert.Contains(t, out.String(), "--validate_only")
 	assert.Empty(t, err.String(), "STDERR should be empty")
 	assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
 }

--- a/integration/test_resources/help/query_run
+++ b/integration/test_resources/help/query_run
@@ -36,7 +36,7 @@ Flags:
   -f, --file string     path to a query to run
   -h, --help            help for run
       --range string    natural time range for query
-      --start string    start time for query (default "@d")
+      --start string    start time for query (default "-24h")
   -u, --url string      url to a query to run
       --validate_only   validate query only (do not run)
 


### PR DESCRIPTION
## Summary
>As a Lacework user, I would like the CLI to default to an unambiguous time range.  Furthermore, certain Lacework batch operations run daily and we may need to “look back” further than just the “current day”.

Use "Last 24 Hours" instead of "Today"

## How did you test this change?
Change is covered by existing integration

## Issue
https://lacework.atlassian.net/browse/ALLY-943