### PR TITLE
fix(cli): fix lacework query run from library

### DIFF
--- a/cli/cmd/lql_create.go
+++ b/cli/cmd/lql_create.go
@@ -111,7 +111,7 @@ func init() {
 
 	if cli.IsLCLInstalled() {
 		queryCreateCmd.Flags().StringVarP(
-			&queryCmdState.CUVFromLibrary,
+			&queryCmdState.CURVFromLibrary,
 			"library", "l", "",
 			"create query from Lacework Content Library",
 		)

--- a/cli/cmd/lql_update.go
+++ b/cli/cmd/lql_update.go
@@ -64,7 +64,7 @@ func init() {
 
 	if cli.IsLCLInstalled() {
 		queryUpdateCmd.Flags().StringVarP(
-			&queryCmdState.CUVFromLibrary,
+			&queryCmdState.CURVFromLibrary,
 			"library", "l", "",
 			"update query from Lacework Content Library",
 		)

--- a/cli/cmd/lql_validate.go
+++ b/cli/cmd/lql_validate.go
@@ -63,7 +63,7 @@ func init() {
 
 	if cli.IsLCLInstalled() {
 		queryValidateCmd.Flags().StringVarP(
-			&queryCmdState.CUVFromLibrary,
+			&queryCmdState.CURVFromLibrary,
 			"library", "l", "",
 			"validate query from Lacework Content Library",
 		)

--- a/integration/lql_test.go
+++ b/integration/lql_test.go
@@ -40,20 +40,6 @@ func cleanAndCreateQuery(id string, args ...string) (bytes.Buffer, bytes.Buffer,
 	return LaceworkCLIWithTOMLConfig(args...)
 }
 
-func TestQueryAliases(t *testing.T) {
-	// lacework query
-	out, err, exitcode := LaceworkCLI("help", "queries")
-	assert.Contains(t, out.String(), "lacework query [command]")
-	assert.Empty(t, err.String(), "STDERR should be empty")
-	assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
-
-	// lacework lql
-	out, err, exitcode = LaceworkCLI("help", "lql")
-	assert.Contains(t, out.String(), "lacework query [command]")
-	assert.Empty(t, err.String(), "STDERR should be empty")
-	assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
-}
-
 func TestQueryBase(t *testing.T) {
 	out, err, exitcode := LaceworkCLI("query")
 	assert.Contains(t, out.String(), "create")
@@ -98,9 +84,19 @@ func TestQueryRunID(t *testing.T) {
 	assert.Empty(t, err.String(), "STDERR should be empty")
 	assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
 
-	// validate_only
+	// bad - file
+	_, err, exitcode = LaceworkCLIWithTOMLConfig("query", "run", queryID, "--file", "foo")
+	assert.Contains(t, err.String(), "ERROR flag --file not applicable when specifying query_id argument")
+	assert.Equal(t, 1, exitcode, "EXITCODE is not the expected one")
+
+	// bad - url
+	_, err, exitcode = LaceworkCLIWithTOMLConfig("query", "run", queryID, "--url", "foo")
+	assert.Contains(t, err.String(), "ERROR flag --url not applicable when specifying query_id argument")
+	assert.Equal(t, 1, exitcode, "EXITCODE is not the expected one")
+
+	// bad - validate_only
 	_, err, exitcode = LaceworkCLIWithTOMLConfig("query", "run", queryID, "--validate_only")
-	assert.Contains(t, err.String(), "ERROR flag --validate_only unavailable when specifying query_id argument")
+	assert.Contains(t, err.String(), "ERROR flag --validate_only not applicable when specifying query_id argument")
 	assert.Equal(t, 1, exitcode, "EXITCODE is not the expected one")
 }
 


### PR DESCRIPTION
## Summary
`lacework query run` was confused about how to get the query

## How did you test this change?
Manually
Partial Integration Automation (we don't have integration testing for Lacework Content Library yet)

## Issue
https://lacework.atlassian.net/browse/ALLY-977