### PR TITLE
feat(cli): colorize CDK commands

### DIFF
--- a/cli/cmd/cli_unix.go
+++ b/cli/cmd/cli_unix.go
@@ -24,6 +24,7 @@ import (
 	"os"
 
 	"github.com/AlecAivazis/survey/v2"
+	"github.com/fatih/color"
 )
 
 // used by configure.go
@@ -33,6 +34,12 @@ var configureListCmdSetProfileEnv = `export LW_PROFILE="my-profile"`
 var promptIconsFunc = func(icons *survey.IconSet) {
 	icons.Question.Text = "▸"
 }
+
+// A variety of colorized icons used throughout the code
+var (
+	successIcon = color.HiGreenString("✓")
+	failureIcon = color.HiRedString("✖") //nolint
+)
 
 // Env variables found in GCP, AWS and Azure cloudshell.
 // Used to determine if cli is running on cloudshell.

--- a/cli/cmd/cli_windows.go
+++ b/cli/cmd/cli_windows.go
@@ -22,6 +22,7 @@ import (
 	"os"
 
 	"github.com/AlecAivazis/survey/v2"
+	"github.com/fatih/color"
 )
 
 // used by configure.go
@@ -31,6 +32,12 @@ var configureListCmdSetProfileEnv = `$env:LW_PROFILE = 'my-profile'`
 var promptIconsFunc = func(icons *survey.IconSet) {
 	icons.Question.Text = ">"
 }
+
+// A variety of colorized icons used throughout the code
+var (
+	successIcon = color.HiGreenString("√")
+	failureIcon = color.HiRedString("×") //nolint
+)
 
 // UpdateCommand returns the command that a user should run to update the cli
 // to the latest available version (windows specific command)

--- a/cli/cmd/component.go
+++ b/cli/cmd/component.go
@@ -169,7 +169,9 @@ func (c *cliState) LoadComponents() {
 	}
 }
 func runComponentsList(_ *cobra.Command, _ []string) (err error) {
+	cli.StartProgress("Loading components state...")
 	cli.LwComponents, err = lwcomponent.LoadState(cli.LwApi)
+	cli.StopProgress()
 	if err != nil {
 		err = errors.Wrap(err, "unable to list components")
 		return
@@ -223,8 +225,10 @@ func componentsToTable() [][]string {
 }
 
 func runComponentsInstall(_ *cobra.Command, args []string) (err error) {
+	cli.StartProgress("Loading components state...")
 	// @afiune maybe move the state to the cache and fetch if it if has expired
 	cli.LwComponents, err = lwcomponent.LoadState(cli.LwApi)
+	cli.StopProgress()
 	if err != nil {
 		err = errors.Wrap(err, "unable to load components")
 		return
@@ -264,8 +268,10 @@ func runComponentsInstall(_ *cobra.Command, args []string) (err error) {
 }
 
 func runComponentsUpdate(_ *cobra.Command, args []string) (err error) {
+	cli.StartProgress("Loading components state...")
 	// @afiune maybe move the state to the cache and fetch if it if has expired
 	cli.LwComponents, err = lwcomponent.LoadState(cli.LwApi)
+	cli.StopProgress()
 	if err != nil {
 		err = errors.Wrap(err, "unable to load components")
 		return
@@ -327,9 +333,11 @@ func runComponentsUpdate(_ *cobra.Command, args []string) (err error) {
 }
 
 func runComponentsDelete(_ *cobra.Command, args []string) (err error) {
+	cli.StartProgress("Loading components state...")
 	// @afiune maybe move the state to the cache and fetch if it if has expired
 	// @afiune DO WE NEED THIS? It should already be loaded
 	cli.LwComponents, err = lwcomponent.LocalState()
+	cli.StopProgress()
 	if err != nil {
 		err = errors.Wrap(err, "unable to load components")
 		return

--- a/cli/cmd/component.go
+++ b/cli/cmd/component.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/fatih/color"
 	"github.com/olekukonko/tablewriter"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -201,8 +202,18 @@ func runComponentsList(_ *cobra.Command, _ []string) (err error) {
 func componentsToTable() [][]string {
 	out := [][]string{}
 	for _, cdata := range cli.LwComponents.Components {
+		var colorize *color.Color
+		switch cdata.Status() {
+		case lwcomponent.NotInstalled:
+			colorize = color.New(color.FgWhite, color.Bold)
+		case lwcomponent.Installed:
+			colorize = color.New(color.FgGreen, color.Bold)
+		case lwcomponent.UpdateAvailable:
+			colorize = color.New(color.FgYellow, color.Bold)
+		}
+
 		out = append(out, []string{
-			cdata.Status().String(),
+			colorize.Sprintf(cdata.Status().String()),
 			cdata.Name,
 			cdata.LatestVersion.String(),
 			cdata.Description,
@@ -232,9 +243,10 @@ func runComponentsInstall(_ *cobra.Command, args []string) (err error) {
 		err = errors.Wrap(err, "unable to install component")
 		return
 	}
+	cli.OutputChecklist(successIcon, "Component %s installed\n", color.HiYellowString(component.Name))
+	cli.OutputChecklist(successIcon, "Signature verified\n")
 
 	cli.StartProgress(fmt.Sprintf("Configuring component %s...", component.Name))
-
 	// component life cycle: initialize
 	stdout, stderr, errCmd := component.RunAndReturn([]string{"cdk-init"}, nil, cli.envs()...)
 	if errCmd != nil {
@@ -243,9 +255,11 @@ func runComponentsInstall(_ *cobra.Command, args []string) (err error) {
 	} else {
 		cli.Log.Infow("component life cycle", "stdout", stdout, "stderr", stderr)
 	}
-
 	cli.StopProgress()
-	cli.OutputHuman("The component %s was installed.\n", args[0])
+
+	cli.OutputChecklist(successIcon, "Component configured\n")
+	cli.OutputHuman("\nInstallation completed.\n")
+	// @afiune print breadcrumbs of what to do with this component
 	return
 }
 
@@ -275,6 +289,11 @@ func runComponentsUpdate(_ *cobra.Command, args []string) (err error) {
 		return nil
 	}
 
+	currentVersion, err := component.CurrentVersion()
+	if err != nil {
+		return err
+	}
+
 	cli.StartProgress(fmt.Sprintf("Updating component %s...", component.Name))
 	err = cli.LwComponents.Install(args[0])
 	cli.StopProgress()
@@ -282,8 +301,28 @@ func runComponentsUpdate(_ *cobra.Command, args []string) (err error) {
 		err = errors.Wrap(err, "unable to update component")
 		return
 	}
+	cli.OutputChecklist(successIcon, "Component %s updated to %s\n",
+		color.HiYellowString(component.Name),
+		color.HiCyanString(fmt.Sprintf("v%s", component.LatestVersion.String())))
+	cli.OutputChecklist(successIcon, "Signature verified\n")
 
-	cli.OutputHuman("The component %s was updated.\n", args[0])
+	cli.StartProgress(fmt.Sprintf("Reconfiguring %s component...", component.Name))
+	// component life cycle: reconfigure
+	stdout, stderr, errCmd := component.RunAndReturn(
+		[]string{"cdk-reconfigure", currentVersion.String(), component.LatestVersion.String()},
+		nil, cli.envs()...)
+	if errCmd != nil {
+		cli.Log.Warnw("component life cycle",
+			"error", errCmd.Error(), "stdout", stdout, "stderr", stderr)
+	} else {
+		cli.Log.Infow("component life cycle", "stdout", stdout, "stderr", stderr)
+	}
+	cli.StopProgress()
+
+	cli.OutputChecklist(successIcon, "Component reconfigured\n")
+	cli.OutputHuman("\nUpdate completed.\n")
+	// @afiune display update breadcrumbs
+	// maybe tell the user whats new on this version?
 	return
 }
 
@@ -310,6 +349,19 @@ func runComponentsDelete(_ *cobra.Command, args []string) (err error) {
 		return
 	}
 
+	cli.StartProgress("Cleaning component data...")
+	// component life cycle: remove
+	stdout, stderr, errCmd := component.RunAndReturn([]string{"cdk-remove"}, nil, cli.envs()...)
+	if errCmd != nil {
+		cli.Log.Warnw("component life cycle",
+			"error", errCmd.Error(), "stdout", stdout, "stderr", stderr)
+	} else {
+		cli.Log.Infow("component life cycle", "stdout", stdout, "stderr", stderr)
+	}
+	cli.StopProgress()
+
+	cli.OutputChecklist(successIcon, "Component data removed\n")
+
 	cli.StartProgress("Deleting component...")
 	defer cli.StopProgress()
 
@@ -326,6 +378,10 @@ func runComponentsDelete(_ *cobra.Command, args []string) (err error) {
 	}
 
 	cli.StopProgress()
-	cli.OutputHuman("The component %s was deleted.\n", args[0])
+
+	cli.OutputChecklist(successIcon, "Component %s deleted\n", color.HiYellowString(component.Name))
+	cli.OutputHuman("\n- We will do better next time.\n")
+	cli.OutputHuman("\nDo you want to provide feedback?\n")
+	cli.OutputHuman("Reach out to us at %s\n", color.HiCyanString("support@lacework.net"))
 	return
 }

--- a/cli/cmd/outputs.go
+++ b/cli/cmd/outputs.go
@@ -40,14 +40,20 @@ func (c *cliState) OutputJSON(v interface{}) error {
 	return nil
 }
 
+// OutputChecklist prints out a message with an icon formatted as a checklist,
+// note that all strings should come already colorized
+func (c *cliState) OutputChecklist(icon, message string, a ...interface{}) {
+	c.OutputHuman(fmt.Sprintf(" [%s] %s", icon, message), a...)
+}
+
 // OutputHuman will print out the provided message if the cli state is
 // configured to talk to humans, to switch to json format use --json
 func (c *cliState) OutputHuman(format string, a ...interface{}) {
 	if c.HumanOutput() {
 		if len(a) == 0 {
-			fmt.Fprint(os.Stdout, format)
+			fmt.Fprint(color.Output, format)
 		} else {
-			fmt.Fprintf(os.Stdout, format, a...)
+			fmt.Fprintf(color.Output, format, a...)
 		}
 	}
 }

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/fatih/color"
 	homedir "github.com/mitchellh/go-homedir"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -241,6 +242,8 @@ func initConfig() {
 	if viper.GetBool("nocolor") {
 		cli.Log.Info("turning off colors")
 		cli.JsonF.DisabledColor = true
+		color.NoColor = true
+		os.Setenv("NO_COLOR", "true")
 	}
 
 	if viper.GetBool("noninteractive") {


### PR DESCRIPTION
## Summary
This change is adding colors to the CDK commnads:

### `lacework component list`
![Screen Shot 2022-07-13 at 10 37 08 PM](https://user-images.githubusercontent.com/5712253/179016763-2d4bb693-511f-49fb-9b27-6124c6cb8727.png)

### `lacework component install`

<img width="1204" alt="Screen Shot 2022-07-13 at 10 36 14 PM" src="https://user-images.githubusercontent.com/5712253/179017043-0d7fd746-0d96-46ff-b7a5-19aa829c5095.png">

### `lacework component uninstall`
![Screen Shot 2022-07-14 at 8 21 27 AM](https://user-images.githubusercontent.com/5712253/179018263-44dd4eac-49fb-4aa7-8865-291b80e033f5.png)

### `lacework component update`

![Screen Shot 2022-07-14 at 8 23 52 AM](https://user-images.githubusercontent.com/5712253/179018561-89a4ffab-e57c-4708-9504-7c7fc086805b.png)

## How did you test this change?

Run all commands locally.

## Issue

https://lacework.atlassian.net/browse/ALLY-1088