### PR TITLE
fix(cli): account flag domain fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -163,7 +163,7 @@ install-cli: build-cli-cross-platform ## Build and install the Lacework CLI bina
 ifeq (x86_64, $(shell uname -m))
 	mv bin/$(PACKAGENAME)-$(shell uname -s | tr '[:upper:]' '[:lower:]')-amd64 /usr/local/bin/$(CLINAME)
 else
-	mv bin/$(PACKAGENAME)-$(shell uname -s | tr '[:upper:]' '[:lower:]')-386 /usr/local/bin/$(CLINAME)
+	mv bin/$(PACKAGENAME)-$(shell uname -s | tr '[:upper:]' '[:lower:]')-$(shell uname -m) /usr/local/bin/$(CLINAME)
 endif
 	@echo "\nThe lacework cli has been installed at /usr/local/bin"
 

--- a/cli/cmd/configure.go
+++ b/cli/cmd/configure.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -177,6 +178,14 @@ func runConfigureSetup() error {
 		err := loadUIJsonFile(configureJsonFile)
 		if err != nil {
 			return errors.Wrap(err, "unable to load keys from the provided json file")
+		}
+	} else {
+		if match, _ := regexp.MatchString(".lacework.net", cli.Account); match {
+			d, err := lwdomain.New(cli.Account)
+			if err != nil {
+				return errors.Wrap(err, "unable to configure the command-line: account")
+			}
+			cli.Account = d.String()
 		}
 	}
 
@@ -373,7 +382,6 @@ func loadUIJsonFile(file string) error {
 	cli.KeyID = auth.KeyID
 	cli.Secret = auth.Secret
 	cli.Subaccount = strings.ToLower(auth.SubAccount)
-
 	if auth.Account != "" {
 		d, err := lwdomain.New(auth.Account)
 		if err != nil {

--- a/integration/configure_test.go
+++ b/integration/configure_test.go
@@ -57,9 +57,9 @@ func TestConfigureCommandNonInteractive(t *testing.T) {
 	defer os.RemoveAll(home)
 	out, errB, exitcode := LaceworkCLIWithHome(home, "configure",
 		"--noninteractive",
-		"-a", "my-account",
-		"-k", "my-key",
-		"-s", "my-secret",
+		"-a", "my-account.lacework.net",
+		"-k", "my-key-000000000000000000000000000000000000000000000000",
+		"-s", "my-secret-00000000000000000000",
 		"--subaccount", "my-sub-account",
 	)
 
@@ -78,10 +78,52 @@ func TestConfigureCommandNonInteractive(t *testing.T) {
 	assert.Equal(t, `[default]
   account = "my-account"
   subaccount = "my-sub-account"
-  api_key = "my-key"
-  api_secret = "my-secret"
+  api_key = "my-key-000000000000000000000000000000000000000000000000"
+  api_secret = "my-secret-00000000000000000000"
   version = 2
 `, string(laceworkTOML), "there is a problem with the generated config")
+}
+
+func TestConfigureCommandNonInteractiveFailures(t *testing.T) {
+	home, err := ioutil.TempDir("", "lacework-cli")
+	if err != nil {
+		panic(err)
+	}
+
+	defer os.RemoveAll(home)
+
+	tests := []struct {
+		account    string
+		api_key    string
+		api_secret string
+		desc       string
+	}{
+		{
+			"my-account.lacework.net",
+			"my-key-00000000000000000000000000000000000000000000000",
+			"my-secret-00000000000000000000",
+			"api_key length less than 55 characters",
+		},
+		{
+			"my-account.lacework.net",
+			"my-key-000000000000000000000000000000000000000000000000",
+			"my-secret-0000000000000000000",
+			"api_secret length less than 30",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			_, _, errno := LaceworkCLIWithHome(home, "configure",
+				"--noninteractive",
+				"-a", tc.account,
+				"-k", tc.api_key,
+				"-s", tc.api_secret,
+				"--subaccount", "my-sub-account",
+			)
+			assert.True(t, errno != 0, tc.desc)
+		})
+	}
 }
 
 func createJSONFileLikeWebUI(content string) string {

--- a/lwconfig/config.go
+++ b/lwconfig/config.go
@@ -66,12 +66,24 @@ func (p *Profile) Verify() error {
 	if p.Account == "" {
 		return errors.New("account missing")
 	}
+
 	if p.ApiKey == "" {
 		return errors.New("api_key missing")
 	}
+
+	if len(p.ApiKey) < 55 {
+		return errors.New("api_key must have more than 55 characters")
+	}
+
 	if p.ApiSecret == "" {
 		return errors.New("api_secret missing")
 	}
+
+	if len(p.ApiSecret) < 30 {
+
+		return errors.New("api_secret must have more than 30 characters")
+	}
+
 	return nil
 }
 

--- a/lwconfig/config_test.go
+++ b/lwconfig/config_test.go
@@ -1,0 +1,85 @@
+package lwconfig
+
+import "testing"
+
+func TestProfile_Verify(t *testing.T) {
+	tests := []struct {
+		profile Profile
+		desc    string
+		error   bool
+	}{
+		{
+			Profile{
+				Account:   "test.test.corp",
+				ApiKey:    "0000000000000000000000000000000000000000000000000000000",
+				ApiSecret: "000000000000000000000000000000",
+			},
+			"fields present and valid",
+			false,
+		},
+		{
+			Profile{
+				Account:   "test.test.corp.lacework.net",
+				ApiKey:    "0000000000000000000000000000000000000000000000000000000",
+				ApiSecret: "000000000000000000000000000000",
+			},
+			"fields present and valid full URL",
+			false,
+		},
+		{
+			Profile{
+				Account:   "",
+				ApiKey:    "0000000000000000000000000000000000000000000000000000000",
+				ApiSecret: "000000000000000000000000000000",
+			},
+			"account empty",
+			true,
+		},
+		{
+			Profile{
+				Account:   "test.test.corp.lacework.net",
+				ApiKey:    "",
+				ApiSecret: "000000000000000000000000000000",
+			},
+			"apikey empty",
+			true,
+		},
+		{
+			Profile{
+				Account:   "test.test.corp.lacework.net",
+				ApiKey:    "0000000000000000000000000000000000000000000000000000000",
+				ApiSecret: "",
+			},
+			"apisecret empty",
+			true,
+		},
+		{
+			Profile{
+				Account:   "test.test.corp.lacework.net",
+				ApiKey:    "000000000000000000000000000000000000000000000000000000",
+				ApiSecret: "000000000000000000000000000000",
+			},
+			"apikey length less than 55 characters",
+			true,
+		},
+		{
+			Profile{
+				Account:   "test.test.corp.lacework.net",
+				ApiKey:    "0000000000000000000000000000000000000000000000000000000",
+				ApiSecret: "00000000000000000000000000000",
+			},
+			"api secret length less than 30 characters",
+			true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			err := tc.profile.Verify()
+			if (err != nil) != tc.error {
+				t.Error("Incorrect result")
+			}
+		})
+	}
+
+}


### PR DESCRIPTION
## Summary

The Ecosystem onboarding bundle invokes the Lacework CLI using `configure` in non-interactive mode with the global flags - not using `json_file`. If the customer provided the onboarding service with the full URL (i.e. account.cluster.lacework.net) the onboarding script would pass that full URL to the CLI leading to an error.  I think the UI, that makes use of the onboarding service, will run into this same issue.

This PR seeks to address this issue by treating the non-interactive `configure` account flag the same as if the information was provided by `json_file`. As in we make use of the `lwdomain` package to validate and select the relevant domain information.

The -a/--account flag will act like the --json_file flag and account prompt by striping the '.lacework.net' domain from the URL - if provided.

Apply the prompt validation to Profile.Verify, i.e. key and secret length requirements.

Makefile install-cli now works with arm64. 

## How did you test this change?

-   Unit tests
-   Integration tests
-   Manual tests
-   Invocation via onboard bundle [script](https://github.com/lacework/services/blob/main/cloud-account-registrar/onboarding/base_onboard_bundle.sh)

## Issue

[ALLY-1161](https://lacework.atlassian.net/browse/ALLY-1161)
