### PR TITLE
fix: Make azure active directory integration default to false RAIN-30986

### DIFF
--- a/cli/cmd/generate_azure.go
+++ b/cli/cmd/generate_azure.go
@@ -354,7 +354,7 @@ func initGenerateAzureTfCommandFlags() {
 	generateAzureTfCommand.PersistentFlags().BoolVar(
 		&GenerateAzureCommandState.CreateAdIntegration,
 		"ad_create",
-		true,
+		false,
 		"create new active directory integration")
 
 	generateAzureTfCommand.PersistentFlags().BoolVar(

--- a/integration/test_resources/help/cloud-account_iac-generate_azure
+++ b/integration/test_resources/help/cloud-account_iac-generate_azure
@@ -20,7 +20,7 @@ Aliases:
 Flags:
       --activity_log                           enable active log integration
       --activity_log_integration_name string   specify a custom activity log integration name
-      --ad_create                              create new active directory integration (default true)
+      --ad_create                              create new active directory integration
       --ad_id string                           existing active directory application id
       --ad_pass string                         existing active directory application password
       --ad_pid string                          existing active directory application service principle id


### PR DESCRIPTION

## Summary
The flag for setting the Azure Active Directory integration in the cli was defaulted to be true, meaning that the absence of the flag meant that an active directory integration was included in the generated terraform, this needed to be set to false as default and only included in the terraform if the user explicitly required it

## How did you test this change?
Tested the change manually and checked the results.
Re-ran all the unit-tests
Re-ran all the Integration tests

## Issue
https://lacework.atlassian.net/browse/RAIN-30986
