### PR TITLE
refactor(cdk): improve GetComponent / IsInstalled funcs

### DIFF
--- a/cli/cmd/component.go
+++ b/cli/cmd/component.go
@@ -211,8 +211,8 @@ func runComponentsInstall(_ *cobra.Command, args []string) (err error) {
 		return
 	}
 
-	component := cli.LwComponents.GetComponent(args[0])
-	if component == nil {
+	component, found := cli.LwComponents.GetComponent(args[0])
+	if !found {
 		err = errors.New("component not found. Try running 'lacework component list'")
 		return
 	}
@@ -237,8 +237,8 @@ func runComponentsUpdate(_ *cobra.Command, args []string) (err error) {
 		return
 	}
 
-	component := cli.LwComponents.GetComponent(args[0])
-	if component == nil {
+	component, found := cli.LwComponents.GetComponent(args[0])
+	if !found {
 		err = errors.New("component not found. Try running 'lacework component list'")
 		return
 	}
@@ -276,13 +276,13 @@ func runComponentsDelete(_ *cobra.Command, args []string) (err error) {
 		return
 	}
 
-	component := cli.LwComponents.GetComponent(args[0])
-	if component == nil {
+	component, found := cli.LwComponents.GetComponent(args[0])
+	if !found {
 		err = errors.New("component not found. Try running 'lacework component list'")
 		return
 	}
 
-	if component.Status() != lwcomponent.Installed {
+	if !component.IsInstalled() {
 		err = errors.Errorf(
 			"component not installed. Try running 'lacework component install %s'",
 			args[0],

--- a/cli/cmd/lacework_content_library_internal_test.go
+++ b/cli/cmd/lacework_content_library_internal_test.go
@@ -311,7 +311,7 @@ func TestLoadLCLNotFound(t *testing.T) {
 	_, err := cli.LoadLCL()
 	assert.Equal(
 		t,
-		"unable to load Lacework Content Library: Lacework Content Library is not installed",
+		"unable to load Lacework Content Library: component not installed",
 		err.Error(),
 	)
 }

--- a/lwcomponent/component.go
+++ b/lwcomponent/component.go
@@ -87,15 +87,23 @@ func LocalState() (*State, error) {
 	return state, err
 }
 
-// GetComponent returns the pointer of a component, if the component does not
-// exit, this function will return `nil`
-func (s State) GetComponent(name string) *Component {
+// GetComponent returns the pointer of a component, if the component is not
+// found, this function will return a `nil` pointer and `false`
+//
+// Usage:
+// ```go
+// component, found := s.GetComponent(name)
+// if !found {
+//   fmt.Println("Component %s not found", name)
+// }
+// ```
+func (s State) GetComponent(name string) (*Component, bool) {
 	for i := range s.Components {
 		if s.Components[i].Name == name {
-			return &s.Components[i]
+			return &s.Components[i], true
 		}
 	}
-	return nil
+	return nil, false
 }
 
 // WriteState stores the components state to disk
@@ -132,8 +140,8 @@ func Dir() (string, error) {
 }
 
 func (s State) Install(name string) error {
-	component := s.GetComponent(name)
-	if component == nil {
+	component, found := s.GetComponent(name)
+	if !found {
 		return errors.New("component not found")
 	}
 

--- a/lwcomponent/component_test.go
+++ b/lwcomponent/component_test.go
@@ -95,8 +95,15 @@ func TestGetComponent(t *testing.T) {
 		mockComponent2,
 	}
 
-	assert.Equal(t, mockComponent, *tempState.GetComponent("lacework-mock-component"))
-	assert.Nil(t, tempState.GetComponent("no-such-component"))
+	subjectComponent, found := tempState.GetComponent("lacework-mock-component")
+	if assert.True(t, found) {
+		assert.Equal(t, mockComponent, *subjectComponent)
+	}
+
+	subjectComponent, found = tempState.GetComponent("no-such-component")
+	if assert.False(t, found) {
+		assert.Nil(t, subjectComponent)
+	}
 }
 
 func TestLoadState(t *testing.T) {

--- a/lwcomponent/status.go
+++ b/lwcomponent/status.go
@@ -40,6 +40,12 @@ func (cs Status) String() string {
 	}
 }
 
+// IsInstalled returns true if the component is installed on disk
 func (c Component) IsInstalled() bool {
-	return c.Status() == Installed
+	switch c.Status() {
+	case Installed, UpdateAvailable:
+		return true
+	default:
+		return false
+	}
 }


### PR DESCRIPTION
## Summary

Finishing touches to release the CDK.

Improved `GetComponent()` to follow Golang idiomatic best practices, new usage:
```go
// GetComponent returns the pointer of a component, if the component is not
// found, this function will return a `nil` pointer and `false`
//
// Usage:
// ```go
// component, found := s.GetComponent(name)
// if !found {
//   fmt.Println("Component %s not found", name)
// }
// ```
``` 

Fixed `IsInstalled()` to return `true` when a component is installed but needs an update, this
is a different status and it was not being caught when a component was installed but needed
to be updated.

## How did you test this change?

Tested locally and in Windows! 🪟

![Screen Shot 2022-06-09 at 10 27 20 PM](https://user-images.githubusercontent.com/5712253/172939548-5ed3c6fb-9415-49cf-8c91-36adb0debb8d.png)

## Issue

https://lacework.atlassian.net/browse/ALLY-964
