### PR TITLE
fix(cli): panic while detecting ESM on Ubuntu sys

### DIFF
--- a/internal/file/file.go
+++ b/internal/file/file.go
@@ -28,5 +28,8 @@ func FileExists(filename string) bool {
 	if os.IsNotExist(err) {
 		return false
 	}
+	if f == nil {
+		return false
+	}
 	return !f.IsDir()
 }

--- a/internal/file/file_test.go
+++ b/internal/file/file_test.go
@@ -21,6 +21,7 @@ package file_test
 import (
 	"io/ioutil"
 	"os"
+	"path"
 	"testing"
 
 	"github.com/lacework/go-sdk/internal/file"
@@ -37,8 +38,23 @@ func TestFileExistsWhenFileActuallyExists(t *testing.T) {
 
 func TestFileExistsWhenFileIsADirectory(t *testing.T) {
 	dir, err := ioutil.TempDir("", "bar")
+
 	if assert.Nil(t, err) {
 		assert.False(t, file.FileExists(dir))
+		os.RemoveAll(dir)
+	}
+}
+
+func TestFileExistsButWeDontHavePermissions(t *testing.T) {
+	dir, err := ioutil.TempDir("", "root")
+
+	// create a directory that we can't read
+	os.Mkdir(path.Join(dir, "protected"), 0700)
+	os.WriteFile(path.Join(dir, "protected", "bubulubu"), []byte("data"), 0644)
+	os.Chmod(path.Join(dir, "protected"), 0000)
+
+	if assert.Nil(t, err) {
+		assert.False(t, file.FileExists(path.Join(dir, "protected", "bubulubu")))
 		os.RemoveAll(dir)
 	}
 }


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/lacework/go-sdk) and create your branch from `main`
  2. Run `make prepare` in the repository root
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`make test`)
  5. Format your code (`make fmt`)
  6. Make sure your code lints (`make lint`)
  7. If you are updating the Lacework CLI, make sure it compiles (`make build-cli-cross-platform`)
  8. Follow the commit message standard (`type(scope): subject`) documented in [DEVELOPER_GUIDELINES.md](https://github.com/lacework/go-sdk/blob/main/DEVELOPER_GUIDELINES.md#commit-message-standard)
  9. If you haven't already, configure signed commits by [telling git about your signing key](https://docs.github.com/en/github/authenticating-to-github/managing-commit-signature-verification/telling-git-about-your-signing-key) and [signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)

  Learn more about contributing: https://github.com/lacework/go-sdk/blob/main/CONTRIBUTING.md
-->

## Summary
Running Lacework CLI to check for host vulnerabilities on local Ubuntu images caused a panic.

The affected commands are:
```
lacework vulnerability host scan-pkg-manifest --local
```

and
```
lacework vulnerability host generate-pkg-manifest
```

This PR fixes this issue.

## How did you test this change?
Added unit tests that replicate the issue (panic)

<img width="1009" alt="Screen Shot 2022-05-25 at 5 38 18 PM" src="https://user-images.githubusercontent.com/5712253/170302901-a318aadf-3ed7-4b42-833f-a97c0c926979.png">


## Issue
Closes https://lacework.atlassian.net/browse/ALLY-1004

