### PR TITLE
feat(cli): ubuntu ESM support

### DIFF
--- a/cli/cmd/package_manifest_test.go
+++ b/cli/cmd/package_manifest_test.go
@@ -225,8 +225,25 @@ func TestMergeHostVulnScanPkgManifestResponses(t *testing.T) {
 	}
 }
 
-func TestIsEsmEnabled(t *testing.T) {
+func TestIsEsmEnabledWhenIsNotEnabled(t *testing.T) {
 	assert.False(t, cli.IsEsmEnabled())
+}
+
+func TestIsEsmEnabledWhenIsActuallyEnabled(t *testing.T) {
+	file, err := ioutil.TempFile("", "ubuntu-advantage-status-json")
+	assert.Nil(t, err)
+	_, err = file.WriteString(mockUbuntuUAStatusFile)
+	assert.Nil(t, err)
+
+	procUAStatusFile = file.Name()
+
+	defer func() {
+		os.Remove(file.Name())
+		// rollback
+		procUAStatusFile = "/proc/1/root/var/lib/ubuntu-advantage/status.json"
+	}()
+
+	assert.True(t, cli.IsEsmEnabled())
 }
 
 func TestParseOsRelease(t *testing.T) {
@@ -274,4 +291,111 @@ PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-poli
 VERSION_CODENAME=bionic
 UBUNTU_CODENAME=bionic
 `
+	mockUbuntuUAStatusFile = `{
+  "execution_details": "No Ubuntu Advantage operations are running",
+  "machine_id": "abc123",
+  "origin": "free",
+  "_doc": "Content provided in json response is currently considered Experimental and may change",
+  "account": {
+    "name": "test@lacework.net",
+    "id": "abc123",
+    "external_account_ids": [],
+    "created_at": "2022-01-25T23:06:47+00:00"
+  },
+  "expires": "9999-12-31T00:00:00+00:00",
+  "execution_status": "inactive",
+  "version": "27.2.2~16.04.1",
+  "notices": [],
+  "_schema_version": "0.1",
+  "config_path": "/etc/ubuntu-advantage/uaclient.conf",
+  "attached": true,
+  "services": [
+    {
+      "entitled": "yes",
+      "description_override": null,
+      "name": "cc-eal",
+      "status_details": "CC EAL2 is not configured",
+      "description": "Common Criteria EAL2 Provisioning Packages",
+      "status": "disabled",
+      "available": "yes"
+    },
+    {
+      "entitled": "yes",
+      "description_override": null,
+      "name": "cis",
+      "status_details": "CIS Audit is not configured",
+      "description": "Center for Internet Security Audit Tools",
+      "status": "disabled",
+      "available": "yes"
+    },
+    {
+      "entitled": "no",
+      "description_override": null,
+      "name": "esm-apps",
+      "status_details": "",
+      "description": "UA Apps: Extended Security Maintenance (ESM)",
+      "status": "—",
+      "available": "yes"
+    },
+    {
+      "entitled": "yes",
+      "description_override": null,
+      "name": "esm-infra",
+      "status_details": "UA Infra: ESM is active",
+      "description": "UA Infra: Extended Security Maintenance (ESM)",
+      "status": "enabled",
+      "available": "yes"
+    },
+    {
+      "entitled": "yes",
+      "description_override": null,
+      "name": "fips",
+      "status_details": "FIPS is not configured",
+      "description": "NIST-certified core packages",
+      "status": "disabled",
+      "available": "yes"
+    },
+    {
+      "entitled": "yes",
+      "description_override": null,
+      "name": "fips-updates",
+      "status_details": "FIPS Updates is not configured",
+      "description": "NIST-certified core packages with priority security updates",
+      "status": "disabled",
+      "available": "yes"
+    },
+    {
+      "entitled": "yes",
+      "description_override": null,
+      "name": "livepatch",
+      "status_details": "",
+      "description": "Canonical Livepatch service",
+      "status": "enabled",
+      "available": "yes"
+    }
+  ],
+  "contract": {
+    "products": [
+      "free"
+    ],
+    "name": "test@lacework.net",
+    "id": "abc123",
+    "tech_support_level": "n/a",
+    "created_at": "2022-01-25T23:06:47+00:00"
+  },
+  "config": {
+    "security_url": "https://ubuntu.com/security",
+    "data_dir": "/var/lib/ubuntu-advantage",
+    "ua_config": {
+      "apt_http_proxy": null,
+      "https_proxy": null,
+      "http_proxy": null,
+      "apt_https_proxy": null
+    },
+    "log_level": "debug",
+    "log_file": "/var/log/ubuntu-advantage.log",
+    "contract_url": "https://contracts.canonical.com"
+  },
+  "effective": "2022-01-25T23:06:47+00:00"
+}`
 )

--- a/cli/cmd/package_manifest_test.go
+++ b/cli/cmd/package_manifest_test.go
@@ -225,6 +225,10 @@ func TestMergeHostVulnScanPkgManifestResponses(t *testing.T) {
 	}
 }
 
+func TestIsEsmEnabled(t *testing.T) {
+	assert.False(t, cli.IsEsmEnabled())
+}
+
 func TestParseOsRelease(t *testing.T) {
 	file, err := ioutil.TempFile("", "os-release")
 	assert.Nil(t, err)


### PR DESCRIPTION

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/lacework/go-sdk) and create your branch from `main`
  2. Run `make prepare` in the repository root
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`make test`)
  5. Format your code (`make fmt`)
  6. Make sure your code lints (`make lint`)
  7. If you are updating the Lacework CLI, make sure it compiles (`make build-cli-cross-platform`)
  8. Follow the commit message standard (`type(scope): subject`) documented in [DEVELOPER_GUIDELINES.md](https://github.com/lacework/go-sdk/blob/main/DEVELOPER_GUIDELINES.md#commit-message-standard)
  9. If you haven't already, configure signed commits by [telling git about your signing key](https://docs.github.com/en/github/authenticating-to-github/managing-commit-signature-verification/telling-git-about-your-signing-key) and [signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)

  Learn more about contributing: https://github.com/lacework/go-sdk/blob/main/CONTRIBUTING.md
-->

## Summary
We have added CVE data for ESM-enabled machines. This PR is adding
support for the CLI to detect when ESM is enabled on Ubuntu machines and
if so, it will add `esm` to the OS version.


Signed-off-by: Salim Afiune Maya <afiune@lacework.net>


## How did you test this change?

Built a CLI binary and deployed it to an EC2 instance with ESM-enabled
```
root@ip-172-31-66-25:~# lacework version
lacework v0.31.1-dev (sha:521f2e40d175ddcc66c234611434999581ecf569) (time:20220413174742)
```
Generated a package manifest and verified that is returns the right os version with `esm` append
```
root@ip-172-31-66-25:~# lacework vuln host generate-pkg-manifest
{
  "os_pkg_info_list": [
    {
      "os": "ubuntu",
      "os_ver": "16.04esm",
      "pkg": "accountsservice",
      "pkg_ver": "0.6.40-2ubuntu11.6"
    },
    {
      "os": "ubuntu",
      "os_ver": "16.04esm",
      "pkg": "acl",
      "pkg_ver": "2.2.52-3"
    },

    < ... suppressed output ... >
    {
      "os": "ubuntu",
      "os_ver": "16.04esm",
      "pkg": "zlib1g",
      "pkg_ver": "1:1.2.8.dfsg-2ubuntu4.3+esm1"
    }
  ]
}
```
Finally, run a scan:
```
root@ip-172-31-66-25:~# lacework vuln host scan-pkg-manifest  --local
         VULNERABILITIES
----------------------------------
    SEVERITY   COUNT   FIXABLE
  -----------+-------+----------
    Critical       1         1
    High          15         9
    Medium       789       579
    Low          144        66
    Info          22         2

       CVE ID         SEVERITY    SCORE       PACKAGE                    VERSION                           FIX VERSION
-------------------+------------+-------+-----------------+------------------------------------+-----------------------------------
  CVE-2017-5754      Critical     5.6     firefox           45.0.2+build1-0ubuntu1               0:57.0.4+build1-0ubuntu0.16.04.1
  CVE-2019-11707     High         8.8     firefox           45.0.2+build1-0ubuntu1               0:67.0.3+build1-0ubuntu0.16.04.1
  CVE-2020-6820      High         8.1     firefox           45.0.2+build1-0ubuntu1               0:74.0.1+build1-0ubuntu0.16.04.1
  CVE-2017-5715      High         5.6     firefox           45.0.2+build1-0ubuntu1               0:57.0.4+build1-0ubuntu0.16.04.1
  CVE-2022-25235     High         9.8     firefox           45.0.2+build1-0ubuntu1
  CVE-2020-26950     High         8.8     firefox           45.0.2+build1-0ubuntu1               0:82.0.3+build1-0ubuntu0.16.04.1
  CVE-2019-11708     High         10.0    firefox           45.0.2+build1-0ubuntu1               0:67.0.4+build1-0ubuntu0.16.04.1
  CVE-2022-25236     High         9.8     firefox           45.0.2+build1-0ubuntu1
  CVE-2017-5753      High         5.6     firefox           45.0.2+build1-0ubuntu1               0:57.0.4+build1-0ubuntu0.16.04.1
  CVE-2020-27170     High         4.7     linux-aws         4.4.0.1139.144
```

## Issue
Jira: https://lacework.atlassian.net/browse/ALLY-883
