### PR TITLE
fix(api): add newResponse for function SearchAllPages

### DIFF
--- a/api/v2_vulnerabilities.go
+++ b/api/v2_vulnerabilities.go
@@ -220,8 +220,12 @@ func (svc *v2HostVulnerabilityService) SearchAllPages(filters SearchFilter) (
 	for {
 		all = append(all, response.Data...)
 
-		pageOk, err = svc.client.NextPage(&response)
+		newResponse := VulnerabilitiesContainersResponse{
+			Paging: response.Paging,
+		}
+		pageOk, err = svc.client.NextPage(&newResponse)
 		if err == nil && pageOk {
+			response = newResponse
 			continue
 		}
 		break

--- a/api/v2_vulnerabilities.go
+++ b/api/v2_vulnerabilities.go
@@ -83,7 +83,7 @@ func (svc *v2ContainerVulnerabilityService) SearchAllPages(filters SearchFilter)
 	for {
 		all = append(all, response.Data...)
 
-		newResponse := VulnerabilitiesHostResponse{
+		newResponse := VulnerabilitiesContainersResponse{
 			Paging: response.Paging,
 		}
 		pageOk, err = svc.client.NextPage(&newResponse)

--- a/api/v2_vulnerabilities.go
+++ b/api/v2_vulnerabilities.go
@@ -220,7 +220,7 @@ func (svc *v2HostVulnerabilityService) SearchAllPages(filters SearchFilter) (
 	for {
 		all = append(all, response.Data...)
 
-		newResponse := VulnerabilitiesContainersResponse{
+		newResponse := VulnerabilitiesHostResponse{
 			Paging: response.Paging,
 		}
 		pageOk, err = svc.client.NextPage(&newResponse)

--- a/api/v2_vulnerabilities.go
+++ b/api/v2_vulnerabilities.go
@@ -83,7 +83,7 @@ func (svc *v2ContainerVulnerabilityService) SearchAllPages(filters SearchFilter)
 	for {
 		all = append(all, response.Data...)
 
-		newResponse := VulnerabilitiesContainersResponse{
+		newResponse := VulnerabilitiesHostResponse{
 			Paging: response.Paging,
 		}
 		pageOk, err = svc.client.NextPage(&newResponse)

--- a/api/v2_vulnerabilities.go
+++ b/api/v2_vulnerabilities.go
@@ -83,8 +83,12 @@ func (svc *v2ContainerVulnerabilityService) SearchAllPages(filters SearchFilter)
 	for {
 		all = append(all, response.Data...)
 
-		pageOk, err = svc.client.NextPage(&response)
+		newResponse := VulnerabilitiesContainersResponse{
+			Paging: response.Paging,
+		}
+		pageOk, err = svc.client.NextPage(&newResponse)
 		if err == nil && pageOk {
+			response = newResponse
 			continue
 		}
 		break


### PR DESCRIPTION
This is necessary as using the current response to iterate over pages
corrupts data that are slices, such as the tags within imageInfo. This is because
the memory address from the previous response will still contain data from the previous request.
By creating a new response using the nextPage url we get a new spot in memory to put the next
requests data.
