### PR TITLE
fix(cdk): run component dynamically

### DIFF
--- a/cli/cmd/component.go
+++ b/cli/cmd/component.go
@@ -141,18 +141,24 @@ func (c *cliState) LoadComponents() {
 			rootCmd.AddCommand(
 				&cobra.Command{
 					// @afiune strip `lw-` from component?
-					Use: component.Name,
-					// @afiune should we build this or add it as component specification
-					Short:                 fmt.Sprintf("component %s", component.Name),
-					Long:                  component.Description,
+					Use:                   component.Name,
+					Short:                 component.Description,
 					Annotations:           map[string]string{"type": "component"},
 					Version:               ver.String(),
 					DisableFlagParsing:    true,
 					DisableFlagsInUseLine: true,
 					RunE: func(cmd *cobra.Command, args []string) error {
 						cli.Log.Debugw("running component", "component", cmd.Use, "args", args)
-						// @afiune what if the component needs other env variables
-						return component.RunAndOutput(args, c.envs()...)
+						f, ok := cli.LwComponents.GetComponent(cmd.Use)
+						if ok {
+							// @afiune what if the component needs other env variables
+							return f.RunAndOutput(args, c.envs()...)
+						}
+
+						// We will land here only if we couldn't run the component, which is not
+						// possible since we are adding the components dynamically, still if it
+						// happens, let the user know that we would love to hear their feedback
+						return errors.New("something went pretty wrong here, contact support@lacework.net")
 					},
 				},
 			)


### PR DESCRIPTION
## Summary

Since we are building the tree of commands from the available components, if there are
more than one component, the function injected gets overridden to the last component
loaded. Which essentially means that all commands will be running the same "last"
component.

This fixes that issue by loading the component dynamically, and then, running it. 

## How did you test this change?

Installed two components and run them separately.

Additionally, removed the Long description and moved it to be the Short one. Looks better.
```
➜  go-sdk git:(afiune/fix-cdk-run-component) lacework help
The Lacework Command Line Interface is a tool that helps you manage the
Lacework cloud security platform. Use it to manage compliance reports,
external integrations, vulnerability scans, and other operations.

Start by configuring the Lacework CLI with the command:

    lacework configure

This will prompt you for your Lacework account and a set of API access keys.

Usage:
  lacework [command]

Available Commands:
  access-token            Generate temporary API access tokens
  account                 Manage accounts in an organization (org admins only)
  agent                   Manage Lacework agents
  alert-profile           Manage alert profiles
  alert-rule              Manage alert rules
  api                     Helper to call Lacework's API
  cloud-account           Manage cloud accounts
  completion              Generate the autocompletion script for the specified shell
  compliance              Manage compliance reports
  configure               Configure the Lacework CLI
  event                   Inspect Lacework events
  help                    Help about any command
  integration             Manage external integrations
  policy                  Manage policies
  query                   Run and manage queries
  report-rule             Manage report rules
  resource-group          Manage resource groups
  team-member             Manage team members
  version                 Print the Lacework CLI version
  vulnerability           Container and host vulnerability assessments
  vulnerability-exception Manage vulnerability exceptions

Commands from components:
  afiune-test-component   A dummy component for testing
  iac-scanner             Infrastructure as Code (IaC) scanner
```

## Issue

N/A
