### PR TITLE
feat(cli): default template when creating LQL queries

### DIFF
--- a/cli/cmd/lql.go
+++ b/cli/cmd/lql.go
@@ -271,7 +271,7 @@ queryText: |-
           --- Add query filter(s), if any. If not, remove this block.
       }
       return {
-          --- List fields to return from the selected source. Use 'lacework query show-source <datasource>'
+          --- List fields to return from the selected source. Use 'lacework query describe <datasource>'.
       }
   }`
 		prompt.HideDefault = true

--- a/cli/cmd/lql.go
+++ b/cli/cmd/lql.go
@@ -257,10 +257,28 @@ func inputQueryFromURL(url string) (query string, err error) {
 func inputQueryFromEditor(action string) (query string, err error) {
 	prompt := &survey.Editor{
 		Message:  fmt.Sprintf("Type a query to %s", action),
-		FileName: "query*.lql",
+		FileName: "query*.yaml",
 	}
-	err = survey.AskOne(prompt, &query)
 
+	if action == "create" {
+		prompt.Default = `queryId: YourQueryID
+queryText: |-
+  {
+      source {
+          // Select a datasource. To list all available datasources use 'lacework query sources'.
+      }
+      filter {
+          // Add query filter(s), if any. If not, remove this block.
+      }
+      return {
+          // List fields to return from the selected source. Use 'lacework query show-source <datasource>'
+      }
+  }`
+		prompt.HideDefault = true
+		prompt.AppendDefault = true
+	}
+
+	err = survey.AskOne(prompt, &query)
 	return
 }
 

--- a/cli/cmd/lql.go
+++ b/cli/cmd/lql.go
@@ -265,13 +265,13 @@ func inputQueryFromEditor(action string) (query string, err error) {
 queryText: |-
   {
       source {
-          // Select a datasource. To list all available datasources use 'lacework query sources'.
+          --- Select a datasource. To list all available datasources use 'lacework query sources'.
       }
       filter {
-          // Add query filter(s), if any. If not, remove this block.
+          --- Add query filter(s), if any. If not, remove this block.
       }
       return {
-          // List fields to return from the selected source. Use 'lacework query show-source <datasource>'
+          --- List fields to return from the selected source. Use 'lacework query show-source <datasource>'
       }
   }`
 		prompt.HideDefault = true

--- a/cli/cmd/outputs.go
+++ b/cli/cmd/outputs.go
@@ -39,11 +39,15 @@ func (c *cliState) OutputJSON(v interface{}) error {
 	return nil
 }
 
-// OutputHumanRead will print out the provided message if the cli state is
+// OutputHuman will print out the provided message if the cli state is
 // configured to talk to humans, to switch to json format use --json
 func (c *cliState) OutputHuman(format string, a ...interface{}) {
 	if c.HumanOutput() {
-		fmt.Fprintf(os.Stdout, format, a...)
+		if len(a) == 0 {
+			fmt.Fprint(os.Stdout, format)
+		} else {
+			fmt.Fprintf(os.Stdout, format, a...)
+		}
 	}
 }
 

--- a/integration/lql_create_test.go
+++ b/integration/lql_create_test.go
@@ -78,8 +78,3 @@ func TestQueryCreateFile(t *testing.T) {
 	assert.Empty(t, stderr.String(), "STDERR should be empty")
 	assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
 }
-
-func TestQueryCreateURL(t *testing.T) {
-	// This is tested by virtue of setup in other tests
-	return
-}

--- a/integration/lql_create_unix_test.go
+++ b/integration/lql_create_unix_test.go
@@ -1,0 +1,87 @@
+//go:build query && !windows
+
+// Author:: Salim Afiune Maya (<afiune@lacework.net>)
+// Copyright:: Copyright 2022, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package integration
+
+import (
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/Netflix/go-expect"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestQueryCreateFromEditor(t *testing.T) {
+	dir := createTOMLConfigFromCIvars()
+	defer os.RemoveAll(dir)
+
+	// teardown
+	defer LaceworkCLIWithHome(dir, "query", "delete", queryID)
+
+	_ = runFakeTerminalTestFromDir(t, dir,
+		func(c *expect.Console) {
+			expectString(t, c, "Type a query to create")
+			c.SendLine("")
+			time.Sleep(time.Millisecond)
+			// Replace first like with query id
+			c.Send(fmt.Sprintf("c$queryId: %s\x1b", queryID))
+			time.Sleep(time.Millisecond)
+			// Move to line number 5 and add source
+			c.Send("5GoCloudTrailRawEvents\x1b")
+			time.Sleep(time.Millisecond)
+			// Move to line number 9 and add filter
+			c.Send("9GoEVENT_NAME like 'GetBucket%'\x1b")
+			time.Sleep(time.Millisecond)
+			// Move to line number 13 and add return
+			c.Send("13GoINSERT_ID\x1b")
+			time.Sleep(time.Millisecond)
+			c.SendLine(":wq!") // save and close
+			time.Sleep(time.Millisecond)
+			expectString(t, c,
+				fmt.Sprintf("The query %s was created.", queryID))
+		},
+		"query", "create",
+	)
+
+	t.Run("verify query editions", func(t *testing.T) {
+		stdout, stderr, exitcode := LaceworkCLIWithHome(dir, "query", "show", queryID)
+		assert.Empty(t,
+			stderr.String(),
+			"STDERR should be empty")
+		assert.Contains(t,
+			stdout.String(),
+			"--- Select a datasource. To list all available datasources use 'lacework query sources'.",
+			"STDOUT changed, please update")
+		assert.Contains(t,
+			stdout.String(),
+			"--- Add query filter(s), if any. If not, remove this block.",
+			"STDOUT changed, please update")
+		assert.Contains(t,
+			stdout.String(),
+			"--- ",
+			"STDOUT changed, please update")
+		assert.Contains(t, stdout.String(), "CloudTrailRawEvents", "STDOUT changed, please update")
+		assert.Contains(t, stdout.String(), "EVENT_NAME like 'GetBucket%'", "STDOUT changed, please update")
+		assert.Contains(t, stdout.String(), "INSERT_ID", "STDOUT changed, please update")
+		assert.Equal(t, 0, exitcode,
+			"EXITCODE is not the expected one")
+	})
+}

--- a/integration/lql_create_unix_test.go
+++ b/integration/lql_create_unix_test.go
@@ -76,7 +76,7 @@ func TestQueryCreateFromEditor(t *testing.T) {
 			"STDOUT changed, please update")
 		assert.Contains(t,
 			stdout.String(),
-			"--- ",
+			"--- List fields to return from the selected source. Use 'lacework query describe <datasource>'.",
 			"STDOUT changed, please update")
 		assert.Contains(t, stdout.String(), "CloudTrailRawEvents", "STDOUT changed, please update")
 		assert.Contains(t, stdout.String(), "EVENT_NAME like 'GetBucket%'", "STDOUT changed, please update")


### PR DESCRIPTION
## Summary

As a Lacework CLI user,
I want to have a boilerplate template when creating new LQL queries,
So I don't have to type the entire query from scratch.
## How did you test this change?

I run the command `lacework query create` without inputs and my default editor opened with:

<img width="1119" alt="Screen Shot 2022-04-11 at 10 26 59 PM" src="https://user-images.githubusercontent.com/5712253/162826126-08863599-989c-4263-8707-a890cf2a96d1.png">



## Issue

N/A - Needed for my Hackathon Project.
