### PR TITLE
style(cli): use switch instead of if statements

### DIFF
--- a/cli/cmd/lql.go
+++ b/cli/cmd/lql.go
@@ -470,7 +470,6 @@ func runQuery(cmd *cobra.Command, args []string) error {
 			queryCmdState.FailOnCount,
 			len(response.Data),
 		)
-		fmt.Println(queryFailonError.ExitCode)
 		if queryFailonError.NonCompliant() {
 			cmd.SilenceUsage = true
 			return queryFailonError

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -101,12 +101,12 @@ This will prompt you for your Lacework account and a set of API access keys.`,
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() (err error) {
 	defer func() {
-		var vpe *vulnerabilityPolicyError
-		if errors.As(err, &vpe) {
+		switch err.(type) {
+		case *vulnerabilityPolicyError:
+			vpe := err.(*vulnerabilityPolicyError)
 			exitwithCode(vpe, vpe.ExitCode)
-		}
-		var qfe *queryFailonError
-		if errors.As(err, &qfe) {
+		case *queryFailonError:
+			qfe := err.(*queryFailonError)
 			exitwithCode(qfe, qfe.ExitCode)
 		}
 	}()


### PR DESCRIPTION
## Summary

I wanted to make a style change to switch the use of if statements in favor of a switch statement, doing so
I saw one leftover `fmt.Println()` which I am removing. 

Nice feature @hazedav !!

![tenor-116042133](https://user-images.githubusercontent.com/5712253/173867505-1c1071c5-edec-48ba-b39d-64f79ecf26d6.gif)


## How did you test this change?
Ran a query with a matching expression and without it.

## Issue
https://lacework.atlassian.net/browse/ALLY-485