### PR TITLE
fix(cli): only display datasource relationships when avail

### DIFF
--- a/cli/cmd/lql_sources.go
+++ b/cli/cmd/lql_sources.go
@@ -147,13 +147,17 @@ func showQuerySource(_ *cobra.Command, args []string) error {
 			getShowQuerySourceTable(datasourceResponse.Data.ResultSchema),
 		),
 	)
-	cli.OutputHuman("\n")
-	cli.OutputHuman(
-		renderSimpleTable(
-			[]string{"Relationship Name", "From", "To", "Cardinality", "Description"},
-			getShowQuerySourceRelationshipsTable(datasourceResponse.Data.SourceRelationships),
-		),
-	)
+	// if source relationships exist
+	if len(datasourceResponse.Data.SourceRelationships) > 0 {
+		cli.OutputHuman("\n")
+		cli.OutputHuman(
+			renderSimpleTable(
+				[]string{"Relationship Name", "From", "To", "Cardinality", "Description"},
+				getShowQuerySourceRelationshipsTable(datasourceResponse.Data.SourceRelationships),
+			),
+		)
+	}
+	// breadcrumb
 	cli.OutputHuman("\nUse 'lacework query preview-source <datasource_id>' to see an actual result from the data source.\n")
 	return nil
 }

--- a/integration/lql_sources_test.go
+++ b/integration/lql_sources_test.go
@@ -61,7 +61,7 @@ func TestQueryShowSourceTable(t *testing.T) {
 	assert.NotContains(t, out.String(), "RELATIONSHIP NAME")
 
 	// relationships
-	out, err, exitcode := LaceworkCLIWithTOMLConfig("query", "describe", "LW_HE_FILES")
+	out, err, exitcode = LaceworkCLIWithTOMLConfig("query", "show-source", "LW_HE_FILES")
 	assert.Contains(t, out.String(), "RELATIONSHIP NAME")
 	assert.Empty(t, err.String(), "STDERR should be empty")
 	assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")

--- a/integration/lql_sources_test.go
+++ b/integration/lql_sources_test.go
@@ -55,6 +55,13 @@ func TestQueryShowSourceTable(t *testing.T) {
 	assert.Contains(t, out.String(), "FIELD NAME")
 	assert.Contains(t, out.String(), "INSERT_ID")
 	assert.Contains(t, out.String(), "preview-source")
+	assert.Empty(t, err.String(), "STDERR should be empty")
+	assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
+	// no relationships
+	assert.NotContains(t, out.String(), "RELATIONSHIP NAME")
+
+	// relationships
+	out, err, exitcode := LaceworkCLIWithTOMLConfig("query", "describe", "LW_HE_FILES")
 	assert.Contains(t, out.String(), "RELATIONSHIP NAME")
 	assert.Empty(t, err.String(), "STDERR should be empty")
 	assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")


### PR DESCRIPTION
## Summary
Only display datasource relationship information if actually available

## How did you test this change?
Automated Integration

## Issue
ALLY-974
