### PR TITLE
feat(cli): add gcp compliance report disable warning

### DIFF
--- a/cli/cmd/compliance_azure.go
+++ b/cli/cmd/compliance_azure.go
@@ -523,7 +523,7 @@ func complianceAzureDisableReportCmdPrompt(arg string) (int, error) {
 	switch arg {
 	case "CIS", "CIS_1_0", "AZURE_CIS":
 		message = `WARNING! Disabling all recommendations for CIS_1_0 will disable the following reports and its corresponding compliance alerts:
- AWS CIS Benchmark
+ AZURE CIS Benchmark
  PCI Benchmark
  SOC 2 Report
 
@@ -531,7 +531,7 @@ func complianceAzureDisableReportCmdPrompt(arg string) (int, error) {
  `
 	case "CIS_1_3_1", "AZURE_CIS_131":
 		message = `WARNING! Disabling all recommendations for CIS_1_3_1 will disable the following reports and its corresponding compliance alerts:
- CIS Benchmark 1.3.1
+ AZURE CIS Benchmark 1.3.1
  PCI Benchmark Rev2
  SOC 2 Report Rev2
  HIPAA Report


### PR DESCRIPTION
Signed-off-by: Ross <ross.moles@lacework.net>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/lacework/go-sdk) and create your branch from `main`
  2. Run `make prepare` in the repository root
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`make test`)
  5. Format your code (`make fmt`)
  6. Make sure your code lints (`make lint`)
  7. If you are updating the Lacework CLI, make sure it compiles (`make build-cli-cross-platform`)
  8. Follow the commit message standard (`type(scope): subject`) documented in [DEVELOPER_GUIDELINES.md](https://github.com/lacework/go-sdk/blob/main/DEVELOPER_GUIDELINES.md#commit-message-standard)
  9. If you haven't already, configure signed commits by [telling git about your signing key](https://docs.github.com/en/github/authenticating-to-github/managing-commit-signature-verification/telling-git-about-your-signing-key) and [signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)

  Learn more about contributing: https://github.com/lacework/go-sdk/blob/main/CONTRIBUTING.md
-->

## Summary

As a user, I would like to fully understand the implications of compliance report disable and be able to abandon ship if necessary.

## How did you test this change?

Manually

## Issue

https://lacework.atlassian.net/browse/ALLY-997
