### PR TITLE
refactor(cli): query run progress message

### DIFF
--- a/api/lql_execute.go
+++ b/api/lql_execute.go
@@ -54,9 +54,12 @@ type ExecuteQueryByIDRequest struct {
 	Arguments []ExecuteQueryArgument `json:"arguments"`
 }
 
-func validateQueryArguments(args []ExecuteQueryArgument) (err error) {
-	var hasStart, hasEnd bool
-	var start, end time.Time
+func validateQueryArguments(args []ExecuteQueryArgument) error {
+	var (
+		hasStart, hasEnd bool
+		start, end       time.Time
+		err              error
+	)
 
 	for _, arg := range args {
 		if arg.Name == QueryStartTimeRange {

--- a/api/lql_execute.go
+++ b/api/lql_execute.go
@@ -32,9 +32,16 @@ type ExecuteQuery struct {
 	EvaluatorID string `json:"evaluatorId,omitempty"`
 }
 
+type ExecuteQueryArgumentName string
+
+const (
+	QueryStartTimeRange ExecuteQueryArgumentName = "StartTimeRange"
+	QueryEndTimeRange   ExecuteQueryArgumentName = "EndTimeRange"
+)
+
 type ExecuteQueryArgument struct {
-	Name  string `json:"name"`
-	Value string `json:"value"`
+	Name  ExecuteQueryArgumentName `json:"name"`
+	Value string                   `json:"value"`
 }
 
 type ExecuteQueryRequest struct {
@@ -52,7 +59,7 @@ func validateQueryArguments(args []ExecuteQueryArgument) (err error) {
 	var start, end time.Time
 
 	for _, arg := range args {
-		if arg.Name == "StartTimeRange" {
+		if arg.Name == QueryStartTimeRange {
 			hasStart = true
 			start, err = validateQueryTimeString(arg.Value)
 		}
@@ -60,7 +67,7 @@ func validateQueryArguments(args []ExecuteQueryArgument) (err error) {
 			return errors.Wrap(err, "invalid StartTimeRange argument")
 		}
 
-		if arg.Name == "EndTimeRange" {
+		if arg.Name == QueryEndTimeRange {
 			hasEnd = true
 			end, err = validateQueryTimeString(arg.Value)
 		}

--- a/api/lql_execute_internal_test.go
+++ b/api/lql_execute_internal_test.go
@@ -43,7 +43,7 @@ var validateQueryArgumentsTests = []validateQueryArgumentsTest{
 	validateQueryArgumentsTest{
 		name: "start-bad",
 		arguments: []ExecuteQueryArgument{
-			ExecuteQueryArgument{Name: "StartTimeRange", Value: ""},
+			ExecuteQueryArgument{Name: QueryStartTimeRange, Value: ""},
 		},
 		retrn: errors.New(
 			`invalid StartTimeRange argument: parsing time "" as "2006-01-02T15:04:05.000Z": cannot parse "" as "2006"`),
@@ -51,7 +51,7 @@ var validateQueryArgumentsTests = []validateQueryArgumentsTest{
 	validateQueryArgumentsTest{
 		name: "start-nonutc",
 		arguments: []ExecuteQueryArgument{
-			ExecuteQueryArgument{Name: "StartTimeRange", Value: "2021-07-11T00:00:00.123Z07:00"},
+			ExecuteQueryArgument{Name: QueryStartTimeRange, Value: "2021-07-11T00:00:00.123Z07:00"},
 		},
 		retrn: errors.New(
 			`invalid StartTimeRange argument: parsing time "2021-07-11T00:00:00.123Z07:00": extra text: "07:00"`),
@@ -59,7 +59,7 @@ var validateQueryArgumentsTests = []validateQueryArgumentsTest{
 	validateQueryArgumentsTest{
 		name: "start-good",
 		arguments: []ExecuteQueryArgument{
-			ExecuteQueryArgument{Name: "StartTimeRange", Value: "2021-07-12T00:00:00.000Z"},
+			ExecuteQueryArgument{Name: QueryStartTimeRange, Value: "2021-07-12T00:00:00.000Z"},
 		},
 		retrn: nil,
 	},
@@ -81,7 +81,7 @@ var validateQueryArgumentsTests = []validateQueryArgumentsTest{
 	validateQueryArgumentsTest{
 		name: "range-bad",
 		arguments: []ExecuteQueryArgument{
-			ExecuteQueryArgument{Name: "StartTimeRange", Value: "2021-07-13T00:00:00.000Z"},
+			ExecuteQueryArgument{Name: QueryStartTimeRange, Value: "2021-07-13T00:00:00.000Z"},
 			ExecuteQueryArgument{Name: "EndTimeRange", Value: "2021-07-12T00:00:00.000Z"},
 		},
 		retrn: errors.New(
@@ -90,7 +90,7 @@ var validateQueryArgumentsTests = []validateQueryArgumentsTest{
 	validateQueryArgumentsTest{
 		name: "range-good",
 		arguments: []ExecuteQueryArgument{
-			ExecuteQueryArgument{Name: "StartTimeRange", Value: "2021-07-12T00:00:00.000Z"},
+			ExecuteQueryArgument{Name: QueryStartTimeRange, Value: "2021-07-12T00:00:00.000Z"},
 			ExecuteQueryArgument{Name: "EndTimeRange", Value: "2021-07-13T00:00:00.000Z"},
 		},
 		retrn: nil,

--- a/api/lql_execute_test.go
+++ b/api/lql_execute_test.go
@@ -32,11 +32,11 @@ import (
 var (
 	executeQueryArguments = []api.ExecuteQueryArgument{
 		api.ExecuteQueryArgument{
-			Name:  "StartTimeRange",
+			Name:  api.QueryStartTimeRange,
 			Value: "2021-07-11T00:00:00.000Z",
 		},
 		api.ExecuteQueryArgument{
-			Name:  "EndTimeRange",
+			Name:  api.QueryEndTimeRange,
 			Value: "2021-07-12T00:00:00.000Z",
 		},
 	}

--- a/cli/cmd/lql.go
+++ b/cli/cmd/lql.go
@@ -402,11 +402,11 @@ func runQuery(cmd *cobra.Command, args []string) error {
 
 	queryArgs := []api.ExecuteQueryArgument{
 		api.ExecuteQueryArgument{
-			Name:  "StartTimeRange",
+			Name:  api.QueryStartTimeRange,
 			Value: start.UTC().Format(lwtime.RFC3339Milli),
 		},
 		api.ExecuteQueryArgument{
-			Name:  "EndTimeRange",
+			Name:  api.QueryEndTimeRange,
 			Value: end.UTC().Format(lwtime.RFC3339Milli),
 		},
 	}
@@ -479,9 +479,9 @@ func getRunStartProgressMessage(args []api.ExecuteQueryArgument) string {
 	)
 	for _, arg := range args {
 		switch arg.Name {
-		case "StartTimeRange":
+		case api.QueryStartTimeRange:
 			startTime, startErr = time.Parse(time.RFC3339, arg.Value)
-		case "EndTimeRange":
+		case api.QueryEndTimeRange:
 			endTime, endErr = time.Parse(time.RFC3339, arg.Value)
 		}
 	}

--- a/cli/cmd/lql_internal_test.go
+++ b/cli/cmd/lql_internal_test.go
@@ -160,3 +160,66 @@ func TestParseQueryTime(t *testing.T) {
 		})
 	}
 }
+
+type getRunStartProgressMessageTest struct {
+	Name                string
+	StartTime           string
+	EndTime             string
+	ReferenceTimeFormat string
+	Return              string
+}
+
+var (
+	getRunStartProgressMessageTests = []getRunStartProgressMessageTest{
+		{
+			Name:                "no-start",
+			EndTime:             "2006-02-02T15:04:05-07:00",
+			ReferenceTimeFormat: time.RFC3339,
+			Return:              "Executing query",
+		},
+		{
+			Name:                "no-end",
+			StartTime:           "2006-02-02T15:04:05-07:00",
+			ReferenceTimeFormat: time.RFC3339,
+			Return:              "Executing query",
+		},
+		{
+			Name:                "basic",
+			StartTime:           "2006-02-02T15:04:05-07:00",
+			EndTime:             "2006-02-03T15:04:05-07:00",
+			ReferenceTimeFormat: time.RFC3339,
+			Return:              "Executing query in the time range 2006-Feb-2 22:04:05 UTC - 2006-Feb-3 22:04:05 UTC",
+		},
+	}
+)
+
+func TestRunStartProgressMessage(t *testing.T) {
+	for _, grspmt := range getRunStartProgressMessageTests {
+		t.Run(grspmt.Name, func(t *testing.T) {
+			args := []api.ExecuteQueryArgument{}
+
+			if grspmt.StartTime != "" {
+				startTime, startErr := time.Parse(grspmt.ReferenceTimeFormat, grspmt.StartTime)
+				if startErr != nil {
+					assert.FailNow(t, startErr.Error())
+				}
+				args = append(args, api.ExecuteQueryArgument{
+					Name:  "StartTimeRange",
+					Value: startTime.UTC().Format(lwtime.RFC3339Milli),
+				})
+			}
+			if grspmt.EndTime != "" {
+				endTime, endErr := time.Parse(grspmt.ReferenceTimeFormat, grspmt.EndTime)
+				if endErr != nil {
+					assert.FailNow(t, endErr.Error())
+				}
+				args = append(args, api.ExecuteQueryArgument{
+					Name:  "EndTimeRange",
+					Value: endTime.UTC().Format(lwtime.RFC3339Milli),
+				})
+			}
+
+			assert.Equal(t, grspmt.Return, getRunStartProgressMessage(args))
+		})
+	}
+}

--- a/cli/cmd/lql_internal_test.go
+++ b/cli/cmd/lql_internal_test.go
@@ -204,7 +204,7 @@ func TestRunStartProgressMessage(t *testing.T) {
 					assert.FailNow(t, startErr.Error())
 				}
 				args = append(args, api.ExecuteQueryArgument{
-					Name:  "StartTimeRange",
+					Name:  api.QueryStartTimeRange,
 					Value: startTime.UTC().Format(lwtime.RFC3339Milli),
 				})
 			}
@@ -214,7 +214,7 @@ func TestRunStartProgressMessage(t *testing.T) {
 					assert.FailNow(t, endErr.Error())
 				}
 				args = append(args, api.ExecuteQueryArgument{
-					Name:  "EndTimeRange",
+					Name:  api.QueryEndTimeRange,
 					Value: endTime.UTC().Format(lwtime.RFC3339Milli),
 				})
 			}

--- a/cli/cmd/lql_preview.go
+++ b/cli/cmd/lql_preview.go
@@ -85,11 +85,11 @@ func previewQuerySource(_ *cobra.Command, args []string) error {
 
 		executeQuery.Arguments = []api.ExecuteQueryArgument{
 			api.ExecuteQueryArgument{
-				Name:  "StartTimeRange",
+				Name:  api.QueryStartTimeRange,
 				Value: start.UTC().Format(lwtime.RFC3339Milli),
 			},
 			api.ExecuteQueryArgument{
-				Name:  "EndTimeRange",
+				Name:  api.QueryEndTimeRange,
 				Value: end.UTC().Format(lwtime.RFC3339Milli),
 			},
 		}


### PR DESCRIPTION
## Summary
> I feel the way this function is written allows us to make easy mistakes such as 1) having the arguments in a different order and getting the start/end time wrong, and 2) passing less than two arguments which will throw a panic trying to access elements that don't exist since we are not checking that the array has at least two elements.

## How did you test this change?
Unit testing

## Issue
https://lacework.atlassian.net/browse/ALLY-1015
