### PR TITLE
fix(install.ps1): modify User $Path correctly

### DIFF
--- a/cli/install.ps1
+++ b/cli/install.ps1
@@ -98,8 +98,6 @@ Function Install-Lacework-CLI {
     $exe = (Get-ChildItem (Join-Path ($workdir) "bin"))
     Copy-Item "$($exe.FullName)" $laceworkPath -Force
     $env:PATH = New-PathString -StartingPath $env:PATH -Path $laceworkPath
-    $machinePath = [System.Environment]::GetEnvironmentVariable("PATH", "Machine")
-    $machinePath = New-PathString -StartingPath $machinePath -Path $laceworkPath
 
     $isAdmin = $false
     try {
@@ -107,9 +105,13 @@ Function Install-Lacework-CLI {
         $isAdmin = $currentPrincipal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
     } finally {
         if ($isAdmin) {
+            $machinePath = [System.Environment]::GetEnvironmentVariable("PATH", "Machine")
+            $machinePath = New-PathString -StartingPath $machinePath -Path $laceworkPath
             [System.Environment]::SetEnvironmentVariable("PATH", $machinePath, "Machine")
         } else {
-            [System.Environment]::SetEnvironmentVariable("PATH", $machinePath, "User")
+            $userPath = [System.Environment]::GetEnvironmentVariable("PATH", "User")
+            $userPath = New-PathString -StartingPath $userPath -Path $laceworkPath
+            [System.Environment]::SetEnvironmentVariable("PATH", $userPath, "User")
         }
     }
 }


### PR DESCRIPTION
## Summary

When an non-admin Windows user would install the Lacework CLI, we were
modifying the User's $Path environment variable incorrectly. In fact, we
were overriding the entire $Path to be the System's $Path (at the Machine)

This change is fixing this issue by properly updating the Users' or
System wide $Path environment variable.

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>

## How did you test this change?

Used our local Windows dev environment.

To test this code run this code:
```powershell
Set-ExecutionPolicy Bypass -Scope Process -Force
iex ((New-Object System.Net.WebClient).DownloadString('https://github.com/lacework/go-sdk/raw/5d03ed7e05e99d6df09f81d214e03f9a46f71553/cli/install.ps1'))
```

## Issue

Jira:
- https://lacework.atlassian.net/browse/LINK-812
- https://lacework.atlassian.net/browse/ALLY-1103
