### PR TITLE
fix(lwcomponent): proper os agnostic pathing

### DIFF
--- a/lwcomponent/error.go
+++ b/lwcomponent/error.go
@@ -1,0 +1,15 @@
+package lwcomponent
+
+import "github.com/pkg/errors"
+
+var (
+	ErrComponentNotFound = errors.New("component not found on disk")
+)
+
+// IsNotFound returns a boolean indicating whether the error is known to
+// have determined the component is not found. It is satisfied by
+// ErrNotApplyComment
+//
+func IsNotFound(err error) bool {
+	return errors.Is(err, ErrComponentNotFound)
+}

--- a/lwcomponent/error_test.go
+++ b/lwcomponent/error_test.go
@@ -1,0 +1,18 @@
+package lwcomponent_test
+
+import (
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/lacework/go-sdk/lwcomponent"
+)
+
+func TestIsNotFound(t *testing.T) {
+	err := errors.New("some other error")
+	assert.Equal(t, false, lwcomponent.IsNotFound(err))
+
+	err = lwcomponent.ErrComponentNotFound
+	assert.Equal(t, true, lwcomponent.IsNotFound(err))
+}


### PR DESCRIPTION
## Summary
We should be use `path/filepath` for `Join()` in order to properly handle windows path switching.
We should be using `.exe` for windows binary components (otherwise we get a file not found during exec)...

## How did you test this change?
Vagrant

## Issue
https://lacework.atlassian.net/browse/ALLY-843
