### PR TITLE
feat: show query start time in progress spinner

### DIFF
--- a/cli/cmd/lql.go
+++ b/cli/cmd/lql.go
@@ -429,8 +429,10 @@ func runQueryByID(id string, args []api.ExecuteQueryArgument) (
 ) {
 	cli.Log.Debugw("running query", "query", id)
 	msg := "Executing query"
-	if startTime, err := time.Parse(time.RFC3339, args[0].Value); err == nil {
-		msg = fmt.Sprintf("%s starting at %s", msg, startTime.Format("2006-Jan-2 15:04:05 MST"))
+	startTime, startErr := time.Parse(time.RFC3339, args[0].Value)
+	endTime, endErr := time.Parse(time.RFC3339, args[1].Value)
+	if startErr == nil && endErr == nil {
+		msg = fmt.Sprintf("%s in the time range %s - %s", msg, startTime.Format("2006-Jan-2 15:04:05 MST"), endTime.Format("2006-Jan-2 15:04:05 MST"))
 	}
 	cli.StartProgress(msg)
 	defer cli.StopProgress()
@@ -458,8 +460,10 @@ func runAdhocQuery(cmd *cobra.Command, args []api.ExecuteQueryArgument) (
 	}
 
 	msg := "Executing query"
-	if startTime, err := time.Parse(time.RFC3339, args[0].Value); err == nil {
-		msg = fmt.Sprintf("%s starting at %s", msg, startTime.Format("2006-Jan-2 15:04:05 MST"))
+	startTime, startErr := time.Parse(time.RFC3339, args[0].Value)
+	endTime, endErr := time.Parse(time.RFC3339, args[1].Value)
+	if startErr == nil && endErr == nil {
+		msg = fmt.Sprintf("%s in the time range %s - %s", msg, startTime.Format("2006-Jan-2 15:04:05 MST"), endTime.Format("2006-Jan-2 15:04:05 MST"))
 	}
 	cli.StartProgress(msg)
 	defer cli.StopProgress()

--- a/cli/cmd/lql.go
+++ b/cli/cmd/lql.go
@@ -428,8 +428,11 @@ func runQueryByID(id string, args []api.ExecuteQueryArgument) (
 	error,
 ) {
 	cli.Log.Debugw("running query", "query", id)
-
-	cli.StartProgress(" Executing query...")
+	msg := "Executing query"
+	if startTime, err := time.Parse(time.RFC3339, args[0].Value); err == nil {
+		msg = fmt.Sprintf("%s starting at %s", msg, startTime.Format("2006-Jan-2 15:04:05 MST"))
+	}
+	cli.StartProgress(msg)
 	defer cli.StopProgress()
 
 	request := api.ExecuteQueryByIDRequest{
@@ -454,7 +457,11 @@ func runAdhocQuery(cmd *cobra.Command, args []api.ExecuteQueryArgument) (
 		return
 	}
 
-	cli.StartProgress(" Executing query...")
+	msg := "Executing query"
+	if startTime, err := time.Parse(time.RFC3339, args[0].Value); err == nil {
+		msg = fmt.Sprintf("%s starting at %s", msg, startTime.Format("2006-Jan-2 15:04:05 MST"))
+	}
+	cli.StartProgress(msg)
 	defer cli.StopProgress()
 
 	// execute query


### PR DESCRIPTION
Signed-off-by: Darren Murray <darren.murray@lacework.net>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/lacework/go-sdk) and create your branch from `main`
  2. Run `make prepare` in the repository root
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`make test`)
  5. Format your code (`make fmt`)
  6. Make sure your code lints (`make lint`)
  7. If you are updating the Lacework CLI, make sure it compiles (`make build-cli-cross-platform`)
  8. Follow the commit message standard (`type(scope): subject`) documented in [DEVELOPER_GUIDELINES.md](https://github.com/lacework/go-sdk/blob/main/DEVELOPER_GUIDELINES.md#commit-message-standard)
  9. If you haven't already, configure signed commits by [telling git about your signing key](https://docs.github.com/en/github/authenticating-to-github/managing-commit-signature-verification/telling-git-about-your-signing-key) and [signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)

  Learn more about contributing: https://github.com/lacework/go-sdk/blob/main/CONTRIBUTING.md
-->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

When running the `lacework query run` command, display the start time and end time of time range the query is executing in the progress spinner.

## How did you test this change?

<!--
  How exactly did you verify that your PR solves the issue you wanted to solve?
  Include any other relevant information such as how to use the new functionality, screenshots, etc.
-->

run cmd 
`lacework query run <query-id>`
`lacework query run <query-id> --start -1hr`

example output:
```
>  Executing query in the time range 2022-May-25 13:12:43 UTC - 2022-May-26 13:12:43 UTC 
```


## Issue
https://lacework.atlassian.net/browse/ALLY-938


<!--
  Include the link to a Jira/Github issue
-->
