### PR TITLE
fix: vulnerabilty_exception fixable parameter omit when unset

### DIFF
--- a/api/vulnerability_exceptions.go
+++ b/api/vulnerability_exceptions.go
@@ -446,7 +446,7 @@ type VulnerabilityExceptionPackage struct {
 	Version string
 }
 
-func (vc VulnerabilityExceptionCriteria) FixableEnabled()  *bool {
+func (vc VulnerabilityExceptionCriteria) FixableEnabled() *bool {
 	if vc.Fixable == nil {
 		return nil
 	}

--- a/api/vulnerability_exceptions.go
+++ b/api/vulnerability_exceptions.go
@@ -447,7 +447,7 @@ type VulnerabilityExceptionPackage struct {
 }
 
 func (vc VulnerabilityExceptionCriteria) FixableEnabled() *bool {
-	if vc.Fixable == nil || len(vc.Fixable) == 0{
+	if vc.Fixable == nil || len(vc.Fixable) == 0 {
 		return nil
 	}
 

--- a/api/vulnerability_exceptions.go
+++ b/api/vulnerability_exceptions.go
@@ -446,11 +446,17 @@ type VulnerabilityExceptionPackage struct {
 	Version string
 }
 
-func (vc VulnerabilityExceptionCriteria) FixableEnabled() bool {
-	if len(vc.Fixable) > 0 {
-		return vc.Fixable[0] == 1
+func (vc VulnerabilityExceptionCriteria) FixableEnabled()  *bool {
+	if vc.Fixable == nil {
+		return nil
 	}
-	return false
+
+	if len(vc.Fixable) > 0 {
+		truePtr := vc.Fixable[0] == 1
+		return &truePtr
+	}
+	falsePtr := false
+	return &falsePtr
 }
 
 func NewVulnerabilityExceptionPackages(packageMap []map[string]string) []VulnerabilityExceptionPackage {

--- a/api/vulnerability_exceptions.go
+++ b/api/vulnerability_exceptions.go
@@ -447,7 +447,7 @@ type VulnerabilityExceptionPackage struct {
 }
 
 func (vc VulnerabilityExceptionCriteria) FixableEnabled() *bool {
-	if vc.Fixable == nil {
+	if vc.Fixable == nil || len(vc.Fixable) == 0{
 		return nil
 	}
 

--- a/api/vulnerability_exceptions_test.go
+++ b/api/vulnerability_exceptions_test.go
@@ -316,6 +316,31 @@ func TestVulnerabilityExceptionUpdate(t *testing.T) {
 	}
 }
 
+func TestFixableEnabled(t *testing.T) {
+	tests := []struct {
+	 name string
+	 value []int
+	 expected *bool
+	}{
+		{"fixable is false", []int{0}, boolPtr(false)},
+		{"fixable is true", []int{1}, boolPtr(true)},
+		{"fixable is empty", []int{}, nil},
+		{"fixable is nil", nil, nil},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+		criteria := api.VulnerabilityExceptionCriteria{Fixable: test.value}
+		assert.Equal(t, criteria.FixableEnabled(), test.expected)
+		})
+	}
+}
+
+func boolPtr(b bool) *bool {
+    boolVar := b
+    return &boolVar
+}
+
 func generateVulnerabilityExceptions(guids []string) string {
 	vulnerabilityExceptions := make([]string, len(guids))
 	for i, guid := range guids {

--- a/api/vulnerability_exceptions_test.go
+++ b/api/vulnerability_exceptions_test.go
@@ -318,9 +318,9 @@ func TestVulnerabilityExceptionUpdate(t *testing.T) {
 
 func TestFixableEnabled(t *testing.T) {
 	tests := []struct {
-	 name string
-	 value []int
-	 expected *bool
+		name     string
+		value    []int
+		expected *bool
 	}{
 		{"fixable is false", []int{0}, boolPtr(false)},
 		{"fixable is true", []int{1}, boolPtr(true)},
@@ -330,15 +330,15 @@ func TestFixableEnabled(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-		criteria := api.VulnerabilityExceptionCriteria{Fixable: test.value}
-		assert.Equal(t, criteria.FixableEnabled(), test.expected)
+			criteria := api.VulnerabilityExceptionCriteria{Fixable: test.value}
+			assert.Equal(t, criteria.FixableEnabled(), test.expected)
 		})
 	}
 }
 
 func boolPtr(b bool) *bool {
-    boolVar := b
-    return &boolVar
+	boolVar := b
+	return &boolVar
 }
 
 func generateVulnerabilityExceptions(guids []string) string {


### PR DESCRIPTION
Signed-off-by: Darren Murray [darren.murray@lacework.net](mailto:darren.murray@lacework.net)

Issue:
https://lacework.atlassian.net/browse/ALLY-1085
Fixes https://github.com/lacework/terraform-provider-lacework/issues/339

Description:
Allow fixable to be nil value