### PR TITLE
test: fix pipeline to check for low vulns

### DIFF
--- a/integration/host_vulnerability_test.go
+++ b/integration/host_vulnerability_test.go
@@ -268,13 +268,13 @@ func TestHostScanPkgManifestFailOnSeverity(t *testing.T) {
 		t.Skip(fmt.Sprintf("skipping %s", t.Name()))
 	}
 	out, err, exitcode := LaceworkCLIWithTOMLConfig(
-		"vulnerability", "host", "scan-pkg-manifest", "--local", "--fail_on_severity", "medium")
+		"vulnerability", "host", "scan-pkg-manifest", "--local", "--fail_on_severity", "low")
 
 	if runtime.GOOS == "linux" {
 		// CLI should terminate with exit code 1
 		assert.Equal(t, 9, exitcode, "EXITCODE is not the expected one")
 		assert.Contains(t, err.String(),
-			"ERROR (FAIL-ON): vulnerabilities found with threshold 'medium' (exit code: 9)",
+			"ERROR (FAIL-ON): vulnerabilities found with threshold 'low' (exit code: 9)",
 			"STDERR does not match")
 	} else {
 		assert.Contains(t, err.String(), "unable to generate package manifest: unsupported platform", "STDERR doesn't match")


### PR DESCRIPTION
## Summary
Our nightly build is failing with:
```
=== Failed                                                                                                                                                            
=== FAIL: integration TestHostScanPkgManifestFailOnSeverity (8.44s)                                                                                                   
    host_vulnerability_test.go:275:                                                                                                                                   
                Error Trace:    host_vulnerability_test.go:275                                                                                                        
                Error:          Not equal:                                                                                                                            
                                expected: 9                                                                                                                           
                                actual  : 0                                                                                                                           
                Test:           TestHostScanPkgManifestFailOnSeverity                                                                                                 
                Messages:       EXITCODE is not the expected one                                                                                                      
    host_vulnerability_test.go:276:                                                                                                                                   
                Error Trace:    host_vulnerability_test.go:276                                                                                                        
                Error:          "" does not contain "ERROR (FAIL-ON): vulnerabilities found with threshold 'medium' (exit code: 9)"                                   
                Test:           TestHostScanPkgManifestFailOnSeverity                                                                                                 
                Messages:       STDERR does not match                                                                                                                 
                                                                                                                                                                      
DONE 353 tests, 1 failure in 238.967s  
```

## How did you test this change?

will run the pipeline...

## Issue

N/A