### PR TITLE
chore(lql): fully remove evaluatorId

### DIFF
--- a/api/lql.go
+++ b/api/lql.go
@@ -29,9 +29,8 @@ import (
 )
 
 type NewQuery struct {
-	QueryID     string `json:"queryId" yaml:"queryId"`
-	QueryText   string `json:"queryText" yaml:"queryText"`
-	EvaluatorID string `json:"evaluatorId,omitempty" yaml:"evaluatorId,omitempty"`
+	QueryID   string `json:"queryId" yaml:"queryId"`
+	QueryText string `json:"queryText" yaml:"queryText"`
 }
 
 func ParseNewQuery(s string) (NewQuery, error) {
@@ -61,7 +60,6 @@ type UpdateQuery struct {
 type Query struct {
 	QueryID        string                   `json:"queryId" yaml:"queryId"`
 	QueryText      string                   `json:"queryText" yaml:"queryText"`
-	EvaluatorID    string                   `json:"evaluatorId" yaml:"evaluatorId"`
 	Owner          string                   `json:"owner"`
 	LastUpdateTime string                   `json:"lastUpdateTime"`
 	LastUpdateUser string                   `json:"lastUpdateUser"`

--- a/api/lql_execute.go
+++ b/api/lql_execute.go
@@ -28,8 +28,7 @@ import (
 )
 
 type ExecuteQuery struct {
-	QueryText   string `json:"queryText"`
-	EvaluatorID string `json:"evaluatorId,omitempty"`
+	QueryText string `json:"queryText"`
 }
 
 type ExecuteQueryArgumentName string

--- a/api/lql_validate.go
+++ b/api/lql_validate.go
@@ -19,8 +19,7 @@
 package api
 
 type ValidateQuery struct {
-	QueryText   string `json:"queryText"`
-	EvaluatorID string `json:"evaluatorId,omitempty"`
+	QueryText string `json:"queryText"`
 }
 
 func (svc *QueryService) Validate(vq ValidateQuery) (

--- a/api/policy.go
+++ b/api/policy.go
@@ -46,7 +46,6 @@ func NewV2PolicyService(c *Client) *PolicyService {
 var ValidPolicySeverities = []string{"critical", "high", "medium", "low", "info"}
 
 type NewPolicy struct {
-	EvaluatorID   string   `json:"evaluatorId,omitempty" yaml:"evaluatorId,omitempty"`
 	PolicyID      string   `json:"policyId,omitempty" yaml:"policyId,omitempty" `
 	PolicyType    string   `json:"policyType" yaml:"policyType"`
 	QueryID       string   `json:"queryId" yaml:"queryId"`
@@ -98,7 +97,6 @@ This would prevent someone from toggling something to disabled or 0 respectively
 As such we are using pointers instead of primitives for booleans and integers in this struct
 */
 type UpdatePolicy struct {
-	EvaluatorID   string   `json:"evaluatorId,omitempty" yaml:"evaluatorId,omitempty"`
 	PolicyID      string   `json:"policyId,omitempty" yaml:"policyId,omitempty"`
 	PolicyType    string   `json:"policyType,omitempty" yaml:"policyType,omitempty"`
 	QueryID       string   `json:"queryId,omitempty" yaml:"queryId,omitempty"`
@@ -145,7 +143,6 @@ func ParseUpdatePolicy(s string) (UpdatePolicy, error) {
 }
 
 type Policy struct {
-	EvaluatorID    string   `json:"evaluatorId" yaml:"evaluatorId"`
 	PolicyID       string   `json:"policyId" yaml:"policyId"`
 	PolicyType     string   `json:"policyType" yaml:"-"`
 	QueryID        string   `json:"queryId" yaml:"queryId"`

--- a/cli/cmd/lql.go
+++ b/cli/cmd/lql.go
@@ -516,8 +516,7 @@ func runAdhocQuery(cmd *cobra.Command, args []api.ExecuteQueryArgument) (
 	// execute query
 	executeQuery := api.ExecuteQueryRequest{
 		Query: api.ExecuteQuery{
-			QueryText:   newQuery.QueryText,
-			EvaluatorID: newQuery.EvaluatorID,
+			QueryText: newQuery.QueryText,
 		},
 		Arguments: args,
 	}

--- a/cli/cmd/lql_update.go
+++ b/cli/cmd/lql_update.go
@@ -89,9 +89,8 @@ func updateQuery(cmd *cobra.Command, args []string) error {
 		}
 
 		queryYaml, err := yaml.Marshal(&api.NewQuery{
-			QueryID:     queryRes.Data.QueryID,
-			QueryText:   queryRes.Data.QueryText,
-			EvaluatorID: queryRes.Data.EvaluatorID,
+			QueryID:   queryRes.Data.QueryID,
+			QueryText: queryRes.Data.QueryText,
 		})
 		if err != nil {
 			return errors.Wrap(err, msg)

--- a/cli/cmd/lql_validate.go
+++ b/cli/cmd/lql_validate.go
@@ -89,8 +89,7 @@ func validateQuery(cmd *cobra.Command, args []string) error {
 
 func validateQueryAndOutput(nq api.NewQuery) error {
 	vq := api.ValidateQuery{
-		QueryText:   nq.QueryText,
-		EvaluatorID: nq.EvaluatorID,
+		QueryText: nq.QueryText,
 	}
 
 	cli.StartProgress(" Validating query...")


### PR DESCRIPTION
## Summary
We deprecated evaluatorId and now it should be fully removed

## How did you test this change?
Automated integration testing (still includes examples with and without evaluatorId)

## Issue
https://lacework.atlassian.net/browse/ALLY-1094