### PR TITLE
feat(cli): sort query and policy library lists 

### DIFF
--- a/cli/cmd/lql_library.go
+++ b/cli/cmd/lql_library.go
@@ -19,6 +19,8 @@
 package cmd
 
 import (
+	"sort"
+
 	"github.com/lacework/go-sdk/api"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -52,6 +54,10 @@ func getListQueryLibraryTable(queries map[string]LCLQuery) (out [][]string) {
 	for id := range queries {
 		out = append(out, []string{id})
 	}
+	// order by ID
+	sort.Slice(out, func(i, j int) bool {
+		return out[i][0] < out[j][0]
+	})
 	return
 }
 

--- a/cli/cmd/policy.go
+++ b/cli/cmd/policy.go
@@ -281,6 +281,29 @@ func inputPolicyFromEditor(action string) (policy string, err error) {
 	return
 }
 
+func sortPolicyTable(out [][]string, policyIDIndex int) {
+	// order by ID (special handling for policy ID numbers)
+	sort.Slice(out, func(i, j int) bool {
+		iMatch := policyIDIntRE.FindStringSubmatch(out[i][policyIDIndex])
+		jMatch := policyIDIntRE.FindStringSubmatch(out[j][policyIDIndex])
+		// both regexes must match
+		// both regexes must have proper lengths since we'll be using...
+		// ...direct access from here on out
+		if iMatch == nil || jMatch == nil || len(iMatch) != 3 || len(jMatch) != 3 {
+			return out[i][0] < out[j][0]
+		}
+		// if string portions aren't the same
+		if iMatch[1] != jMatch[1] {
+			return out[i][0] < out[j][0]
+		}
+		// if string portions are the same; compare based on ints
+		// no error checking needed for Atoi since use regexp \d+
+		iNum, _ := strconv.Atoi(iMatch[2])
+		jNum, _ := strconv.Atoi(jMatch[2])
+		return iNum < jNum
+	})
+}
+
 func policyTable(policies []api.Policy) (out [][]string) {
 	for _, policy := range policies {
 		state := "disabled"
@@ -301,28 +324,9 @@ func policyTable(policies []api.Policy) (out [][]string) {
 			policy.QueryID,
 			strings.Join(policy.Tags, "\n"),
 		})
-
-		// order by ID (special handling for policy ID numbers)
-		sort.Slice(out, func(i, j int) bool {
-			iMatch := policyIDIntRE.FindStringSubmatch(out[i][0])
-			jMatch := policyIDIntRE.FindStringSubmatch(out[j][0])
-			// both regexes must match
-			// both regexes must have proper lengths since we'll be using...
-			// ...direct access from here on out
-			if iMatch == nil || jMatch == nil || len(iMatch) != 3 || len(jMatch) != 3 {
-				return out[i][0] < out[j][0]
-			}
-			// if string portions aren't the same
-			if iMatch[1] != jMatch[1] {
-				return out[i][0] < out[j][0]
-			}
-			// if string portions are the same; compare based on ints
-			// no error checking needed for Atoi since use regexp \d+
-			iNum, _ := strconv.Atoi(iMatch[2])
-			jNum, _ := strconv.Atoi(jMatch[2])
-			return iNum < jNum
-		})
 	}
+	sortPolicyTable(out, 0)
+
 	return
 }
 

--- a/cli/cmd/policy_library.go
+++ b/cli/cmd/policy_library.go
@@ -100,6 +100,7 @@ func policyLibraryTable(policies map[string]LCLPolicy) (out [][]string) {
 			strings.Join(policy.Tags, "\n"),
 		})
 	}
+	sortPolicyTable(out, 0)
 	return
 }
 


### PR DESCRIPTION

## Summary
Similar to `query ls` and `policy ls` we want to sort the outputs of `query list-library` and `policy list-library` respectively

## How did you test this change?
Existing automated testing

## Issue
https://lacework.atlassian.net/browse/ALLY-911