### PR TITLE
fix(cdk): JSON output for 'component list' command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,7 @@ integration-only: install-tools ## Run integration tests
 		version \
 		generation \
 		team_members \
+		component \
 		vulnerability" -run=$(regex)
 
 .PHONY: integration-lql

--- a/cli/cmd/component.go
+++ b/cli/cmd/component.go
@@ -177,6 +177,10 @@ func runComponentsList(_ *cobra.Command, _ []string) (err error) {
 		return
 	}
 
+	if cli.JSONOutput() {
+		return cli.OutputJSON(cli.LwComponents)
+	}
+
 	if len(cli.LwComponents.Components) == 0 {
 		msg := "There are no components available, " +
 			"come back later or contact support. (version: %s)\n"

--- a/integration/component_test.go
+++ b/integration/component_test.go
@@ -1,0 +1,42 @@
+//go:build component
+
+// Author:: Salim Afiune Maya (<afiune@lacework.net>)
+// Copyright:: Copyright 2022, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+package integration
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestComponentList(t *testing.T) {
+	out, err, exitcode := LaceworkCLIWithTOMLConfig("component", "list")
+	assert.Empty(t, err.String(), "STDERR should be empty")
+	assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
+	assert.Contains(t, out.String(),
+		"There are no components available, come back later or contact support.",
+		"STDOUT changed, maybe there are now components in production?")
+}
+
+func TestComponentListJSON(t *testing.T) {
+	out, err, exitcode := LaceworkCLIWithTOMLConfig("component", "list", "--json")
+	assert.Empty(t, err.String(), "STDERR should be empty")
+	assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
+	assert.Contains(t, out.String(), "\"components\": []",
+		"JSON changed, maybe there are now components in production?")
+}


### PR DESCRIPTION
## Summary

The command `lacework component list` wasn't working with the `--json` flag. This change
fixes that problem and display proper JSON output.

## How did you test this change?

Added integration tests and checked on QAN.

## Issue

N/A