### PR TITLE
fix: add missing gcp compliance report types to get-report command

### DIFF
--- a/cli/cmd/compliance_gcp.go
+++ b/cli/cmd/compliance_gcp.go
@@ -114,13 +114,16 @@ Then, select one GUID from an integration and visualize its details using the co
 			}
 
 			switch compCmdState.Type {
-			case "CIS", "CIS12", "K8S", "HIPAA", "SOC", "PCI":
+			case "CIS", "CIS12", "K8S", "HIPAA", "SOC", "PCI", "ISO_27001", "PCI_Rev2", "SOC_Rev2", "HIPAA_Rev2", "NIST_CSF",
+				"NIST_800_53_REV4", "NIST_800_171_REV2":
 				compCmdState.Type = fmt.Sprintf("GCP_%s", compCmdState.Type)
 				return nil
-			case "GCP_CIS", "GCP_CIS12", "GCP_K8S", "GCP_HIPAA", "GCP_SOC", "GCP_PCI":
+			case "GCP_CIS", "GCP_CIS12", "GCP_K8S", "GCP_HIPAA", "GCP_SOC", "GCP_PCI", "GCP_ISO_27001", "GCP_PCI_Rev2", "GCP_SOC_Rev2",
+				"GCP_HIPAA_Rev2", "GCP_GCP_NIST_CSF", "GCP_NIST_800_53_REV4", "GCP_NIST_800_171_REV2":
 				return nil
 			default:
-				return errors.New("supported report types are: CIS, CIS12, K8S, HIPAA, SOC, or PCI")
+				return errors.New("supported report types are: CIS, CIS12, K8S, HIPAA, SOC, ISO_27001, PCI, PCI_Rev2, SOC_Rev2, " +
+					"HIPAA_Rev2, NIST_CSF, NIST_800_53_REV4 or NIST_800_171_REV2")
 			}
 		},
 		Short: "Get the latest GCP compliance report",


### PR DESCRIPTION
Signed-off-by: Darren Murray <darren.murray@lacework.net>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/lacework/go-sdk) and create your branch from `main`
  2. Run `make prepare` in the repository root
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`make test`)
  5. Format your code (`make fmt`)
  6. Make sure your code lints (`make lint`)
  7. If you are updating the Lacework CLI, make sure it compiles (`make build-cli-cross-platform`)
  8. Follow the commit message standard (`type(scope): subject`) documented in [DEVELOPER_GUIDELINES.md](https://github.com/lacework/go-sdk/blob/main/DEVELOPER_GUIDELINES.md#commit-message-standard)
  9. If you haven't already, configure signed commits by [telling git about your signing key](https://docs.github.com/en/github/authenticating-to-github/managing-commit-signature-verification/telling-git-about-your-signing-key) and [signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)

  Learn more about contributing: https://github.com/lacework/go-sdk/blob/main/CONTRIBUTING.md
-->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

Add missing gcp report types to `lacework compliance gcp get-report` command

## How did you test this change?

<!--
  How exactly did you verify that your PR solves the issue you wanted to solve?
  Include any other relevant information such as how to use the new functionality, screenshots, etc.
-->
Run : 
`lacework compliance gcp get-report <organization> <project_id> --type NIST_CSF`
`lacework compliance gcp get-report <organization> <project_id> --type ISO_27001`
`lacework ...PCI_Rev2`
`lacework ...NIST_CSF`
`lacework ...NIST_800_171_REV2`
`lacework ...HIPAA_Rev2`
`lacework ...NIST_800_171_REV2`

## Issue

<!--
  Include the link to a Jira/Github issue
-->
