### PR TITLE
fix(lql): add line break when no preview found

### DIFF
--- a/cli/cmd/lql_preview.go
+++ b/cli/cmd/lql_preview.go
@@ -112,6 +112,6 @@ func previewQuerySource(_ *cobra.Command, args []string) error {
 		}
 		return cli.OutputJSON(response.Data[0])
 	}
-	cli.OutputHuman("No results found for datasource")
+	cli.OutputHuman("No results found for datasource\n")
 	return nil
 }


### PR DESCRIPTION

## Summary
Add newline to "No results found for datasource"

## How did you test this change?
Manually
Existing Integration

## Issue
https://lacework.atlassian.net/browse/ALLY-1122
