### PR TITLE
fix(api): detect FQDN as account in api.NewClient()

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -24,8 +24,10 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 	"time"
 
+	"github.com/lacework/go-sdk/lwdomain"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
 )
@@ -78,6 +80,15 @@ func (fn clientFunc) apply(c *Client) error {
 func NewClient(account string, opts ...Option) (*Client, error) {
 	if account == "" {
 		return nil, errors.New("account cannot be empty")
+	}
+
+	// verify if the user provided the full qualified domain name
+	if strings.Contains(account, ".lacework.net") {
+		domain, err := lwdomain.New(account)
+		if err != nil {
+			return nil, err
+		}
+		account = domain.Account
 	}
 
 	baseURL, err := url.Parse(fmt.Sprintf("https://%s.lacework.net", account))

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -34,6 +34,14 @@ func TestNewClient(t *testing.T) {
 	c, err := api.NewClient("test")
 	if assert.Nil(t, err) {
 		assert.Equal(t, "v1", c.ApiVersion(), "default API version should be v1")
+		assert.Equal(t, "https://test.lacework.net", c.URL(), "domain does not match")
+	}
+}
+
+func TestNewClientFullDomainURL(t *testing.T) {
+	c, err := api.NewClient("account.lacework.net")
+	if assert.Nil(t, err) {
+		assert.Equal(t, "https://account.lacework.net", c.URL(), "domain should be detected and correctly configured")
 	}
 }
 


### PR DESCRIPTION

## Summary

This change is fixing a problem where users of the Go SDK try to use the FQDN downloaded from
the Lacework console to create a new API client, we are now verifying and cleaning it up.

## How did you test this change?

Added unit tests.

## Issue

Closes https://github.com/lacework/go-sdk/issues/860
