### PR TITLE
refactor(cli): updated terminology for fail_on

### DIFF
--- a/cli/cmd/errors.go
+++ b/cli/cmd/errors.go
@@ -54,12 +54,12 @@ func NewVulnerabilityPolicyError(
 
 // Example of an error message sent to the end-user:
 //
-// ERROR ENFORCE POLICY: fixable vulnerabilities found with threshold 'critical' (exit code: 9)
+// ERROR (FAIL-ON): fixable vulnerabilities found with threshold 'critical' (exit code: 9)
 func (e *vulnerabilityPolicyError) Error() string {
 	if e.ExitCode == 0 {
 		return ""
 	}
-	return fmt.Sprintf("ENFORCE POLICY: %s (exit code: %d)", e.Message, e.ExitCode)
+	return fmt.Sprintf("(FAIL-ON): %s (exit code: %d)", e.Message, e.ExitCode)
 }
 
 func (e *vulnerabilityPolicyError) Unwrap() error {

--- a/cli/cmd/errors_test.go
+++ b/cli/cmd/errors_test.go
@@ -31,7 +31,7 @@ func TestVulnerabilityPolicyErrorFailOnFixable(t *testing.T) {
 	if assert.Truef(t, mockPolicy.NonCompliant(), "policy should not be compliant") {
 		assert.Equal(t, 9, mockPolicy.ExitCode)
 		assert.Equal(t,
-			"ENFORCE POLICY: fixable vulnerabilities found (exit code: 9)",
+			"(FAIL-ON): fixable vulnerabilities found (exit code: 9)",
 			mockPolicy.Error(),
 		)
 		assert.Falsef(t, mockPolicy.Compliant(), "policy should not be compliant")
@@ -45,7 +45,7 @@ func TestVulnerabilityPolicyErrorFailOnSeverityWithFixable(t *testing.T) {
 	if assert.Truef(t, mockPolicy.NonCompliant(), "policy should not be compliant") {
 		assert.Equal(t, 9, mockPolicy.ExitCode)
 		assert.Equal(t,
-			"ENFORCE POLICY: fixable vulnerabilities found with threshold 'high' (exit code: 9)",
+			"(FAIL-ON): fixable vulnerabilities found with threshold 'high' (exit code: 9)",
 			mockPolicy.Error(),
 		)
 		assert.Falsef(t, mockPolicy.Compliant(), "policy should not be compliant")
@@ -59,7 +59,7 @@ func TestVulnerabilityPolicyErrorFailOnSeverityHigh(t *testing.T) {
 	if assert.Truef(t, mockPolicy.NonCompliant(), "policy should not be compliant") {
 		assert.Equal(t, 9, mockPolicy.ExitCode)
 		assert.Equal(t,
-			"ENFORCE POLICY: vulnerabilities found with threshold 'high' (exit code: 9)",
+			"(FAIL-ON): vulnerabilities found with threshold 'high' (exit code: 9)",
 			mockPolicy.Error(),
 		)
 		assert.Falsef(t, mockPolicy.Compliant(), "policy should not be compliant")

--- a/integration/container_vulnerability_test.go
+++ b/integration/container_vulnerability_test.go
@@ -425,7 +425,7 @@ func _TestContainerVulnerabilityCommandsEndToEnd(t *testing.T) {
 		// CLI should terminate with exit code 9
 		assert.Equal(t, 9, exitcode, "EXITCODE is not the expected one")
 		assert.Contains(t, err.String(),
-			"ERROR ENFORCE POLICY: vulnerabilities found with threshold 'high' (exit code: 9)",
+			"ERROR (FAIL-ON): vulnerabilities found with threshold 'high' (exit code: 9)",
 			"STDERR doesn't match")
 	})
 
@@ -437,7 +437,7 @@ func _TestContainerVulnerabilityCommandsEndToEnd(t *testing.T) {
 		// CLI should terminate with exit code 9
 		assert.Equal(t, 9, exitcode, "EXITCODE is not the expected one")
 		assert.Contains(t, err.String(),
-			"ERROR ENFORCE POLICY: fixable vulnerabilities found with threshold 'high' (exit code: 9)",
+			"ERROR (FAIL-ON): fixable vulnerabilities found with threshold 'high' (exit code: 9)",
 			"STDERR doesn't match")
 	})
 
@@ -449,7 +449,7 @@ func _TestContainerVulnerabilityCommandsEndToEnd(t *testing.T) {
 		// CLI should terminate with exit code 9
 		assert.Equal(t, 9, exitcode, "EXITCODE is not the expected one")
 		assert.Contains(t, err.String(),
-			"ERROR ENFORCE POLICY: fixable vulnerabilities found (exit code: 9)",
+			"ERROR (FAIL-ON): fixable vulnerabilities found (exit code: 9)",
 			"STDERR doesn't match")
 	})
 

--- a/integration/host_vulnerability_test.go
+++ b/integration/host_vulnerability_test.go
@@ -274,7 +274,7 @@ func TestHostScanPkgManifestFailOnSeverity(t *testing.T) {
 		// CLI should terminate with exit code 1
 		assert.Equal(t, 9, exitcode, "EXITCODE is not the expected one")
 		assert.Contains(t, err.String(),
-			"ERROR ENFORCE POLICY: vulnerabilities found with threshold 'medium' (exit code: 9)",
+			"ERROR (FAIL-ON): vulnerabilities found with threshold 'medium' (exit code: 9)",
 			"STDERR does not match")
 	} else {
 		assert.Contains(t, err.String(), "unable to generate package manifest: unsupported platform", "STDERR doesn't match")
@@ -294,7 +294,7 @@ func TestHostVulnerabilityFailOnSeverityThreshold(t *testing.T) {
 	// CLI should terminate with exit code 9
 	assert.Equal(t, 9, exitcode, "EXITCODE is not the expected one")
 	assert.Contains(t, err.String(),
-		"ERROR ENFORCE POLICY: vulnerabilities found with threshold 'high' (exit code: 9)",
+		"ERROR (FAIL-ON): vulnerabilities found with threshold 'high' (exit code: 9)",
 		"STDERR does not match")
 }
 
@@ -308,7 +308,7 @@ func TestHostVulnerabilityFailOnFixable(t *testing.T) {
 	// CLI should terminate with exit code 9
 	assert.Equal(t, 9, exitcode, "EXITCODE is not the expected one")
 	assert.Contains(t, err.String(),
-		"ERROR ENFORCE POLICY: fixable vulnerabilities found (exit code: 9)",
+		"ERROR (FAIL-ON): fixable vulnerabilities found (exit code: 9)",
 		"STDERR does not match")
 }
 
@@ -322,7 +322,7 @@ func TestHostVulnerabilityFailOnFixableWithSeverity(t *testing.T) {
 	// CLI should terminate with exit code 9
 	assert.Equal(t, 9, exitcode, "EXITCODE is not the expected one")
 	assert.Contains(t, err.String(),
-		"ERROR ENFORCE POLICY: fixable vulnerabilities found with threshold 'high' (exit code: 9)",
+		"ERROR (FAIL-ON): fixable vulnerabilities found with threshold 'high' (exit code: 9)",
 		"STDERR does not match")
 }
 
@@ -336,7 +336,7 @@ func TestHostVulnerabilityFailOnFixableWithJson(t *testing.T) {
 	// CLI should terminate with exit code 9
 	assert.Equal(t, 9, exitcode, "EXITCODE is not the expected one")
 	assert.Contains(t, err.String(),
-		"ERROR ENFORCE POLICY: fixable vulnerabilities found (exit code: 9)",
+		"ERROR (FAIL-ON): fixable vulnerabilities found (exit code: 9)",
 		"STDERR does not match")
 }
 


### PR DESCRIPTION
## Summary
As a Lacework CLI user “ENFORCE POLICY” terminology is confusing and overloaded when I ask the CLI to fail on certain criteria.

## How did you test this change?
Existing automation has been updated

## Issue
https://lacework.atlassian.net/browse/ALLY-1011