### PR TITLE
fix(cli): install.ps1 avoid Windows agent collision

### DIFF
--- a/cli/install.ps1
+++ b/cli/install.ps1
@@ -94,10 +94,9 @@ Function Assert-Shasum($archive) {
 
 Function Install-Lacework-CLI {
     $laceworkPath = Join-Path $env:ProgramData Lacework
-    if (Test-Path $laceworkPath) { Remove-Item $laceworkPath -Recurse -Force }
-    New-Item $laceworkPath -ItemType Directory | Out-Null
+    if (-not (Test-Path $laceworkPath)) { New-Item $laceworkPath -ItemType Directory | Out-Null }
     $exe = (Get-ChildItem (Join-Path ($workdir) "bin"))
-    Copy-Item "$($exe.FullName)" $laceworkPath
+    Copy-Item "$($exe.FullName)" $laceworkPath -Force
     $env:PATH = New-PathString -StartingPath $env:PATH -Path $laceworkPath
     $machinePath = [System.Environment]::GetEnvironmentVariable("PATH", "Machine")
     $machinePath = New-PathString -StartingPath $machinePath -Path $laceworkPath


### PR DESCRIPTION
## Summary

This change is fixing the problem where, if a Windows workstation has
our agent installed and the user tries to install the Lacework CLI, the
installation script fails with:
```
Cannot remove item C:/Program Data/Lacework/Logs/LWData_0.log because it
is being used.
```

The solution is updating the installation script to avoid removing the
entire directory and instead, forcing the installation of the Lacework
CLI.

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>

## How did you test this change?

I used our Vagrant Windows 10 box and tested the script locally, also users can point
directly to this script with the following commands:
```
Set-ExecutionPolicy Bypass -Scope Process -Force;
iex ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/lacework/go-sdk/0917a32a5380804883b4bdf6728addcb1e44341c/cli/install.ps1'))
```
### With This Fix
<img width="1509" alt="Screen Shot 2022-07-08 at 8 39 43 AM" src="https://user-images.githubusercontent.com/5712253/178025357-fe35df66-64f8-4e50-bf00-1ced05e7e805.png">

### Without The Fix
<img width="1515" alt="Screen Shot 2022-07-08 at 8 40 15 AM" src="https://user-images.githubusercontent.com/5712253/178025425-2510f4d2-b9ba-4d63-8ee3-e7795601c2ae.png">

## Issue

https://lacework.atlassian.net/browse/ALLY-1082
