### PR TITLE
fix(cli): policy-sync should not touch policy state

### DIFF
--- a/cli/cmd/policy_library.go
+++ b/cli/cmd/policy_library.go
@@ -481,6 +481,9 @@ func policySyncExecuteChanges(lcl *LaceworkContentLibrary, psos []PolicySyncOper
 				if err != nil {
 					return errors.Wrap(err, msg)
 				}
+				// remove state from policies we're updating
+				updatePolicy.Enabled = nil
+				updatePolicy.AlertEnabled = nil
 
 				cli.StartProgress(" Updating policy...")
 				updateResponse, err := cli.LwApi.V2.Policy.Update(updatePolicy)


### PR DESCRIPTION
## Summary
As a user sync’ing policies I would prefer that they don’t sync the state portion of the policy definition such that policies that I have enabled or disabled remain enabled/disabled as such.

## How did you test this change?
Manually.  We do not have CDK integration testing yet.

## Issue
https://lacework.atlassian.net/browse/ALLY-1008