### PR TITLE
fix(cli): Add MachineDetail tags 

### DIFF
--- a/api/entities_machine_details.go
+++ b/api/entities_machine_details.go
@@ -89,20 +89,42 @@ type MachineDetailEntity struct {
 	Os            string    `json:"os"`
 	OsVersion     string    `json:"osVersion"`
 	Tags          struct {
-		Account        string `json:"Account"`
-		AmiID          string `json:"AmiId"`
-		ExternalIP     string `json:"ExternalIp"`
-		Hostname       string `json:"Hostname"`
-		Name           string `json:"Name"`
-		InstanceID     string `json:"InstanceId"`
-		InternalIP     string `json:"InternalIp"`
-		LwTokenShort   string `json:"LwTokenShort"`
-		SubnetID       string `json:"SubnetId"`
-		VMInstanceType string `json:"VmInstanceType"`
-		VMProvider     string `json:"VmProvider"`
-		VpcID          string `json:"VpcId"`
-		Zone           string `json:"Zone"`
-		Arch           string `json:"arch"`
-		Os             string `json:"os"`
+		// Shared Tags
+		Arch           string `json:"arch,omitempty"`
+		ExternalIP     string `json:"ExternalIp,omitempty"`
+		Hostname       string `json:"Hostname,omitempty"`
+		InstanceID     string `json:"InstanceId,omitempty"`
+		InternalIP     string `json:"InternalIp,omitempty"`
+		LwTokenShort   string `json:"LwTokenShort,omitempty"`
+		Os             string `json:"os,omitempty"`
+		VMInstanceType string `json:"VmInstanceType,omitempty"`
+		VMProvider     string `json:"VmProvider,omitempty"`
+		Zone           string `json:"Zone,omitempty"`
+
+		// AWS Tags
+		Account  string `json:"Account,omitempty"`
+		AmiID    string `json:"AmiId,omitempty"`
+		Name     string `json:"Name,omitempty"`
+		SubnetID string `json:"SubnetId,omitempty"`
+		VpcID    string `json:"VpcId,omitempty"`
+
+		// GCP Tags
+		Cluster                 string `json:"Cluster,omitempty"`
+		ClusterLocation         string `json:"cluster-location,omitempty"`
+		ClusterName             string `json:"cluster-name,omitempty"`
+		ClusterUID              string `json:"cluster-uid,omitempty"`
+		CreatedBy               string `json:"created-by,omitempty"`
+		EnableOSLogin           string `json:"enable-oslogin,omitempty"`
+		Env                     string `json:"Env,omitempty"`
+		GCEtags                 string `json:"GCEtags,omitempty"`
+		GCIEnsureGKEDocker      string `json:"gci-ensure-gke-docker,omitempty"`
+		GCIUpdateStrategy       string `json:"gci-update-strategy,omitempty"`
+		GoogleComputeEnablePCID string `json:"google-compute-enable-pcid,omitempty"`
+		InstanceName            string `json:"InstanceName,omitempty"`
+		InstanceTemplate        string `json:"InstanceTemplate,omitempty"`
+		KubeLabels              string `json:"kube-labels,omitempty"`
+		LWKubernetesCluster     string `json:"lw_KubernetesCluster,omitempty"`
+		NumericProjectID        string `json:"NumericProjectId,omitempty"`
+		ProjectID               string `json:"ProjectId,omitempty"`
 	} `json:"tags"`
 }

--- a/cli/cmd/flags.go
+++ b/cli/cmd/flags.go
@@ -72,6 +72,11 @@ func getFiltersFrom(T interface{}, prefix string) []string {
 
 		// only use a field if it has a 'json' tag
 		if fieldJSON, ok := rt.Field(i).Tag.Lookup("json"); ok {
+			// split fieldJSON by comma to handle omitempty/omitzero modifiers
+			fieldJSONSlice := strings.Split(fieldJSON, ",")
+			if len(fieldJSONSlice) > 0 {
+				fieldJSON = fieldJSONSlice[0]
+			}
 
 			// if there is any prefix, we need to append it to the JSON field
 			if prefix != "" {

--- a/integration/test_resources/help/agent_list
+++ b/integration/test_resources/help/agent_list
@@ -17,21 +17,38 @@ The available keys for this command are:
     * mid
     * os
     * osVersion
-    * tags.Account
-    * tags.AmiId
+    * tags.arch
     * tags.ExternalIp
     * tags.Hostname
-    * tags.Name
     * tags.InstanceId
     * tags.InternalIp
     * tags.LwTokenShort
-    * tags.SubnetId
+    * tags.os
     * tags.VmInstanceType
     * tags.VmProvider
-    * tags.VpcId
     * tags.Zone
-    * tags.arch
-    * tags.os
+    * tags.Account
+    * tags.AmiId
+    * tags.Name
+    * tags.SubnetId
+    * tags.VpcId
+    * tags.Cluster
+    * tags.cluster-location
+    * tags.cluster-name
+    * tags.cluster-uid
+    * tags.created-by
+    * tags.enable-oslogin
+    * tags.Env
+    * tags.GCEtags
+    * tags.gci-ensure-gke-docker
+    * tags.gci-update-strategy
+    * tags.google-compute-enable-pcid
+    * tags.InstanceName
+    * tags.InstanceTemplate
+    * tags.kube-labels
+    * tags.lw_KubernetesCluster
+    * tags.NumericProjectId
+    * tags.ProjectId
 
 Usage:
   lacework agent list [flags]


### PR DESCRIPTION
## Summary
The API has a structure defined for machine details tags.  The problem is the platform does not return a deterministic set of tags.  At a minimum the structure needs to be extended to output the set of tags known to GKE.

## How did you test this change?
Manual
Existing automation

## Issue
https://lacework.atlassian.net/browse/ALLY-1009
