### PR TITLE
test(api): verify vuln exception accepts no resource scope

### DIFF
--- a/api/vulnerability_exceptions_test.go
+++ b/api/vulnerability_exceptions_test.go
@@ -70,6 +70,31 @@ func TestNewVulnerabilityException(t *testing.T) {
 	assert.Equal(t, []string{"Critical"}, vulnerabilityException.VulnerabilityCriteria.Severity)
 }
 
+func TestNewVulnerabilityExceptionNoResourceScope(t *testing.T) {
+	mypackages := []api.VulnerabilityExceptionPackage{
+		{Name: "PackageOne", Version: "1.2.3"},
+		{Name: "PackageOne", Version: "1.2.4"},
+		{Name: "PackageTwo", Version: "1.2.3"},
+	}
+
+	vulnerabilityException := api.NewVulnerabilityException("MyVulnException",
+		api.VulnerabilityExceptionConfig{
+			Type:            api.VulnerabilityExceptionTypeHost,
+			Description:     "This is a vuln exception",
+			ExceptionReason: api.VulnerabilityExceptionReasonCompensatingControls,
+			Severities:      api.VulnerabilityExceptionSeverities{api.VulnerabilityExceptionSeverityCritical},
+			Fixable:         true,
+			Package:         mypackages,
+			ExpiryTime:      time.UnixMilli(1642187718414),
+		})
+
+	vulnJson, err := json.Marshal(vulnerabilityException)
+	assert.NoError(t, err)
+	assert.Equal(t, mockVulnHostWithoutResourceScopeRequest, string(vulnJson))
+	assert.Equal(t, []string{"1.2.3", "1.2.4"}, vulnerabilityException.VulnerabilityCriteria.Package[0]["PackageOne"])
+	assert.Equal(t, []string{"Critical"}, vulnerabilityException.VulnerabilityCriteria.Severity)
+}
+
 func TestHostVulnerabilityExceptionGet(t *testing.T) {
 	var (
 		intgGUID      = intgguid.New()
@@ -444,3 +469,4 @@ func singleMockCtrVulnerabilityException(id string) string {
 }
 
 var mockVulnHostRequest = `{"state":1,"exceptionName":"MyVulnException","exceptionType":"Host","exceptionReason":"Compensating Controls","props":{"description":"This is a vuln exception"},"vulnerabilityCriteria":{"package":[{"PackageOne":["1.2.3","1.2.4"]},{"PackageTwo":["1.2.3"]}],"severity":["Critical"],"fixable":[1]},"resourceScope":{"hostname":["exampleHost1"]},"expiryTime":"2022-01-14T19:15:18.414Z"}`
+var mockVulnHostWithoutResourceScopeRequest = `{"state":1,"exceptionName":"MyVulnException","exceptionType":"Host","exceptionReason":"Compensating Controls","props":{"description":"This is a vuln exception"},"vulnerabilityCriteria":{"package":[{"PackageOne":["1.2.3","1.2.4"]},{"PackageTwo":["1.2.3"]}],"severity":["Critical"],"fixable":[1]},"expiryTime":"2022-01-14T19:15:18.414Z"}`


### PR DESCRIPTION
## Summary

The Lacework API indicates that the resource scope is optional but the code in the `api` go package
doesn't seem to support it.

## How did you test this change?

TBA

## Issue

https://lacework.atlassian.net/browse/ALLY-1017