### PR TITLE
feat(cli): output query in YAML format

### DIFF
--- a/cli/cmd/cli_state.go
+++ b/cli/cmd/cli_state.go
@@ -65,6 +65,7 @@ type cliState struct {
 	workers        sync.WaitGroup
 	spinner        *spinner.Spinner
 	jsonOutput     bool
+	yamlOutput     bool
 	csvOutput      bool
 	nonInteractive bool
 	noCache        bool
@@ -375,6 +376,12 @@ func (c *cliState) EnableJSONOutput() {
 	c.jsonOutput = true
 }
 
+// EnableYAMLOutput enables the cli to display YAML output
+func (c *cliState) EnableYAMLOutput() {
+	c.Log.Info("switch output to yaml format")
+	c.yamlOutput = true
+}
+
 // EnableJSONOutput enables the cli to display human readable output
 func (c *cliState) EnableHumanOutput() {
 	c.Log.Info("switch output to human format")
@@ -392,9 +399,14 @@ func (c *cliState) JSONOutput() bool {
 	return c.jsonOutput
 }
 
+// YAMLOutput returns true if the cli is configured to display YAML output
+func (c *cliState) YAMLOutput() bool {
+	return c.yamlOutput
+}
+
 // HumanOutput returns true if the cli is configured to display human readable output
 func (c *cliState) HumanOutput() bool {
-	return !c.jsonOutput && !c.csvOutput
+	return !c.jsonOutput && !c.csvOutput && !c.yamlOutput
 }
 
 // CSVOutput returns true if the cli is configured to display csv output

--- a/cli/cmd/lql.go
+++ b/cli/cmd/lql.go
@@ -47,6 +47,9 @@ var (
 		Start        string
 		URL          string
 		ValidateOnly bool
+
+		// output query in YAML format
+		YAML bool
 	}{}
 
 	// queryCmd represents the lql parent command

--- a/cli/cmd/lql.go
+++ b/cli/cmd/lql.go
@@ -47,9 +47,6 @@ var (
 		Start        string
 		URL          string
 		ValidateOnly bool
-
-		// output query in YAML format
-		YAML bool
 	}{}
 
 	// queryCmd represents the lql parent command

--- a/cli/cmd/lql_show.go
+++ b/cli/cmd/lql_show.go
@@ -32,7 +32,7 @@ var (
 		Short: "Show a query",
 		Long:  `Show a query.`,
 		Args:  cobra.ExactArgs(1),
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			b, err := cmd.Flags().GetBool("yaml")
 			if err != nil {
 				return errors.Wrap(err, "unable to parse --yaml flag")

--- a/cli/cmd/lql_show.go
+++ b/cli/cmd/lql_show.go
@@ -21,6 +21,9 @@ package cmd
 import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v2"
+
+	"github.com/lacework/go-sdk/api"
 )
 
 var (
@@ -36,6 +39,11 @@ var (
 
 func init() {
 	queryCmd.AddCommand(queryShowCmd)
+
+	queryShowCmd.Flags().BoolVar(
+		&queryCmdState.YAML,
+		"yaml", false, "output query in YAML format",
+	)
 }
 
 func showQuery(_ *cobra.Command, args []string) error {
@@ -50,6 +58,18 @@ func showQuery(_ *cobra.Command, args []string) error {
 		return cli.OutputJSON(queryResponse.Data)
 	}
 
-	cli.OutputHuman(queryResponse.Data.QueryText)
+	if queryCmdState.YAML {
+		queryYaml, err := yaml.Marshal(&api.NewQuery{
+			QueryID:   queryResponse.Data.QueryID,
+			QueryText: queryResponse.Data.QueryText,
+		})
+		if err != nil {
+			return errors.Wrap(err, "unable to format query in YAML format")
+		}
+		cli.OutputHuman(string(queryYaml))
+	} else {
+		cli.OutputHuman(queryResponse.Data.QueryText)
+	}
+
 	return nil
 }

--- a/cli/cmd/lql_show.go
+++ b/cli/cmd/lql_show.go
@@ -21,7 +21,6 @@ package cmd
 import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v2"
 
 	"github.com/lacework/go-sdk/api"
 )
@@ -33,15 +32,24 @@ var (
 		Short: "Show a query",
 		Long:  `Show a query.`,
 		Args:  cobra.ExactArgs(1),
-		RunE:  showQuery,
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			b, err := cmd.Flags().GetBool("yaml")
+			if err != nil {
+				return errors.Wrap(err, "unable to parse --yaml flag")
+			}
+			if b {
+				cli.EnableYAMLOutput()
+			}
+			return nil
+		},
+		RunE: showQuery,
 	}
 )
 
 func init() {
 	queryCmd.AddCommand(queryShowCmd)
 
-	queryShowCmd.Flags().BoolVar(
-		&queryCmdState.YAML,
+	queryShowCmd.Flags().Bool(
 		"yaml", false, "output query in YAML format",
 	)
 }
@@ -54,22 +62,18 @@ func showQuery(_ *cobra.Command, args []string) error {
 	if err != nil {
 		return errors.Wrap(err, "unable to show query")
 	}
+
 	if cli.JSONOutput() {
 		return cli.OutputJSON(queryResponse.Data)
 	}
 
-	if queryCmdState.YAML {
-		queryYaml, err := yaml.Marshal(&api.NewQuery{
+	if cli.YAMLOutput() {
+		return cli.OutputYAML(&api.NewQuery{
 			QueryID:   queryResponse.Data.QueryID,
 			QueryText: queryResponse.Data.QueryText,
 		})
-		if err != nil {
-			return errors.Wrap(err, "unable to format query in YAML format")
-		}
-		cli.OutputHuman(string(queryYaml))
-	} else {
-		cli.OutputHuman(queryResponse.Data.QueryText)
 	}
 
+	cli.OutputHuman(queryResponse.Data.QueryText)
 	return nil
 }

--- a/cli/cmd/outputs.go
+++ b/cli/cmd/outputs.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/pkg/errors"
+	"gopkg.in/yaml.v2"
 )
 
 // OutputJSON will print out the JSON representation of the provided data
@@ -118,4 +119,15 @@ func (c *cliState) OutputNonDefaultProfileFlag() string {
 		return fmt.Sprintf(" --profile %s", c.Profile)
 	}
 	return ""
+}
+
+// OutputYAML will print out the YAML representation of the provided data
+func (c *cliState) OutputYAML(v interface{}) error {
+	y, err := yaml.Marshal(v)
+	if err != nil {
+		c.Log.Debugw("unable to pretty print YAML object", "raw", v)
+		return err
+	}
+	fmt.Fprint(os.Stdout, string(y))
+	return nil
 }

--- a/integration/lql_show_test.go
+++ b/integration/lql_show_test.go
@@ -20,6 +20,7 @@
 package integration
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -39,6 +40,13 @@ func TestQueryShowNoInput(t *testing.T) {
 	assert.Equal(t, 1, exitcode, "EXITCODE is not the expected one")
 }
 
-func TestQueryShow(t *testing.T) {
-	// tested by virtue of TestQueryCreateFile
+func TestQueryShowYAML(t *testing.T) {
+	queryIdFromPlatform := "LW_Global_AWS_CTA_AccessKeyDeleted"
+	out, stderr, exitcode := LaceworkCLIWithTOMLConfig(
+		"query", "show", queryIdFromPlatform, "--yaml")
+	assert.Contains(t, out.String(), fmt.Sprintf("queryId: %s", queryIdFromPlatform))
+	assert.Contains(t, out.String(), "queryText: |-")
+	assert.Contains(t, out.String(), "INSERT_ID")
+	assert.Empty(t, stderr.String(), "STDERR should be empty")
+	assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
 }

--- a/integration/policy_test.go
+++ b/integration/policy_test.go
@@ -343,19 +343,29 @@ func TestPolicyShowHelp(t *testing.T) {
 }
 
 func TestPolicyShow(t *testing.T) {
-	// show (output)
-	out, err, exitcode := LaceworkCLIWithTOMLConfig("policy", "show", "lacework-global-1")
-	assert.Contains(t, out.String(), "POLICY ID")
-	assert.Contains(t, out.String(), "lacework-global-1")
-	assert.Empty(t, err.String(), "STDERR should be empty")
-	assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
+	t.Run("Human Output", func(t *testing.T) {
+		out, err, exitcode := LaceworkCLIWithTOMLConfig("policy", "show", "lacework-global-1")
+		assert.Contains(t, out.String(), "POLICY ID")
+		assert.Contains(t, out.String(), "lacework-global-1")
+		assert.Empty(t, err.String(), "STDERR should be empty")
+		assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
+	})
 
-	// show (output json)
-	out, err, exitcode = LaceworkCLIWithTOMLConfig("policy", "show", "lacework-global-1", "--json")
-	assert.Contains(t, out.String(), `"policyId"`)
-	assert.Contains(t, out.String(), `"lacework-global-1"`)
-	assert.Empty(t, err.String(), "STDERR should be empty")
-	assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
+	t.Run("JSON Output", func(t *testing.T) {
+		out, err, exitcode := LaceworkCLIWithTOMLConfig("policy", "show", "lacework-global-1", "--json")
+		assert.Contains(t, out.String(), `"policyId"`)
+		assert.Contains(t, out.String(), `"lacework-global-1"`)
+		assert.Empty(t, err.String(), "STDERR should be empty")
+		assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
+	})
+
+	t.Run("YAML Output", func(t *testing.T) {
+		out, err, exitcode := LaceworkCLIWithTOMLConfig("policy", "show", "lacework-global-1", "--yaml")
+		assert.Contains(t, out.String(), `policyId: lacework-global-1`)
+		assert.Contains(t, out.String(), `remediation: |-`)
+		assert.Empty(t, err.String(), "STDERR should be empty")
+		assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
+	})
 }
 
 func TestPolicyUpdateHelp(t *testing.T) {

--- a/integration/test_resources/help/policy_show
+++ b/integration/test_resources/help/policy_show
@@ -8,6 +8,7 @@ Aliases:
 
 Flags:
   -h, --help   help for show
+      --yaml   output query in YAML format
 
 Global Flags:
   -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)

--- a/integration/test_resources/help/query_show
+++ b/integration/test_resources/help/query_show
@@ -5,6 +5,7 @@ Usage:
 
 Flags:
   -h, --help   help for show
+      --yaml   output query in YAML format
 
 Global Flags:
   -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)


### PR DESCRIPTION

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/lacework/go-sdk) and create your branch from `main`
  2. Run `make prepare` in the repository root
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`make test`)
  5. Format your code (`make fmt`)
  6. Make sure your code lints (`make lint`)
  7. If you are updating the Lacework CLI, make sure it compiles (`make build-cli-cross-platform`)
  8. Follow the commit message standard (`type(scope): subject`) documented in [DEVELOPER_GUIDELINES.md](https://github.com/lacework/go-sdk/blob/main/DEVELOPER_GUIDELINES.md#commit-message-standard)
  9. If you haven't already, configure signed commits by [telling git about your signing key](https://docs.github.com/en/github/authenticating-to-github/managing-commit-signature-verification/telling-git-about-your-signing-key) and [signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)

  Learn more about contributing: https://github.com/lacework/go-sdk/blob/main/CONTRIBUTING.md
-->

## Summary

Since the Lacework CLI support YAML format, we need to have a way to present queries with that format,
this PR adds a new flag `--yaml` to output the query in YAML format.

## How did you test this change?

Added integration tests. 🚀

## Issue

Hackathon https://lacework.atlassian.net/browse/HACK-55
