### PR TITLE
Ally 1161 cli subdomain capture

### DIFF
--- a/cli/cmd/configure.go
+++ b/cli/cmd/configure.go
@@ -223,10 +223,10 @@ func runConfigureSetup() error {
 			newProfile.Subaccount = subaccount
 		}
 		cli.OutputHuman("\n")
-	}
-
-	if err := newProfile.Verify(); err != nil {
-		return errors.Wrap(err, "unable to configure the command-line")
+	} else {
+		if err := newProfile.Verify(); err != nil {
+			return errors.Wrap(err, "unable to configure the command-line")
+		}
 	}
 
 	if err := lwconfig.StoreProfileAt(viper.ConfigFileUsed(), cli.Profile, newProfile); err != nil {
@@ -373,13 +373,8 @@ func loadUIJsonFile(file string) error {
 	cli.KeyID = auth.KeyID
 	cli.Secret = auth.Secret
 	cli.Subaccount = strings.ToLower(auth.SubAccount)
-
 	if auth.Account != "" {
-		d, err := lwdomain.New(auth.Account)
-		if err != nil {
-			return err
-		}
-		cli.Account = d.String()
+		cli.Account = auth.Account
 	}
 
 	return nil

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -161,7 +161,7 @@ func init() {
 		"access token (replaces the use of api_key and api_secret)",
 	)
 	rootCmd.PersistentFlags().StringP("account", "a", "",
-		"account subdomain of URL (i.e. <ACCOUNT>.lacework.net)",
+		"account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)",
 	)
 	rootCmd.PersistentFlags().String("subaccount", "",
 		"sub-account name inside your organization (org admins only)",

--- a/cli/docs/lacework.md
+++ b/cli/docs/lacework.md
@@ -23,7 +23,7 @@ This will prompt you for your Lacework account and a set of API access keys.
 ### Options
 
 ```
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/cli/docs/lacework_access-token.md
+++ b/cli/docs/lacework_access-token.md
@@ -27,7 +27,7 @@ lacework access-token [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/cli/docs/lacework_account.md
+++ b/cli/docs/lacework_account.md
@@ -31,7 +31,7 @@ To enroll your Lacework account in an organization follow the documentation:
 ### Options inherited from parent commands
 
 ```
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/cli/docs/lacework_account_list.md
+++ b/cli/docs/lacework_account_list.md
@@ -25,7 +25,7 @@ lacework account list [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/cli/docs/lacework_agent.md
+++ b/cli/docs/lacework_agent.md
@@ -29,7 +29,7 @@ For a complete list of supported operating systems, visit:
 ### Options inherited from parent commands
 
 ```
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/cli/docs/lacework_agent_install.md
+++ b/cli/docs/lacework_agent_install.md
@@ -59,7 +59,7 @@ lacework agent install <[user@]host[:port]> [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/cli/docs/lacework_agent_token.md
+++ b/cli/docs/lacework_agent_token.md
@@ -26,7 +26,7 @@ complete, the old token can safely be disabled without interrupting Lacework ser
 ### Options inherited from parent commands
 
 ```
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/cli/docs/lacework_agent_token_create.md
+++ b/cli/docs/lacework_agent_token_create.md
@@ -21,7 +21,7 @@ lacework agent token create <name> [description] [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/cli/docs/lacework_agent_token_list.md
+++ b/cli/docs/lacework_agent_token_list.md
@@ -21,7 +21,7 @@ lacework agent token list [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/cli/docs/lacework_agent_token_show.md
+++ b/cli/docs/lacework_agent_token_show.md
@@ -21,7 +21,7 @@ lacework agent token show <token> [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/cli/docs/lacework_agent_token_update.md
+++ b/cli/docs/lacework_agent_token_update.md
@@ -41,7 +41,7 @@ lacework agent token update <token> [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/cli/docs/lacework_alert-rule.md
+++ b/cli/docs/lacework_alert-rule.md
@@ -28,7 +28,7 @@ An alert rule has three parts:
 ### Options inherited from parent commands
 
 ```
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/cli/docs/lacework_alert-rule_create.md
+++ b/cli/docs/lacework_alert-rule_create.md
@@ -21,7 +21,7 @@ lacework alert-rule create [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/cli/docs/lacework_alert-rule_delete.md
+++ b/cli/docs/lacework_alert-rule_delete.md
@@ -25,7 +25,7 @@ lacework alert-rule delete <alert_rule_id> [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/cli/docs/lacework_alert-rule_list.md
+++ b/cli/docs/lacework_alert-rule_list.md
@@ -25,7 +25,7 @@ lacework alert-rule list [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/cli/docs/lacework_alert-rule_show.md
+++ b/cli/docs/lacework_alert-rule_show.md
@@ -25,7 +25,7 @@ lacework alert-rule show <alert_rule_id> [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/cli/docs/lacework_api.md
+++ b/cli/docs/lacework_api.md
@@ -47,7 +47,7 @@ lacework api <method> <path> [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/cli/docs/lacework_cloud-account.md
+++ b/cli/docs/lacework_cloud-account.md
@@ -21,7 +21,7 @@ Manage cloud account integrations with Lacework
 ### Options inherited from parent commands
 
 ```
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/cli/docs/lacework_cloud-account_list.md
+++ b/cli/docs/lacework_cloud-account_list.md
@@ -22,7 +22,7 @@ lacework cloud-account list [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/cli/docs/lacework_compliance.md
+++ b/cli/docs/lacework_compliance.md
@@ -40,7 +40,7 @@ Use the following command to list all available integrations in your account:
 ### Options inherited from parent commands
 
 ```
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/cli/docs/lacework_compliance_aws.md
+++ b/cli/docs/lacework_compliance_aws.md
@@ -36,7 +36,7 @@ To run an ad-hoc compliance assessment:
 ### Options inherited from parent commands
 
 ```
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/cli/docs/lacework_compliance_aws_get-report.md
+++ b/cli/docs/lacework_compliance_aws_get-report.md
@@ -48,7 +48,7 @@ lacework compliance aws get-report <account_id> [recommendation_id] [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/cli/docs/lacework_compliance_aws_list-accounts.md
+++ b/cli/docs/lacework_compliance_aws_list-accounts.md
@@ -25,7 +25,7 @@ lacework compliance aws list-accounts [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/cli/docs/lacework_compliance_aws_run-assessment.md
+++ b/cli/docs/lacework_compliance_aws_run-assessment.md
@@ -25,7 +25,7 @@ lacework compliance aws run-assessment <account_id> [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/cli/docs/lacework_compliance_azure.md
+++ b/cli/docs/lacework_compliance_azure.md
@@ -40,7 +40,7 @@ To run an ad-hoc compliance assessment use the command:
 ### Options inherited from parent commands
 
 ```
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/cli/docs/lacework_compliance_azure_get-report.md
+++ b/cli/docs/lacework_compliance_azure_get-report.md
@@ -47,7 +47,7 @@ lacework compliance azure get-report <tenant_id> <subscriptions_id> [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/cli/docs/lacework_compliance_azure_list-subscriptions.md
+++ b/cli/docs/lacework_compliance_azure_list-subscriptions.md
@@ -29,7 +29,7 @@ lacework compliance azure list-subscriptions <tenant_id> [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/cli/docs/lacework_compliance_azure_list-tenants.md
+++ b/cli/docs/lacework_compliance_azure_list-tenants.md
@@ -25,7 +25,7 @@ lacework compliance azure list-tenants [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/cli/docs/lacework_compliance_azure_run-assessment.md
+++ b/cli/docs/lacework_compliance_azure_run-assessment.md
@@ -29,7 +29,7 @@ lacework compliance azure run-assessment <tenant_id> [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/cli/docs/lacework_compliance_google.md
+++ b/cli/docs/lacework_compliance_google.md
@@ -40,7 +40,7 @@ To run an ad-hoc compliance assessment use the command:
 ### Options inherited from parent commands
 
 ```
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/cli/docs/lacework_compliance_google_get-report.md
+++ b/cli/docs/lacework_compliance_google_get-report.md
@@ -47,7 +47,7 @@ lacework compliance google get-report <organization_id> <project_id> [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/cli/docs/lacework_compliance_google_list-projects.md
+++ b/cli/docs/lacework_compliance_google_list-projects.md
@@ -34,7 +34,7 @@ lacework compliance google list-projects <organization_id> [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/cli/docs/lacework_compliance_google_list.md
+++ b/cli/docs/lacework_compliance_google_list.md
@@ -25,7 +25,7 @@ lacework compliance google list [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/cli/docs/lacework_compliance_google_run-assessment.md
+++ b/cli/docs/lacework_compliance_google_run-assessment.md
@@ -29,7 +29,7 @@ lacework compliance google run-assessment <org_or_project_id> [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/cli/docs/lacework_configure.md
+++ b/cli/docs/lacework_configure.md
@@ -43,7 +43,7 @@ lacework configure [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/cli/docs/lacework_configure_get.md
+++ b/cli/docs/lacework_configure_get.md
@@ -20,7 +20,7 @@ lacework configure get [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --debug               turn on debug logging

--- a/cli/docs/lacework_configure_list.md
+++ b/cli/docs/lacework_configure_list.md
@@ -29,7 +29,7 @@ lacework configure list [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/cli/docs/lacework_configure_show.md
+++ b/cli/docs/lacework_configure_show.md
@@ -39,7 +39,7 @@ lacework configure show <config_key> [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/cli/docs/lacework_event.md
+++ b/cli/docs/lacework_event.md
@@ -21,7 +21,7 @@ Inspect events reported by the Lacework platform
 ### Options inherited from parent commands
 
 ```
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/cli/docs/lacework_event_list.md
+++ b/cli/docs/lacework_event_list.md
@@ -38,7 +38,7 @@ lacework event list [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/cli/docs/lacework_event_open.md
+++ b/cli/docs/lacework_event_open.md
@@ -25,7 +25,7 @@ lacework event open <event_id> [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/cli/docs/lacework_event_show.md
+++ b/cli/docs/lacework_event_show.md
@@ -25,7 +25,7 @@ lacework event show <event_id> [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/cli/docs/lacework_integration.md
+++ b/cli/docs/lacework_integration.md
@@ -21,7 +21,7 @@ Manage external integrations with the Lacework platform
 ### Options inherited from parent commands
 
 ```
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/cli/docs/lacework_integration_create.md
+++ b/cli/docs/lacework_integration_create.md
@@ -25,7 +25,7 @@ lacework integration create [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/cli/docs/lacework_integration_delete.md
+++ b/cli/docs/lacework_integration_delete.md
@@ -27,7 +27,7 @@ lacework integration delete <int_guid> [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/cli/docs/lacework_integration_list.md
+++ b/cli/docs/lacework_integration_list.md
@@ -22,7 +22,7 @@ lacework integration list [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/cli/docs/lacework_integration_show.md
+++ b/cli/docs/lacework_integration_show.md
@@ -21,7 +21,7 @@ lacework integration show <int_guid> [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/cli/docs/lacework_policy.md
+++ b/cli/docs/lacework_policy.md
@@ -50,7 +50,7 @@ To view the LQL query associated with the policy, use the query ID.
 ### Options inherited from parent commands
 
 ```
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/cli/docs/lacework_policy_create.md
+++ b/cli/docs/lacework_policy_create.md
@@ -44,7 +44,7 @@ lacework policy create [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/cli/docs/lacework_policy_delete.md
+++ b/cli/docs/lacework_policy_delete.md
@@ -29,7 +29,7 @@ lacework policy delete <policy_id> [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/cli/docs/lacework_policy_list.md
+++ b/cli/docs/lacework_policy_list.md
@@ -29,7 +29,7 @@ lacework policy list [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/cli/docs/lacework_policy_show.md
+++ b/cli/docs/lacework_policy_show.md
@@ -26,7 +26,7 @@ lacework policy show <policy_id> [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/cli/docs/lacework_policy_update.md
+++ b/cli/docs/lacework_policy_update.md
@@ -45,7 +45,7 @@ lacework policy update [policy_id] [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/cli/docs/lacework_query.md
+++ b/cli/docs/lacework_query.md
@@ -46,7 +46,7 @@ To execute a query.
 ### Options inherited from parent commands
 
 ```
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/cli/docs/lacework_query_create.md
+++ b/cli/docs/lacework_query_create.md
@@ -99,7 +99,7 @@ lacework query create [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/cli/docs/lacework_query_delete.md
+++ b/cli/docs/lacework_query_delete.md
@@ -28,7 +28,7 @@ lacework query delete <query_id> [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/cli/docs/lacework_query_list-sources.md
+++ b/cli/docs/lacework_query_list-sources.md
@@ -25,7 +25,7 @@ lacework query list-sources [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/cli/docs/lacework_query_list.md
+++ b/cli/docs/lacework_query_list.md
@@ -25,7 +25,7 @@ lacework query list [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/cli/docs/lacework_query_run.md
+++ b/cli/docs/lacework_query_run.md
@@ -57,7 +57,7 @@ lacework query run [query_id] [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/cli/docs/lacework_query_show-source.md
+++ b/cli/docs/lacework_query_show-source.md
@@ -25,7 +25,7 @@ lacework query show-source <datasource_id> [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/cli/docs/lacework_query_show.md
+++ b/cli/docs/lacework_query_show.md
@@ -26,7 +26,7 @@ lacework query show <query_id> [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/cli/docs/lacework_query_update.md
+++ b/cli/docs/lacework_query_update.md
@@ -43,7 +43,7 @@ lacework query update [query_id] [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/cli/docs/lacework_query_validate.md
+++ b/cli/docs/lacework_query_validate.md
@@ -43,7 +43,7 @@ lacework query validate [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/cli/docs/lacework_resource-group.md
+++ b/cli/docs/lacework_resource-group.md
@@ -21,7 +21,7 @@ Manage Lacework-identifiable assets via the use of resource groups.
 ### Options inherited from parent commands
 
 ```
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/cli/docs/lacework_resource-group_create.md
+++ b/cli/docs/lacework_resource-group_create.md
@@ -25,7 +25,7 @@ lacework resource-group create [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/cli/docs/lacework_resource-group_delete.md
+++ b/cli/docs/lacework_resource-group_delete.md
@@ -25,7 +25,7 @@ lacework resource-group delete <resource_group_id> [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/cli/docs/lacework_resource-group_list.md
+++ b/cli/docs/lacework_resource-group_list.md
@@ -25,7 +25,7 @@ lacework resource-group list [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/cli/docs/lacework_resource-group_show.md
+++ b/cli/docs/lacework_resource-group_show.md
@@ -25,7 +25,7 @@ lacework resource-group show <resource_group_id> [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/cli/docs/lacework_version.md
+++ b/cli/docs/lacework_version.md
@@ -29,7 +29,7 @@ lacework version [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/cli/docs/lacework_vulnerability.md
+++ b/cli/docs/lacework_vulnerability.md
@@ -21,7 +21,7 @@ Container and host vulnerability assessments.
 ### Options inherited from parent commands
 
 ```
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/cli/docs/lacework_vulnerability_container.md
+++ b/cli/docs/lacework_vulnerability_container.md
@@ -36,7 +36,7 @@ Then navigate to Settings > Integrations > Container Registry.
 ### Options inherited from parent commands
 
 ```
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/cli/docs/lacework_vulnerability_container_list-assessments.md
+++ b/cli/docs/lacework_vulnerability_container_list-assessments.md
@@ -35,7 +35,7 @@ lacework vulnerability container list-assessments [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/cli/docs/lacework_vulnerability_container_list-registries.md
+++ b/cli/docs/lacework_vulnerability_container_list-registries.md
@@ -25,7 +25,7 @@ lacework vulnerability container list-registries [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/cli/docs/lacework_vulnerability_container_scan-status.md
+++ b/cli/docs/lacework_vulnerability_container_scan-status.md
@@ -33,7 +33,7 @@ lacework vulnerability container scan-status <request_id> [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/cli/docs/lacework_vulnerability_container_scan.md
+++ b/cli/docs/lacework_vulnerability_container_scan.md
@@ -45,7 +45,7 @@ lacework vulnerability container scan <registry> <repository> <tag|digest> [flag
 ### Options inherited from parent commands
 
 ```
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/cli/docs/lacework_vulnerability_container_show-assessment.md
+++ b/cli/docs/lacework_vulnerability_container_show-assessment.md
@@ -45,7 +45,7 @@ lacework vulnerability container show-assessment <sha256:hash> [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/cli/docs/lacework_vulnerability_host.md
+++ b/cli/docs/lacework_vulnerability_host.md
@@ -23,7 +23,7 @@ from hosts with the Lacework datacollector agent installed.
 ### Options inherited from parent commands
 
 ```
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/cli/docs/lacework_vulnerability_host_generate-pkg-manifest.md
+++ b/cli/docs/lacework_vulnerability_host_generate-pkg-manifest.md
@@ -31,7 +31,7 @@ lacework vulnerability host generate-pkg-manifest [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/cli/docs/lacework_vulnerability_host_list-cves.md
+++ b/cli/docs/lacework_vulnerability_host_list-cves.md
@@ -35,7 +35,7 @@ lacework vulnerability host list-cves [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/cli/docs/lacework_vulnerability_host_list-hosts.md
+++ b/cli/docs/lacework_vulnerability_host_list-hosts.md
@@ -32,7 +32,7 @@ lacework vulnerability host list-hosts <cve_id> [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/cli/docs/lacework_vulnerability_host_scan-pkg-manifest.md
+++ b/cli/docs/lacework_vulnerability_host_scan-pkg-manifest.md
@@ -54,7 +54,7 @@ lacework vulnerability host scan-pkg-manifest <manifest> [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/cli/docs/lacework_vulnerability_host_show-assessment.md
+++ b/cli/docs/lacework_vulnerability_host_show-assessment.md
@@ -41,7 +41,7 @@ lacework vulnerability host show-assessment <machine_id> [flags]
 ### Options inherited from parent commands
 
 ```
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/access-token
+++ b/integration/test_resources/help/access-token
@@ -9,7 +9,7 @@ Flags:
   -h, --help                   help for access-token
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/account
+++ b/integration/test_resources/help/account
@@ -22,7 +22,7 @@ Flags:
   -h, --help   help for account
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/account_list
+++ b/integration/test_resources/help/account_list
@@ -10,7 +10,7 @@ Flags:
   -h, --help   help for list
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/agent
+++ b/integration/test_resources/help/agent
@@ -20,7 +20,7 @@ Flags:
   -h, --help   help for agent
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/agent_install
+++ b/integration/test_resources/help/agent_install
@@ -41,7 +41,7 @@ Flags:
       --trust_host_key         automatically add host keys to the ~/.ssh/known_hosts file
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/agent_list
+++ b/integration/test_resources/help/agent_list
@@ -62,7 +62,7 @@ Flags:
   -h, --help             help for list
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/agent_token
+++ b/integration/test_resources/help/agent_token
@@ -21,7 +21,7 @@ Flags:
   -h, --help   help for token
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/agent_token_create
+++ b/integration/test_resources/help/agent_token_create
@@ -7,7 +7,7 @@ Flags:
   -h, --help   help for create
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/agent_token_list
+++ b/integration/test_resources/help/agent_token_list
@@ -10,7 +10,7 @@ Flags:
   -h, --help   help for list
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/agent_token_show
+++ b/integration/test_resources/help/agent_token_show
@@ -7,7 +7,7 @@ Flags:
   -h, --help   help for show
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/agent_token_update
+++ b/integration/test_resources/help/agent_token_update
@@ -23,7 +23,7 @@ Flags:
       --name string          new agent access token name
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/alert-profile
+++ b/integration/test_resources/help/alert-profile
@@ -20,7 +20,7 @@ Flags:
   -h, --help   help for alert-profile
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/alert-profile_create
+++ b/integration/test_resources/help/alert-profile_create
@@ -7,7 +7,7 @@ Flags:
   -h, --help   help for create
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/alert-profile_delete
+++ b/integration/test_resources/help/alert-profile_delete
@@ -7,7 +7,7 @@ Flags:
   -h, --help   help for delete
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/alert-profile_list
+++ b/integration/test_resources/help/alert-profile_list
@@ -10,7 +10,7 @@ Flags:
   -h, --help   help for list
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/alert-profile_show
+++ b/integration/test_resources/help/alert-profile_show
@@ -10,7 +10,7 @@ Flags:
   -h, --help   help for show
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/alert-profile_update
+++ b/integration/test_resources/help/alert-profile_update
@@ -7,7 +7,7 @@ Flags:
   -h, --help   help for update
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/alert-rule
+++ b/integration/test_resources/help/alert-rule
@@ -22,7 +22,7 @@ Flags:
   -h, --help   help for alert-rule
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/alert-rule_create
+++ b/integration/test_resources/help/alert-rule_create
@@ -7,7 +7,7 @@ Flags:
   -h, --help   help for create
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/alert-rule_delete
+++ b/integration/test_resources/help/alert-rule_delete
@@ -7,7 +7,7 @@ Flags:
   -h, --help   help for delete
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/alert-rule_list
+++ b/integration/test_resources/help/alert-rule_list
@@ -10,7 +10,7 @@ Flags:
   -h, --help   help for list
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/alert-rule_show
+++ b/integration/test_resources/help/alert-rule_show
@@ -7,7 +7,7 @@ Flags:
   -h, --help   help for show
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/api
+++ b/integration/test_resources/help/api
@@ -28,7 +28,7 @@ Flags:
   -h, --help          help for api
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/cloud-account
+++ b/integration/test_resources/help/cloud-account
@@ -14,7 +14,7 @@ Flags:
   -h, --help   help for cloud-account
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/cloud-account_iac-generate
+++ b/integration/test_resources/help/cloud-account_iac-generate
@@ -15,7 +15,7 @@ Flags:
   -h, --help   help for iac-generate
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/cloud-account_iac-generate_aws
+++ b/integration/test_resources/help/cloud-account_iac-generate_aws
@@ -47,7 +47,7 @@ Flags:
       --sqs_queue_name string                 specify SQS queue name if creating new one
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/cloud-account_iac-generate_azure
+++ b/integration/test_resources/help/cloud-account_iac-generate_azure
@@ -39,7 +39,7 @@ Flags:
       --terraform-apply                        run terraform apply for the generated hcl
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/cloud-account_iac-generate_gcp
+++ b/integration/test_resources/help/cloud-account_iac-generate_gcp
@@ -43,7 +43,7 @@ Flags:
       --service_account_credentials string            specify service account credentials JSON file path (leave blank to make use of google credential ENV vars)
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/cloud-account_list
+++ b/integration/test_resources/help/cloud-account_list
@@ -8,7 +8,7 @@ Flags:
   -t, --type string   list all cloud accounts of a specific type
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/completion
+++ b/integration/test_resources/help/completion
@@ -14,7 +14,7 @@ Flags:
   -h, --help   help for completion
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/completion_bash
+++ b/integration/test_resources/help/completion_bash
@@ -27,7 +27,7 @@ Flags:
       --no-descriptions   disable completion descriptions
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/completion_fish
+++ b/integration/test_resources/help/completion_fish
@@ -18,7 +18,7 @@ Flags:
       --no-descriptions   disable completion descriptions
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/completion_powershell
+++ b/integration/test_resources/help/completion_powershell
@@ -15,7 +15,7 @@ Flags:
       --no-descriptions   disable completion descriptions
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/completion_zsh
+++ b/integration/test_resources/help/completion_zsh
@@ -25,7 +25,7 @@ Flags:
       --no-descriptions   disable completion descriptions
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/compliance
+++ b/integration/test_resources/help/compliance
@@ -33,7 +33,7 @@ Flags:
   -h, --help   help for compliance
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/compliance_aws
+++ b/integration/test_resources/help/compliance_aws
@@ -26,7 +26,7 @@ Flags:
   -h, --help   help for aws
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/compliance_aws_get-report
+++ b/integration/test_resources/help/compliance_aws_get-report
@@ -32,7 +32,7 @@ Flags:
       --type string        report type to display, supported types: CIS, NIST_800-53_Rev4, NIST_800-171_Rev2, ISO_2700, HIPAA, SOC, SOC_Rev2, or PCI (default "CIS")
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/compliance_aws_list-accounts
+++ b/integration/test_resources/help/compliance_aws_list-accounts
@@ -10,7 +10,7 @@ Flags:
   -h, --help   help for list-accounts
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/compliance_aws_run-assessment
+++ b/integration/test_resources/help/compliance_aws_run-assessment
@@ -10,7 +10,7 @@ Flags:
   -h, --help   help for run-assessment
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/compliance_azure
+++ b/integration/test_resources/help/compliance_azure
@@ -34,7 +34,7 @@ Flags:
   -h, --help   help for azure
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/compliance_azure_get-report
+++ b/integration/test_resources/help/compliance_azure_get-report
@@ -31,7 +31,7 @@ Flags:
       --type string        report type to display, supported types: CIS, SOC, or PCI (default "CIS")
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/compliance_azure_list
+++ b/integration/test_resources/help/compliance_azure_list
@@ -10,7 +10,7 @@ Flags:
   -h, --help   help for list
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/compliance_azure_list-subscriptions
+++ b/integration/test_resources/help/compliance_azure_list-subscriptions
@@ -14,7 +14,7 @@ Flags:
   -h, --help   help for list-subscriptions
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/compliance_azure_run-assessment
+++ b/integration/test_resources/help/compliance_azure_run-assessment
@@ -14,7 +14,7 @@ Flags:
   -h, --help   help for run-assessment
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/compliance_google
+++ b/integration/test_resources/help/compliance_google
@@ -34,7 +34,7 @@ Flags:
   -h, --help   help for google
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/compliance_google_get-report
+++ b/integration/test_resources/help/compliance_google_get-report
@@ -31,7 +31,7 @@ Flags:
       --type string        report type to display, supported types: CIS, CIS12, K8S, HIPAA, SOC, or PCI (default "CIS")
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/compliance_google_list
+++ b/integration/test_resources/help/compliance_google_list
@@ -10,7 +10,7 @@ Flags:
   -h, --help   help for list
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/compliance_google_list-projects
+++ b/integration/test_resources/help/compliance_google_list-projects
@@ -18,7 +18,7 @@ Flags:
   -h, --help   help for list-projects
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/compliance_google_run-assessment
+++ b/integration/test_resources/help/compliance_google_run-assessment
@@ -14,7 +14,7 @@ Flags:
   -h, --help   help for run-assessment
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/component
+++ b/integration/test_resources/help/component
@@ -16,7 +16,7 @@ Flags:
   -h, --help   help for component
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/component_install
+++ b/integration/test_resources/help/component_install
@@ -7,7 +7,7 @@ Flags:
   -h, --help   help for install
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/component_list
+++ b/integration/test_resources/help/component_list
@@ -10,7 +10,7 @@ Flags:
   -h, --help   help for list
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/component_uninstall
+++ b/integration/test_resources/help/component_uninstall
@@ -10,7 +10,7 @@ Flags:
   -h, --help   help for uninstall
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/component_update
+++ b/integration/test_resources/help/component_update
@@ -7,7 +7,7 @@ Flags:
   -h, --help   help for update
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/configure
+++ b/integration/test_resources/help/configure
@@ -31,7 +31,7 @@ Flags:
   -j, --json_file string   loads the API key JSON file downloaded from the WebUI
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/configure_list
+++ b/integration/test_resources/help/configure_list
@@ -14,7 +14,7 @@ Flags:
   -h, --help   help for list
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/configure_show
+++ b/integration/test_resources/help/configure_show
@@ -21,7 +21,7 @@ Flags:
   -h, --help   help for show
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/configure_switch-profile
+++ b/integration/test_resources/help/configure_switch-profile
@@ -15,7 +15,7 @@ Flags:
   -h, --help   help for switch-profile
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/event
+++ b/integration/test_resources/help/event
@@ -15,7 +15,7 @@ Flags:
   -h, --help   help for event
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/event_list
+++ b/integration/test_resources/help/event_list
@@ -20,7 +20,7 @@ Flags:
       --start string      start of the time range in UTC (format: yyyy-MM-ddTHH:mm:ssZ)
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/event_open
+++ b/integration/test_resources/help/event_open
@@ -7,7 +7,7 @@ Flags:
   -h, --help   help for open
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/event_show
+++ b/integration/test_resources/help/event_show
@@ -7,7 +7,7 @@ Flags:
   -h, --help   help for show
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/help
+++ b/integration/test_resources/help/help
@@ -8,7 +8,7 @@ Flags:
   -h, --help   help for help
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/integration
+++ b/integration/test_resources/help/integration
@@ -16,7 +16,7 @@ Flags:
   -h, --help   help for integration
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/integration_create
+++ b/integration/test_resources/help/integration_create
@@ -7,7 +7,7 @@ Flags:
   -h, --help   help for create
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/integration_delete
+++ b/integration/test_resources/help/integration_delete
@@ -9,7 +9,7 @@ Flags:
   -h, --help   help for delete
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/integration_list
+++ b/integration/test_resources/help/integration_list
@@ -8,7 +8,7 @@ Flags:
   -t, --type string   list all integrations of a specific type
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/integration_show
+++ b/integration/test_resources/help/integration_show
@@ -7,7 +7,7 @@ Flags:
   -h, --help   help for show
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/no-command-provided
+++ b/integration/test_resources/help/no-command-provided
@@ -34,7 +34,7 @@ Available Commands:
   vulnerability-exception Manage vulnerability exceptions
 
 Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/policy
+++ b/integration/test_resources/help/policy
@@ -48,7 +48,7 @@ Flags:
   -h, --help   help for policy
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/policy-exception
+++ b/integration/test_resources/help/policy-exception
@@ -20,7 +20,7 @@ Flags:
   -h, --help   help for policy-exception
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/policy-exception_create
+++ b/integration/test_resources/help/policy-exception_create
@@ -17,7 +17,7 @@ Flags:
   -h, --help   help for create
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/policy-exception_delete
+++ b/integration/test_resources/help/policy-exception_delete
@@ -14,7 +14,7 @@ Flags:
   -h, --help   help for delete
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/policy-exception_list
+++ b/integration/test_resources/help/policy-exception_list
@@ -10,7 +10,7 @@ Flags:
   -h, --help   help for list
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/policy-exception_show
+++ b/integration/test_resources/help/policy-exception_show
@@ -10,7 +10,7 @@ Flags:
   -h, --help   help for show
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/policy_create
+++ b/integration/test_resources/help/policy_create
@@ -25,7 +25,7 @@ Flags:
   -u, --url string    url to a policy to create
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/policy_delete
+++ b/integration/test_resources/help/policy_delete
@@ -11,7 +11,7 @@ Flags:
   -h, --help      help for delete
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/policy_disable
+++ b/integration/test_resources/help/policy_disable
@@ -20,7 +20,7 @@ Flags:
       --tag string   disable all policies with the specified tag
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/policy_enable
+++ b/integration/test_resources/help/policy_enable
@@ -20,7 +20,7 @@ Flags:
       --tag string   enable all policies with the specified tag
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/policy_list
+++ b/integration/test_resources/help/policy_list
@@ -14,7 +14,7 @@ Flags:
       --tag string        only show policies with the specified tag
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/policy_list-tags
+++ b/integration/test_resources/help/policy_list-tags
@@ -10,7 +10,7 @@ Flags:
   -h, --help   help for list-tags
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/policy_show
+++ b/integration/test_resources/help/policy_show
@@ -11,7 +11,7 @@ Flags:
       --yaml   output query in YAML format
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/policy_update
+++ b/integration/test_resources/help/policy_update
@@ -27,7 +27,7 @@ Flags:
   -u, --url string    url to a policy to update
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/query
+++ b/integration/test_resources/help/query
@@ -46,7 +46,7 @@ Flags:
   -h, --help   help for query
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/query_create
+++ b/integration/test_resources/help/query_create
@@ -80,7 +80,7 @@ Flags:
   -u, --url string    url to a query to create
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/query_delete
+++ b/integration/test_resources/help/query_delete
@@ -10,7 +10,7 @@ Flags:
   -h, --help   help for delete
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/query_list
+++ b/integration/test_resources/help/query_list
@@ -10,7 +10,7 @@ Flags:
   -h, --help   help for list
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/query_list-sources
+++ b/integration/test_resources/help/query_list-sources
@@ -10,7 +10,7 @@ Flags:
   -h, --help   help for list-sources
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/query_preview-source
+++ b/integration/test_resources/help/query_preview-source
@@ -7,7 +7,7 @@ Flags:
   -h, --help   help for preview-source
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/query_run
+++ b/integration/test_resources/help/query_run
@@ -42,7 +42,7 @@ Flags:
       --validate_only          validate query only (do not run)
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/query_show
+++ b/integration/test_resources/help/query_show
@@ -8,7 +8,7 @@ Flags:
       --yaml   output query in YAML format
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/query_show-source
+++ b/integration/test_resources/help/query_show-source
@@ -10,7 +10,7 @@ Flags:
   -h, --help   help for show-source
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/query_update
+++ b/integration/test_resources/help/query_update
@@ -24,7 +24,7 @@ Flags:
   -u, --url string    url to a query to update
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/query_validate
+++ b/integration/test_resources/help/query_validate
@@ -24,7 +24,7 @@ Flags:
   -u, --url string    url to a query to validate
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/report-rule
+++ b/integration/test_resources/help/report-rule
@@ -23,7 +23,7 @@ Flags:
   -h, --help   help for report-rule
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/report-rule_create
+++ b/integration/test_resources/help/report-rule_create
@@ -7,7 +7,7 @@ Flags:
   -h, --help   help for create
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/report-rule_delete
+++ b/integration/test_resources/help/report-rule_delete
@@ -7,7 +7,7 @@ Flags:
   -h, --help   help for delete
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/report-rule_list
+++ b/integration/test_resources/help/report-rule_list
@@ -10,7 +10,7 @@ Flags:
   -h, --help   help for list
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/report-rule_show
+++ b/integration/test_resources/help/report-rule_show
@@ -7,7 +7,7 @@ Flags:
   -h, --help   help for show
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/resource-group
+++ b/integration/test_resources/help/resource-group
@@ -16,7 +16,7 @@ Flags:
   -h, --help   help for resource-group
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/resource-group_create
+++ b/integration/test_resources/help/resource-group_create
@@ -7,7 +7,7 @@ Flags:
   -h, --help   help for create
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/resource-group_delete
+++ b/integration/test_resources/help/resource-group_delete
@@ -7,7 +7,7 @@ Flags:
   -h, --help   help for delete
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/resource-group_list
+++ b/integration/test_resources/help/resource-group_list
@@ -10,7 +10,7 @@ Flags:
   -h, --help   help for list
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/resource-group_show
+++ b/integration/test_resources/help/resource-group_show
@@ -7,7 +7,7 @@ Flags:
   -h, --help   help for show
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/team-member
+++ b/integration/test_resources/help/team-member
@@ -17,7 +17,7 @@ Flags:
   -h, --help   help for team-member
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/team-member_create
+++ b/integration/test_resources/help/team-member_create
@@ -7,7 +7,7 @@ Flags:
   -h, --help   help for create
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/team-member_delete
+++ b/integration/test_resources/help/team-member_delete
@@ -7,7 +7,7 @@ Flags:
   -h, --help   help for delete
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/team-member_list
+++ b/integration/test_resources/help/team-member_list
@@ -10,7 +10,7 @@ Flags:
   -h, --help   help for list
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/team-member_show
+++ b/integration/test_resources/help/team-member_show
@@ -7,7 +7,7 @@ Flags:
   -h, --help   help for show
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/version
+++ b/integration/test_resources/help/version
@@ -11,7 +11,7 @@ Flags:
   -h, --help   help for version
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/vulnerability
+++ b/integration/test_resources/help/vulnerability
@@ -14,7 +14,7 @@ Flags:
   -h, --help   help for vulnerability
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/vulnerability-exception
+++ b/integration/test_resources/help/vulnerability-exception
@@ -16,7 +16,7 @@ Flags:
   -h, --help   help for vulnerability-exception
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/vulnerability-exception_create
+++ b/integration/test_resources/help/vulnerability-exception_create
@@ -7,7 +7,7 @@ Flags:
   -h, --help   help for create
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/vulnerability-exception_delete
+++ b/integration/test_resources/help/vulnerability-exception_delete
@@ -7,7 +7,7 @@ Flags:
   -h, --help   help for delete
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/vulnerability-exception_list
+++ b/integration/test_resources/help/vulnerability-exception_list
@@ -10,7 +10,7 @@ Flags:
   -h, --help   help for list
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/vulnerability-exception_show
+++ b/integration/test_resources/help/vulnerability-exception_show
@@ -7,7 +7,7 @@ Flags:
   -h, --help   help for show
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/vulnerability-exception_show_show-assessment
+++ b/integration/test_resources/help/vulnerability-exception_show_show-assessment
@@ -7,7 +7,7 @@ Flags:
   -h, --help   help for show
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/vulnerability_container
+++ b/integration/test_resources/help/vulnerability_container
@@ -32,7 +32,7 @@ Flags:
   -h, --help   help for container
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/vulnerability_container_list-assessments
+++ b/integration/test_resources/help/vulnerability_container_list-assessments
@@ -20,7 +20,7 @@ Flags:
       --start string         start of the time range in UTC (format: yyyy-MM-ddTHH:mm:ssZ)
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/vulnerability_container_list-registries
+++ b/integration/test_resources/help/vulnerability_container_list-registries
@@ -10,7 +10,7 @@ Flags:
   -h, --help   help for list-registries
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/vulnerability_container_scan
+++ b/integration/test_resources/help/vulnerability_container_scan
@@ -26,7 +26,7 @@ Flags:
       --severity string           filter vulnerability assessment by severity threshold (critical, high, medium, low, info)
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/vulnerability_container_scan-status
+++ b/integration/test_resources/help/vulnerability_container_scan-status
@@ -18,7 +18,7 @@ Flags:
       --severity string           filter vulnerability assessment by severity threshold (critical, high, medium, low, info)
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/vulnerability_container_show-assessment
+++ b/integration/test_resources/help/vulnerability_container_show-assessment
@@ -30,7 +30,7 @@ Flags:
       --severity string           filter vulnerability assessment by severity threshold (critical, high, medium, low, info)
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/vulnerability_host
+++ b/integration/test_resources/help/vulnerability_host
@@ -15,7 +15,7 @@ Flags:
   -h, --help   help for host
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/vulnerability_host_generate-pkg-manifest
+++ b/integration/test_resources/help/vulnerability_host_generate-pkg-manifest
@@ -13,7 +13,7 @@ Flags:
   -h, --help   help for generate-pkg-manifest
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/vulnerability_host_list-cves
+++ b/integration/test_resources/help/vulnerability_host_list-cves
@@ -17,7 +17,7 @@ Flags:
       --severity string   filter vulnerability assessment by severity threshold (critical, high, medium, low, info)
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/vulnerability_host_list-hosts
+++ b/integration/test_resources/help/vulnerability_host_list-hosts
@@ -14,7 +14,7 @@ Flags:
       --online    only show hosts that are online
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/vulnerability_host_scan-pkg-manifest
+++ b/integration/test_resources/help/vulnerability_host_scan-pkg-manifest
@@ -36,7 +36,7 @@ Flags:
       --packages                  show a list of packages with CVE count
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/vulnerability_host_show-assessment
+++ b/integration/test_resources/help/vulnerability_host_show-assessment
@@ -26,7 +26,7 @@ Flags:
       --severity string           filter vulnerability assessment by severity threshold (critical, high, medium, low, info)
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/integration/test_resources/help/windows/configure_switch-profile
+++ b/integration/test_resources/help/windows/configure_switch-profile
@@ -15,7 +15,7 @@ Flags:
   -h, --help   help for switch-profile
 
 Global Flags:
-  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -a, --account string      account URL (i.e. <ACCOUNT>[.CUSTER][.corp].lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)

--- a/lwconfig/config.go
+++ b/lwconfig/config.go
@@ -25,6 +25,8 @@ import (
 	"os"
 	"path"
 
+	"github.com/lacework/go-sdk/lwdomain"
+
 	"github.com/BurntSushi/toml"
 	"github.com/mitchellh/go-homedir"
 	"github.com/pkg/errors"
@@ -66,12 +68,30 @@ func (p *Profile) Verify() error {
 	if p.Account == "" {
 		return errors.New("account missing")
 	}
+
+	d, err := lwdomain.New(p.Account)
+	if err != nil {
+		return errors.Wrap(err, "account")
+	}
+	p.Account = d.String()
+
 	if p.ApiKey == "" {
 		return errors.New("api_key missing")
 	}
+
+	if len(p.ApiKey) < 55 {
+		return errors.New("api_key must have more than 55 characters")
+	}
+
 	if p.ApiSecret == "" {
 		return errors.New("api_secret missing")
 	}
+
+	if len(p.ApiSecret) < 30 {
+
+		return errors.New("api_secret must have more than 30 characters")
+	}
+
 	return nil
 }
 

--- a/lwconfig/config_test.go
+++ b/lwconfig/config_test.go
@@ -1,0 +1,94 @@
+package lwconfig
+
+import "testing"
+
+func TestProfile_Verify(t *testing.T) {
+	tests := []struct {
+		profile Profile
+		desc    string
+		error   bool
+	}{
+		{
+			Profile{
+				Account:   "test.test.corp.lacework.net",
+				ApiKey:    "0000000000000000000000000000000000000000000000000000000",
+				ApiSecret: "000000000000000000000000000000",
+			},
+			"fields present and valid",
+			false,
+		},
+		{
+			Profile{
+				Account:   "",
+				ApiKey:    "0000000000000000000000000000000000000000000000000000000",
+				ApiSecret: "000000000000000000000000000000",
+			},
+			"account empty",
+			true,
+		},
+		{
+			Profile{
+				Account:   "test.test.corp.lacework.net",
+				ApiKey:    "",
+				ApiSecret: "000000000000000000000000000000",
+			},
+			"apikey empty",
+			true,
+		},
+		{
+			Profile{
+				Account:   "test.test.corp.lacework.net",
+				ApiKey:    "0000000000000000000000000000000000000000000000000000000",
+				ApiSecret: "",
+			},
+			"apisecret empty",
+			true,
+		},
+		{
+			Profile{
+				Account:   "test.test.corp.lacework.net",
+				ApiKey:    "000000000000000000000000000000000000000000000000000000",
+				ApiSecret: "000000000000000000000000000000",
+			},
+			"apikey length less than 55 characters",
+			true,
+		},
+		{
+			Profile{
+				Account:   "test.test.corp.lacework.net",
+				ApiKey:    "0000000000000000000000000000000000000000000000000000000",
+				ApiSecret: "00000000000000000000000000000",
+			},
+			"api secret length less than 30 characters",
+			true,
+		},
+		{
+			Profile{
+				Account:   "test.test.wiz.net",
+				ApiKey:    "0000000000000000000000000000000000000000000000000000000",
+				ApiSecret: "000000000000000000000000000000",
+			},
+			"account domain not supported",
+			true,
+		},
+		{
+			Profile{
+				Account:   "test",
+				ApiKey:    "0000000000000000000000000000000000000000000000000000000",
+				ApiSecret: "000000000000000000000000000000",
+			},
+			"account domain not detected",
+			true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			err := tc.profile.Verify()
+			if (err != nil) != tc.error {
+				t.Error("Incorrect result")
+			}
+		})
+	}
+
+}


### PR DESCRIPTION
## Summary

The Ecosystem onboarding bundle invokes the Lacework CLI using `configure` in non-interactive mode with the global flags - not using `json_file`.  If the customer provided the onboarding service with the full URL (i.e. account.cluster.lacework.net) the onboarding script would pass that full URL to the CLI leading to an error.

This PR seeks to address this issue by treating the non-interactive `configure` account flag the same as if the information was provided by `json_file`.  As in we make use of the `lwdomain` package to validate and select the relevant domain information.

This PR also ensure that the api_key and api_secret validation see in interactive mode is made use of.

I have not deduplicated the validation code from the interactive prompt path.

## How did you test this change?

- Unit test
- Manual test
- Invocation via onboard bundle [script](https://github.com/lacework/services/blob/main/cloud-account-registrar/onboarding/base_onboard_bundle.sh) 

## Issue

[ALLY-1161](https://lacework.atlassian.net/browse/ALLY-1161)