### PR TITLE
feat(cdk): leave breadcrumbs after installation and update

### DIFF
--- a/cli/cmd/component.go
+++ b/cli/cmd/component.go
@@ -263,7 +263,11 @@ func runComponentsInstall(_ *cobra.Command, args []string) (err error) {
 
 	cli.OutputChecklist(successIcon, "Component configured\n")
 	cli.OutputHuman("\nInstallation completed.\n")
-	// @afiune print breadcrumbs of what to do with this component
+
+	if component.Breadcrumbs.InstallationMessage != "" {
+		cli.OutputHuman("\n")
+		cli.OutputHuman(component.Breadcrumbs.InstallationMessage)
+	}
 	return
 }
 
@@ -327,8 +331,11 @@ func runComponentsUpdate(_ *cobra.Command, args []string) (err error) {
 
 	cli.OutputChecklist(successIcon, "Component reconfigured\n")
 	cli.OutputHuman("\nUpdate completed.\n")
-	// @afiune display update breadcrumbs
-	// maybe tell the user whats new on this version?
+
+	if component.Breadcrumbs.UpdateMessage != "" {
+		cli.OutputHuman("\n")
+		cli.OutputHuman(component.Breadcrumbs.UpdateMessage)
+	}
 	return
 }
 

--- a/lwcomponent/component.go
+++ b/lwcomponent/component.go
@@ -211,12 +211,20 @@ type Artifact struct {
 	//Size ?
 }
 
+// Components should leave a trail/crumb after installation or update,
+// these messages will be shown by the Lacework CLI
+type Breadcrumbs struct {
+	InstallationMessage string `json:"installationMessage,omitempty"`
+	UpdateMessage       string `json:"updateMessage,omitempty"`
+}
+
 type Component struct {
 	Name          string         `json:"name"`
 	Description   string         `json:"description"`
 	Type          Type           `json:"type"`
 	LatestVersion semver.Version `json:"version"`
 	Artifacts     []Artifact     `json:"artifacts"`
+	Breadcrumbs   Breadcrumbs    `json:"breadcrumbs,omitempty"`
 
 	// @dhazekamp command_name required when CLICommand is true?
 	CommandName string `json:"command_name"`


### PR DESCRIPTION
# User Story
As a user of the Lacework CLI adopting the new Cloud Development Kit (CDK),
I want to know what are the things I can do after installing a new component and,
what things changed when I upgraded an existing component,
So that I can quickly start using the new component and know what things changed with a component upgrade.  

## Summary

Our CDK Components should leave a trail/crumb after installation or
update, these messages will be shown by the Lacework CLI, every
component owns the message that will be displayed.

## How did you test this change?
Updated the content-library and tested in QAN:

<img width="709" alt="Screen Shot 2022-08-01 at 11 10 54 AM" src="https://user-images.githubusercontent.com/5712253/182220500-125899b0-41fa-4c20-943c-81f4f4213cd6.png">

Example message for the inline vulnerability scanner:
<img width="493" alt="Screen Shot 2022-08-01 at 1 28 50 PM" src="https://user-images.githubusercontent.com/5712253/182241495-2a292ce2-debd-4878-b89a-0c89a6c64227.png">

When following the breadcrumbs:
<img width="380" alt="Screen Shot 2022-08-01 at 1 29 51 PM" src="https://user-images.githubusercontent.com/5712253/182241588-55a71885-1cf1-4a62-843a-eb3a945a895e.png">

## Issue

https://lacework.atlassian.net/browse/ALLY-1079

Relates to:
* https://github.com/lacework/rainbow/pull/9320
* https://github.com/lacework-dev/lacework-content/pull/720