### PR TITLE
build(cli): detect when signing process has completed

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -166,7 +166,7 @@ download_artifacts() {
   log "downloading signed artifacts for v$VERSION"
   aws s3 sync "s3://lacework-cli/builds/v${VERSION}/signed" bin/signed
 
-  while [ ! -n "$(ls -1 bin/signed 2>/dev/null)"  ]; do
+  while [ ! -n "$(ls -1 bin/signed/.completed 2>/dev/null)"  ]; do
     log "waiting for signed artifacts..."
     sleep 5
     aws s3 sync "s3://lacework-cli/builds/v${VERSION}/signed" bin/signed


### PR DESCRIPTION

## Summary

Depends on https://github.com/lacework-dev/lacework-cli-signing/pull/1

We will now detect when the signing process has completed by looking for a file named `.signed/completed`

## How did you test this change?

Run pipelines manually

## Issue

https://lacework.atlassian.net/browse/ALLY-970