### PR TITLE
feat(cli): include status in vuln ctr scan assesment output

### DIFF
--- a/api/vulnerabilities_container.go
+++ b/api/vulnerabilities_container.go
@@ -316,6 +316,7 @@ type ContainerVulnerability struct {
 	Link        string                 `json:"link"`
 	FixVersion  string                 `json:"fix_version"`
 	Metadata    map[string]interface{} `json:"metadata"`
+	Status      string                 `json:"status"`
 }
 
 // traverseMetadata will try to extract an interface from the nested tree of key

--- a/cli/cmd/vuln_container.go
+++ b/cli/cmd/vuln_container.go
@@ -626,7 +626,7 @@ func buildVulnerabilityDetailsReportTable(details vulnerabilityDetailsReport) st
 			report.WriteString(
 				renderCustomTable(
 					[]string{"CVE ID", "Severity", "Package", "Current Version",
-						"Fix Version", "Introduced in Layer"},
+						"Fix Version", "Introduced in Layer", "Status"},
 					vulnImageTable,
 					tableFunc(func(t *tablewriter.Table) {
 						t.SetBorder(false)
@@ -696,6 +696,7 @@ type vulnTable struct {
 	CreatedBy      string
 	CVSSv2Score    float64
 	CVSSv3Score    float64
+	Status         string
 }
 
 type filteredImageTable struct {
@@ -818,6 +819,7 @@ func filterVulContainerImageLayers(image *api.VulnContainerImage) filteredImageT
 					CreatedBy:      createdBy,
 					CVSSv2Score:    vul.CVSSv2Score(),
 					CVSSv3Score:    vul.CVSSv3Score(),
+					Status:         vul.Status,
 				})
 
 				filteredPkg.Vulnerabilities = append(filteredPkg.Vulnerabilities, vul)
@@ -870,6 +872,7 @@ func vulContainerImageLayersToTable(imageTable filteredImageTable) [][]string {
 			vuln.CurrentVersion,
 			vuln.FixVersion,
 			vuln.CreatedBy,
+			vuln.Status,
 		})
 	}
 

--- a/cli/cmd/vulnerability_exceptions_test.go
+++ b/cli/cmd/vulnerability_exceptions_test.go
@@ -18,6 +18,7 @@
 package cmd
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -28,6 +29,51 @@ import (
 func TestBuildVulnerabilityException(t *testing.T) {
 	vulnExceptionPropertiesTable := buildVulnerabilityExceptionsPropsTable(mockVulnException)
 	assert.Equal(t, vulnExceptionPropertiesTable, vulnPropertiesOutput)
+}
+
+func TestCVEValidate(t *testing.T) {
+	cveRegEx, _ := regexp.Compile(CveRegex)
+	alasRegEx, _ := regexp.Compile(AlasRegex)
+
+	cveTableTest := []struct {
+		Name     string
+		Input    string
+		Regex    *regexp.Regexp
+		Expected bool
+	}{{
+		Name:     "CVE Valid",
+		Input:    "CVE-2022-28948",
+		Regex:    cveRegEx,
+		Expected: true,
+	}, {
+		Name:     "CVE Invalid",
+		Input:    "CV-202-28948",
+		Regex:    cveRegEx,
+		Expected: false,
+	}, {
+		Name:     "ALAS Valid",
+		Input:    "ALAS-2022-1788",
+		Regex:    alasRegEx,
+		Expected: true,
+	}, {
+		Name:     "ALAS Valid",
+		Input:    "ALAS2-2022-1802",
+		Regex:    alasRegEx,
+		Expected: true,
+	},
+		{
+			Name:     "ALAS Invalid",
+			Input:    "ALA-2022-1788",
+			Regex:    alasRegEx,
+			Expected: false,
+		},
+	}
+	for _, test := range cveTableTest {
+		t.Run(test.Name, func(t *testing.T) {
+			result := test.Regex.MatchString(test.Input)
+			assert.Equal(t, result, test.Expected)
+		})
+	}
 }
 
 var (

--- a/cli/cmd/vulnerability_test.go
+++ b/cli/cmd/vulnerability_test.go
@@ -174,7 +174,8 @@ func TestBuildVulnContainerAssessmentReportsWithVulnerabilitiesPackagesViewWithF
                   }
                 },
                 "name": "CVE-2021-36159",
-                "severity": "critical"
+                "severity": "critical",
+                "status": "Vulnerable"
               }
             ]
           }
@@ -226,6 +227,7 @@ func mockVulnerabilityAssessment() *api.VulnContainerAssessment {
                 "description": "",
                 "fix_version": "2.10.6-r0",
                 "link": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-30139",
+                "status": "Vulnerable",
                 "metadata": {
                   "NVD": {
                     "CVSSv2": {
@@ -248,6 +250,7 @@ func mockVulnerabilityAssessment() *api.VulnContainerAssessment {
                 "description": "",
                 "fix_version": "2.10.7-r0",
                 "link": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-36159",
+                "status": "Vulnerable",
                 "metadata": {
                   "NVD": {
                     "CVSSv2": {
@@ -277,6 +280,7 @@ func mockVulnerabilityAssessment() *api.VulnContainerAssessment {
                 "description": "",
                 "fix_version": "1.1.24-r10",
                 "link": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-28928",
+                "status": "Vulnerable",
                 "metadata": {
                   "NVD": {
                     "CVSSv2": {

--- a/cli/cmd/vulnerabilty_exceptions.go
+++ b/cli/cmd/vulnerabilty_exceptions.go
@@ -32,6 +32,9 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const CveRegex = `(?i)CVE-\d{4}-\d{4,7}`
+const AlasRegex = `(?i)ALAS(2?)-\d{4}-\d{3,7}`
+
 var (
 	// vulnerability-exceptions command is used to manage lacework vulnerability exceptions
 	vulnerabilityExceptionCommand = &cobra.Command{
@@ -343,17 +346,18 @@ func transformVulnerabilityExceptionPackages(packages string) []api.Vulnerabilit
 
 func validateCveFormat() survey.Validator {
 	return func(val interface{}) error {
-		cveRegEx, _ := regexp.Compile(`(?i)CVE-\d{4}-\d{4,7}`)
+		cveRegEx, _ := regexp.Compile(CveRegex)
+		alasRegEx, _ := regexp.Compile(AlasRegex)
 		if list, ok := val.([]core.OptionAnswer); ok {
 			for _, i := range list {
-				if !cveRegEx.MatchString(i.Value) {
-					return fmt.Errorf("CVE format is invalid. Please format corretly eg: CVE-2014-0001")
+				if !cveRegEx.MatchString(i.Value) && !alasRegEx.MatchString(i.Value) {
+					return fmt.Errorf("CVE format is invalid. Please format corretly eg: CVE-2014-0001, ALAS2-2022-1788")
 				}
 			}
 		} else {
 			value := val.(string)
-			if !cveRegEx.MatchString(value) {
-				return fmt.Errorf("CVE format is invalid. Please format corretly eg: CVE-2014-0001")
+			if !cveRegEx.MatchString(value) && !alasRegEx.MatchString(value) {
+				return fmt.Errorf("CVE format is invalid. Please format corretly eg: CVE-2014-0001,  ALAS2-2022-1788")
 			}
 		}
 		return nil

--- a/integration/event_test.go
+++ b/integration/event_test.go
@@ -137,7 +137,7 @@ func TestEventCommandOpenError(t *testing.T) {
 		"EXITCODE is not the expected one")
 }
 
-func TestEventCommandListSeverityWithJsonFlag(t *testing.T) {
+func _TestEventCommandListSeverityWithJsonFlag(t *testing.T) {
 	out, err, exitcode := LaceworkCLIWithTOMLConfig("event", "list", "--severity", "high", "--json")
 	severities := []string{"\"severity\": 3", "\"severity\": 4", "\"severity\": 5"}
 	assert.Empty(t,

--- a/integration/event_test.go
+++ b/integration/event_test.go
@@ -137,7 +137,7 @@ func TestEventCommandOpenError(t *testing.T) {
 		"EXITCODE is not the expected one")
 }
 
-func _TestEventCommandListSeverityWithJsonFlag(t *testing.T) {
+func TestEventCommandListSeverityWithJsonFlag(t *testing.T) {
 	out, err, exitcode := LaceworkCLIWithTOMLConfig("event", "list", "--severity", "high", "--json")
 	severities := []string{"\"severity\": 3", "\"severity\": 4", "\"severity\": 5"}
 	assert.Empty(t,


### PR DESCRIPTION
Signed-off-by: Darren Murray <darren.murray@lacework.net>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/lacework/go-sdk) and create your branch from `main`
  2. Run `make prepare` in the repository root
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`make test`)
  5. Format your code (`make fmt`)
  6. Make sure your code lints (`make lint`)
  7. If you are updating the Lacework CLI, make sure it compiles (`make build-cli-cross-platform`)
  8. Follow the commit message standard (`type(scope): subject`) documented in [DEVELOPER_GUIDELINES.md](https://github.com/lacework/go-sdk/blob/main/DEVELOPER_GUIDELINES.md#commit-message-standard)
  9. If you haven't already, configure signed commits by [telling git about your signing key](https://docs.github.com/en/github/authenticating-to-github/managing-commit-signature-verification/telling-git-about-your-signing-key) and [signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)

  Learn more about contributing: https://github.com/lacework/go-sdk/blob/main/CONTRIBUTING.md
-->

## Summary
Add `Status` field to container scan assessment output.

Create a new vulnerability exception. Add the cve-id as a criteria
`lacework ve create`


![image](https://user-images.githubusercontent.com/75614232/177811574-81218f81-bda3-46d8-ac13-70f9fc386155.png)

Run a new container assessment.


![image](https://user-images.githubusercontent.com/75614232/177811618-2e5dc0cb-ab83-4ffa-a7f8-321d8d39b436.png)



<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## How did you test this change?
Run `lacework vulnerability container scan-status <scan-id>`

## Issue

https://lacework.atlassian.net/browse/ALLY-1038
