### PR TITLE
docs: fix path to examples in readme

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -57,4 +57,4 @@ func main() {
 }
 ```
 
-Look at the [examples/](examples/) folder for more examples.
+Look at the [_examples/](_examples/) folder for more examples.


### PR DESCRIPTION
## Summary
This will fix the api readme file to point to the right examples directory.

## How did you test this change?
verified the new path is the correct one

## Issue
haven't created one for this