### PR TITLE
fix(cli): subtract 1 minute from machine details end time

### DIFF
--- a/cli/cmd/agent_list.go
+++ b/cli/cmd/agent_list.go
@@ -74,7 +74,7 @@ func listAgents(_ *cobra.Command, _ []string) error {
 	var (
 		progressMsg = "Fetching list of agents"
 		response    = &api.MachineDetailsEntityResponse{}
-		now         = time.Now().UTC()
+		now         = time.Now().UTC().Add(-1 * time.Minute)
 		before      = now.AddDate(0, 0, -7) // 7 days from ago
 		filters     = api.SearchFilter{
 			TimeFilter: &api.TimeFilter{


### PR DESCRIPTION
## Summary

Customers are reporting issues running the command `lacework agent list`, specifically on Windows machines.

Error message:
```
ERROR unable to list agents via MachineDetails search:
  [POST] https://account.lacework.net/api/v2/Entities/MachineDetails/search
  [400] endTime cannot be after current time
```

## How did you test this change?

We shared a built binary to the customer and they validated that it now works.

## Issue

https://lacework.atlassian.net/browse/ALLY-1067
