### PR TITLE
feat(cli): adds lql datasource relationships 

### DIFF
--- a/api/datasources.go
+++ b/api/datasources.go
@@ -36,15 +36,24 @@ type DatasourceResponse struct {
 }
 
 type Datasource struct {
-	Name         string             `json:"name"`
-	Description  string             `json:"description"`
-	ResultSchema []DatasourceSchema `json:"resultSchema"`
+	Name                string                   `json:"name"`
+	Description         string                   `json:"description"`
+	ResultSchema        []DatasourceSchema       `json:"resultSchema"`
+	SourceRelationships []DatasourceRelationship `json:"sourceRelationships"`
 }
 
 type DatasourceSchema struct {
 	Name        string `json:"name"`
 	DataType    string `json:"dataType"`
 	Description string `json:"description"`
+}
+
+type DatasourceRelationship struct {
+	Name          string `json:"name"`
+	Description   string `json:"description"`
+	From          string `json:"from"`
+	To            string `json:"to"`
+	ToCardinality string `json:"toCardinality"`
 }
 
 // DatasourcesService is a service that interacts with the Datasources

--- a/cli/cmd/lql_sources.go
+++ b/cli/cmd/lql_sources.go
@@ -108,6 +108,19 @@ func getShowQuerySourceTable(resultSchema []api.DatasourceSchema) (out [][]strin
 	return
 }
 
+func getShowQuerySourceRelationshipsTable(relationships []api.DatasourceRelationship) (out [][]string) {
+	for _, relationship := range relationships {
+		out = append(out, []string{
+			relationship.Name,
+			relationship.From,
+			relationship.To,
+			relationship.ToCardinality,
+			relationship.Description,
+		})
+	}
+	return
+}
+
 func showQuerySource(_ *cobra.Command, args []string) error {
 	cli.Log.Debugw("retrieving datasource", "id", args[0])
 
@@ -132,6 +145,13 @@ func showQuerySource(_ *cobra.Command, args []string) error {
 		renderSimpleTable(
 			[]string{"Field Name", "Data Type", "Description"},
 			getShowQuerySourceTable(datasourceResponse.Data.ResultSchema),
+		),
+	)
+	cli.OutputHuman("\n")
+	cli.OutputHuman(
+		renderSimpleTable(
+			[]string{"Relationship Name", "From", "To", "Cardinality", "Description"},
+			getShowQuerySourceRelationshipsTable(datasourceResponse.Data.SourceRelationships),
 		),
 	)
 	cli.OutputHuman("\nUse 'lacework query preview-source <datasource_id>' to see an actual result from the data source.\n")

--- a/integration/lql_sources_test.go
+++ b/integration/lql_sources_test.go
@@ -62,6 +62,7 @@ func TestQueryListSourcesJSON(t *testing.T) {
 	assert.Contains(t, out.String(), "[")
 	assert.Contains(t, out.String(), `"CloudTrailRawEvents"`)
 	assert.Contains(t, out.String(), "]")
+	assert.Contains(t, out.String(), "sourceRelationships")
 	assert.Empty(t, err.String(), "STDERR should be empty")
 	assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
 }
@@ -90,6 +91,7 @@ func TestQueryShowSourceTable(t *testing.T) {
 	assert.Contains(t, out.String(), "FIELD NAME")
 	assert.Contains(t, out.String(), "INSERT_ID")
 	assert.Contains(t, out.String(), "preview-source")
+	assert.Contains(t, out.String(), "RELATIONSHIP NAME")
 	assert.Empty(t, err.String(), "STDERR should be empty")
 	assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
 }


### PR DESCRIPTION
## Summary

> As a Lacework user I would like to understand the underlying relationships (i.e. implicit joins) of a given Lacework datasource.

At some point `sourceRelationships` was added to `v2/Datasources` we want to ensure that we can output this information if requested via verbose (i.e. json) output for list-sources as well as an additional table for show-source


## How did you test this change?
Automated integration
Manually

## Issue
https://lacework.atlassian.net/browse/ALLY-974