### PR TITLE
docs(cli): updating help for query run

### DIFF
--- a/cli/cmd/lql.go
+++ b/cli/cmd/lql.go
@@ -103,20 +103,19 @@ Start and End times are required to run a query:
 
 1.  Start and End times must be specified in one of the following formats:
 
-    A. A relative time specifier  
-    B. RFC3339 Date and Time  
-    C. Epoch time in milliseconds  
+    A. A relative time specifier
+    B. RFC3339 Date and Time
+    C. Epoch time in milliseconds
 
 2. Start and End times must be specified in one of the following ways:
 
-    A. As StartTimeRange and EndTimeRange in the ParamInfo block within the query  
-    B. As start_time_range and end_time_range if specifying JSON  
-    C. As --start and --end CLI flags  
+    A. As StartTimeRange and EndTimeRange in the ParamInfo block within the query
+    B. As start_time_range and end_time_range if specifying JSON
+    C. As --start and --end CLI flags
 
 3. Start and End time precedence:
 
-    A. CLI flags take precedence over JSON specifications  
-    B. JSON specifications take precedence over ParamInfo specifications  `,
+    A. CLI flags take precedence over JSON specifications`,
 		Args: cobra.MaximumNArgs(1),
 		PreRunE: func(_ *cobra.Command, _ []string) error {
 			if queryCmdState.FailOnCount != "" {
@@ -181,7 +180,7 @@ func init() {
 	queryRunCmd.Flags().StringVarP(
 		&queryCmdState.FailOnCount,
 		"fail_on_count", "", "",
-		"fail if the results from a query match the provided expression",
+		"fail if the results from a query match the provided expression (e.g. '>0')",
 	)
 }
 

--- a/cli/docs/lacework_query_run.md
+++ b/cli/docs/lacework_query_run.md
@@ -22,20 +22,19 @@ Start and End times are required to run a query:
 
 1.  Start and End times must be specified in one of the following formats:
 
-    A. A relative time specifier  
-    B. RFC3339 Date and Time  
-    C. Epoch time in milliseconds  
+    A. A relative time specifier
+    B. RFC3339 Date and Time
+    C. Epoch time in milliseconds
 
 2. Start and End times must be specified in one of the following ways:
 
-    A. As StartTimeRange and EndTimeRange in the ParamInfo block within the query  
-    B. As start_time_range and end_time_range if specifying JSON  
-    C. As --start and --end CLI flags  
+    A. As StartTimeRange and EndTimeRange in the ParamInfo block within the query
+    B. As start_time_range and end_time_range if specifying JSON
+    C. As --start and --end CLI flags
 
 3. Start and End time precedence:
 
-    A. CLI flags take precedence over JSON specifications  
-    B. JSON specifications take precedence over ParamInfo specifications  
+    A. CLI flags take precedence over JSON specifications
 
 ```
 lacework query run [query_id] [flags]
@@ -45,7 +44,7 @@ lacework query run [query_id] [flags]
 
 ```
       --end string             end time for query (default "now")
-      --fail_on_count string   fail if the results from a query match the provided expression
+      --fail_on_count string   fail if the results from a query match the provided expression (e.g. '>0')
   -f, --file string            path to a query to run
   -h, --help                   help for run
       --range string           natural time range for query

--- a/integration/test_resources/help/query_run
+++ b/integration/test_resources/help/query_run
@@ -10,20 +10,19 @@ Start and End times are required to run a query:
 
 1.  Start and End times must be specified in one of the following formats:
 
-    A. A relative time specifier  
-    B. RFC3339 Date and Time  
-    C. Epoch time in milliseconds  
+    A. A relative time specifier 
+    B. RFC3339 Date and Time
+    C. Epoch time in milliseconds
 
 2. Start and End times must be specified in one of the following ways:
 
-    A. As StartTimeRange and EndTimeRange in the ParamInfo block within the query  
-    B. As start_time_range and end_time_range if specifying JSON  
-    C. As --start and --end CLI flags  
+    A. As StartTimeRange and EndTimeRange in the ParamInfo block within the query
+    B. As start_time_range and end_time_range if specifying JSON
+    C. As --start and --end CLI flags
 
 3. Start and End time precedence:
 
-    A. CLI flags take precedence over JSON specifications  
-    B. JSON specifications take precedence over ParamInfo specifications
+    A. CLI flags take precedence over JSON specifications
 
 Usage:
   lacework query run [query_id] [flags]
@@ -33,7 +32,7 @@ Aliases:
 
 Flags:
       --end string             end time for query (default "now")
-      --fail_on_count string   fail if the results from a query match the provided expression
+      --fail_on_count string   fail if the results from a query match the provided expression (e.g. '>0')
   -f, --file string            path to a query to run
   -h, --help                   help for run
       --range string           natural time range for query

--- a/integration/test_resources/help/query_run
+++ b/integration/test_resources/help/query_run
@@ -10,7 +10,7 @@ Start and End times are required to run a query:
 
 1.  Start and End times must be specified in one of the following formats:
 
-    A. A relative time specifier 
+    A. A relative time specifier
     B. RFC3339 Date and Time
     C. Epoch time in milliseconds
 


### PR DESCRIPTION
## Summary
Adding example for `--failon` flag

## How did you test this change?
Automated testing
Manual testing `lacework query run -h`

## Issue
https://lacework.atlassian.net/browse/ALLY-1093
