### PR TITLE
test: disable file test since CI runs as root

### DIFF
--- a/internal/file/file_test.go
+++ b/internal/file/file_test.go
@@ -46,6 +46,13 @@ func TestFileExistsWhenFileIsADirectory(t *testing.T) {
 }
 
 func TestFileExistsButWeDontHavePermissions(t *testing.T) {
+	// @afiune don't run it in Codefresh since the pipeline runs as root
+	// and root has access to all files and directories
+	if os.Getenv("CI") != "" {
+		t.Skip("skipping since CI runs as root, and root has permissions")
+		return
+	}
+
 	dir, err := ioutil.TempDir("", "root")
 
 	// create a directory that we can't read


### PR DESCRIPTION

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/lacework/go-sdk) and create your branch from `main`
  2. Run `make prepare` in the repository root
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`make test`)
  5. Format your code (`make fmt`)
  6. Make sure your code lints (`make lint`)
  7. If you are updating the Lacework CLI, make sure it compiles (`make build-cli-cross-platform`)
  8. Follow the commit message standard (`type(scope): subject`) documented in [DEVELOPER_GUIDELINES.md](https://github.com/lacework/go-sdk/blob/main/DEVELOPER_GUIDELINES.md#commit-message-standard)
  9. If you haven't already, configure signed commits by [telling git about your signing key](https://docs.github.com/en/github/authenticating-to-github/managing-commit-signature-verification/telling-git-about-your-signing-key) and [signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)

  Learn more about contributing: https://github.com/lacework/go-sdk/blob/main/CONTRIBUTING.md
-->

## Summary

Disable a test in our CI system since the pipeline runs as root, and root has access to every file and directory.

## How did you test this change?

Run the test locally and the CI system should skip this test.

## Issue

https://lacework.atlassian.net/browse/ALLY-1004
