### PR TITLE
feat(api): Add S3BucketArn field to allow BYOB for AWS EKS Audit Log

### DIFF
--- a/api/_examples/cloud-accounts/aws-eks-audit/main.go
+++ b/api/_examples/cloud-accounts/aws-eks-audit/main.go
@@ -41,7 +41,8 @@ func main() {
 			RoleArn:    "arn:aws:iam::123456789000:role/lw-iam-b8c91298",
 			ExternalID: "abc123",
 		},
-		SnsArn: "arn:aws:sns:us-west-2:0123456789:foo-lacework-eks:00777777-ab77-1234-a123-a12ab1d12c1d",
+		SnsArn:      "arn:aws:sns:us-west-2:0123456789:foo-lacework-eks:00777777-ab77-1234-a123-a12ab1d12c1d",
+		S3BucketArn: "arn:aws:s3:::lacework-example-eks-bucket",
 	}
 
 	awsEksAuditCloudAccount := api.NewCloudAccount(

--- a/api/cloud_accounts_aws_eks_audit.go
+++ b/api/cloud_accounts_aws_eks_audit.go
@@ -48,6 +48,7 @@ type AwsEksAuditIntegration struct {
 type AwsEksAuditData struct {
 	Credentials AwsEksAuditCredentials `json:"crossAccountCredentials"`
 	SnsArn      string                 `json:"snsArn"`
+	S3BucketArn string                 `json:"s3BucketArn"`
 }
 
 type AwsEksAuditCredentials struct {

--- a/api/cloud_accounts_aws_eks_audit_test.go
+++ b/api/cloud_accounts_aws_eks_audit_test.go
@@ -160,3 +160,149 @@ func singleAwsEksAuditCloudAccount(id string) string {
   }
   `
 }
+
+func TestCloudAccountsAwsEksAuditByobGet(t *testing.T) {
+	var (
+		intgGUID   = intgguid.New()
+		apiPath    = fmt.Sprintf("CloudAccounts/%s", intgGUID)
+		fakeServer = lacework.MockServer()
+	)
+	fakeServer.UseApiV2()
+	fakeServer.MockToken("TOKEN")
+	defer fakeServer.Close()
+
+	fakeServer.MockAPI(apiPath, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method, "GetAwsEksAudit() should be a GET method")
+		fmt.Fprintf(w, generateCloudAccountResponse(singleAwsEksAuditCloudAccountByob(intgGUID)))
+	})
+
+	c, err := api.NewClient("test",
+		api.WithApiV2(),
+		api.WithToken("TOKEN"),
+		api.WithURL(fakeServer.URL()),
+	)
+	assert.Nil(t, err)
+
+	response, err := c.V2.CloudAccounts.GetAwsEksAudit(intgGUID)
+	assert.Nil(t, err)
+	assert.NotNil(t, response)
+	assert.Equal(t, intgGUID, response.Data.IntgGuid)
+	assert.Equal(t, "integration_name", response.Data.Name)
+	assert.True(t, response.Data.State.Ok)
+	assert.Equal(t, "arn:foo:bar", response.Data.Data.Credentials.RoleArn)
+	assert.Equal(t, "0123456789", response.Data.Data.Credentials.ExternalID)
+	assert.Equal(
+		t,
+		"arn:aws:sns:us-west-2:0123456789:foo-lacework-eks:00777777-ab77-1234-a123-a12ab1d12c1d",
+		response.Data.Data.SnsArn,
+	)
+	assert.Equal(
+		t,
+		"arn:aws:s3:::lacework-example-eks-bucket",
+		response.Data.Data.S3BucketArn,
+	)
+}
+
+func TestCloudAccountsAwsEksAuditByobUpdate(t *testing.T) {
+	var (
+		intgGUID   = intgguid.New()
+		apiPath    = fmt.Sprintf("CloudAccounts/%s", intgGUID)
+		fakeServer = lacework.MockServer()
+	)
+	fakeServer.UseApiV2()
+	fakeServer.MockToken("TOKEN")
+	defer fakeServer.Close()
+
+	fakeServer.MockAPI(apiPath, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "PATCH", r.Method, "UpdateAwsEksAudit() should be a PATCH method")
+
+		if assert.NotNil(t, r.Body) {
+			body := httpBodySniffer(r)
+			assert.Contains(t, body, intgGUID, "INTG_GUID missing")
+			assert.Contains(t, body, "integration_name", "cloud account name is missing")
+			assert.Contains(t, body, "AwsEksAudit", "wrong cloud account type")
+			assert.Contains(t, body, "arn:bubu:lubu", "wrong role arn")
+			assert.Contains(t, body, "abc123", "wrong external ID")
+			assert.Contains(
+				t,
+				body,
+				"arn:aws:sns:us-west-2:0123456789:foo-lacework-eks:00777777-ab77-1234-a123-a12ab1d12c1d",
+				"wrong sns arn")
+			assert.Contains(
+				t,
+				body,
+				"arn:aws:s3:::lacework-example-eks-bucket",
+				"wrong s3 bucket arn")
+			assert.Contains(t, body, "enabled\":1", "cloud account is not enabled")
+		}
+
+		fmt.Fprintf(w, generateCloudAccountResponse(singleAwsEksAuditCloudAccountByob(intgGUID)))
+	})
+
+	c, err := api.NewClient("test",
+		api.WithApiV2(),
+		api.WithToken("TOKEN"),
+		api.WithURL(fakeServer.URL()),
+	)
+	assert.Nil(t, err)
+
+	cloudAccount := api.NewCloudAccount("integration_name",
+		api.AwsEksAuditCloudAccount,
+		api.AwsEksAuditData{
+			SnsArn:      "arn:aws:sns:us-west-2:0123456789:foo-lacework-eks:00777777-ab77-1234-a123-a12ab1d12c1d",
+			S3BucketArn: "arn:aws:s3:::lacework-example-eks-bucket",
+			Credentials: api.AwsEksAuditCredentials{
+				RoleArn:    "arn:bubu:lubu",
+				ExternalID: "abc123",
+			},
+		},
+	)
+	assert.Equal(t, "integration_name", cloudAccount.Name, "AwsEksAudit cloud account name mismatch")
+	assert.Equal(t, "AwsEksAudit", cloudAccount.Type, "a new AwsEksAudit cloud account should match its type")
+	assert.Equal(t, 1, cloudAccount.Enabled, "a new AwsEksAudit cloud account should be enabled")
+	cloudAccount.IntgGuid = intgGUID
+
+	response, err := c.V2.CloudAccounts.UpdateAwsEksAudit(cloudAccount)
+	assert.Nil(t, err)
+	assert.NotNil(t, response)
+	assert.Equal(t, intgGUID, response.Data.IntgGuid)
+	assert.Equal(t,
+		"arn:aws:sns:us-west-2:0123456789:foo-lacework-eks:00777777-ab77-1234-a123-a12ab1d12c1d",
+		response.Data.Data.SnsArn)
+	assert.Equal(t,
+		"arn:aws:s3:::lacework-example-eks-bucket",
+		response.Data.Data.S3BucketArn)
+}
+
+func singleAwsEksAuditCloudAccountByob(id string) string {
+	return `
+  {
+    "createdOrUpdatedBy": "salim.afiunemaya@lacework.net",
+    "createdOrUpdatedTime": "2021-06-01T19:28:00.092Z",
+	"enabled": 1,
+    "intgGuid": "` + id + `",
+    "isOrg": 0,
+    "name": "integration_name",
+    "state": {
+      "details": {
+        "complianceOpsDeniedAccess": [
+          "GetBucketAcl",
+          "GetBucketLogging"
+        ]
+      },
+      "lastSuccessfulTime": 1624456896915,
+      "lastUpdatedTime": 1624456896915,
+      "ok": true
+    },
+	"type": "AwsEksAudit",
+    "data": {
+      "snsArn":      "arn:aws:sns:us-west-2:0123456789:foo-lacework-eks:00777777-ab77-1234-a123-a12ab1d12c1d",
+      "s3BucketArn": "arn:aws:s3:::lacework-example-eks-bucket",
+      "crossAccountCredentials": {
+        "externalId": "0123456789",
+        "roleArn": "arn:foo:bar"
+      }
+    }
+  }
+  `
+}


### PR DESCRIPTION
Signed-off-by: Ross <ross.moles@lacework.net>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/lacework/go-sdk) and create your branch from `main`
  2. Run `make prepare` in the repository root
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`make test`)
  5. Format your code (`make fmt`)
  6. Make sure your code lints (`make lint`)
  7. If you are updating the Lacework CLI, make sure it compiles (`make build-cli-cross-platform`)
  8. Follow the commit message standard (`type(scope): subject`) documented in [DEVELOPER_GUIDELINES.md](https://github.com/lacework/go-sdk/blob/main/DEVELOPER_GUIDELINES.md#commit-message-standard)
  9. If you haven't already, configure signed commits by [telling git about your signing key](https://docs.github.com/en/github/authenticating-to-github/managing-commit-signature-verification/telling-git-about-your-signing-key) and [signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)

  Learn more about contributing: https://github.com/lacework/go-sdk/blob/main/CONTRIBUTING.md
-->

## Summary

Adding `S3BucketArn` to the AwsEksAudit schema to enable BYOB for customer integrations

blocked by https://github.com/lacework/rainbow/pull/8699

## How did you test this change?

Currently only unit tests. 

## Issue

https://lacework.atlassian.net/browse/ALLY-993
