### PR TITLE
feat(cdk): pass env variable LW_COMPONENT_NAME

### DIFF
--- a/cli/cmd/component.go
+++ b/cli/cmd/component.go
@@ -152,7 +152,9 @@ func (c *cliState) LoadComponents() {
 						f, ok := cli.LwComponents.GetComponent(cmd.Use)
 						if ok {
 							// @afiune what if the component needs other env variables
-							return f.RunAndOutput(args, c.envs()...)
+							envs := []string{fmt.Sprintf("LW_COMPONENT_NAME=%s", cmd.Use)}
+							envs = append(envs, c.envs()...)
+							return f.RunAndOutput(args, envs...)
 						}
 
 						// We will land here only if we couldn't run the component, which is not


### PR DESCRIPTION

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/lacework/go-sdk) and create your branch from `main`
  2. Run `make prepare` in the repository root
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`make test`)
  5. Format your code (`make fmt`)
  6. Make sure your code lints (`make lint`)
  7. If you are updating the Lacework CLI, make sure it compiles (`make build-cli-cross-platform`)
  8. Follow the commit message standard (`type(scope): subject`) documented in [DEVELOPER_GUIDELINES.md](https://github.com/lacework/go-sdk/blob/main/DEVELOPER_GUIDELINES.md#commit-message-standard)
  9. If you haven't already, configure signed commits by [telling git about your signing key](https://docs.github.com/en/github/authenticating-to-github/managing-commit-signature-verification/telling-git-about-your-signing-key) and [signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)

  Learn more about contributing: https://github.com/lacework/go-sdk/blob/main/CONTRIBUTING.md
-->

## Summary
To integrate the Soluble CLI into the Lacework CLI we are planning to add it as a
component (an extension) so that customers can discover and use it out-of-the-box.

This new environmental variable will allow us to inject the name of the component
at runtime so that all the help messages reflect the correct component name.

Depends on https://github.com/soluble-ai/soluble-cli/pull/431

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>


## How did you test this change?
Built both, the Lacework CLI and the Soluble CLI and tested:

<img width="939" alt="Screen Shot 2022-06-22 at 4 02 51 PM" src="https://user-images.githubusercontent.com/5712253/175051455-61af668c-38e6-45a0-90fb-3b2b58f95eb8.png">

<img width="1042" alt="Screen Shot 2022-06-22 at 4 09 43 PM" src="https://user-images.githubusercontent.com/5712253/175051469-cddbe63d-9c97-40a8-8b14-c82e13cc3bd6.png">


## Issue

https://lacework.atlassian.net/browse/RAIN-33521
