### PR TITLE
iac gcp update

### DIFF
--- a/cli/cmd/generate_gcp.go
+++ b/cli/cmd/generate_gcp.go
@@ -44,6 +44,8 @@ var (
 	QuestionGcpEnableBucketForceDestroy = "Enable bucket force destroy?"
 	QuestionGcpUseExistingSink          = "Use an existing sink?"
 	QuestionGcpExistingSinkName         = "Specify the existing sink name"
+	QuestionGcpPrefix                   = "Specify prefix to be used with generated resources: (optional)"
+	QuestionGcpWaitTime                 = "Specify the amount of time to wait before the next resource is provisioned: (optional)"
 
 	GcpAdvancedOptIntegrationName           = "Customize integration name(s)"
 	QuestionGcpConfigurationIntegrationName = "Specify a custom configuration integration name: (optional)"
@@ -120,6 +122,8 @@ See help output for more details on the parameter value(s) required for Terrafor
 				gcp.WithCustomFilter(GenerateGcpCommandState.CustomFilter),
 				gcp.WithGoogleWorkspaceFilter(GenerateGcpCommandState.GoogleWorkspaceFilter),
 				gcp.WithK8sFilter(GenerateGcpCommandState.K8sFilter),
+				gcp.WithPrefix(GenerateGcpCommandState.Prefix),
+				gcp.WithWaitTime(GenerateGcpCommandState.WaitTime),
 			}
 
 			if GenerateGcpCommandState.OrganizationIntegration {
@@ -371,6 +375,16 @@ func initGenerateGcpTfCommandFlags() {
 		true,
 		"filter out GKE logs from GCP Audit Log sinks")
 	generateGcpTfCommand.PersistentFlags().StringVar(
+		&GenerateGcpCommandState.Prefix,
+		"prefix",
+		"",
+		"prefix that will be used at the beginning of every generated resource")
+	generateGcpTfCommand.PersistentFlags().StringVar(
+		&GenerateGcpCommandState.WaitTime,
+		"wait_time",
+		"",
+		"amount of time to wait before the next resource is provisioned")
+	generateGcpTfCommand.PersistentFlags().StringVar(
 		&GenerateGcpCommandState.AuditLogIntegrationName,
 		"audit_log_integration_name",
 		"",
@@ -584,6 +598,16 @@ func promptGcpAuditLogQuestions(config *gcp.GenerateGcpTfConfigurationArgs, extr
 			Checks:   []*bool{&config.AuditLog, &extraState.UseExistingSink},
 			Required: true,
 			Response: &config.ExistingLogSinkName,
+		},
+		{
+			Prompt:   &survey.Input{Message: QuestionGcpPrefix, Default: config.Prefix},
+			Checks:   []*bool{&config.AuditLog},
+			Response: &config.Prefix,
+		},
+		{
+			Prompt:   &survey.Input{Message: QuestionGcpWaitTime, Default: config.WaitTime},
+			Checks:   []*bool{&config.AuditLog},
+			Response: &config.WaitTime,
 		},
 	}, config.AuditLog)
 

--- a/cli/cmd/generate_gcp.go
+++ b/cli/cmd/generate_gcp.go
@@ -109,6 +109,8 @@ See help output for more details on the parameter value(s) required for Terrafor
 				gcp.WithAuditLogIntegrationName(GenerateGcpCommandState.AuditLogIntegrationName),
 				gcp.WithLaceworkProfile(GenerateGcpCommandState.LaceworkProfile),
 				gcp.WithLogBucketLifecycleRuleAge(GenerateGcpCommandState.LogBucketLifecycleRuleAge),
+				gcp.WithFoldersToInclude(GenerateGcpCommandState.FoldersToInclude),
+				gcp.WithFoldersToExclude(GenerateGcpCommandState.FoldersToExclude),
 			}
 
 			if GenerateGcpCommandState.OrganizationIntegration {
@@ -121,6 +123,10 @@ See help output for more details on the parameter value(s) required for Terrafor
 
 			if GenerateGcpCommandState.EnableUBLA {
 				mods = append(mods, gcp.WithEnableUBLA())
+			}
+
+			if len(GenerateGcpCommandState.FoldersToExclude) > 0 {
+				mods = append(mods, gcp.WithIncludeRootProjects(GenerateGcpCommandState.IncludeRootProjects))
 			}
 
 			// Create new struct
@@ -340,6 +346,23 @@ func initGenerateGcpTfCommandFlags() {
 		"audit_log_integration_name",
 		"",
 		"specify a custom audit log integration name")
+	generateGcpTfCommand.PersistentFlags().StringArrayVarP(
+		&GenerateGcpCommandState.FoldersToExclude,
+		"folders_to_exclude",
+		"e",
+		[]string{},
+		"List of root folders to exclude in an organization-level integration")
+	generateGcpTfCommand.PersistentFlags().BoolVar(
+		&GenerateGcpCommandState.IncludeRootProjects,
+		"include_root_projects",
+		true,
+		"Disables logic that includes root-level projects if excluding folders")
+	generateGcpTfCommand.PersistentFlags().StringArrayVarP(
+		&GenerateGcpCommandState.FoldersToInclude,
+		"folders_to_include",
+		"i",
+		[]string{},
+		"List of root folders to include in an organization-level integration")
 	generateGcpTfCommand.PersistentFlags().BoolVar(
 		&GenerateGcpCommandExtraState.TerraformApply,
 		"apply",

--- a/cli/cmd/generate_gcp.go
+++ b/cli/cmd/generate_gcp.go
@@ -37,10 +37,7 @@ var (
 	QuestionGcpUseExistingBucket        = "Use an existing bucket?"
 	QuestionGcpExistingBucketName       = "Specify an existing bucket name:"
 	QuestionGcpConfigureNewBucket       = "Configure settings for new bucket?"
-	QuestionGcpBucketName               = "Specify new bucket name: (optional)"
 	QuestionGcpBucketRegion             = "Specify the bucket region: (optional)"
-	QuestionGcpBucketLocation           = "Specify the bucket location: (optional)"
-	QuestionGcpBucketRetention          = "Specify the bucket retention days: (optional)"
 	QuestionGcpBucketLifecycle          = "Specify the bucket lifecycle rule age: (optional)"
 	QuestionGcpEnableUBLA               = "Enable uniform bucket level access(UBLA)?"
 	QuestionGcpEnableBucketForceDestroy = "Enable bucket force destroy?"
@@ -107,13 +104,10 @@ See help output for more details on the parameter value(s) required for Terrafor
 				gcp.WithPubSubSubscriptionLabels(GenerateGcpCommandState.PubSubSubscriptionLabels),
 				gcp.WithPubSubTopicLabels(GenerateGcpCommandState.PubSubTopicLabels),
 				gcp.WithBucketRegion(GenerateGcpCommandState.BucketRegion),
-				gcp.WithBucketLocation(GenerateGcpCommandState.BucketLocation),
-				gcp.WithBucketName(GenerateGcpCommandState.BucketName),
 				gcp.WithExistingLogBucketName(GenerateGcpCommandState.ExistingLogBucketName),
 				gcp.WithExistingLogSinkName(GenerateGcpCommandState.ExistingLogSinkName),
 				gcp.WithAuditLogIntegrationName(GenerateGcpCommandState.AuditLogIntegrationName),
 				gcp.WithLaceworkProfile(GenerateGcpCommandState.LaceworkProfile),
-				gcp.WithLogBucketRetentionDays(GenerateGcpCommandState.LogBucketRetentionDays),
 				gcp.WithLogBucketLifecycleRuleAge(GenerateGcpCommandState.LogBucketLifecycleRuleAge),
 			}
 
@@ -317,16 +311,6 @@ func initGenerateGcpTfCommandFlags() {
 		"",
 		"specify bucket region")
 	generateGcpTfCommand.PersistentFlags().StringVar(
-		&GenerateGcpCommandState.BucketLocation,
-		"bucket_location",
-		"",
-		"specify bucket location")
-	generateGcpTfCommand.PersistentFlags().StringVar(
-		&GenerateGcpCommandState.BucketName,
-		"bucket_name",
-		"",
-		"specify new bucket name")
-	generateGcpTfCommand.PersistentFlags().StringVar(
 		&GenerateGcpCommandState.ExistingLogBucketName,
 		"existing_bucket_name",
 		"",
@@ -351,11 +335,6 @@ func initGenerateGcpTfCommandFlags() {
 		"bucket_lifecycle_rule_age",
 		-1,
 		"specify the lifecycle rule age")
-	generateGcpTfCommand.PersistentFlags().IntVar(
-		&GenerateGcpCommandState.LogBucketRetentionDays,
-		"bucket_retention_days",
-		0,
-		"specify the bucket retention days")
 	generateGcpTfCommand.PersistentFlags().StringVar(
 		&GenerateGcpCommandState.AuditLogIntegrationName,
 		"audit_log_integration_name",
@@ -515,25 +494,10 @@ func promptGcpAuditLogQuestions(config *gcp.GenerateGcpTfConfigurationArgs, extr
 			Response: &extraState.ConfigureNewBucketSettings,
 		},
 		{
-			Prompt:   &survey.Input{Message: QuestionGcpBucketName, Default: config.BucketName},
-			Checks:   []*bool{&config.AuditLog, &newBucket, &extraState.ConfigureNewBucketSettings},
-			Response: &config.BucketName,
-		},
-		{
 			Prompt:   &survey.Input{Message: QuestionGcpBucketRegion, Default: config.BucketRegion},
 			Checks:   []*bool{&config.AuditLog, &newBucket, &extraState.ConfigureNewBucketSettings},
 			Opts:     []survey.AskOpt{survey.WithValidator(validateGcpRegion)},
 			Response: &config.BucketRegion,
-		},
-		{
-			Prompt:   &survey.Input{Message: QuestionGcpBucketLocation, Default: config.BucketLocation},
-			Checks:   []*bool{&config.AuditLog, &newBucket, &extraState.ConfigureNewBucketSettings},
-			Response: &config.BucketLocation,
-		},
-		{
-			Prompt:   &survey.Input{Message: QuestionGcpBucketRetention, Default: "0"},
-			Checks:   []*bool{&config.AuditLog, &newBucket, &extraState.ConfigureNewBucketSettings},
-			Response: &config.LogBucketRetentionDays,
 		},
 		{
 			Prompt:   &survey.Input{Message: QuestionGcpBucketLifecycle, Default: "-1"},

--- a/integration/gcp_generation_test.go
+++ b/integration/gcp_generation_test.go
@@ -397,14 +397,8 @@ func TestGenerationAdvancedAuditLogOptsNewBucketConfiguredGcp(t *testing.T) {
 			c.SendLine("n")
 			expectString(t, c, cmd.QuestionGcpConfigureNewBucket)
 			c.SendLine("y")
-			expectString(t, c, cmd.QuestionGcpBucketName)
-			c.SendLine("newBucketMcBucketFace")
 			expectString(t, c, cmd.QuestionGcpBucketRegion)
 			c.SendLine("us-west1")
-			expectString(t, c, cmd.QuestionGcpBucketLocation)
-			c.SendLine("us")
-			expectString(t, c, cmd.QuestionGcpBucketRetention)
-			c.SendLine("10")
 			expectString(t, c, cmd.QuestionGcpBucketLifecycle)
 			c.SendLine("420")
 			expectString(t, c, cmd.QuestionGcpEnableUBLA)
@@ -428,10 +422,7 @@ func TestGenerationAdvancedAuditLogOptsNewBucketConfiguredGcp(t *testing.T) {
 	// Create the TF directly with lwgenerate and validate same result via CLI
 	buildTf, _ := gcp.NewTerraform(true, true,
 		gcp.WithProjectId("project-1"),
-		gcp.WithBucketName("newBucketMcBucketFace"),
 		gcp.WithBucketRegion("us-west1"),
-		gcp.WithBucketLocation("us"),
-		gcp.WithLogBucketRetentionDays(10),
 		gcp.WithLogBucketLifecycleRuleAge(420),
 		gcp.WithEnableUBLA(),
 	).Generate()
@@ -467,14 +458,8 @@ func TestGenerationAdvancedAuditLogOptsExistingSinkGcp(t *testing.T) {
 			c.SendLine("n")
 			expectString(t, c, cmd.QuestionGcpConfigureNewBucket)
 			c.SendLine("y")
-			expectString(t, c, cmd.QuestionGcpBucketName)
-			c.SendLine("newBucketMcBucketFace")
 			expectString(t, c, cmd.QuestionGcpBucketRegion)
 			c.SendLine("us-west1")
-			expectString(t, c, cmd.QuestionGcpBucketLocation)
-			c.SendLine("us")
-			expectString(t, c, cmd.QuestionGcpBucketRetention)
-			c.SendLine("10")
 			expectString(t, c, cmd.QuestionGcpBucketLifecycle)
 			c.SendLine("420")
 			expectString(t, c, cmd.QuestionGcpEnableUBLA)
@@ -498,10 +483,7 @@ func TestGenerationAdvancedAuditLogOptsExistingSinkGcp(t *testing.T) {
 	// Create the TF directly with lwgenerate and validate same result via CLI
 	buildTf, _ := gcp.NewTerraform(true, true,
 		gcp.WithProjectId("project-1"),
-		gcp.WithBucketName("newBucketMcBucketFace"),
 		gcp.WithBucketRegion("us-west1"),
-		gcp.WithBucketLocation("us"),
-		gcp.WithLogBucketRetentionDays(10),
 		gcp.WithLogBucketLifecycleRuleAge(420),
 		gcp.WithEnableUBLA(),
 	).Generate()

--- a/integration/test_resources/help/cloud-account_iac-generate_gcp
+++ b/integration/test_resources/help/cloud-account_iac-generate_gcp
@@ -23,24 +23,30 @@ Flags:
       --audit_log                                     enable audit log integration
       --audit_log_integration_name string             specify a custom audit log integration name
       --bucket_lifecycle_rule_age int                 specify the lifecycle rule age (default -1)
-      --bucket_location string                        specify bucket location
-      --bucket_name string                            specify new bucket name
       --bucket_region string                          specify bucket region
-      --bucket_retention_days int                     specify the bucket retention days
       --configuration                                 enable configuration integration
       --configuration_integration_name string         specify a custom configuration integration name
+      --custom_bucket_name string                     override prefix based storage bucket name generation with a custom name
+      --custom_filter string                          customer defined Audit Log filter which will supersede all other filter options when defined
       --enable_force_destroy_bucket                   enable force bucket destroy
       --enable_ubla                                   enable universal bucket level access(ubla)
       --existing_bucket_name string                   specify existing bucket name
       --existing_service_account_name string          specify existing service account name
       --existing_service_account_private_key string   specify existing service account private key (base64 encoded)
       --existing_sink_name string                     specify existing sink name
+  -e, --folders_to_exclude stringArray                List of root folders to exclude in an organization-level integration
+  -i, --folders_to_include stringArray                list of root folders to include in an organization-level integration
+      --google_workspace_filter                       filter out Google Workspace login logs from GCP Audit Log sinks (default true)
   -h, --help                                          help for gcp
+      --include_root_projects                         Disables logic that includes root-level projects if excluding folders (default true)
+      --k8s_filter                                    filter out GKE logs from GCP Audit Log sinks (default true)
       --organization_id string                        specify the organization id (only set if organization_integration is set)
       --organization_integration                      enable organization integration
       --output string                                 location to write generated content (default is ~/lacework/gcp)
+      --prefix string                                 prefix that will be used at the beginning of every generated resource
       --project_id string                             specify the project id to be used to provision lacework resources (required)
       --service_account_credentials string            specify service account credentials JSON file path (leave blank to make use of google credential ENV vars)
+      --wait_time string                              amount of time to wait before the next resource is provisioned
 
 Global Flags:
   -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)

--- a/lwgenerate/_examples/azure/main.go
+++ b/lwgenerate/_examples/azure/main.go
@@ -43,7 +43,7 @@ func ConfigWithoutActivityLog() {
 func CustomActiveDirectory() {
 	hcl, err := azure.NewTerraform(true, true, false,
 		azure.WithConfigIntegrationName("Test Config Rename"),
-		azure.WithAuditLogIntegrationName("Test Activity Log Rename"),
+		azure.WithActivityLogIntegrationName("Test Activity Log Rename"),
 		azure.WithAdApplicationPassword("AD-Test-Password"),
 		azure.WithAdServicePrincipalId("AD-Test-Principal-ID"),
 		azure.WithAdApplicationId("AD-Test-Application-ID"),

--- a/lwgenerate/constants.go
+++ b/lwgenerate/constants.go
@@ -24,5 +24,5 @@ const (
 	GcpConfigSource    = "lacework/config/gcp"
 	GcpConfigVersion   = "~> 2.0"
 	GcpAuditLogSource  = "lacework/audit-log/gcp"
-	GcpAuditLogVersion = "~> 2.0"
+	GcpAuditLogVersion = "~> 3.0"
 )

--- a/lwgenerate/gcp/gcp.go
+++ b/lwgenerate/gcp/gcp.go
@@ -81,12 +81,6 @@ type GenerateGcpTfConfigurationArgs struct {
 	// Supply a GCP region for the new bucket. EU/US/ASIA
 	BucketRegion string
 
-	// Supply a GCP location for the new bucket. Defaults to global
-	BucketLocation string
-
-	// Supply a name for the new bucket
-	BucketName string
-
 	// Existing Bucket Name
 	ExistingLogBucketName string
 
@@ -102,10 +96,6 @@ type GenerateGcpTfConfigurationArgs struct {
 	// Number of days to keep audit logs in Lacework GCS bucket before deleting.
 	// If left empty the TF will default to -1
 	LogBucketLifecycleRuleAge int
-
-	// The number of days to keep logs before deleting.
-	// If left as 0 the TF will default to 30.
-	LogBucketRetentionDays int
 
 	// If AuditLog is true, give the user the opportunity to name their integration. Defaults to "TF audit_log"
 	AuditLogIntegrationName string
@@ -250,20 +240,6 @@ func WithBucketRegion(region string) GcpTerraformModifier {
 	}
 }
 
-// WithBucketLocation Set the name of the bucket that will receive log objects
-func WithBucketLocation(location string) GcpTerraformModifier {
-	return func(c *GenerateGcpTfConfigurationArgs) {
-		c.BucketLocation = location
-	}
-}
-
-// WithBucketName Set the Location in which the Bucket should be created
-func WithBucketName(name string) GcpTerraformModifier {
-	return func(c *GenerateGcpTfConfigurationArgs) {
-		c.BucketName = name
-	}
-}
-
 // WithExistingLogBucketName Set the bucket Name of an existing Audit Log Bucket setup
 func WithExistingLogBucketName(name string) GcpTerraformModifier {
 	return func(c *GenerateGcpTfConfigurationArgs) {
@@ -297,13 +273,6 @@ func WithEnableUBLA() GcpTerraformModifier {
 func WithLogBucketLifecycleRuleAge(ruleAge int) GcpTerraformModifier {
 	return func(c *GenerateGcpTfConfigurationArgs) {
 		c.LogBucketLifecycleRuleAge = ruleAge
-	}
-}
-
-// WithLogBucketRetentionDays Set the number of days to keep logs before deleting. Default is 30
-func WithLogBucketRetentionDays(days int) GcpTerraformModifier {
-	return func(c *GenerateGcpTfConfigurationArgs) {
-		c.LogBucketRetentionDays = days
 	}
 }
 
@@ -470,10 +439,6 @@ func createAuditLog(args *GenerateGcpTfConfigurationArgs) (*hclwrite.Block, erro
 				attributes["lifecycle_rule_age"] = args.LogBucketLifecycleRuleAge
 			}
 
-			if args.BucketName != "" {
-				attributes["log_bucket"] = args.BucketName
-			}
-
 			if args.AuditLogLabels != nil {
 				attributes["labels"] = args.AuditLogLabels
 			}
@@ -492,14 +457,6 @@ func createAuditLog(args *GenerateGcpTfConfigurationArgs) (*hclwrite.Block, erro
 
 			if args.BucketRegion != "" {
 				attributes["bucket_region"] = args.BucketRegion
-			}
-
-			if args.BucketLocation != "" {
-				attributes["log_bucket_location"] = args.BucketLocation
-			}
-
-			if args.LogBucketRetentionDays != 0 {
-				attributes["log_bucket_retention_days"] = args.LogBucketRetentionDays
 			}
 		}
 

--- a/lwgenerate/gcp/gcp.go
+++ b/lwgenerate/gcp/gcp.go
@@ -118,6 +118,10 @@ type GenerateGcpTfConfigurationArgs struct {
 	GoogleWorkspaceFilter bool
 
 	K8sFilter bool
+
+	Prefix string
+
+	WaitTime string
 }
 
 // Ensure all combinations of inputs are valid for supported spec
@@ -338,6 +342,18 @@ func WithGoogleWorkspaceFilter(filter bool) GcpTerraformModifier {
 func WithK8sFilter(filter bool) GcpTerraformModifier {
 	return func(c *GenerateGcpTfConfigurationArgs) {
 		c.K8sFilter = filter
+	}
+}
+
+func WithPrefix(prefix string) GcpTerraformModifier {
+	return func(c *GenerateGcpTfConfigurationArgs) {
+		c.Prefix = prefix
+	}
+}
+
+func WithWaitTime(waitTime string) GcpTerraformModifier {
+	return func(c *GenerateGcpTfConfigurationArgs) {
+		c.WaitTime = waitTime
 	}
 }
 
@@ -602,6 +618,14 @@ func createAuditLog(args *GenerateGcpTfConfigurationArgs) (*hclwrite.Block, erro
 		// Default true in gcp-audit-log TF module
 		if args.K8sFilter != true {
 			attributes["k8s_filter"] = args.K8sFilter
+		}
+
+		if args.Prefix != "" {
+			attributes["prefix"] = args.Prefix
+		}
+
+		if args.WaitTime != "" {
+			attributes["wait_time"] = args.WaitTime
 		}
 
 		moduleDetails = append(moduleDetails,

--- a/lwgenerate/gcp/gcp_test.go
+++ b/lwgenerate/gcp/gcp_test.go
@@ -126,28 +126,6 @@ func TestGenerationProjectLevelAuditLogBucketRegion(t *testing.T) {
 	assert.Equal(t, reqProvider(moduleImportProjectLevelAuditLogBucketRegion), hcl)
 }
 
-func TestGenerationProjectLevelAuditLogBucketLocation(t *testing.T) {
-	hcl, err := gcp.NewTerraform(false, true,
-		gcp.WithGcpServiceAccountCredentials("/path/to/credentials"),
-		gcp.WithProjectId("project1"),
-		gcp.WithBucketLocation("us"),
-	).Generate()
-	assert.Nil(t, err)
-	assert.NotNil(t, hcl)
-	assert.Equal(t, reqProvider(moduleImportProjectLevelAuditLogBucketLocation), hcl)
-}
-
-func TestGenerationProjectLevelAuditLogBucketName(t *testing.T) {
-	hcl, err := gcp.NewTerraform(false, true,
-		gcp.WithGcpServiceAccountCredentials("/path/to/credentials"),
-		gcp.WithProjectId("project1"),
-		gcp.WithBucketName("foo"),
-	).Generate()
-	assert.Nil(t, err)
-	assert.NotNil(t, hcl)
-	assert.Equal(t, reqProvider(moduleImportProjectLevelAuditLogBucketName), hcl)
-}
-
 func TestGenerationProjectLevelAuditLogExistingBucketName(t *testing.T) {
 	hcl, err := gcp.NewTerraform(false, true,
 		gcp.WithGcpServiceAccountCredentials("/path/to/credentials"),
@@ -201,17 +179,6 @@ func TestGenerationProjectLevelAuditLogBucketLifecycleRuleAge(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, hcl)
 	assert.Equal(t, reqProvider(moduleImportProjectLevelAuditLogBucketLifecycleRuleAge), hcl)
-}
-
-func TestGenerationProjectLevelAuditLogBucketRetentionDays(t *testing.T) {
-	hcl, err := gcp.NewTerraform(false, true,
-		gcp.WithGcpServiceAccountCredentials("/path/to/credentials"),
-		gcp.WithProjectId("project1"),
-		gcp.WithLogBucketRetentionDays(420),
-	).Generate()
-	assert.Nil(t, err)
-	assert.NotNil(t, hcl)
-	assert.Equal(t, reqProvider(moduleImportProjectLevelAuditLogBucketRetentionDays), hcl)
 }
 
 func TestGenerationOrganizationLevelAuditLogWithoutConfig(t *testing.T) {
@@ -378,7 +345,7 @@ var laceworkProvider = `provider "lacework" {
 
 var moduleImportProjectLevelAuditLogWithConfiguration = `module "gcp_project_audit_log" {
   source                       = "lacework/audit-log/gcp"
-  version                      = "~> 2.0"
+  version                      = "~> 3.0"
   service_account_name         = module.gcp_project_level_config.service_account_name
   service_account_private_key  = module.gcp_project_level_config.service_account_private_key
   use_existing_service_account = true
@@ -387,20 +354,20 @@ var moduleImportProjectLevelAuditLogWithConfiguration = `module "gcp_project_aud
 
 var moduleImportProjectLevelAuditLogWithoutConfiguration = `module "gcp_project_audit_log" {
   source  = "lacework/audit-log/gcp"
-  version = "~> 2.0"
+  version = "~> 3.0"
 }
 `
 
 var moduleImportProjectLevelAuditLogCustomIntegrationName = `module "gcp_project_audit_log" {
   source                    = "lacework/audit-log/gcp"
-  version                   = "~> 2.0"
+  version                   = "~> 3.0"
   lacework_integration_name = "custom_integration_name"
 }
 `
 
 var moduleImportProjectLevelAuditLogLabels = `module "gcp_project_audit_log" {
   source  = "lacework/audit-log/gcp"
-  version = "~> 2.0"
+  version = "~> 3.0"
   labels = {
     key = "value"
   }
@@ -409,7 +376,7 @@ var moduleImportProjectLevelAuditLogLabels = `module "gcp_project_audit_log" {
 
 var moduleImportProjectLevelAuditLogBucketLabels = `module "gcp_project_audit_log" {
   source  = "lacework/audit-log/gcp"
-  version = "~> 2.0"
+  version = "~> 3.0"
   bucket_labels = {
     key = "value"
   }
@@ -418,7 +385,7 @@ var moduleImportProjectLevelAuditLogBucketLabels = `module "gcp_project_audit_lo
 
 var moduleImportProjectLevelAuditLogPubSubSubscriptionLabels = `module "gcp_project_audit_log" {
   source  = "lacework/audit-log/gcp"
-  version = "~> 2.0"
+  version = "~> 3.0"
   pubsub_subscription_labels = {
     key = "value"
   }
@@ -427,7 +394,7 @@ var moduleImportProjectLevelAuditLogPubSubSubscriptionLabels = `module "gcp_proj
 
 var moduleImportProjectLevelAuditLogPubSubTopicLabels = `module "gcp_project_audit_log" {
   source  = "lacework/audit-log/gcp"
-  version = "~> 2.0"
+  version = "~> 3.0"
   pubsub_topic_labels = {
     key = "value"
   }
@@ -436,70 +403,49 @@ var moduleImportProjectLevelAuditLogPubSubTopicLabels = `module "gcp_project_aud
 
 var moduleImportProjectLevelAuditLogBucketRegion = `module "gcp_project_audit_log" {
   source        = "lacework/audit-log/gcp"
-  version       = "~> 2.0"
+  version       = "~> 3.0"
   bucket_region = "us-west"
-}
-`
-
-var moduleImportProjectLevelAuditLogBucketLocation = `module "gcp_project_audit_log" {
-  source              = "lacework/audit-log/gcp"
-  version             = "~> 2.0"
-  log_bucket_location = "us"
-}
-`
-
-var moduleImportProjectLevelAuditLogBucketName = `module "gcp_project_audit_log" {
-  source     = "lacework/audit-log/gcp"
-  version    = "~> 2.0"
-  log_bucket = "foo"
 }
 `
 
 var moduleImportProjectLevelAuditLogExistingBucketName = `module "gcp_project_audit_log" {
   source               = "lacework/audit-log/gcp"
-  version              = "~> 2.0"
+  version              = "~> 3.0"
   existing_bucket_name = "foo"
 }
 `
 
 var moduleImportProjectLevelAuditLogExistingLogSinkName = `module "gcp_project_audit_log" {
   source             = "lacework/audit-log/gcp"
-  version            = "~> 2.0"
+  version            = "~> 3.0"
   existing_sink_name = "foo"
 }
 `
 
 var moduleImportProjectLevelAuditLogEnableForceDestroyBucket = `module "gcp_project_audit_log" {
   source               = "lacework/audit-log/gcp"
-  version              = "~> 2.0"
+  version              = "~> 3.0"
   bucket_force_destroy = true
 }
 `
 
 var moduleImportProjectLevelAuditLogEnableUBLA = `module "gcp_project_audit_log" {
   source      = "lacework/audit-log/gcp"
-  version     = "~> 2.0"
+  version     = "~> 3.0"
   enable_ubla = true
 }
 `
 
 var moduleImportProjectLevelAuditLogBucketLifecycleRuleAge = `module "gcp_project_audit_log" {
   source             = "lacework/audit-log/gcp"
-  version            = "~> 2.0"
+  version            = "~> 3.0"
   lifecycle_rule_age = 420
-}
-`
-
-var moduleImportProjectLevelAuditLogBucketRetentionDays = `module "gcp_project_audit_log" {
-  source                    = "lacework/audit-log/gcp"
-  version                   = "~> 2.0"
-  log_bucket_retention_days = 420
 }
 `
 
 var moduleImportOrganizationLevelAuditLogWithConfiguration = `module "gcp_organization_level_audit_log" {
   source                       = "lacework/audit-log/gcp"
-  version                      = "~> 2.0"
+  version                      = "~> 3.0"
   org_integration              = true
   organization_id              = "123456789"
   service_account_name         = module.gcp_organization_level_config.service_account_name
@@ -510,14 +456,14 @@ var moduleImportOrganizationLevelAuditLogWithConfiguration = `module "gcp_organi
 
 var moduleImportOrganizationLevelAuditLogWithoutConfiguration = `module "gcp_organization_level_audit_log" {
   source          = "lacework/audit-log/gcp"
-  version         = "~> 2.0"
+  version         = "~> 3.0"
   org_integration = true
   organization_id = "123456789"
 }
 `
 var moduleImportOrganizationLevelAuditLogCustomIntegrationName = `module "gcp_organization_level_audit_log" {
   source                    = "lacework/audit-log/gcp"
-  version                   = "~> 2.0"
+  version                   = "~> 3.0"
   lacework_integration_name = "custom_integration_name"
   org_integration           = true
   organization_id           = "123456789"

--- a/lwgenerate/gcp/gcp_test.go
+++ b/lwgenerate/gcp/gcp_test.go
@@ -447,6 +447,28 @@ func TestGenerationOrganizationLevelAuditLogIncludeRootProjectsTrue(t *testing.T
 	assert.Equal(t, reqProvider(moduleImportOrganizationLevelAuditLogIncludeRootProjectsTrue), hcl)
 }
 
+func TestGenerationProjectLevelAuditLogPrefix(t *testing.T) {
+	hcl, err := gcp.NewTerraform(false, true,
+		gcp.WithGcpServiceAccountCredentials("/path/to/credentials"),
+		gcp.WithProjectId("project1"),
+		gcp.WithPrefix("rar"),
+	).Generate()
+	assert.Nil(t, err)
+	assert.NotNil(t, hcl)
+	assert.Equal(t, reqProvider(moduleImportProjectLevelAuditLogPrefix), hcl)
+}
+
+func TestGenerationProjectLevelAuditLogWaitTime(t *testing.T) {
+	hcl, err := gcp.NewTerraform(false, true,
+		gcp.WithGcpServiceAccountCredentials("/path/to/credentials"),
+		gcp.WithProjectId("project1"),
+		gcp.WithWaitTime("30s"),
+	).Generate()
+	assert.Nil(t, err)
+	assert.NotNil(t, hcl)
+	assert.Equal(t, reqProvider(moduleImportProjectLevelAuditLogWaitTime), hcl)
+}
+
 var requiredProviders = `terraform {
   required_providers {
     lacework = {
@@ -731,5 +753,19 @@ var moduleImportOrganizationLevelAuditLogIncludeRootProjectsTrue = `module "gcp_
   folders_to_exclude = ["abc"]
   org_integration    = true
   organization_id    = "123456789"
+}
+`
+
+var moduleImportProjectLevelAuditLogPrefix = `module "gcp_project_audit_log" {
+  source  = "lacework/audit-log/gcp"
+  version = "~> 3.0"
+  prefix  = "rar"
+}
+`
+
+var moduleImportProjectLevelAuditLogWaitTime = `module "gcp_project_audit_log" {
+  source    = "lacework/audit-log/gcp"
+  version   = "~> 3.0"
+  wait_time = "30s"
 }
 `

--- a/lwgenerate/gcp/gcp_test.go
+++ b/lwgenerate/gcp/gcp_test.go
@@ -318,6 +318,73 @@ func TestGenerationOrganizationLevelConfigurationCustomIntegrationName(t *testin
 	assert.Equal(t, reqProvider(moduleImportOrganizationLevelConfigurationCustomIntegrationName), hcl)
 }
 
+func TestGenerationOrganizationLevelAuditLogFoldersToInclude(t *testing.T) {
+	hcl, err := gcp.NewTerraform(false, true,
+		gcp.WithGcpServiceAccountCredentials("/path/to/credentials"),
+		gcp.WithProjectId("project1"),
+		gcp.WithOrganizationIntegration(true),
+		gcp.WithOrganizationId("123456789"),
+		gcp.WithFoldersToInclude([]string{"abc", "abc", "def", "def"}),
+	).Generate()
+	assert.Nil(t, err)
+	assert.NotNil(t, hcl)
+	assert.Equal(t, reqProvider(moduleImportOrganizationLevelAuditLogFoldersToInclude), hcl)
+}
+
+func TestGenerationOrganizationLevelAuditLogFoldersToExclude(t *testing.T) {
+	hcl, err := gcp.NewTerraform(false, true,
+		gcp.WithGcpServiceAccountCredentials("/path/to/credentials"),
+		gcp.WithProjectId("project1"),
+		gcp.WithOrganizationIntegration(true),
+		gcp.WithOrganizationId("123456789"),
+		gcp.WithFoldersToExclude([]string{"abc", "def"}),
+	).Generate()
+	assert.Nil(t, err)
+	assert.NotNil(t, hcl)
+	assert.Equal(t, reqProvider(moduleImportOrganizationLevelAuditLogFoldersToExclude), hcl)
+}
+
+func TestGenerationOrganizationLevelAuditLogIncludeRootProjectsSolo(t *testing.T) {
+	hcl, err := gcp.NewTerraform(false, true,
+		gcp.WithGcpServiceAccountCredentials("/path/to/credentials"),
+		gcp.WithProjectId("project1"),
+		gcp.WithOrganizationIntegration(true),
+		gcp.WithOrganizationId("123456789"),
+		gcp.WithIncludeRootProjects(false),
+	).Generate()
+	assert.Nil(t, err)
+	assert.NotNil(t, hcl)
+	assert.Equal(t, reqProvider(moduleImportOrganizationLevelAuditLogIncludeRootProjectsSolo), hcl)
+}
+
+func TestGenerationOrganizationLevelAuditLogIncludeRootProjectsFalse(t *testing.T) {
+	hcl, err := gcp.NewTerraform(false, true,
+		gcp.WithGcpServiceAccountCredentials("/path/to/credentials"),
+		gcp.WithProjectId("project1"),
+		gcp.WithOrganizationIntegration(true),
+		gcp.WithOrganizationId("123456789"),
+		gcp.WithIncludeRootProjects(false),
+		gcp.WithFoldersToExclude([]string{"abc"}),
+	).Generate()
+	assert.Nil(t, err)
+	assert.NotNil(t, hcl)
+	assert.Equal(t, reqProvider(moduleImportOrganizationLevelAuditLogIncludeRootProjectsFalse), hcl)
+}
+
+func TestGenerationOrganizationLevelAuditLogIncludeRootProjectsTrue(t *testing.T) {
+	hcl, err := gcp.NewTerraform(false, true,
+		gcp.WithGcpServiceAccountCredentials("/path/to/credentials"),
+		gcp.WithProjectId("project1"),
+		gcp.WithOrganizationIntegration(true),
+		gcp.WithOrganizationId("123456789"),
+		gcp.WithIncludeRootProjects(true),
+		gcp.WithFoldersToExclude([]string{"abc"}),
+	).Generate()
+	assert.Nil(t, err)
+	assert.NotNil(t, hcl)
+	assert.Equal(t, reqProvider(moduleImportOrganizationLevelAuditLogIncludeRootProjectsTrue), hcl)
+}
+
 var requiredProviders = `terraform {
   required_providers {
     lacework = {
@@ -517,5 +584,50 @@ var moduleImportOrganizationLevelConfigurationCustomIntegrationName = `module "g
   lacework_integration_name = "custom_integration_name"
   org_integration           = true
   organization_id           = "123456789"
+}
+`
+
+var moduleImportOrganizationLevelAuditLogFoldersToInclude = `module "gcp_organization_level_audit_log" {
+  source             = "lacework/audit-log/gcp"
+  version            = "~> 3.0"
+  folders_to_include = ["abc", "def"]
+  org_integration    = true
+  organization_id    = "123456789"
+}
+`
+
+var moduleImportOrganizationLevelAuditLogFoldersToExclude = `module "gcp_organization_level_audit_log" {
+  source             = "lacework/audit-log/gcp"
+  version            = "~> 3.0"
+  folders_to_exclude = ["abc", "def"]
+  org_integration    = true
+  organization_id    = "123456789"
+}
+`
+
+var moduleImportOrganizationLevelAuditLogIncludeRootProjectsSolo = `module "gcp_organization_level_audit_log" {
+  source          = "lacework/audit-log/gcp"
+  version         = "~> 3.0"
+  org_integration = true
+  organization_id = "123456789"
+}
+`
+
+var moduleImportOrganizationLevelAuditLogIncludeRootProjectsFalse = `module "gcp_organization_level_audit_log" {
+  source                = "lacework/audit-log/gcp"
+  version               = "~> 3.0"
+  folders_to_exclude    = ["abc"]
+  include_root_projects = false
+  org_integration       = true
+  organization_id       = "123456789"
+}
+`
+
+var moduleImportOrganizationLevelAuditLogIncludeRootProjectsTrue = `module "gcp_organization_level_audit_log" {
+  source             = "lacework/audit-log/gcp"
+  version            = "~> 3.0"
+  folders_to_exclude = ["abc"]
+  org_integration    = true
+  organization_id    = "123456789"
 }
 `

--- a/lwgenerate/gcp/gcp_test.go
+++ b/lwgenerate/gcp/gcp_test.go
@@ -181,6 +181,68 @@ func TestGenerationProjectLevelAuditLogBucketLifecycleRuleAge(t *testing.T) {
 	assert.Equal(t, reqProvider(moduleImportProjectLevelAuditLogBucketLifecycleRuleAge), hcl)
 }
 
+func TestGenerationProjectLevelAuditLogCustomBucketName(t *testing.T) {
+	hcl, err := gcp.NewTerraform(false, true,
+		gcp.WithGcpServiceAccountCredentials("/path/to/credentials"),
+		gcp.WithProjectId("project1"),
+		gcp.WithCustomBucketName("bucket"),
+	).Generate()
+	assert.Nil(t, err)
+	assert.NotNil(t, hcl)
+	assert.Equal(t, reqProvider(moduleImportProjectLevelAuditLogCustomBucketName), hcl)
+}
+
+func TestGenerationProjectLevelAuditLogCustomFilter(t *testing.T) {
+	hcl, err := gcp.NewTerraform(false, true,
+		gcp.WithGcpServiceAccountCredentials("/path/to/credentials"),
+		gcp.WithProjectId("project1"),
+		gcp.WithCustomFilter("custom-filter"),
+	).Generate()
+	assert.Nil(t, err)
+	assert.NotNil(t, hcl)
+	assert.Equal(t, reqProvider(moduleImportProjectLevelAuditLogCustomFilter), hcl)
+}
+
+func TestGenerationProjectLevelAuditLogGoogleWorkspaceFilter(t *testing.T) {
+	hcl, err := gcp.NewTerraform(false, true,
+		gcp.WithGcpServiceAccountCredentials("/path/to/credentials"),
+		gcp.WithProjectId("project1"),
+		gcp.WithGoogleWorkspaceFilter(true),
+	).Generate()
+	assert.Nil(t, err)
+	assert.NotNil(t, hcl)
+	assert.Equal(t, reqProvider(moduleImportProjectLevelAuditLogGoogleWorkspaceFilter), hcl)
+
+	hcl, err = gcp.NewTerraform(false, true,
+		gcp.WithGcpServiceAccountCredentials("/path/to/credentials"),
+		gcp.WithProjectId("project1"),
+		gcp.WithGoogleWorkspaceFilter(false),
+	).Generate()
+	assert.Nil(t, err)
+	assert.NotNil(t, hcl)
+	assert.Equal(t, reqProvider(moduleImportProjectLevelAuditLogGoogleWorkspaceFilterFalse), hcl)
+}
+
+func TestGenerationProjectLevelAuditLogK8sFilter(t *testing.T) {
+	hcl, err := gcp.NewTerraform(false, true,
+		gcp.WithGcpServiceAccountCredentials("/path/to/credentials"),
+		gcp.WithProjectId("project1"),
+		gcp.WithK8sFilter(true),
+	).Generate()
+	assert.Nil(t, err)
+	assert.NotNil(t, hcl)
+	assert.Equal(t, reqProvider(moduleImportProjectLevelAuditLogK8sFilter), hcl)
+
+	hcl, err = gcp.NewTerraform(false, true,
+		gcp.WithGcpServiceAccountCredentials("/path/to/credentials"),
+		gcp.WithProjectId("project1"),
+		gcp.WithK8sFilter(false),
+	).Generate()
+	assert.Nil(t, err)
+	assert.NotNil(t, hcl)
+	assert.Equal(t, reqProvider(moduleImportProjectLevelAuditLogK8sFilterFalse), hcl)
+}
+
 func TestGenerationOrganizationLevelAuditLogWithoutConfig(t *testing.T) {
 	hcl, err := gcp.NewTerraform(false, true,
 		gcp.WithGcpServiceAccountCredentials("/path/to/credentials"),
@@ -507,6 +569,46 @@ var moduleImportProjectLevelAuditLogBucketLifecycleRuleAge = `module "gcp_projec
   source             = "lacework/audit-log/gcp"
   version            = "~> 3.0"
   lifecycle_rule_age = 420
+}
+`
+
+var moduleImportProjectLevelAuditLogCustomBucketName = `module "gcp_project_audit_log" {
+  source             = "lacework/audit-log/gcp"
+  version            = "~> 3.0"
+  custom_bucket_name = "bucket"
+}
+`
+
+var moduleImportProjectLevelAuditLogCustomFilter = `module "gcp_project_audit_log" {
+  source        = "lacework/audit-log/gcp"
+  version       = "~> 3.0"
+  custom_filter = "custom-filter"
+}
+`
+
+var moduleImportProjectLevelAuditLogGoogleWorkspaceFilter = `module "gcp_project_audit_log" {
+  source  = "lacework/audit-log/gcp"
+  version = "~> 3.0"
+}
+`
+
+var moduleImportProjectLevelAuditLogGoogleWorkspaceFilterFalse = `module "gcp_project_audit_log" {
+  source                  = "lacework/audit-log/gcp"
+  version                 = "~> 3.0"
+  google_workspace_filter = false
+}
+`
+
+var moduleImportProjectLevelAuditLogK8sFilter = `module "gcp_project_audit_log" {
+  source  = "lacework/audit-log/gcp"
+  version = "~> 3.0"
+}
+`
+
+var moduleImportProjectLevelAuditLogK8sFilterFalse = `module "gcp_project_audit_log" {
+  source     = "lacework/audit-log/gcp"
+  version    = "~> 3.0"
+  k8s_filter = false
 }
 `
 


### PR DESCRIPTION
## Summary

Updating CLI `iac-generate` command to match `terraform-gcp-audit-log` variables

Advanced filters option:

![image](https://user-images.githubusercontent.com/5750305/191464381-dbab44cb-d19c-4e9a-8536-7a5340359d7d.png)

![image](https://user-images.githubusercontent.com/5750305/191464553-6f521e89-63ea-4277-a33d-b4d4b85d7d09.png)


## How did you test this change?

Unit and integration testing

## Issue

[ALLY-923](https://lacework.atlassian.net/browse/ALLY-923)