### PR TITLE
fix(cli): compliance gcp enable command

### DIFF
--- a/cli/cmd/compliance_gcp.go
+++ b/cli/cmd/compliance_gcp.go
@@ -403,7 +403,7 @@ To enable all recommendations for CIS_1_2 report run:
 			}
 
 			// set state of all recommendations in this report to enabled
-			patchReq := api.NewRecommendationV1State(schema, false)
+			patchReq := api.NewRecommendationV1State(schema, true)
 			cli.StartProgress("enabling recommendations...")
 			response, err := cli.LwApi.Recommendations.Gcp.Patch(patchReq)
 			cli.StopProgress()


### PR DESCRIPTION
fix `lacework comp gcp enable <report_type>`

The CLI command `lacework compliance gcp enable` had been incorrectly set to send `disable` in the request body. This only affected the Gcp command. Aws and Azure were correct.

This fix set the correct request body.