### PR TITLE
feat: Add support for APIv2 CloudAccounts List

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -102,6 +102,7 @@ const (
 	apiV2AlertRuleFromGUID = "v2/AlertRules/%s"
 
 	apiV2CloudAccounts        = "v2/CloudAccounts"
+	apiV2CloudAccountsByType  = "v2/CloudAccounts/%s"
 	apiV2CloudAccountFromGUID = "v2/CloudAccounts/%s"
 
 	apiV2AgentAccessTokens       = "v2/AgentAccessTokens"

--- a/api/api.go
+++ b/api/api.go
@@ -101,9 +101,8 @@ const (
 	apiV2AlertRules        = "v2/AlertRules"
 	apiV2AlertRuleFromGUID = "v2/AlertRules/%s"
 
-	apiV2CloudAccounts        = "v2/CloudAccounts"
-	apiV2CloudAccountsByType  = "v2/CloudAccounts/%s"
-	apiV2CloudAccountFromGUID = "v2/CloudAccounts/%s"
+	apiV2CloudAccounts          = "v2/CloudAccounts"
+	apiV2CloudAccountsWithParam = "v2/CloudAccounts/%s"
 
 	apiV2AgentAccessTokens       = "v2/AgentAccessTokens"
 	apiV2AgentAccessTokensSearch = "v2/AgentAccessTokens/search"

--- a/api/cloud_accounts.go
+++ b/api/cloud_accounts.go
@@ -84,15 +84,29 @@ type cloudAccountType int
 const (
 	// type that defines a non-existing Cloud Account integration
 	NoneCloudAccount cloudAccountType = iota
+	AwsCfgCloudAccount
 	AwsCtSqsCloudAccount
 	AwsEksAuditCloudAccount
+	AwsUsGovCfgCloudAccount
+	AwsUsGovCtSqsCloudAccount
+	AzureAlSeqCloudAccount
+	AzureCfgCloudAccount
+	GcpAtSesCloudAccount
+	GcpCfgCloudAccount
 )
 
 // CloudAccountTypes is the list of available Cloud Account integration types
 var CloudAccountTypes = map[cloudAccountType]string{
-	NoneCloudAccount:        "None",
-	AwsCtSqsCloudAccount:    "AwsCtSqs",
-	AwsEksAuditCloudAccount: "AwsEksAudit",
+	NoneCloudAccount:          "None",
+	AwsCfgCloudAccount:        "AwsCfg",
+	AwsCtSqsCloudAccount:      "AwsCtSqs",
+	AwsEksAuditCloudAccount:   "AwsEksAudit",
+	AwsUsGovCfgCloudAccount:   "AwsUsGovCfg",
+	AwsUsGovCtSqsCloudAccount: "AwsUsGovCtSqs",
+	AzureAlSeqCloudAccount:    "AzureAlSeq",
+	AzureCfgCloudAccount:      "AzureCfg",
+	GcpAtSesCloudAccount:      "GcpAtSes",
+	GcpCfgCloudAccount:        "GcpCfg",
 }
 
 // String returns the string representation of a Cloud Account integration type
@@ -188,8 +202,22 @@ type v2CommonIntegrationData struct {
 	State                *V2IntegrationState `json:"state,omitempty"`
 }
 
-func (common v2CommonIntegrationData) ID() string {
-	return common.IntgGuid
+func (c v2CommonIntegrationData) ID() string {
+	return c.IntgGuid
+}
+
+func (c v2CommonIntegrationData) Status() string {
+	if c.Enabled == 1 {
+		return "Enabled"
+	}
+	return "Disabled"
+}
+
+func (c v2CommonIntegrationData) StateString() string {
+	if c.State != nil && c.State.Ok {
+		return "Ok"
+	}
+	return "Check"
 }
 
 type V2IntegrationState struct {
@@ -222,18 +250,4 @@ func (svc *CloudAccountsService) update(guid string, data interface{}, response 
 func (svc *CloudAccountsService) listByType(caType cloudAccountType, response interface{}) error {
 	apiPath := fmt.Sprintf(apiV2CloudAccountsByType, caType.String())
 	return svc.client.RequestDecoder("GET", apiPath, nil, &response)
-}
-
-func (c v2CommonIntegrationData) Status() string {
-	if c.Enabled == 1 {
-		return "Enabled"
-	}
-	return "Disabled"
-}
-
-func (c v2CommonIntegrationData) StateString() string {
-	if c.State != nil && c.State.Ok {
-		return "Ok"
-	}
-	return "Check"
 }

--- a/api/cloud_accounts.go
+++ b/api/cloud_accounts.go
@@ -134,7 +134,7 @@ func (svc *CloudAccountsService) List() (response CloudAccountsResponse, err err
 // ListByType lists the cloud accounts from the provided type that are available
 // on the Lacework Server
 func (svc *CloudAccountsService) ListByType(caType cloudAccountType) (response CloudAccountsResponse, err error) {
-	err = svc.listByType(caType, &response)
+	err = svc.get(caType.String(), &response)
 	return
 }
 
@@ -170,6 +170,9 @@ func (svc *CloudAccountsService) Delete(guid string) error {
 //
 //    Where <Type> is the Cloud Account integration type.
 func (svc *CloudAccountsService) Get(guid string, response interface{}) error {
+	if guid == "" {
+		return errors.New("specify an intgGuid")
+	}
 	return svc.get(guid, &response)
 }
 
@@ -231,11 +234,8 @@ func (svc *CloudAccountsService) create(data interface{}, response interface{}) 
 	return svc.client.RequestEncoderDecoder("POST", apiV2CloudAccounts, data, response)
 }
 
-func (svc *CloudAccountsService) get(guid string, response interface{}) error {
-	if guid == "" {
-		return errors.New("specify an intgGuid")
-	}
-	apiPath := fmt.Sprintf(apiV2CloudAccountsWithParam, guid)
+func (svc *CloudAccountsService) get(param string, response interface{}) error {
+	apiPath := fmt.Sprintf(apiV2CloudAccountsWithParam, param)
 	return svc.client.RequestDecoder("GET", apiPath, nil, response)
 }
 
@@ -245,9 +245,4 @@ func (svc *CloudAccountsService) update(guid string, data interface{}, response 
 	}
 	apiPath := fmt.Sprintf(apiV2CloudAccountsWithParam, guid)
 	return svc.client.RequestEncoderDecoder("PATCH", apiPath, data, response)
-}
-
-func (svc *CloudAccountsService) listByType(caType cloudAccountType, response interface{}) error {
-	apiPath := fmt.Sprintf(apiV2CloudAccountsWithParam, caType.String())
-	return svc.client.RequestDecoder("GET", apiPath, nil, &response)
 }

--- a/api/cloud_accounts.go
+++ b/api/cloud_accounts.go
@@ -155,7 +155,7 @@ func (svc *CloudAccountsService) Delete(guid string) error {
 
 	return svc.client.RequestDecoder(
 		"DELETE",
-		fmt.Sprintf(apiV2CloudAccountFromGUID, guid),
+		fmt.Sprintf(apiV2CloudAccountsWithParam, guid),
 		nil,
 		nil,
 	)
@@ -235,7 +235,7 @@ func (svc *CloudAccountsService) get(guid string, response interface{}) error {
 	if guid == "" {
 		return errors.New("specify an intgGuid")
 	}
-	apiPath := fmt.Sprintf(apiV2CloudAccountFromGUID, guid)
+	apiPath := fmt.Sprintf(apiV2CloudAccountsWithParam, guid)
 	return svc.client.RequestDecoder("GET", apiPath, nil, response)
 }
 
@@ -243,11 +243,11 @@ func (svc *CloudAccountsService) update(guid string, data interface{}, response 
 	if guid == "" {
 		return errors.New("specify an intgGuid")
 	}
-	apiPath := fmt.Sprintf(apiV2CloudAccountFromGUID, guid)
+	apiPath := fmt.Sprintf(apiV2CloudAccountsWithParam, guid)
 	return svc.client.RequestEncoderDecoder("PATCH", apiPath, data, response)
 }
 
 func (svc *CloudAccountsService) listByType(caType cloudAccountType, response interface{}) error {
-	apiPath := fmt.Sprintf(apiV2CloudAccountsByType, caType.String())
+	apiPath := fmt.Sprintf(apiV2CloudAccountsWithParam, caType.String())
 	return svc.client.RequestDecoder("GET", apiPath, nil, &response)
 }

--- a/api/cloud_accounts.go
+++ b/api/cloud_accounts.go
@@ -117,6 +117,13 @@ func (svc *CloudAccountsService) List() (response CloudAccountsResponse, err err
 	return
 }
 
+// ListByType lists the cloud accounts from the provided type that are available
+// on the Lacework Server
+func (svc *CloudAccountsService) ListByType(caType cloudAccountType) (response CloudAccountsResponse, err error) {
+	err = svc.listByType(caType, &response)
+	return
+}
+
 // Create creates a single Cloud Account integration
 func (svc *CloudAccountsService) Create(integration CloudAccountRaw) (
 	response CloudAccountResponse,
@@ -210,4 +217,23 @@ func (svc *CloudAccountsService) update(guid string, data interface{}, response 
 	}
 	apiPath := fmt.Sprintf(apiV2CloudAccountFromGUID, guid)
 	return svc.client.RequestEncoderDecoder("PATCH", apiPath, data, response)
+}
+
+func (svc *CloudAccountsService) listByType(caType cloudAccountType, response interface{}) error {
+	apiPath := fmt.Sprintf(apiV2CloudAccountsByType, caType.String())
+	return svc.client.RequestDecoder("GET", apiPath, nil, &response)
+}
+
+func (c v2CommonIntegrationData) Status() string {
+	if c.Enabled == 1 {
+		return "Enabled"
+	}
+	return "Disabled"
+}
+
+func (c v2CommonIntegrationData) StateString() string {
+	if c.State != nil && c.State.Ok {
+		return "Ok"
+	}
+	return "Check"
 }

--- a/api/cloud_accounts_test.go
+++ b/api/cloud_accounts_test.go
@@ -183,11 +183,12 @@ func TestCloudAccountsDelete(t *testing.T) {
 func TestCloudAccountsList(t *testing.T) {
 	var (
 		awsIntgGUIDs   = []string{intgguid.New(), intgguid.New(), intgguid.New()}
+		awsEksAuditLogGUIDs = []string{intgguid.New()}
 		azureIntgGUIDs = []string{intgguid.New(), intgguid.New()}
 		gcpIntgGUIDs   = []string{
 			intgguid.New(), intgguid.New(), intgguid.New(), intgguid.New(),
 		}
-		allGUIDs    = append(azureIntgGUIDs, append(gcpIntgGUIDs, awsIntgGUIDs...)...)
+		allGUIDs    = append(awsEksAuditLogGUIDs, append(azureIntgGUIDs, append(gcpIntgGUIDs, awsIntgGUIDs...)...)...)
 		expectedLen = len(allGUIDs)
 		fakeServer  = lacework.MockServer()
 	)
@@ -198,6 +199,7 @@ func TestCloudAccountsList(t *testing.T) {
 			assert.Equal(t, "GET", r.Method, "List() should be a GET method")
 			cloudAccounts := []string{
 				generateCloudAccounts(awsIntgGUIDs, "AwsCtSqs"),
+				generateCloudAccounts(awsEksAuditLogGUIDs, "AwsEksAudit"),
 				// TODO @afiune come back here and update these Cloud Accounts types when they exist
 				generateCloudAccounts(gcpIntgGUIDs, "AwsCtSqs"),   // "GcpCfg"),
 				generateCloudAccounts(azureIntgGUIDs, "AwsCtSqs"), // "AzureAlSeq"),
@@ -227,12 +229,55 @@ func TestCloudAccountsList(t *testing.T) {
 	}
 }
 
+func TestCloudAccountsListByType(t *testing.T) {
+	var (
+		awsIntgGUIDs   = []string{intgguid.New(), intgguid.New(), intgguid.New()}
+		expectedLen = len(awsIntgGUIDs)
+		fakeServer  = lacework.MockServer()
+	)
+	fakeServer.UseApiV2()
+	fakeServer.MockToken("TOKEN")
+	fakeServer.MockAPI("CloudAccounts/AwsCtSqs",
+		func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "GET", r.Method, "List() should be a GET method")
+			cloudAccounts := []string{
+				generateCloudAccounts(awsIntgGUIDs, "AwsCtSqs"),
+			}
+			fmt.Fprintf(w,
+				generateCloudAccountsResponse(
+					strings.Join(cloudAccounts, ", "),
+				),
+			)
+		},
+	)
+	defer fakeServer.Close()
+
+	c, err := api.NewClient("test",
+		api.WithApiV2(),
+		api.WithToken("TOKEN"),
+		api.WithURL(fakeServer.URL()),
+	)
+	assert.Nil(t, err)
+
+	caType, _ := api.FindCloudAccountType("AwsCtSqs")
+	response, err := c.V2.CloudAccounts.ListByType(caType)
+	assert.Nil(t, err)
+	assert.NotNil(t, response)
+	print(response.Data)
+	assert.Equal(t, expectedLen, len(response.Data))
+	for _, d := range response.Data {
+		assert.Contains(t, awsIntgGUIDs, d.IntgGuid)
+	}
+}
+
 func generateCloudAccounts(guids []string, iType string) string {
 	cloudAccounts := make([]string, len(guids))
 	for i, guid := range guids {
 		switch iType {
 		case api.AwsCtSqsCloudAccount.String():
 			cloudAccounts[i] = singleAwsCtSqsCloudAccount(guid)
+		case api.AwsEksAuditCloudAccount.String():
+			cloudAccounts[i] = singleAwsEksAuditCloudAccount(guid)
 			// TODO @afiune come back here and update these Cloud Accounts types
 			// when they exist
 			//case api.AwsCfgCloudAccount.String():

--- a/api/cloud_accounts_test.go
+++ b/api/cloud_accounts_test.go
@@ -182,10 +182,10 @@ func TestCloudAccountsDelete(t *testing.T) {
 
 func TestCloudAccountsList(t *testing.T) {
 	var (
-		awsIntgGUIDs   = []string{intgguid.New(), intgguid.New(), intgguid.New()}
+		awsIntgGUIDs        = []string{intgguid.New(), intgguid.New(), intgguid.New()}
 		awsEksAuditLogGUIDs = []string{intgguid.New()}
-		azureIntgGUIDs = []string{intgguid.New(), intgguid.New()}
-		gcpIntgGUIDs   = []string{
+		azureIntgGUIDs      = []string{intgguid.New(), intgguid.New()}
+		gcpIntgGUIDs        = []string{
 			intgguid.New(), intgguid.New(), intgguid.New(), intgguid.New(),
 		}
 		allGUIDs    = append(awsEksAuditLogGUIDs, append(azureIntgGUIDs, append(gcpIntgGUIDs, awsIntgGUIDs...)...)...)
@@ -231,9 +231,9 @@ func TestCloudAccountsList(t *testing.T) {
 
 func TestCloudAccountsListByType(t *testing.T) {
 	var (
-		awsIntgGUIDs   = []string{intgguid.New(), intgguid.New(), intgguid.New()}
-		expectedLen = len(awsIntgGUIDs)
-		fakeServer  = lacework.MockServer()
+		awsIntgGUIDs = []string{intgguid.New(), intgguid.New(), intgguid.New()}
+		expectedLen  = len(awsIntgGUIDs)
+		fakeServer   = lacework.MockServer()
 	)
 	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")

--- a/cli/cmd/cloud_account.go
+++ b/cli/cmd/cloud_account.go
@@ -53,7 +53,7 @@ var (
 
 			cli.OutputHuman(
 				renderSimpleTable(
-					[]string{"Integration GUID", "Name", "Type", "Status", "State"},
+					[]string{"Cloud Account Integration GUID", "Name", "Type", "Status", "State"},
 					cloudAccountsToTable(cloudAccounts.Data),
 				),
 			)

--- a/cli/cmd/cloud_account.go
+++ b/cli/cmd/cloud_account.go
@@ -42,13 +42,13 @@ var (
 				return errors.Wrap(err, "unable to get cloud accounts")
 			}
 
-			if cli.JSONOutput() {
-				return cli.OutputJSON(cloudAccounts.Data)
-			}
-
 			if len(cloudAccounts.Data) == 0 {
 				cli.OutputHuman("No cloud accounts found.\n")
 				return nil
+			}
+
+			if cli.JSONOutput() {
+				return cli.OutputJSON(cloudAccounts.Data)
 			}
 
 			cli.OutputHuman(

--- a/cli/cmd/cloud_account.go
+++ b/cli/cmd/cloud_account.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"github.com/lacework/go-sdk/api"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -12,9 +14,75 @@ var (
 		Short:   "Manage cloud accounts",
 		Long:    "Manage cloud account integrations with Lacework",
 	}
+
+	// used by cloud account list to list only a single type of cloud account
+	cloudAccountType string
+
+	// cloudAccountsListCmd represents the list sub-command inside the cloud accounts command
+	cloudAccountListCmd = &cobra.Command{
+		Use:   "list",
+		Short: "List all available cloud account integrations",
+		Args:  cobra.NoArgs,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			var (
+				cloudAccounts api.CloudAccountsResponse
+				err           error
+			)
+
+			if cloudAccountType != "" {
+				caType, found := api.FindCloudAccountType(cloudAccountType)
+				if !found {
+					return errors.Errorf("unknown cloud account type '%s'", cloudAccountType)
+				}
+				cloudAccounts, err = cli.LwApi.V2.CloudAccounts.ListByType(caType)
+			} else {
+				cloudAccounts, err = cli.LwApi.V2.CloudAccounts.List()
+			}
+			if err != nil {
+				return errors.Wrap(err, "unable to get cloud accounts")
+			}
+
+			if cli.JSONOutput() {
+				return cli.OutputJSON(cloudAccounts.Data)
+			}
+
+			if len(cloudAccounts.Data) == 0 {
+				cli.OutputHuman("There was no cloud account found.\n")
+				return nil
+			}
+
+			cli.OutputHuman(
+				renderSimpleTable(
+					[]string{"Integration GUID", "Name", "Type", "Status", "State"},
+					cloudAccountsToTable(cloudAccounts.Data),
+				),
+			)
+			return nil
+		},
+	}
 )
 
 func init() {
 	// add the cloud-account command
 	rootCmd.AddCommand(cloudAccountCommand)
+	cloudAccountCommand.AddCommand(cloudAccountListCmd)
+
+	// add type flag to cloud accounts list command
+	cloudAccountListCmd.Flags().StringVarP(&cloudAccountType,
+		"type", "t", "", "list all cloud accounts of a specific type",
+	)
+}
+
+func cloudAccountsToTable(integrations []api.CloudAccountRaw) [][]string {
+	var out [][]string
+	for _, cadata := range integrations {
+		out = append(out, []string{
+			cadata.IntgGuid,
+			cadata.Name,
+			cadata.Type,
+			cadata.Status(),
+			cadata.StateString(),
+		})
+	}
+	return out
 }

--- a/cli/cmd/cloud_account.go
+++ b/cli/cmd/cloud_account.go
@@ -47,7 +47,7 @@ var (
 			}
 
 			if len(cloudAccounts.Data) == 0 {
-				cli.OutputHuman("There was no cloud account found.\n")
+				cli.OutputHuman("No cloud accounts found.\n")
 				return nil
 			}
 

--- a/cli/cmd/integration.go
+++ b/cli/cmd/integration.go
@@ -139,7 +139,7 @@ var (
 	// integrationCreateCmd represents the create sub-command inside the integration command
 	integrationCreateCmd = &cobra.Command{
 		Use:   "create",
-		Short: "Create an external integrations",
+		Short: "Create an external integration",
 		Args:  cobra.NoArgs,
 		Long:  `Creates an external integration in your account through an interactive session.`,
 		RunE: func(_ *cobra.Command, _ []string) error {
@@ -161,7 +161,7 @@ var (
 	integrationUpdateCmd = &cobra.Command{
 		Use:    "update",
 		Hidden: true,
-		Short:  "Update an external integrations",
+		Short:  "Update an external integration",
 		Args:   cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			return nil
@@ -171,7 +171,7 @@ var (
 	// integrationDeleteCmd represents the delete sub-command inside the integration command
 	integrationDeleteCmd = &cobra.Command{
 		Use:   "delete <int_guid>",
-		Short: "Delete an external integrations",
+		Short: "Delete an external integration",
 		Long: `Delete an external integration by providing an integration GUID.
 
 Integration GUIDs can be found by using the 'lacework integration list' command.`,

--- a/cli/docs/lacework_cloud-account.md
+++ b/cli/docs/lacework_cloud-account.md
@@ -1,0 +1,43 @@
+---
+title: "lacework cloud-account"
+slug: lacework_cloud-account
+hide_title: true
+---
+
+## lacework cloud-account
+
+Manage cloud accounts
+
+### Synopsis
+
+Manage cloud account integrations with Lacework
+
+### Options
+
+```
+  -h, --help   help for cloud-account
+```
+
+### Options inherited from parent commands
+
+```
+  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -k, --api_key string      access key id
+  -s, --api_secret string   secret access key
+      --api_token string    access token (replaces the use of api_key and api_secret)
+      --debug               turn on debug logging
+      --json                switch commands output from human-readable to json format
+      --nocache             turn off caching
+      --nocolor             turn off colors
+      --noninteractive      turn off interactive mode (disable spinners, prompts, etc.)
+      --organization        access organization level data sets (org admins only)
+  -p, --profile string      switch between profiles configured at ~/.lacework.toml
+      --subaccount string   sub-account name inside your organization (org admins only)
+```
+
+### SEE ALSO
+
+* [lacework](lacework.md)	 - A tool to manage the Lacework cloud security platform.
+* [lacework cloud-account iac-generate](lacework_cloud-account_iac-generate.md)	 - Create IaC code
+* [lacework cloud-account list](lacework_cloud-account_list.md)	 - List all available cloud account integrations
+

--- a/cli/docs/lacework_cloud-account_list.md
+++ b/cli/docs/lacework_cloud-account_list.md
@@ -1,0 +1,42 @@
+---
+title: "lacework cloud-account list"
+slug: lacework_cloud-account_list
+hide_title: true
+---
+
+## lacework cloud-account list
+
+List all available cloud account integrations
+
+```
+lacework cloud-account list [flags]
+```
+
+### Options
+
+```
+  -h, --help          help for list
+  -t, --type string   list all cloud accounts of a specific type
+```
+
+### Options inherited from parent commands
+
+```
+  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -k, --api_key string      access key id
+  -s, --api_secret string   secret access key
+      --api_token string    access token (replaces the use of api_key and api_secret)
+      --debug               turn on debug logging
+      --json                switch commands output from human-readable to json format
+      --nocache             turn off caching
+      --nocolor             turn off colors
+      --noninteractive      turn off interactive mode (disable spinners, prompts, etc.)
+      --organization        access organization level data sets (org admins only)
+  -p, --profile string      switch between profiles configured at ~/.lacework.toml
+      --subaccount string   sub-account name inside your organization (org admins only)
+```
+
+### SEE ALSO
+
+* [lacework cloud-account](lacework_cloud-account.md)	 - Manage cloud accounts
+

--- a/cli/docs/lacework_integration.md
+++ b/cli/docs/lacework_integration.md
@@ -38,8 +38,8 @@ Manage external integrations with the Lacework platform
 ### SEE ALSO
 
 * [lacework](lacework.md)	 - A tool to manage the Lacework cloud security platform.
-* [lacework integration create](lacework_integration_create.md)	 - Create an external integrations
-* [lacework integration delete](lacework_integration_delete.md)	 - Delete an external integrations
+* [lacework integration create](lacework_integration_create.md)	 - Create an external integration
+* [lacework integration delete](lacework_integration_delete.md)	 - Delete an external integration
 * [lacework integration list](lacework_integration_list.md)	 - List all available external integrations
 * [lacework integration show](lacework_integration_show.md)	 - Show details about a specific external integration
 

--- a/cli/docs/lacework_integration_create.md
+++ b/cli/docs/lacework_integration_create.md
@@ -6,7 +6,7 @@ hide_title: true
 
 ## lacework integration create
 
-Create an external integrations
+Create an external integration
 
 ### Synopsis
 

--- a/cli/docs/lacework_integration_delete.md
+++ b/cli/docs/lacework_integration_delete.md
@@ -6,7 +6,7 @@ hide_title: true
 
 ## lacework integration delete
 
-Delete an external integrations
+Delete an external integration
 
 ### Synopsis
 

--- a/integration/cloud_account_test.go
+++ b/integration/cloud_account_test.go
@@ -1,0 +1,103 @@
+//go:build cloudAccount
+
+// Author:: Salim Afiune Maya (<afiune@lacework.net>)
+// Copyright:: Copyright 2020, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cloudAccount
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCloudAccountCommandAliases(t *testing.T) {
+	// lacework cloud-account
+	out, err, exitcode := LaceworkCLI("help", "cloud-account")
+	assert.Contains(t, out.String(), "lacework cloud-account [command]")
+	assert.Empty(t, err.String(), "STDERR should be empty")
+	assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
+
+	// lacework cloud-accounts
+	out, err, exitcode = LaceworkCLI("help", "cloud-accounts")
+	assert.Contains(t, out.String(), "lacework cloud-accounts [command]")
+	assert.Empty(t, err.String(), "STDERR should be empty")
+	assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
+
+	// lacework cloud
+	out, err, exitcode = LaceworkCLI("help", "cloud")
+	assert.Contains(t, out.String(), "lacework cloud [command]")
+	assert.Empty(t, err.String(), "STDERR should be empty")
+	assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
+
+	// lacework ca
+	out, err, exitcode = LaceworkCLI("help", "ca")
+	assert.Contains(t, out.String(), "lacework ca [command]")
+	assert.Empty(t, err.String(), "STDERR should be empty")
+	assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
+}
+
+func _TestCloudAccountCommandList(t *testing.T) {
+	out, err, exitcode := LaceworkCLIWithTOMLConfig("cloud-account", "list")
+	assert.Contains(t, out.String(), "CLOUD ACCOUNT INTEGRATION GUID",
+		"STDOUT table headers changed, please check")
+	assert.Contains(t, out.String(), "NAME",
+		"STDOUT table headers changed, please check")
+	assert.Contains(t, out.String(), "TYPE",
+		"STDOUT table headers changed, please check")
+	assert.Contains(t, out.String(), "STATUS",
+		"STDOUT table headers changed, please check")
+	assert.Contains(t, out.String(), "STATE",
+		"STDOUT table headers changed, please check")
+	assert.Empty(t,
+		err.String(),
+		"STDERR should be empty")
+	assert.Equal(t, 0, exitcode,
+		"EXITCODE is not the expected one")
+}
+
+func _TestCloudAccountCommandListWithTypeFlag(t *testing.T) {
+	out, err, exitcode := LaceworkCLIWithTOMLConfig("cloud-account", "list", "--type", "AWS_CFG")
+	assert.Contains(t, out.String(), "CLOUD ACCOUNT INTEGRATION GUID",
+		"STDOUT table headers changed, please check")
+	assert.Contains(t, out.String(), "NAME",
+		"STDOUT table headers changed, please check")
+	assert.Contains(t, out.String(), "TYPE",
+		"STDOUT table headers changed, please check")
+	assert.Contains(t, out.String(), "STATUS",
+		"STDOUT table headers changed, please check")
+
+	// TODO @afiune lets try to create an environment where we can be 100% sure that
+	// cloud account integrations will exist and assert against it
+
+	assert.Empty(t,
+		err.String(),
+		"STDERR should be empty")
+	assert.Equal(t, 0, exitcode,
+		"EXITCODE is not the expected one")
+}
+
+func _TestCloudAccountCommandListWithTypeFlagErrorUnknownType(t *testing.T) {
+	out, err, exitcode := LaceworkCLIWithTOMLConfig("cloud-account", "list", "--type", "FOO_BAR")
+	assert.Emptyf(t, out.String(),
+		"STDOUT should be empty")
+	assert.Contains(t, err.String(),
+		"ERROR unknown cloud account type 'FOO_BAR'",
+		"STDERR should contain the unknown type")
+	assert.Equal(t, 1, exitcode,
+		"EXITCODE is not the expected one")
+}

--- a/integration/test_resources/help/cloud-account
+++ b/integration/test_resources/help/cloud-account
@@ -8,6 +8,7 @@ Aliases:
 
 Available Commands:
   iac-generate Create IaC code
+  list         List all available cloud account integrations
 
 Flags:
   -h, --help   help for cloud-account

--- a/integration/test_resources/help/cloud-account_list
+++ b/integration/test_resources/help/cloud-account_list
@@ -1,0 +1,22 @@
+List all available cloud account integrations
+
+Usage:
+  lacework cloud-account list [flags]
+
+Flags:
+  -h, --help          help for list
+  -t, --type string   list all cloud accounts of a specific type
+
+Global Flags:
+  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -k, --api_key string      access key id
+  -s, --api_secret string   secret access key
+      --api_token string    access token (replaces the use of api_key and api_secret)
+      --debug               turn on debug logging
+      --json                switch commands output from human-readable to json format
+      --nocache             turn off caching
+      --nocolor             turn off colors
+      --noninteractive      turn off interactive mode (disable spinners, prompts, etc.)
+      --organization        access organization level data sets (org admins only)
+  -p, --profile string      switch between profiles configured at ~/.lacework.toml
+      --subaccount string   sub-account name inside your organization (org admins only)

--- a/integration/test_resources/help/integration
+++ b/integration/test_resources/help/integration
@@ -7,8 +7,8 @@ Aliases:
   integration, integrations, int
 
 Available Commands:
-  create      Create an external integrations
-  delete      Delete an external integrations
+  create      Create an external integration
+  delete      Delete an external integration
   list        List all available external integrations
   show        Show details about a specific external integration
 


### PR DESCRIPTION
Signed-off-by: Ross <ross.moles@lacework.net>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/lacework/go-sdk) and create your branch from `main`
  2. Run `make prepare` in the repository root
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`make test`)
  5. Format your code (`make fmt`)
  6. Make sure your code lints (`make lint`)
  7. If you are updating the Lacework CLI, make sure it compiles (`make build-cli-cross-platform`)
  8. Follow the commit message standard (`type(scope): subject`) documented in [DEVELOPER_GUIDELINES.md](https://github.com/lacework/go-sdk/blob/main/DEVELOPER_GUIDELINES.md#commit-message-standard)
  9. If you haven't already, configure signed commits by [telling git about your signing key](https://docs.github.com/en/github/authenticating-to-github/managing-commit-signature-verification/telling-git-about-your-signing-key) and [signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)

  Learn more about contributing: https://github.com/lacework/go-sdk/blob/main/CONTRIBUTING.md
-->

## Summary

Currently, the `lacework integrations list` command uses the v1 integration API which does not show new cloud account integrations such as the `AwsEksAudit` CA integration.

We should add `lacework cloud-accounts list` as a supported command to ensure users can display all of their cloud account integrations via the CLI. We should aim to add full CRUD for cloud-accounts, but this is a first step to allow the users to at least see their AWS EKS integrations. Ticket to cover full CRUD https://lacework.atlassian.net/browse/ALLY-999

## How did you test this change?

![image](https://user-images.githubusercontent.com/15362434/166436611-94a72f13-545f-44e6-9acd-3e7dd964b94c.png)


## Issue

https://lacework.atlassian.net/browse/ALLY-956
