### PR TITLE
ci: fix policy test

### DIFF
--- a/integration/policy_test.go
+++ b/integration/policy_test.go
@@ -361,7 +361,7 @@ func TestPolicyShow(t *testing.T) {
 	t.Run("YAML Output", func(t *testing.T) {
 		out, err, exitcode := LaceworkCLIWithTOMLConfig("policy", "show", "lacework-global-1", "--yaml")
 		assert.Contains(t, out.String(), `policyId: lacework-global-1`)
-		assert.Contains(t, out.String(), `remediation: |-`)
+		assert.Contains(t, out.String(), `remediation:`)
 		assert.Empty(t, err.String(), "STDERR should be empty")
 		assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
 	})


### PR DESCRIPTION

## Summary

Our nightly build failed. This fixes the following issue:
```
=== FAIL: integration TestPolicyShow/YAML_Output (0.48s)                                                                                                         
    policy_test.go:364:                                                                                                                                          
                Error Trace:    /codefresh/volume/go-sdk/integration/policy_test.go:364                                                                          
                Error:          "policyId: lacework-global-1\npolicyType: Violation\nqueryId: LW_Global_AWS_CTA_VPCChange\ntitle: VPC Change\nenabled: true\ndesc
ription: A VPC was created, deleted or changed\nremediation: Check that the VPC change was expected. Ensure only specified users can\n  modify VPCs.\nseverity: m
edium\nlimit: 1000\nevalFrequency: Hourly\nalertEnabled: true\nalertProfile: LW_CloudTrail_Alerts.VPCChange_AwsResource\ntags:\n- domain:AWS\n- subdomain:Cloudtr
ail\n" does not contain "remediation: |-"                                                                                                                        
                Test:           TestPolicyShow/YAML_Output                                                                                                       
    --- FAIL: TestPolicyShow/YAML_Output (0.48s)     
```

## How did you test this change?

CI should pass.

## Issue

N/A
