### PR TITLE
fix(cli): use proper env var name LW_API_TOKEN

### DIFF
--- a/cli/cmd/cli_state.go
+++ b/cli/cmd/cli_state.go
@@ -423,7 +423,7 @@ func (c *cliState) envs() []string {
 		fmt.Sprintf("LW_SUBACCOUNT=%s", c.Subaccount),
 		fmt.Sprintf("LW_API_KEY=%s", c.KeyID),
 		fmt.Sprintf("LW_API_SECRET=%s", c.Secret),
-		fmt.Sprintf("LW_TOKEN=%s", c.Token),
+		fmt.Sprintf("LW_API_TOKEN=%s", c.Token),
 	}
 }
 


### PR DESCRIPTION
## Summary

All API settings are prefixed with `LW_API_{XYZ}`, the API token should follow that pattern.

## How did you test this change?

No need since this is not used just yet. 

## Issue

Contributes to https://lacework.atlassian.net/browse/ALLY-1083
