### PR TITLE
refactor(cli): migrate fetch accountIds in policy exception to API v2

### DIFF
--- a/cli/cmd/policy_exceptions.go
+++ b/cli/cmd/policy_exceptions.go
@@ -407,16 +407,26 @@ func promptAddExceptionConstraintAwsAccountsList() ([]any, error) {
 	var (
 		values      []any
 		fieldValues []string
+		accountIds  []string
 	)
 
 	cli.StartProgress("Retrieving AWS accounts...")
-	accountIds, err := cli.LwApi.Integrations.AwsAccountIDs()
+	accounts, err := cli.LwApi.V2.CloudAccounts.ListByType(api.AwsCfgCloudAccount)
 	cli.StopProgress()
+
 	if err != nil {
 		return nil, err
 	}
 
-	err = survey.AskOne(&survey.MultiSelect{Message: "Select AWS Accounts:", Options: accountIds}, &fieldValues)
+	if len(accounts.Data) == 0 {
+		return nil, errors.New("no aws cloud accounts found")
+	}
+
+	for _, ca := range accounts.Data {
+		accountIds = append(accountIds, ca.Data.(api.AwsCfgData).AwsAccountID)
+	}
+
+	err = survey.AskOne(&survey.MultiSelect{Message: "Select AWS Accounts:", Options: array.Unique(accountIds)}, &fieldValues)
 	if err != nil {
 		return nil, err
 	}

--- a/cli/cmd/policy_exceptions.go
+++ b/cli/cmd/policy_exceptions.go
@@ -423,7 +423,9 @@ func promptAddExceptionConstraintAwsAccountsList() ([]any, error) {
 	}
 
 	for _, ca := range accounts.Data {
-		accountIds = append(accountIds, ca.Data.(api.AwsCfgData).AwsAccountID)
+		if val, ok := ca.Data.(api.AwsCfgData); ok {
+			accountIds = append(accountIds, val.AwsAccountID)
+		}
 	}
 
 	err = survey.AskOne(&survey.MultiSelect{Message: "Select AWS Accounts:", Options: array.Unique(accountIds)}, &fieldValues)


### PR DESCRIPTION
Signed-off-by: Darren Murray <darren.murray@lacework.net>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/lacework/go-sdk) and create your branch from `main`
  2. Run `make prepare` in the repository root
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`make test`)
  5. Format your code (`make fmt`)
  6. Make sure your code lints (`make lint`)
  7. If you are updating the Lacework CLI, make sure it compiles (`make build-cli-cross-platform`)
  8. Follow the commit message standard (`type(scope): subject`) documented in [DEVELOPER_GUIDELINES.md](https://github.com/lacework/go-sdk/blob/main/DEVELOPER_GUIDELINES.md#commit-message-standard)
  9. If you haven't already, configure signed commits by [telling git about your signing key](https://docs.github.com/en/github/authenticating-to-github/managing-commit-signature-verification/telling-git-about-your-signing-key) and [signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)

  Learn more about contributing: https://github.com/lacework/go-sdk/blob/main/CONTRIBUTING.md
-->

## Summary

Replace usage for v1 api in CLI with v2 api.

## How did you test this change?
Existing tests on CI pass
Run `lacework policy policy-exception create` -> enter accountIds as constraint key

## Issue

https://lacework.atlassian.net/browse/ALLY-1145