### PR TITLE
fix(lwupdater): avoid comparing dev versions

### DIFF
--- a/integration/framework_test.go
+++ b/integration/framework_test.go
@@ -155,6 +155,15 @@ func runLaceworkCLIFromCmd(cmd *exec.Cmd) (int, error) {
 	return 0, nil
 }
 
+func Version(t *testing.T) string {
+	repoVersion, err := ioutil.ReadFile("../VERSION")
+	if err != nil {
+		t.Logf("Unable to read VERSION file, error: '%s'", err.Error())
+		t.Fail()
+	}
+	return string(repoVersion)
+}
+
 func findLaceworkCLIBinary() string {
 	if bin := os.Getenv("LW_CLI_BIN"); bin != "" {
 		return bin

--- a/integration/version_test.go
+++ b/integration/version_test.go
@@ -24,6 +24,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
+	"strings"
 	"testing"
 	"time"
 
@@ -35,6 +36,10 @@ import (
 // To test the daily version check we need to set the environment
 // variable CI_TEST_LWUPDATER=1 so that the framework does not disable it
 func TestDailyVersionCheckEndToEnd(t *testing.T) {
+	if strings.Contains(Version(t), "-dev") {
+		t.Skip("skipping daily version check, running on dev version. (version contains '-dev')")
+	}
+
 	enableTestingUpdaterEnv()
 	defer disableTestingUpdaterEnv()
 
@@ -123,10 +128,9 @@ func TestVersionCommand(t *testing.T) {
 	out, errB, exitcode := LaceworkCLIWithTOMLConfig("version")
 	assert.Empty(t, errB.String())
 	assert.Equal(t, 0, exitcode)
-	assert.Contains(t, out.String(),
-		"A newer version of the Lacework CLI is available! The latest version is v",
-		"version update message should be displayed",
-	)
+	assert.Contains(t, out.String(), "lacework v")
+	assert.Contains(t, out.String(), "(sha:")
+	assert.Contains(t, out.String(), "(time:")
 }
 
 func TestDailyVersionCheckShouldNotRunWhenInNonInteractiveMode(t *testing.T) {

--- a/lwupdater/updater.go
+++ b/lwupdater/updater.go
@@ -26,6 +26,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -77,12 +78,17 @@ func Check(project, current string) (*Version, error) {
 		return new(Version), err
 	}
 
+	outdated := false
+	if !strings.Contains(current, "dev") && current != release.TagName {
+		outdated = true
+	}
+
 	return &Version{
 		Project:        project,
 		CurrentVersion: current,
 		LatestVersion:  release.TagName,
 		LastCheckTime:  time.Now(),
-		Outdated:       current != release.TagName,
+		Outdated:       outdated,
 	}, nil
 }
 

--- a/lwupdater/updater_test.go
+++ b/lwupdater/updater_test.go
@@ -51,6 +51,14 @@ func TestCheck(t *testing.T) {
 	}
 }
 
+func TestCheckSkipDevVersions(t *testing.T) {
+	info, err := lwupdater.Check("go-sdk", "1.30.9-dev")
+	if assert.Nil(t, err) {
+		assert.Equal(t, "1.30.9-dev", info.CurrentVersion)
+		assert.False(t, info.Outdated)
+	}
+}
+
 func TestCheckDisabled(t *testing.T) {
 	// disable the updater
 	os.Setenv(lwupdater.DisableEnv, "1")


### PR DESCRIPTION
## Summary

Every time we run `lacework version` with a development version of the CLI we get the out of date
message, this change is avoiding it by not checking the version if it contains `-dev`.

## How did you test this change?

Added tests, built the CLI locally and ran `lacework version`.
```
$ lacework version
lacework v0.39.1-dev (sha:7ac9e6cf43be68e603f79a105c8d29c5c01a50d1) (time:20220804163533)
```

## Issue

N/A
