### PR TITLE
docs(cli): add default output location

### DIFF
--- a/cli/cmd/generate_aws.go
+++ b/cli/cmd/generate_aws.go
@@ -392,7 +392,7 @@ func initGenerateAwsTfCommandFlags() {
 		&GenerateAwsCommandExtraState.Output,
 		"output",
 		"",
-		"location to write generated content",
+		"location to write generated content (default is ~/lacework/aws)",
 	)
 	generateAwsTfCommand.PersistentFlags().BoolVar(
 		&GenerateAwsCommandState.SnsEncryptionEnabled,

--- a/cli/cmd/generate_azure.go
+++ b/cli/cmd/generate_azure.go
@@ -433,7 +433,7 @@ func initGenerateAzureTfCommandFlags() {
 		&GenerateAzureCommandExtraState.Output,
 		"output",
 		"",
-		"location to write generated content",
+		"location to write generated content (default is ~/lacework/azure)",
 	)
 }
 

--- a/cli/cmd/generate_gcp.go
+++ b/cli/cmd/generate_gcp.go
@@ -371,7 +371,7 @@ func initGenerateGcpTfCommandFlags() {
 		&GenerateGcpCommandExtraState.Output,
 		"output",
 		"",
-		"location to write generated content",
+		"location to write generated content (default is ~/lacework/gcp)",
 	)
 
 }

--- a/integration/test_resources/help/cloud-account_iac-generate_aws
+++ b/integration/test_resources/help/cloud-account_iac-generate_aws
@@ -38,7 +38,7 @@ Flags:
       --existing_sns_topic_arn string         specify existing SNS topic arn
       --force_destroy_s3                      enable force destroy S3 bucket
   -h, --help                                  help for aws
-      --output string                         location to write generated content
+      --output string                         location to write generated content (default is ~/lacework/aws)
       --sns_encryption_enabled                enable encryption on SNS topic when creating one (default true)
       --sns_encryption_key_arn string         specify existing KMS encryption key arn for SNS topic
       --sns_topic_name string                 specify SNS topic name if creating new one

--- a/integration/test_resources/help/cloud-account_iac-generate_azure
+++ b/integration/test_resources/help/cloud-account_iac-generate_azure
@@ -32,7 +32,7 @@ Flags:
       --location string                        specify azure region where storage account logging resides
       --management_group                       management group level integration
       --management_group_id string             specify management group id. Required if mgmt_group provided
-      --output string                          location to write generated content
+      --output string                          location to write generated content (default is ~/lacework/azure)
       --storage_account_name string            specify storage account name
       --storage_resource_group string          specify storage resource group
       --subscription_ids strings               list of subscriptions to grant read access; format is id1,id2,id3

--- a/integration/test_resources/help/cloud-account_iac-generate_gcp
+++ b/integration/test_resources/help/cloud-account_iac-generate_gcp
@@ -38,7 +38,7 @@ Flags:
   -h, --help                                          help for gcp
       --organization_id string                        specify the organization id (only set if organization_integration is set)
       --organization_integration                      enable organization integration
-      --output string                                 location to write generated content
+      --output string                                 location to write generated content (default is ~/lacework/gcp)
       --project_id string                             specify the project id to be used to provision lacework resources (required)
       --service_account_credentials string            specify service account credentials JSON file path (leave blank to make use of google credential ENV vars)
 


### PR DESCRIPTION
## Summary

In response to user feedback, documented the default location of the Terraform code generation commands when not specified via the --output flag. Kept it simple by adding as a mention to the help for the flag itself, since the command output itself shows the location as well. 

## How did you test this change?

Updated pipeline tests.

## Issue

N/A