### PR TITLE
fix(ALLY-1188): Enable the disable of enable_ebla

### DIFF
--- a/cli/cmd/generate_gcp.go
+++ b/cli/cmd/generate_gcp.go
@@ -115,6 +115,7 @@ See help output for more details on the parameter value(s) required for Terrafor
 				gcp.WithLaceworkProfile(GenerateGcpCommandState.LaceworkProfile),
 				gcp.WithLogBucketRetentionDays(GenerateGcpCommandState.LogBucketRetentionDays),
 				gcp.WithLogBucketLifecycleRuleAge(GenerateGcpCommandState.LogBucketLifecycleRuleAge),
+				gcp.WithEnableUBLA(GenerateGcpCommandState.EnableUBLA),
 			}
 
 			if GenerateGcpCommandState.OrganizationIntegration {
@@ -123,10 +124,6 @@ See help output for more details on the parameter value(s) required for Terrafor
 
 			if GenerateGcpCommandState.EnableForceDestroyBucket {
 				mods = append(mods, gcp.WithEnableForceDestroyBucket())
-			}
-
-			if GenerateGcpCommandState.EnableUBLA {
-				mods = append(mods, gcp.WithEnableUBLA())
 			}
 
 			// Create new struct
@@ -344,7 +341,7 @@ func initGenerateGcpTfCommandFlags() {
 	generateGcpTfCommand.PersistentFlags().BoolVar(
 		&GenerateGcpCommandState.EnableUBLA,
 		"enable_ubla",
-		false,
+		true,
 		"enable universal bucket level access(ubla)")
 	generateGcpTfCommand.PersistentFlags().IntVar(
 		&GenerateGcpCommandState.LogBucketLifecycleRuleAge,

--- a/integration/gcp_generation_test.go
+++ b/integration/gcp_generation_test.go
@@ -158,6 +158,84 @@ func TestGenerationAuditlogOnlyGcp(t *testing.T) {
 	assert.Equal(t, buildTf, tfResult)
 }
 
+func TestGenerationAuditlogEnableUBLA(t *testing.T) {
+	os.Setenv("LW_NOCACHE", "true")
+	defer os.Setenv("LW_NOCACHE", "")
+	var final string
+	projectId := "project-1"
+
+	tfResult := runGcpGenerateTest(t,
+		func(c *expect.Console) {
+			expectString(t, c, cmd.QuestionGcpEnableConfiguration)
+			c.SendLine("n")
+			expectString(t, c, cmd.QuestionGcpEnableAuditLog)
+			c.SendLine("y")
+			expectString(t, c, cmd.QuestionGcpProjectID)
+			c.SendLine(projectId)
+			expectString(t, c, cmd.QuestionGcpOrganizationIntegration)
+			c.SendLine("n")
+			expectString(t, c, cmd.QuestionGcpServiceAccountCredsPath)
+			c.SendLine("")
+			expectString(t, c, cmd.QuestionGcpConfigureAdvanced)
+			c.SendLine("n")
+			expectString(t, c, cmd.QuestionRunTfPlan)
+			c.SendLine("n")
+			final, _ = c.ExpectEOF()
+		},
+		"cloud",
+		"iac",
+		"gcp",
+		"--enable_ubla",
+	)
+
+	assert.Contains(t, final, "Terraform code saved in")
+
+	buildTf, _ := gcp.NewTerraform(false, true,
+		gcp.WithProjectId("project-1"),
+		gcp.WithEnableUBLA(true),
+	).Generate()
+	assert.Equal(t, buildTf, tfResult)
+}
+
+func TestGenerationAuditlogDisableUBLA(t *testing.T) {
+	os.Setenv("LW_NOCACHE", "true")
+	defer os.Setenv("LW_NOCACHE", "")
+	var final string
+	projectId := "project-1"
+
+	tfResult := runGcpGenerateTest(t,
+		func(c *expect.Console) {
+			expectString(t, c, cmd.QuestionGcpEnableConfiguration)
+			c.SendLine("n")
+			expectString(t, c, cmd.QuestionGcpEnableAuditLog)
+			c.SendLine("y")
+			expectString(t, c, cmd.QuestionGcpProjectID)
+			c.SendLine(projectId)
+			expectString(t, c, cmd.QuestionGcpOrganizationIntegration)
+			c.SendLine("n")
+			expectString(t, c, cmd.QuestionGcpServiceAccountCredsPath)
+			c.SendLine("")
+			expectString(t, c, cmd.QuestionGcpConfigureAdvanced)
+			c.SendLine("n")
+			expectString(t, c, cmd.QuestionRunTfPlan)
+			c.SendLine("n")
+			final, _ = c.ExpectEOF()
+		},
+		"cloud",
+		"iac",
+		"gcp",
+		"--enable_ubla=false",
+	)
+
+	assert.Contains(t, final, "Terraform code saved in")
+
+	buildTf, _ := gcp.NewTerraform(false, true,
+		gcp.WithProjectId("project-1"),
+		gcp.WithEnableUBLA(false),
+	).Generate()
+	assert.Equal(t, buildTf, tfResult)
+}
+
 // Test organization integration. configuration & audit log
 func TestOrganizationIntegrationConfigAndAuditLogGcp(t *testing.T) {
 	os.Setenv("LW_NOCACHE", "true")
@@ -433,7 +511,7 @@ func TestGenerationAdvancedAuditLogOptsNewBucketConfiguredGcp(t *testing.T) {
 		gcp.WithBucketLocation("us"),
 		gcp.WithLogBucketRetentionDays(10),
 		gcp.WithLogBucketLifecycleRuleAge(420),
-		gcp.WithEnableUBLA(),
+		gcp.WithEnableUBLA(true),
 	).Generate()
 	assert.Equal(t, buildTf, tfResult)
 }
@@ -478,7 +556,7 @@ func TestGenerationAdvancedAuditLogOptsExistingSinkGcp(t *testing.T) {
 			expectString(t, c, cmd.QuestionGcpBucketLifecycle)
 			c.SendLine("420")
 			expectString(t, c, cmd.QuestionGcpEnableUBLA)
-			c.SendLine("y")
+			c.SendLine("n")
 			expectString(t, c, cmd.QuestionGcpUseExistingSink)
 			c.SendLine("n")
 			expectString(t, c, cmd.QuestionGcpAnotherAdvancedOpt)
@@ -503,7 +581,7 @@ func TestGenerationAdvancedAuditLogOptsExistingSinkGcp(t *testing.T) {
 		gcp.WithBucketLocation("us"),
 		gcp.WithLogBucketRetentionDays(10),
 		gcp.WithLogBucketLifecycleRuleAge(420),
-		gcp.WithEnableUBLA(),
+		gcp.WithEnableUBLA(false),
 	).Generate()
 	assert.Equal(t, buildTf, tfResult)
 }

--- a/integration/test_resources/help/cloud-account_iac-generate_gcp
+++ b/integration/test_resources/help/cloud-account_iac-generate_gcp
@@ -30,7 +30,7 @@ Flags:
       --configuration                                 enable configuration integration
       --configuration_integration_name string         specify a custom configuration integration name
       --enable_force_destroy_bucket                   enable force bucket destroy
-      --enable_ubla                                   enable universal bucket level access(ubla)
+      --enable_ubla                                   enable universal bucket level access(ubla) (default true)
       --existing_bucket_name string                   specify existing bucket name
       --existing_service_account_name string          specify existing service account name
       --existing_service_account_private_key string   specify existing service account private key (base64 encoded)

--- a/lwgenerate/gcp/gcp.go
+++ b/lwgenerate/gcp/gcp.go
@@ -156,7 +156,7 @@ type GcpTerraformModifier func(c *GenerateGcpTfConfigurationArgs)
 //     gcp.WithGcpServiceAccountCredentials("/path/to/sa/credentials.json")).Generate()
 //
 func NewTerraform(enableConfig bool, enableAuditLog bool, mods ...GcpTerraformModifier) *GenerateGcpTfConfigurationArgs {
-	config := &GenerateGcpTfConfigurationArgs{AuditLog: enableAuditLog, Configuration: enableConfig}
+	config := &GenerateGcpTfConfigurationArgs{AuditLog: enableAuditLog, Configuration: enableConfig, EnableUBLA: true}
 	// default LogBucketLifecycleRuleAge to -1. This helps us determine if the var has been set by the end user
 	config.LogBucketLifecycleRuleAge = -1
 	for _, m := range mods {
@@ -286,9 +286,9 @@ func WithEnableForceDestroyBucket() GcpTerraformModifier {
 }
 
 // WithEnableUBLA Enable force destroy of the bucket if it has stuff in it
-func WithEnableUBLA() GcpTerraformModifier {
+func WithEnableUBLA(enable bool) GcpTerraformModifier {
 	return func(c *GenerateGcpTfConfigurationArgs) {
-		c.EnableUBLA = true
+		c.EnableUBLA = enable
 	}
 }
 
@@ -486,8 +486,9 @@ func createAuditLog(args *GenerateGcpTfConfigurationArgs) (*hclwrite.Block, erro
 				attributes["bucket_force_destroy"] = true
 			}
 
-			if args.EnableUBLA {
-				attributes["enable_ubla"] = true
+			// Default true in gcp-audit-log TF module
+			if args.EnableUBLA != true {
+				attributes["enable_ubla"] = args.EnableUBLA
 			}
 
 			if args.BucketRegion != "" {

--- a/lwgenerate/gcp/gcp_test.go
+++ b/lwgenerate/gcp/gcp_test.go
@@ -185,11 +185,22 @@ func TestGenerationProjectLevelAuditLogEnableUBLA(t *testing.T) {
 	hcl, err := gcp.NewTerraform(false, true,
 		gcp.WithGcpServiceAccountCredentials("/path/to/credentials"),
 		gcp.WithProjectId("project1"),
-		gcp.WithEnableUBLA(),
+		gcp.WithEnableUBLA(true),
 	).Generate()
 	assert.Nil(t, err)
 	assert.NotNil(t, hcl)
 	assert.Equal(t, reqProvider(moduleImportProjectLevelAuditLogEnableUBLA), hcl)
+}
+
+func TestGenerationProjectLevelAuditLogDisableUBLA(t *testing.T) {
+	hcl, err := gcp.NewTerraform(false, true,
+		gcp.WithGcpServiceAccountCredentials("/path/to/credentials"),
+		gcp.WithProjectId("project1"),
+		gcp.WithEnableUBLA(false),
+	).Generate()
+	assert.Nil(t, err)
+	assert.NotNil(t, hcl)
+	assert.Equal(t, reqProvider(moduleImportProjectLevelAuditLogDisableUBLA), hcl)
 }
 
 func TestGenerationProjectLevelAuditLogBucketLifecycleRuleAge(t *testing.T) {
@@ -477,9 +488,15 @@ var moduleImportProjectLevelAuditLogEnableForceDestroyBucket = `module "gcp_proj
 `
 
 var moduleImportProjectLevelAuditLogEnableUBLA = `module "gcp_project_audit_log" {
+  source  = "lacework/audit-log/gcp"
+  version = "~> 2.0"
+}
+`
+
+var moduleImportProjectLevelAuditLogDisableUBLA = `module "gcp_project_audit_log" {
   source      = "lacework/audit-log/gcp"
   version     = "~> 2.0"
-  enable_ubla = true
+  enable_ubla = false
 }
 `
 


### PR DESCRIPTION
## Summary

The CLI parameter enable_ubla could never be set to false.

Use --enable_ubla=false to disable the TF gcp-audit-log feature.

## How did you test this change?

Unit and integration testing

## Issue

[ALLY-1188](https://lacework.atlassian.net/browse/ALLY-1188)