### PR TITLE
feat(ALLY-923): gcp updates

### DIFF
--- a/cli/cmd/generate_gcp.go
+++ b/cli/cmd/generate_gcp.go
@@ -37,10 +37,8 @@ var (
 	QuestionGcpUseExistingBucket        = "Use an existing bucket?"
 	QuestionGcpExistingBucketName       = "Specify an existing bucket name:"
 	QuestionGcpConfigureNewBucket       = "Configure settings for new bucket?"
-	QuestionGcpBucketName               = "Specify new bucket name: (optional)"
 	QuestionGcpBucketRegion             = "Specify the bucket region: (optional)"
-	QuestionGcpBucketLocation           = "Specify the bucket location: (optional)"
-	QuestionGcpBucketRetention          = "Specify the bucket retention days: (optional)"
+	QuestionGcpCustomBucketName         = "Specify a custom bucket name: (optional)"
 	QuestionGcpBucketLifecycle          = "Specify the bucket lifecycle rule age: (optional)"
 	QuestionGcpEnableUBLA               = "Enable uniform bucket level access(UBLA)?"
 	QuestionGcpEnableBucketForceDestroy = "Enable bucket force destroy?"
@@ -54,6 +52,9 @@ var (
 	QuestionGcpAnotherAdvancedOpt      = "Configure another advanced integration option"
 	GcpAdvancedOptLocation             = "Customize output location"
 	QuestionGcpCustomizeOutputLocation = "Provide the location for the output to be written:"
+	QuestionGcpCustomFilter            = "Specify a custom filter which will supersede all other filter options"
+	QuestionGcpGoogleWorkspaceFilter   = "Filter out Google Workspace login logs from GCP Audit Log sinks?"
+	QuestionGcpK8sFilter               = "Filter out GKE logs from GCP Audit Log sinks?"
 	GcpAdvancedOptDone                 = "Done"
 
 	// GcpRegionRegex regex used for validating region input
@@ -106,15 +107,20 @@ See help output for more details on the parameter value(s) required for Terrafor
 				gcp.WithBucketLabels(GenerateGcpCommandState.BucketLabels),
 				gcp.WithPubSubSubscriptionLabels(GenerateGcpCommandState.PubSubSubscriptionLabels),
 				gcp.WithPubSubTopicLabels(GenerateGcpCommandState.PubSubTopicLabels),
+				gcp.WithCustomBucketName(GenerateGcpCommandState.CustomBucketName),
 				gcp.WithBucketRegion(GenerateGcpCommandState.BucketRegion),
-				gcp.WithBucketLocation(GenerateGcpCommandState.BucketLocation),
-				gcp.WithBucketName(GenerateGcpCommandState.BucketName),
 				gcp.WithExistingLogBucketName(GenerateGcpCommandState.ExistingLogBucketName),
 				gcp.WithExistingLogSinkName(GenerateGcpCommandState.ExistingLogSinkName),
 				gcp.WithAuditLogIntegrationName(GenerateGcpCommandState.AuditLogIntegrationName),
 				gcp.WithLaceworkProfile(GenerateGcpCommandState.LaceworkProfile),
-				gcp.WithLogBucketRetentionDays(GenerateGcpCommandState.LogBucketRetentionDays),
 				gcp.WithLogBucketLifecycleRuleAge(GenerateGcpCommandState.LogBucketLifecycleRuleAge),
+				gcp.WithFoldersToInclude(GenerateGcpCommandState.FoldersToInclude),
+				gcp.WithFoldersToExclude(GenerateGcpCommandState.FoldersToExclude),
+				gcp.WithCustomFilter(GenerateGcpCommandState.CustomFilter),
+				gcp.WithGoogleWorkspaceFilter(GenerateGcpCommandState.GoogleWorkspaceFilter),
+				gcp.WithK8sFilter(GenerateGcpCommandState.K8sFilter),
+				gcp.WithPrefix(GenerateGcpCommandState.Prefix),
+				gcp.WithWaitTime(GenerateGcpCommandState.WaitTime),
 				gcp.WithEnableUBLA(GenerateGcpCommandState.EnableUBLA),
 			}
 
@@ -124,6 +130,10 @@ See help output for more details on the parameter value(s) required for Terrafor
 
 			if GenerateGcpCommandState.EnableForceDestroyBucket {
 				mods = append(mods, gcp.WithEnableForceDestroyBucket())
+			}
+
+			if len(GenerateGcpCommandState.FoldersToExclude) > 0 {
+				mods = append(mods, gcp.WithIncludeRootProjects(GenerateGcpCommandState.IncludeRootProjects))
 			}
 
 			// Create new struct
@@ -307,22 +317,17 @@ func initGenerateGcpTfCommandFlags() {
 		"configuration_integration_name",
 		"",
 		"specify a custom configuration integration name")
+	generateGcpTfCommand.PersistentFlags().StringVar(
+		&GenerateGcpCommandState.CustomBucketName,
+		"custom_bucket_name",
+		"",
+		"override prefix based storage bucket name generation with a custom name")
 	// TODO: Implement AuditLogLabels, BucketLabels, PubSubSubscriptionLabels & PubSubTopicLabels
 	generateGcpTfCommand.PersistentFlags().StringVar(
 		&GenerateGcpCommandState.BucketRegion,
 		"bucket_region",
 		"",
 		"specify bucket region")
-	generateGcpTfCommand.PersistentFlags().StringVar(
-		&GenerateGcpCommandState.BucketLocation,
-		"bucket_location",
-		"",
-		"specify bucket location")
-	generateGcpTfCommand.PersistentFlags().StringVar(
-		&GenerateGcpCommandState.BucketName,
-		"bucket_name",
-		"",
-		"specify new bucket name")
 	generateGcpTfCommand.PersistentFlags().StringVar(
 		&GenerateGcpCommandState.ExistingLogBucketName,
 		"existing_bucket_name",
@@ -348,16 +353,53 @@ func initGenerateGcpTfCommandFlags() {
 		"bucket_lifecycle_rule_age",
 		-1,
 		"specify the lifecycle rule age")
-	generateGcpTfCommand.PersistentFlags().IntVar(
-		&GenerateGcpCommandState.LogBucketRetentionDays,
-		"bucket_retention_days",
-		0,
-		"specify the bucket retention days")
+	generateGcpTfCommand.PersistentFlags().StringVar(
+		&GenerateGcpCommandState.CustomFilter,
+		"custom_filter",
+		"",
+		"customer defined Audit Log filter which will supersede all other filter options when defined")
+	generateGcpTfCommand.PersistentFlags().BoolVar(
+		&GenerateGcpCommandState.GoogleWorkspaceFilter,
+		"google_workspace_filter",
+		true,
+		"filter out Google Workspace login logs from GCP Audit Log sinks")
+	generateGcpTfCommand.PersistentFlags().BoolVar(
+		&GenerateGcpCommandState.K8sFilter,
+		"k8s_filter",
+		true,
+		"filter out GKE logs from GCP Audit Log sinks")
+	generateGcpTfCommand.PersistentFlags().StringVar(
+		&GenerateGcpCommandState.Prefix,
+		"prefix",
+		"",
+		"prefix that will be used at the beginning of every generated resource")
+	generateGcpTfCommand.PersistentFlags().StringVar(
+		&GenerateGcpCommandState.WaitTime,
+		"wait_time",
+		"",
+		"amount of time to wait before the next resource is provisioned")
 	generateGcpTfCommand.PersistentFlags().StringVar(
 		&GenerateGcpCommandState.AuditLogIntegrationName,
 		"audit_log_integration_name",
 		"",
 		"specify a custom audit log integration name")
+	generateGcpTfCommand.PersistentFlags().StringArrayVarP(
+		&GenerateGcpCommandState.FoldersToExclude,
+		"folders_to_exclude",
+		"e",
+		[]string{},
+		"List of root folders to exclude in an organization-level integration")
+	generateGcpTfCommand.PersistentFlags().BoolVar(
+		&GenerateGcpCommandState.IncludeRootProjects,
+		"include_root_projects",
+		true,
+		"Disables logic that includes root-level projects if excluding folders")
+	generateGcpTfCommand.PersistentFlags().StringArrayVarP(
+		&GenerateGcpCommandState.FoldersToInclude,
+		"folders_to_include",
+		"i",
+		[]string{},
+		"list of root folders to include in an organization-level integration")
 	generateGcpTfCommand.PersistentFlags().BoolVar(
 		&GenerateGcpCommandExtraState.TerraformApply,
 		"apply",
@@ -512,25 +554,15 @@ func promptGcpAuditLogQuestions(config *gcp.GenerateGcpTfConfigurationArgs, extr
 			Response: &extraState.ConfigureNewBucketSettings,
 		},
 		{
-			Prompt:   &survey.Input{Message: QuestionGcpBucketName, Default: config.BucketName},
-			Checks:   []*bool{&config.AuditLog, &newBucket, &extraState.ConfigureNewBucketSettings},
-			Response: &config.BucketName,
-		},
-		{
 			Prompt:   &survey.Input{Message: QuestionGcpBucketRegion, Default: config.BucketRegion},
 			Checks:   []*bool{&config.AuditLog, &newBucket, &extraState.ConfigureNewBucketSettings},
 			Opts:     []survey.AskOpt{survey.WithValidator(validateGcpRegion)},
 			Response: &config.BucketRegion,
 		},
 		{
-			Prompt:   &survey.Input{Message: QuestionGcpBucketLocation, Default: config.BucketLocation},
+			Prompt:   &survey.Input{Message: QuestionGcpCustomBucketName, Default: config.CustomBucketName},
 			Checks:   []*bool{&config.AuditLog, &newBucket, &extraState.ConfigureNewBucketSettings},
-			Response: &config.BucketLocation,
-		},
-		{
-			Prompt:   &survey.Input{Message: QuestionGcpBucketRetention, Default: "0"},
-			Checks:   []*bool{&config.AuditLog, &newBucket, &extraState.ConfigureNewBucketSettings},
-			Response: &config.LogBucketRetentionDays,
+			Response: &config.CustomBucketName,
 		},
 		{
 			Prompt:   &survey.Input{Message: QuestionGcpBucketLifecycle, Default: "-1"},
@@ -560,6 +592,21 @@ func promptGcpAuditLogQuestions(config *gcp.GenerateGcpTfConfigurationArgs, extr
 			Checks:   []*bool{&config.AuditLog, &extraState.UseExistingSink},
 			Required: true,
 			Response: &config.ExistingLogSinkName,
+		},
+		{
+			Prompt:   &survey.Input{Message: QuestionGcpCustomFilter, Default: config.CustomFilter},
+			Checks:   []*bool{&config.AuditLog},
+			Response: &config.CustomFilter,
+		},
+		{
+			Prompt:   &survey.Confirm{Message: QuestionGcpGoogleWorkspaceFilter, Default: config.GoogleWorkspaceFilter},
+			Checks:   []*bool{&config.AuditLog},
+			Response: &config.GoogleWorkspaceFilter,
+		},
+		{
+			Prompt:   &survey.Confirm{Message: QuestionGcpK8sFilter, Default: config.K8sFilter},
+			Checks:   []*bool{&config.AuditLog},
+			Response: &config.K8sFilter,
 		},
 	}, config.AuditLog)
 

--- a/integration/gcp_generation_test.go
+++ b/integration/gcp_generation_test.go
@@ -15,6 +15,48 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+const (
+	organizationId = "org-1"
+	projectId      = "project-1"
+)
+
+type MsgRsp struct {
+	message      string
+	response     string
+	skipResponse bool
+}
+
+func msgRsp(message string, response string) MsgRsp {
+	return MsgRsp{message, response, false}
+}
+
+func msgOnly(message string) MsgRsp {
+	return MsgRsp{message, "", true}
+}
+
+func cliExpectations(t *testing.T, c *expect.Console, m []MsgRsp) {
+	for _, e := range m {
+		expectString(t, c, e.message)
+
+		if !e.skipResponse {
+			c.SendLine(e.response)
+		}
+	}
+}
+
+func menuSelect(t *testing.T, c *expect.Console, count int) {
+	for i := 0; i < count-1; i++ {
+		c.Send("\x1B[B")
+	}
+	if count > 0 {
+		c.SendLine("\x1B[B")
+	}
+}
+
+func assertTerraformSaved(t *testing.T, message string) {
+	assert.Contains(t, message, "Terraform code saved in")
+}
+
 // Test failing due to no selection
 func TestGenerationErrorOnNoSelectionGcp(t *testing.T) {
 	os.Setenv("LW_NOCACHE", "true")
@@ -23,11 +65,11 @@ func TestGenerationErrorOnNoSelectionGcp(t *testing.T) {
 	// Run CLI
 	runGcpGenerateTest(t,
 		func(c *expect.Console) {
-			expectString(t, c, cmd.QuestionGcpEnableConfiguration)
-			c.SendLine("n")
-			expectString(t, c, cmd.QuestionGcpEnableAuditLog)
-			c.SendLine("n")
-			expectString(t, c, "ERROR collecting/confirming parameters: must enable audit log or configuration")
+			cliExpectations(t, c, []MsgRsp{
+				msgRsp(cmd.QuestionGcpEnableConfiguration, "n"),
+				msgRsp(cmd.QuestionGcpEnableAuditLog, "n"),
+				msgOnly("ERROR collecting/confirming parameters: must enable audit log or configuration"),
+			})
 		},
 		"cloud",
 		"iac",
@@ -40,25 +82,19 @@ func TestGenerationSimpleGcp(t *testing.T) {
 	os.Setenv("LW_NOCACHE", "true")
 	defer os.Setenv("LW_NOCACHE", "")
 	var final string
-	projectId := "project-1"
 
-	// Run CLI
 	tfResult := runGcpGenerateTest(t,
 		func(c *expect.Console) {
-			expectString(t, c, cmd.QuestionGcpEnableConfiguration)
-			c.SendLine("y")
-			expectString(t, c, cmd.QuestionGcpEnableAuditLog)
-			c.SendLine("y")
-			expectString(t, c, cmd.QuestionGcpProjectID)
-			c.SendLine(projectId)
-			expectString(t, c, cmd.QuestionGcpOrganizationIntegration)
-			c.SendLine("n")
-			expectString(t, c, cmd.QuestionGcpServiceAccountCredsPath)
-			c.SendLine("")
-			expectString(t, c, cmd.QuestionGcpConfigureAdvanced)
-			c.SendLine("n")
-			expectString(t, c, cmd.QuestionRunTfPlan)
-			c.SendLine("n")
+			cliExpectations(t, c, []MsgRsp{
+				msgRsp(cmd.QuestionGcpEnableConfiguration, "y"),
+				msgRsp(cmd.QuestionGcpEnableAuditLog, "y"),
+				msgRsp(cmd.QuestionGcpProjectID, projectId),
+				msgRsp(cmd.QuestionGcpOrganizationIntegration, "n"),
+				msgRsp(cmd.QuestionGcpServiceAccountCredsPath, ""),
+				msgRsp(cmd.QuestionGcpConfigureAdvanced, "n"),
+				msgRsp(cmd.QuestionRunTfPlan, "n"),
+			})
+
 			final, _ = c.ExpectEOF()
 		},
 		"cloud",
@@ -66,12 +102,10 @@ func TestGenerationSimpleGcp(t *testing.T) {
 		"gcp",
 	)
 
-	// Ensure CLI ran correctly
-	assert.Contains(t, final, "Terraform code saved in")
+	assertTerraformSaved(t, final)
 
-	// Create the TF directly with lwgenerate and validate same result via CLI
 	buildTf, _ := gcp.NewTerraform(true, true,
-		gcp.WithProjectId("project-1"),
+		gcp.WithProjectId(projectId),
 	).Generate()
 	assert.Equal(t, buildTf, tfResult)
 }
@@ -81,25 +115,19 @@ func TestGenerationConfigOnlyGcp(t *testing.T) {
 	os.Setenv("LW_NOCACHE", "true")
 	defer os.Setenv("LW_NOCACHE", "")
 	var final string
-	projectId := "project-1"
 
-	// Run CLI
 	tfResult := runGcpGenerateTest(t,
 		func(c *expect.Console) {
-			expectString(t, c, cmd.QuestionGcpEnableConfiguration)
-			c.SendLine("y")
-			expectString(t, c, cmd.QuestionGcpEnableAuditLog)
-			c.SendLine("n")
-			expectString(t, c, cmd.QuestionGcpProjectID)
-			c.SendLine(projectId)
-			expectString(t, c, cmd.QuestionGcpOrganizationIntegration)
-			c.SendLine("n")
-			expectString(t, c, cmd.QuestionGcpServiceAccountCredsPath)
-			c.SendLine("")
-			expectString(t, c, cmd.QuestionGcpConfigureAdvanced)
-			c.SendLine("n")
-			expectString(t, c, cmd.QuestionRunTfPlan)
-			c.SendLine("n")
+			cliExpectations(t, c, []MsgRsp{
+				msgRsp(cmd.QuestionGcpEnableConfiguration, "y"),
+				msgRsp(cmd.QuestionGcpEnableAuditLog, "n"),
+				msgRsp(cmd.QuestionGcpProjectID, projectId),
+				msgRsp(cmd.QuestionGcpOrganizationIntegration, "n"),
+				msgRsp(cmd.QuestionGcpServiceAccountCredsPath, ""),
+				msgRsp(cmd.QuestionGcpConfigureAdvanced, "n"),
+				msgRsp(cmd.QuestionRunTfPlan, "n"),
+			})
+
 			final, _ = c.ExpectEOF()
 		},
 		"cloud",
@@ -107,12 +135,10 @@ func TestGenerationConfigOnlyGcp(t *testing.T) {
 		"gcp",
 	)
 
-	// Ensure CLI ran correctly
-	assert.Contains(t, final, "Terraform code saved in")
+	assertTerraformSaved(t, final)
 
-	// Create the TF directly with lwgenerate and validate same result via CLI
 	buildTf, _ := gcp.NewTerraform(true, false,
-		gcp.WithProjectId("project-1"),
+		gcp.WithProjectId(projectId),
 	).Generate()
 	assert.Equal(t, buildTf, tfResult)
 }
@@ -122,25 +148,19 @@ func TestGenerationAuditlogOnlyGcp(t *testing.T) {
 	os.Setenv("LW_NOCACHE", "true")
 	defer os.Setenv("LW_NOCACHE", "")
 	var final string
-	projectId := "project-1"
 
-	// Run CLI
 	tfResult := runGcpGenerateTest(t,
 		func(c *expect.Console) {
-			expectString(t, c, cmd.QuestionGcpEnableConfiguration)
-			c.SendLine("n")
-			expectString(t, c, cmd.QuestionGcpEnableAuditLog)
-			c.SendLine("y")
-			expectString(t, c, cmd.QuestionGcpProjectID)
-			c.SendLine(projectId)
-			expectString(t, c, cmd.QuestionGcpOrganizationIntegration)
-			c.SendLine("n")
-			expectString(t, c, cmd.QuestionGcpServiceAccountCredsPath)
-			c.SendLine("")
-			expectString(t, c, cmd.QuestionGcpConfigureAdvanced)
-			c.SendLine("n")
-			expectString(t, c, cmd.QuestionRunTfPlan)
-			c.SendLine("n")
+			cliExpectations(t, c, []MsgRsp{
+				msgRsp(cmd.QuestionGcpEnableConfiguration, "n"),
+				msgRsp(cmd.QuestionGcpEnableAuditLog, "y"),
+				msgRsp(cmd.QuestionGcpProjectID, projectId),
+				msgRsp(cmd.QuestionGcpOrganizationIntegration, "n"),
+				msgRsp(cmd.QuestionGcpServiceAccountCredsPath, ""),
+				msgRsp(cmd.QuestionGcpConfigureAdvanced, "n"),
+				msgRsp(cmd.QuestionRunTfPlan, "n"),
+			})
+
 			final, _ = c.ExpectEOF()
 		},
 		"cloud",
@@ -148,12 +168,10 @@ func TestGenerationAuditlogOnlyGcp(t *testing.T) {
 		"gcp",
 	)
 
-	// Ensure CLI ran correctly
-	assert.Contains(t, final, "Terraform code saved in")
+	assertTerraformSaved(t, final)
 
-	// Create the TF directly with lwgenerate and validate same result via CLI
 	buildTf, _ := gcp.NewTerraform(false, true,
-		gcp.WithProjectId("project-1"),
+		gcp.WithProjectId(projectId),
 	).Generate()
 	assert.Equal(t, buildTf, tfResult)
 }
@@ -241,28 +259,20 @@ func TestOrganizationIntegrationConfigAndAuditLogGcp(t *testing.T) {
 	os.Setenv("LW_NOCACHE", "true")
 	defer os.Setenv("LW_NOCACHE", "")
 	var final string
-	projectId := "project-1"
-	organizationId := "org-1"
 
-	// Run CLI
 	tfResult := runGcpGenerateTest(t,
 		func(c *expect.Console) {
-			expectString(t, c, cmd.QuestionGcpEnableConfiguration)
-			c.SendLine("y")
-			expectString(t, c, cmd.QuestionGcpEnableAuditLog)
-			c.SendLine("y")
-			expectString(t, c, cmd.QuestionGcpProjectID)
-			c.SendLine(projectId)
-			expectString(t, c, cmd.QuestionGcpOrganizationIntegration)
-			c.SendLine("y")
-			expectString(t, c, cmd.QuestionGcpOrganizationID)
-			c.SendLine(organizationId)
-			expectString(t, c, cmd.QuestionGcpServiceAccountCredsPath)
-			c.SendLine("")
-			expectString(t, c, cmd.QuestionGcpConfigureAdvanced)
-			c.SendLine("n")
-			expectString(t, c, cmd.QuestionRunTfPlan)
-			c.SendLine("n")
+			cliExpectations(t, c, []MsgRsp{
+				msgRsp(cmd.QuestionGcpEnableConfiguration, "y"),
+				msgRsp(cmd.QuestionGcpEnableAuditLog, "y"),
+				msgRsp(cmd.QuestionGcpProjectID, projectId),
+				msgRsp(cmd.QuestionGcpOrganizationIntegration, "y"),
+				msgRsp(cmd.QuestionGcpOrganizationID, organizationId),
+				msgRsp(cmd.QuestionGcpServiceAccountCredsPath, ""),
+				msgRsp(cmd.QuestionGcpConfigureAdvanced, "n"),
+				msgRsp(cmd.QuestionRunTfPlan, "n"),
+			})
+
 			final, _ = c.ExpectEOF()
 		},
 		"cloud",
@@ -270,14 +280,52 @@ func TestOrganizationIntegrationConfigAndAuditLogGcp(t *testing.T) {
 		"gcp",
 	)
 
-	// Ensure CLI ran correctly
-	assert.Contains(t, final, "Terraform code saved in")
+	assertTerraformSaved(t, final)
 
-	// Create the TF directly with lwgenerate and validate same result via CLI
 	buildTf, _ := gcp.NewTerraform(true, true,
-		gcp.WithProjectId("project-1"),
+		gcp.WithProjectId(projectId),
 		gcp.WithOrganizationIntegration(true),
 		gcp.WithOrganizationId(organizationId),
+	).Generate()
+	assert.Equal(t, buildTf, tfResult)
+}
+
+func TestGeneratePrefixAndWait(t *testing.T) {
+	os.Setenv("LW_NOCACHE", "true")
+	defer os.Setenv("LW_NOCACHE", "")
+	var final string
+	prefix := "prefix-"
+	waitTime := "30s"
+
+	tfResult := runGcpGenerateTest(t,
+		func(c *expect.Console) {
+			cliExpectations(t, c, []MsgRsp{
+				msgRsp(cmd.QuestionGcpEnableConfiguration, "y"),
+				msgRsp(cmd.QuestionGcpEnableAuditLog, "y"),
+				msgRsp(cmd.QuestionGcpProjectID, projectId),
+				msgRsp(cmd.QuestionGcpOrganizationIntegration, "n"),
+				msgRsp(cmd.QuestionGcpServiceAccountCredsPath, ""),
+				msgRsp(cmd.QuestionGcpConfigureAdvanced, "n"),
+				msgRsp(cmd.QuestionRunTfPlan, "n"),
+			})
+
+			final, _ = c.ExpectEOF()
+		},
+		"cloud",
+		"iac",
+		"gcp",
+		"--prefix",
+		prefix,
+		"--wait_time",
+		waitTime,
+	)
+
+	assertTerraformSaved(t, final)
+
+	buildTf, _ := gcp.NewTerraform(true, true,
+		gcp.WithProjectId(projectId),
+		gcp.WithPrefix(prefix),
+		gcp.WithWaitTime(waitTime),
 	).Generate()
 	assert.Equal(t, buildTf, tfResult)
 }
@@ -287,7 +335,6 @@ func TestGenerationSACredsGcp(t *testing.T) {
 	os.Setenv("LW_NOCACHE", "true")
 	defer os.Setenv("LW_NOCACHE", "")
 	var final string
-	projectId := "project-1"
 	serviceAccountCreds := []byte(`{
 		"private_key": "-----BEGIN PRIVATE KEY-----\nMIIEvwIBADANBgkqhkiG9\n97zZ15XlqSAd5r7q2DasgMWYriEHSJb2V6xwvji5kYeV6U\nY5PR+mPfVbb4xX3UMzwUEvK0cw==\n-----END PRIVATE KEY-----\n",
 			"client_email": "test_email@lacework.iam.gserviceaccount.com"
@@ -309,20 +356,16 @@ func TestGenerationSACredsGcp(t *testing.T) {
 	// Run CLI
 	tfResult := runGcpGenerateTest(t,
 		func(c *expect.Console) {
-			expectString(t, c, cmd.QuestionGcpEnableConfiguration)
-			c.SendLine("y")
-			expectString(t, c, cmd.QuestionGcpEnableAuditLog)
-			c.SendLine("y")
-			expectString(t, c, cmd.QuestionGcpProjectID)
-			c.SendLine(projectId)
-			expectString(t, c, cmd.QuestionGcpOrganizationIntegration)
-			c.SendLine("n")
-			expectString(t, c, cmd.QuestionGcpServiceAccountCredsPath)
-			c.SendLine(serviceAccountFilePath)
-			expectString(t, c, cmd.QuestionGcpConfigureAdvanced)
-			c.SendLine("n")
-			expectString(t, c, cmd.QuestionRunTfPlan)
-			c.SendLine("n")
+			cliExpectations(t, c, []MsgRsp{
+				msgRsp(cmd.QuestionGcpEnableConfiguration, "y"),
+				msgRsp(cmd.QuestionGcpEnableAuditLog, "y"),
+				msgRsp(cmd.QuestionGcpProjectID, projectId),
+				msgRsp(cmd.QuestionGcpOrganizationIntegration, "n"),
+				msgRsp(cmd.QuestionGcpServiceAccountCredsPath, serviceAccountFilePath),
+				msgRsp(cmd.QuestionGcpConfigureAdvanced, "n"),
+				msgRsp(cmd.QuestionRunTfPlan, "n"),
+			})
+
 			final, _ = c.ExpectEOF()
 		},
 		"cloud",
@@ -330,12 +373,10 @@ func TestGenerationSACredsGcp(t *testing.T) {
 		"gcp",
 	)
 
-	// Ensure CLI ran correctly
-	assert.Contains(t, final, "Terraform code saved in")
+	assertTerraformSaved(t, final)
 
-	// Create the TF directly with lwgenerate and validate same result via CLI
 	buildTf, _ := gcp.NewTerraform(true, true,
-		gcp.WithProjectId("project-1"),
+		gcp.WithProjectId(projectId),
 		gcp.WithGcpServiceAccountCredentials(serviceAccountFilePath),
 	).Generate()
 	assert.Equal(t, buildTf, tfResult)
@@ -346,49 +387,39 @@ func TestGenerationAdvancedAuditLogOptsExistingBucketGcp(t *testing.T) {
 	os.Setenv("LW_NOCACHE", "true")
 	defer os.Setenv("LW_NOCACHE", "")
 	var final string
-	projectId := "project-1"
 
-	// Run CLI
 	tfResult := runGcpGenerateTest(t,
 		func(c *expect.Console) {
-			expectString(t, c, cmd.QuestionGcpEnableConfiguration)
-			c.SendLine("y")
-			expectString(t, c, cmd.QuestionGcpEnableAuditLog)
-			c.SendLine("y")
-			expectString(t, c, cmd.QuestionGcpProjectID)
-			c.SendLine(projectId)
-			expectString(t, c, cmd.QuestionGcpOrganizationIntegration)
-			c.SendLine("n")
-			expectString(t, c, cmd.QuestionGcpServiceAccountCredsPath)
-			c.SendLine("")
-			expectString(t, c, cmd.QuestionGcpConfigureAdvanced)
-			c.SendLine("y")
-			expectString(t, c, cmd.GcpAdvancedOptAuditLog)
-			// This is key forward x1 in ANSI
-			c.SendLine("\x1B[C")
-			expectString(t, c, cmd.QuestionGcpUseExistingBucket)
-			c.SendLine("y")
-			expectString(t, c, cmd.QuestionGcpExistingBucketName)
-			c.SendLine("bucketMcBucketFace")
-			expectString(t, c, cmd.QuestionGcpUseExistingSink)
-			c.SendLine("n")
-			expectString(t, c, cmd.QuestionGcpAnotherAdvancedOpt)
-			c.SendLine("n")
-			expectString(t, c, cmd.QuestionRunTfPlan)
-			c.SendLine("n")
+			cliExpectations(t, c, []MsgRsp{
+				msgRsp(cmd.QuestionGcpEnableConfiguration, "y"),
+				msgRsp(cmd.QuestionGcpEnableAuditLog, "y"),
+				msgRsp(cmd.QuestionGcpProjectID, projectId),
+				msgRsp(cmd.QuestionGcpOrganizationIntegration, "n"),
+				msgRsp(cmd.QuestionGcpServiceAccountCredsPath, ""),
+				msgRsp(cmd.QuestionGcpConfigureAdvanced, "y"),
+				msgRsp(cmd.GcpAdvancedOptAuditLog, ""),
+				msgRsp(cmd.QuestionGcpUseExistingBucket, "y"),
+				msgRsp(cmd.QuestionGcpExistingBucketName, "bucketMcBucketFace"),
+				msgRsp(cmd.QuestionGcpUseExistingSink, "n"),
+				msgRsp(cmd.QuestionGcpCustomFilter, ""),
+				msgRsp(cmd.QuestionGcpGoogleWorkspaceFilter, ""),
+				msgRsp(cmd.QuestionGcpK8sFilter, ""),
+				msgRsp(cmd.QuestionGcpAnotherAdvancedOpt, "n"),
+				msgRsp(cmd.QuestionRunTfPlan, "n"),
+			})
+
 			final, _ = c.ExpectEOF()
+
 		},
 		"cloud",
 		"iac",
 		"gcp",
 	)
 
-	// Ensure CLI ran correctly
-	assert.Contains(t, final, "Terraform code saved in")
+	assertTerraformSaved(t, final)
 
-	// Create the TF directly with lwgenerate and validate same result via CLI
 	buildTf, _ := gcp.NewTerraform(true, true,
-		gcp.WithProjectId("project-1"),
+		gcp.WithProjectId(projectId),
 		gcp.WithExistingLogBucketName("bucketMcBucketFace"),
 	).Generate()
 	assert.Equal(t, buildTf, tfResult)
@@ -399,36 +430,27 @@ func TestGenerationAdvancedAuditLogOptsNewBucketNotConfiguredGcp(t *testing.T) {
 	os.Setenv("LW_NOCACHE", "true")
 	defer os.Setenv("LW_NOCACHE", "")
 	var final string
-	projectId := "project-1"
 
-	// Run CLI
 	tfResult := runGcpGenerateTest(t,
 		func(c *expect.Console) {
-			expectString(t, c, cmd.QuestionGcpEnableConfiguration)
-			c.SendLine("y")
-			expectString(t, c, cmd.QuestionGcpEnableAuditLog)
-			c.SendLine("y")
-			expectString(t, c, cmd.QuestionGcpProjectID)
-			c.SendLine(projectId)
-			expectString(t, c, cmd.QuestionGcpOrganizationIntegration)
-			c.SendLine("n")
-			expectString(t, c, cmd.QuestionGcpServiceAccountCredsPath)
-			c.SendLine("")
-			expectString(t, c, cmd.QuestionGcpConfigureAdvanced)
-			c.SendLine("y")
-			expectString(t, c, cmd.GcpAdvancedOptAuditLog)
-			// This is key forward x1 in ANSI
-			c.SendLine("\x1B[C")
-			expectString(t, c, cmd.QuestionGcpUseExistingBucket)
-			c.SendLine("n")
-			expectString(t, c, cmd.QuestionGcpConfigureNewBucket)
-			c.SendLine("n")
-			expectString(t, c, cmd.QuestionGcpUseExistingSink)
-			c.SendLine("n")
-			expectString(t, c, cmd.QuestionGcpAnotherAdvancedOpt)
-			c.SendLine("n")
-			expectString(t, c, cmd.QuestionRunTfPlan)
-			c.SendLine("n")
+			cliExpectations(t, c, []MsgRsp{
+				msgRsp(cmd.QuestionGcpEnableConfiguration, "y"),
+				msgRsp(cmd.QuestionGcpEnableAuditLog, "y"),
+				msgRsp(cmd.QuestionGcpProjectID, projectId),
+				msgRsp(cmd.QuestionGcpOrganizationIntegration, "n"),
+				msgRsp(cmd.QuestionGcpServiceAccountCredsPath, ""),
+				msgRsp(cmd.QuestionGcpConfigureAdvanced, "y"),
+				msgRsp(cmd.GcpAdvancedOptAuditLog, ""),
+				msgRsp(cmd.QuestionGcpUseExistingBucket, "n"),
+				msgRsp(cmd.QuestionGcpConfigureNewBucket, "n"),
+				msgRsp(cmd.QuestionGcpUseExistingSink, "n"),
+				msgRsp(cmd.QuestionGcpCustomFilter, ""),
+				msgRsp(cmd.QuestionGcpGoogleWorkspaceFilter, ""),
+				msgRsp(cmd.QuestionGcpK8sFilter, ""),
+				msgRsp(cmd.QuestionGcpAnotherAdvancedOpt, "n"),
+				msgRsp(cmd.QuestionRunTfPlan, "n"),
+			})
+
 			final, _ = c.ExpectEOF()
 		},
 		"cloud",
@@ -436,12 +458,10 @@ func TestGenerationAdvancedAuditLogOptsNewBucketNotConfiguredGcp(t *testing.T) {
 		"gcp",
 	)
 
-	// Ensure CLI ran correctly
-	assert.Contains(t, final, "Terraform code saved in")
+	assertTerraformSaved(t, final)
 
-	// Create the TF directly with lwgenerate and validate same result via CLI
 	buildTf, _ := gcp.NewTerraform(true, true,
-		gcp.WithProjectId("project-1"),
+		gcp.WithProjectId(projectId),
 	).Generate()
 	assert.Equal(t, buildTf, tfResult)
 }
@@ -451,48 +471,32 @@ func TestGenerationAdvancedAuditLogOptsNewBucketConfiguredGcp(t *testing.T) {
 	os.Setenv("LW_NOCACHE", "true")
 	defer os.Setenv("LW_NOCACHE", "")
 	var final string
-	projectId := "project-1"
+	bucketName := "my-new-bucket"
 
 	// Run CLI
 	tfResult := runGcpGenerateTest(t,
 		func(c *expect.Console) {
-			expectString(t, c, cmd.QuestionGcpEnableConfiguration)
-			c.SendLine("y")
-			expectString(t, c, cmd.QuestionGcpEnableAuditLog)
-			c.SendLine("y")
-			expectString(t, c, cmd.QuestionGcpProjectID)
-			c.SendLine(projectId)
-			expectString(t, c, cmd.QuestionGcpOrganizationIntegration)
-			c.SendLine("n")
-			expectString(t, c, cmd.QuestionGcpServiceAccountCredsPath)
-			c.SendLine("")
-			expectString(t, c, cmd.QuestionGcpConfigureAdvanced)
-			c.SendLine("y")
-			expectString(t, c, cmd.GcpAdvancedOptAuditLog)
-			// This is key forward x1 in ANSI
-			c.SendLine("\x1B[C")
-			expectString(t, c, cmd.QuestionGcpUseExistingBucket)
-			c.SendLine("n")
-			expectString(t, c, cmd.QuestionGcpConfigureNewBucket)
-			c.SendLine("y")
-			expectString(t, c, cmd.QuestionGcpBucketName)
-			c.SendLine("newBucketMcBucketFace")
-			expectString(t, c, cmd.QuestionGcpBucketRegion)
-			c.SendLine("us-west1")
-			expectString(t, c, cmd.QuestionGcpBucketLocation)
-			c.SendLine("us")
-			expectString(t, c, cmd.QuestionGcpBucketRetention)
-			c.SendLine("10")
-			expectString(t, c, cmd.QuestionGcpBucketLifecycle)
-			c.SendLine("420")
-			expectString(t, c, cmd.QuestionGcpEnableUBLA)
-			c.SendLine("y")
-			expectString(t, c, cmd.QuestionGcpUseExistingSink)
-			c.SendLine("n")
-			expectString(t, c, cmd.QuestionGcpAnotherAdvancedOpt)
-			c.SendLine("n")
-			expectString(t, c, cmd.QuestionRunTfPlan)
-			c.SendLine("n")
+			cliExpectations(t, c, []MsgRsp{
+				msgRsp(cmd.QuestionGcpEnableConfiguration, "y"),
+				msgRsp(cmd.QuestionGcpEnableAuditLog, "y"),
+				msgRsp(cmd.QuestionGcpProjectID, projectId),
+				msgRsp(cmd.QuestionGcpOrganizationIntegration, "n"),
+				msgRsp(cmd.QuestionGcpServiceAccountCredsPath, ""),
+				msgRsp(cmd.QuestionGcpConfigureAdvanced, "y"),
+				msgRsp(cmd.GcpAdvancedOptAuditLog, ""),
+				msgRsp(cmd.QuestionGcpUseExistingBucket, "n"),
+				msgRsp(cmd.QuestionGcpConfigureNewBucket, "y"),
+				msgRsp(cmd.QuestionGcpBucketRegion, "us-west1"),
+				msgRsp(cmd.QuestionGcpCustomBucketName, bucketName),
+				msgRsp(cmd.QuestionGcpBucketLifecycle, "420"),
+				msgRsp(cmd.QuestionGcpEnableUBLA, "y"),
+				msgRsp(cmd.QuestionGcpUseExistingSink, "n"),
+				msgRsp(cmd.QuestionGcpCustomFilter, ""),
+				msgRsp(cmd.QuestionGcpGoogleWorkspaceFilter, ""),
+				msgRsp(cmd.QuestionGcpK8sFilter, ""),
+				msgRsp(cmd.QuestionGcpAnotherAdvancedOpt, "n"),
+				msgRsp(cmd.QuestionRunTfPlan, "n"),
+			})
 			final, _ = c.ExpectEOF()
 		},
 		"cloud",
@@ -501,15 +505,13 @@ func TestGenerationAdvancedAuditLogOptsNewBucketConfiguredGcp(t *testing.T) {
 	)
 
 	// Ensure CLI ran correctly
-	assert.Contains(t, final, "Terraform code saved in")
+	assertTerraformSaved(t, final)
 
 	// Create the TF directly with lwgenerate and validate same result via CLI
 	buildTf, _ := gcp.NewTerraform(true, true,
-		gcp.WithProjectId("project-1"),
-		gcp.WithBucketName("newBucketMcBucketFace"),
+		gcp.WithProjectId(projectId),
 		gcp.WithBucketRegion("us-west1"),
-		gcp.WithBucketLocation("us"),
-		gcp.WithLogBucketRetentionDays(10),
+		gcp.WithCustomBucketName(bucketName),
 		gcp.WithLogBucketLifecycleRuleAge(420),
 		gcp.WithEnableUBLA(true),
 	).Generate()
@@ -521,48 +523,31 @@ func TestGenerationAdvancedAuditLogOptsExistingSinkGcp(t *testing.T) {
 	os.Setenv("LW_NOCACHE", "true")
 	defer os.Setenv("LW_NOCACHE", "")
 	var final string
-	projectId := "project-1"
 
 	// Run CLI
 	tfResult := runGcpGenerateTest(t,
 		func(c *expect.Console) {
-			expectString(t, c, cmd.QuestionGcpEnableConfiguration)
-			c.SendLine("y")
-			expectString(t, c, cmd.QuestionGcpEnableAuditLog)
-			c.SendLine("y")
-			expectString(t, c, cmd.QuestionGcpProjectID)
-			c.SendLine(projectId)
-			expectString(t, c, cmd.QuestionGcpOrganizationIntegration)
-			c.SendLine("n")
-			expectString(t, c, cmd.QuestionGcpServiceAccountCredsPath)
-			c.SendLine("")
-			expectString(t, c, cmd.QuestionGcpConfigureAdvanced)
-			c.SendLine("y")
-			expectString(t, c, cmd.GcpAdvancedOptAuditLog)
-			// This is key forward x1 in ANSI
-			c.SendLine("\x1B[C")
-			expectString(t, c, cmd.QuestionGcpUseExistingBucket)
-			c.SendLine("n")
-			expectString(t, c, cmd.QuestionGcpConfigureNewBucket)
-			c.SendLine("y")
-			expectString(t, c, cmd.QuestionGcpBucketName)
-			c.SendLine("newBucketMcBucketFace")
-			expectString(t, c, cmd.QuestionGcpBucketRegion)
-			c.SendLine("us-west1")
-			expectString(t, c, cmd.QuestionGcpBucketLocation)
-			c.SendLine("us")
-			expectString(t, c, cmd.QuestionGcpBucketRetention)
-			c.SendLine("10")
-			expectString(t, c, cmd.QuestionGcpBucketLifecycle)
-			c.SendLine("420")
-			expectString(t, c, cmd.QuestionGcpEnableUBLA)
-			c.SendLine("n")
-			expectString(t, c, cmd.QuestionGcpUseExistingSink)
-			c.SendLine("n")
-			expectString(t, c, cmd.QuestionGcpAnotherAdvancedOpt)
-			c.SendLine("n")
-			expectString(t, c, cmd.QuestionRunTfPlan)
-			c.SendLine("n")
+			cliExpectations(t, c, []MsgRsp{
+				msgRsp(cmd.QuestionGcpEnableConfiguration, "y"),
+				msgRsp(cmd.QuestionGcpEnableAuditLog, "y"),
+				msgRsp(cmd.QuestionGcpProjectID, projectId),
+				msgRsp(cmd.QuestionGcpOrganizationIntegration, "n"),
+				msgRsp(cmd.QuestionGcpServiceAccountCredsPath, ""),
+				msgRsp(cmd.QuestionGcpConfigureAdvanced, "y"),
+				msgRsp(cmd.GcpAdvancedOptAuditLog, ""),
+				msgRsp(cmd.QuestionGcpUseExistingBucket, "n"),
+				msgRsp(cmd.QuestionGcpConfigureNewBucket, "y"),
+				msgRsp(cmd.QuestionGcpBucketRegion, "us-west1"),
+				msgRsp(cmd.QuestionGcpCustomBucketName, ""),
+				msgRsp(cmd.QuestionGcpBucketLifecycle, "420"),
+				msgRsp(cmd.QuestionGcpEnableUBLA, "y"),
+				msgRsp(cmd.QuestionGcpUseExistingSink, "n"),
+				msgRsp(cmd.QuestionGcpCustomFilter, ""),
+				msgRsp(cmd.QuestionGcpGoogleWorkspaceFilter, ""),
+				msgRsp(cmd.QuestionGcpK8sFilter, ""),
+				msgRsp(cmd.QuestionGcpAnotherAdvancedOpt, "n"),
+				msgRsp(cmd.QuestionRunTfPlan, "n"),
+			})
 			final, _ = c.ExpectEOF()
 		},
 		"cloud",
@@ -571,17 +556,56 @@ func TestGenerationAdvancedAuditLogOptsExistingSinkGcp(t *testing.T) {
 	)
 
 	// Ensure CLI ran correctly
-	assert.Contains(t, final, "Terraform code saved in")
+	assertTerraformSaved(t, final)
 
 	// Create the TF directly with lwgenerate and validate same result via CLI
 	buildTf, _ := gcp.NewTerraform(true, true,
-		gcp.WithProjectId("project-1"),
-		gcp.WithBucketName("newBucketMcBucketFace"),
+		gcp.WithProjectId(projectId),
 		gcp.WithBucketRegion("us-west1"),
-		gcp.WithBucketLocation("us"),
-		gcp.WithLogBucketRetentionDays(10),
 		gcp.WithLogBucketLifecycleRuleAge(420),
-		gcp.WithEnableUBLA(false),
+		gcp.WithEnableUBLA(true),
+	).Generate()
+	assert.Equal(t, buildTf, tfResult)
+}
+
+func TestGenerationAdvancedAuditLogOpts(t *testing.T) {
+	os.Setenv("LW_NOCACHE", "true")
+	defer os.Setenv("LW_NOCACHE", "")
+	var final string
+	filter := "filter"
+
+	tfResult := runGcpGenerateTest(t,
+		func(c *expect.Console) {
+			cliExpectations(t, c, []MsgRsp{
+				msgRsp(cmd.QuestionGcpEnableConfiguration, "n"),
+				msgRsp(cmd.QuestionGcpEnableAuditLog, "y"),
+				msgRsp(cmd.QuestionGcpProjectID, projectId),
+				msgRsp(cmd.QuestionGcpOrganizationIntegration, "n"),
+				msgRsp(cmd.QuestionGcpServiceAccountCredsPath, ""),
+				msgRsp(cmd.QuestionGcpConfigureAdvanced, "y"),
+				msgRsp(cmd.GcpAdvancedOptAuditLog, ""),
+				msgRsp(cmd.QuestionGcpUseExistingBucket, "y"),
+				msgRsp(cmd.QuestionGcpExistingBucketName, "bucketMcBucketFace"),
+				msgRsp(cmd.QuestionGcpUseExistingSink, "n"),
+				msgRsp(cmd.QuestionGcpCustomFilter, filter),
+				msgRsp(cmd.QuestionGcpGoogleWorkspaceFilter, ""),
+				msgRsp(cmd.QuestionGcpK8sFilter, ""),
+				msgRsp(cmd.QuestionGcpAnotherAdvancedOpt, "n"),
+				msgRsp(cmd.QuestionRunTfPlan, "n"),
+			})
+			final, _ = c.ExpectEOF()
+		},
+		"cloud",
+		"iac",
+		"gcp",
+	)
+
+	assertTerraformSaved(t, final)
+
+	buildTf, _ := gcp.NewTerraform(false, true,
+		gcp.WithProjectId(projectId),
+		gcp.WithExistingLogBucketName("bucketMcBucketFace"),
+		gcp.WithCustomFilter(filter),
 	).Generate()
 	assert.Equal(t, buildTf, tfResult)
 }
@@ -591,34 +615,27 @@ func TestGenerationAdvancedOptsUseExistingSA(t *testing.T) {
 	os.Setenv("LW_NOCACHE", "true")
 	defer os.Setenv("LW_NOCACHE", "")
 	var final string
-	projectId := "project-1"
 
-	// Run CLI
 	tfResult := runGcpGenerateTest(t,
 		func(c *expect.Console) {
-			expectString(t, c, cmd.QuestionGcpEnableConfiguration)
-			c.SendLine("y")
-			expectString(t, c, cmd.QuestionGcpEnableAuditLog)
-			c.SendLine("y")
-			expectString(t, c, cmd.QuestionGcpProjectID)
-			c.SendLine(projectId)
-			expectString(t, c, cmd.QuestionGcpOrganizationIntegration)
-			c.SendLine("n")
-			expectString(t, c, cmd.QuestionGcpServiceAccountCredsPath)
-			c.SendLine("")
-			expectString(t, c, cmd.QuestionGcpConfigureAdvanced)
-			c.SendLine("y")
-			expectString(t, c, cmd.GcpAdvancedOptAuditLog)
-			// This is key forward x1 in ANSI
-			c.SendLine("\x1B[B")
-			expectString(t, c, cmd.QuestionExistingServiceAccountName)
-			c.SendLine("SA_1")
-			expectString(t, c, cmd.QuestionExistingServiceAccountPrivateKey)
-			c.SendLine("cGFzc3dvcmRNY1Bhc3N3b3JkRmFjZQ==")
-			expectString(t, c, cmd.QuestionGcpAnotherAdvancedOpt)
-			c.SendLine("n")
-			expectString(t, c, cmd.QuestionRunTfPlan)
-			c.SendLine("n")
+			cliExpectations(t, c, []MsgRsp{
+				msgRsp(cmd.QuestionGcpEnableConfiguration, "y"),
+				msgRsp(cmd.QuestionGcpEnableAuditLog, "y"),
+				msgRsp(cmd.QuestionGcpProjectID, projectId),
+				msgRsp(cmd.QuestionGcpOrganizationIntegration, "n"),
+				msgRsp(cmd.QuestionGcpServiceAccountCredsPath, ""),
+				msgRsp(cmd.QuestionGcpConfigureAdvanced, "y"),
+				msgOnly(cmd.GcpAdvancedOptAuditLog),
+			})
+
+			menuSelect(t, c, 1)
+
+			cliExpectations(t, c, []MsgRsp{
+				msgRsp(cmd.QuestionExistingServiceAccountName, "SA_1"),
+				msgRsp(cmd.QuestionExistingServiceAccountPrivateKey, "cGFzc3dvcmRNY1Bhc3N3b3JkRmFjZQ=="),
+				msgRsp(cmd.QuestionGcpAnotherAdvancedOpt, "n"),
+				msgRsp(cmd.QuestionRunTfPlan, "n"),
+			})
 			final, _ = c.ExpectEOF()
 		},
 		"cloud",
@@ -626,16 +643,14 @@ func TestGenerationAdvancedOptsUseExistingSA(t *testing.T) {
 		"gcp",
 	)
 
-	// Ensure CLI ran correctly
-	assert.Contains(t, final, "Terraform code saved in")
+	assertTerraformSaved(t, final)
 
 	serviceAccountDetails := &gcp.ExistingServiceAccountDetails{}
 	serviceAccountDetails.Name = "SA_1"
 	serviceAccountDetails.PrivateKey = "cGFzc3dvcmRNY1Bhc3N3b3JkRmFjZQ=="
 
-	// Create the TF directly with lwgenerate and validate same result via CLI
 	buildTf, _ := gcp.NewTerraform(true, true,
-		gcp.WithProjectId("project-1"),
+		gcp.WithProjectId(projectId),
 		gcp.WithExistingServiceAccount(serviceAccountDetails),
 	).Generate()
 	assert.Equal(t, buildTf, tfResult)
@@ -646,35 +661,27 @@ func TestGenerationCustomizedConfigurationIntegrationNameGcp(t *testing.T) {
 	os.Setenv("LW_NOCACHE", "true")
 	defer os.Setenv("LW_NOCACHE", "")
 	var final string
-	projectId := "project-1"
 
-	// Run CLI
 	tfResult := runGcpGenerateTest(t,
 		func(c *expect.Console) {
-			expectString(t, c, cmd.QuestionGcpEnableConfiguration)
-			c.SendLine("y")
-			expectString(t, c, cmd.QuestionGcpEnableAuditLog)
-			c.SendLine("y")
-			expectString(t, c, cmd.QuestionGcpProjectID)
-			c.SendLine(projectId)
-			expectString(t, c, cmd.QuestionGcpOrganizationIntegration)
-			c.SendLine("n")
-			expectString(t, c, cmd.QuestionGcpServiceAccountCredsPath)
-			c.SendLine("")
-			expectString(t, c, cmd.QuestionGcpConfigureAdvanced)
-			c.SendLine("y")
-			expectString(t, c, cmd.GcpAdvancedOptAuditLog)
-			// This is key down x2 in ANSI
-			c.Send("\x1B[B")
-			c.SendLine("\x1B[B")
-			expectString(t, c, cmd.QuestionGcpConfigurationIntegrationName)
-			c.SendLine("customConfigurationIntegrationName")
-			expectString(t, c, cmd.QuestionGcpAuditLogIntegrationName)
-			c.SendLine("")
-			expectString(t, c, cmd.QuestionGcpAnotherAdvancedOpt)
-			c.SendLine("n")
-			expectString(t, c, cmd.QuestionRunTfPlan)
-			c.SendLine("n")
+			cliExpectations(t, c, []MsgRsp{
+				msgRsp(cmd.QuestionGcpEnableConfiguration, "y"),
+				msgRsp(cmd.QuestionGcpEnableAuditLog, "y"),
+				msgRsp(cmd.QuestionGcpProjectID, projectId),
+				msgRsp(cmd.QuestionGcpOrganizationIntegration, "n"),
+				msgRsp(cmd.QuestionGcpServiceAccountCredsPath, ""),
+				msgRsp(cmd.QuestionGcpConfigureAdvanced, "y"),
+				msgOnly(cmd.GcpAdvancedOptAuditLog),
+			})
+
+			menuSelect(t, c, 2)
+
+			cliExpectations(t, c, []MsgRsp{
+				msgRsp(cmd.QuestionGcpConfigurationIntegrationName, "customConfigurationIntegrationName"),
+				msgRsp(cmd.QuestionGcpAuditLogIntegrationName, ""),
+				msgRsp(cmd.QuestionGcpAnotherAdvancedOpt, "n"),
+				msgRsp(cmd.QuestionRunTfPlan, "n"),
+			})
 			final, _ = c.ExpectEOF()
 		},
 		"cloud",
@@ -683,11 +690,11 @@ func TestGenerationCustomizedConfigurationIntegrationNameGcp(t *testing.T) {
 	)
 
 	// Ensure CLI ran correctly
-	assert.Contains(t, final, "Terraform code saved in")
+	assertTerraformSaved(t, final)
 
 	// Create the TF directly with lwgenerate and validate same result via CLI
 	buildTf, _ := gcp.NewTerraform(true, true,
-		gcp.WithProjectId("project-1"),
+		gcp.WithProjectId(projectId),
 		gcp.WithConfigurationIntegrationName("customConfigurationIntegrationName"),
 	).Generate()
 	assert.Equal(t, buildTf, tfResult)
@@ -698,7 +705,6 @@ func TestGenerationCustomizedAuditlogIntegrationNameGcp(t *testing.T) {
 	os.Setenv("LW_NOCACHE", "true")
 	defer os.Setenv("LW_NOCACHE", "")
 	var final string
-	projectId := "project-1"
 
 	// Tempdir for test
 	dir, err := ioutil.TempDir("", "lacework-cli")
@@ -710,30 +716,22 @@ func TestGenerationCustomizedAuditlogIntegrationNameGcp(t *testing.T) {
 	// Run CLI
 	tfResult := runGcpGenerateTest(t,
 		func(c *expect.Console) {
-			expectString(t, c, cmd.QuestionGcpEnableConfiguration)
-			c.SendLine("y")
-			expectString(t, c, cmd.QuestionGcpEnableAuditLog)
-			c.SendLine("y")
-			expectString(t, c, cmd.QuestionGcpProjectID)
-			c.SendLine(projectId)
-			expectString(t, c, cmd.QuestionGcpOrganizationIntegration)
-			c.SendLine("n")
-			expectString(t, c, cmd.QuestionGcpServiceAccountCredsPath)
-			c.SendLine("")
-			expectString(t, c, cmd.QuestionGcpConfigureAdvanced)
-			c.SendLine("y")
-			expectString(t, c, cmd.GcpAdvancedOptAuditLog)
-			// This is key down x2 in ANSI
-			c.Send("\x1B[B")
-			c.SendLine("\x1B[B")
-			expectString(t, c, cmd.QuestionGcpConfigurationIntegrationName)
-			c.SendLine("")
-			expectString(t, c, cmd.QuestionGcpAuditLogIntegrationName)
-			c.SendLine("customAuditlogIntegrationName")
-			expectString(t, c, cmd.QuestionGcpAnotherAdvancedOpt)
-			c.SendLine("n")
-			expectString(t, c, cmd.QuestionRunTfPlan)
-			c.SendLine("n")
+			cliExpectations(t, c, []MsgRsp{
+				msgRsp(cmd.QuestionGcpEnableConfiguration, "y"),
+				msgRsp(cmd.QuestionGcpEnableAuditLog, "y"),
+				msgRsp(cmd.QuestionGcpProjectID, projectId),
+				msgRsp(cmd.QuestionGcpOrganizationIntegration, "n"),
+				msgRsp(cmd.QuestionGcpServiceAccountCredsPath, ""),
+				msgRsp(cmd.QuestionGcpConfigureAdvanced, "y"),
+				msgOnly(cmd.GcpAdvancedOptAuditLog),
+			})
+			menuSelect(t, c, 2)
+			cliExpectations(t, c, []MsgRsp{
+				msgRsp(cmd.QuestionGcpConfigurationIntegrationName, ""),
+				msgRsp(cmd.QuestionGcpAuditLogIntegrationName, "customAuditlogIntegrationName"),
+				msgRsp(cmd.QuestionGcpAnotherAdvancedOpt, "n"),
+				msgRsp(cmd.QuestionRunTfPlan, "n"),
+			})
 			final, _ = c.ExpectEOF()
 		},
 		"cloud",
@@ -741,12 +739,10 @@ func TestGenerationCustomizedAuditlogIntegrationNameGcp(t *testing.T) {
 		"gcp",
 	)
 
-	// Ensure CLI ran correctly
-	assert.Contains(t, final, "Terraform code saved in")
+	assertTerraformSaved(t, final)
 
-	// Create the TF directly with lwgenerate and validate same result via CLI
 	buildTf, _ := gcp.NewTerraform(true, true,
-		gcp.WithProjectId("project-1"),
+		gcp.WithProjectId(projectId),
 		gcp.WithAuditLogIntegrationName("customAuditlogIntegrationName"),
 	).Generate()
 	assert.Equal(t, buildTf, tfResult)
@@ -757,7 +753,6 @@ func TestGenerationCustomizedOutputLocationGcp(t *testing.T) {
 	os.Setenv("LW_NOCACHE", "true")
 	defer os.Setenv("LW_NOCACHE", "")
 	var final string
-	projectId := "project-1"
 
 	// Tempdir for test
 	dir, err := ioutil.TempDir("", "lacework-cli")
@@ -766,32 +761,24 @@ func TestGenerationCustomizedOutputLocationGcp(t *testing.T) {
 	}
 	defer os.RemoveAll(dir)
 
-	// Run CLI
 	runGcpGenerateTest(t,
 		func(c *expect.Console) {
-			expectString(t, c, cmd.QuestionGcpEnableConfiguration)
-			c.SendLine("y")
-			expectString(t, c, cmd.QuestionGcpEnableAuditLog)
-			c.SendLine("y")
-			expectString(t, c, cmd.QuestionGcpProjectID)
-			c.SendLine(projectId)
-			expectString(t, c, cmd.QuestionGcpOrganizationIntegration)
-			c.SendLine("n")
-			expectString(t, c, cmd.QuestionGcpServiceAccountCredsPath)
-			c.SendLine("")
-			expectString(t, c, cmd.QuestionGcpConfigureAdvanced)
-			c.SendLine("y")
-			expectString(t, c, cmd.GcpAdvancedOptAuditLog)
-			// This is key down x3 in ANSI
-			c.Send("\x1B[B")
-			c.Send("\x1B[B")
-			c.SendLine("\x1B[B")
-			expectString(t, c, cmd.QuestionGcpCustomizeOutputLocation)
-			c.SendLine(dir)
-			expectString(t, c, cmd.QuestionGcpAnotherAdvancedOpt)
-			c.SendLine("n")
-			expectString(t, c, cmd.QuestionRunTfPlan)
-			c.SendLine("n")
+			cliExpectations(t, c, []MsgRsp{
+				msgRsp(cmd.QuestionGcpEnableConfiguration, "y"),
+				msgRsp(cmd.QuestionGcpEnableAuditLog, "y"),
+				msgRsp(cmd.QuestionGcpProjectID, projectId),
+				msgRsp(cmd.QuestionGcpOrganizationIntegration, "n"),
+				msgRsp(cmd.QuestionGcpServiceAccountCredsPath, ""),
+				msgRsp(cmd.QuestionGcpConfigureAdvanced, "y"),
+				msgOnly(cmd.GcpAdvancedOptAuditLog),
+			})
+
+			menuSelect(t, c, 3)
+			cliExpectations(t, c, []MsgRsp{
+				msgRsp(cmd.QuestionGcpCustomizeOutputLocation, dir),
+				msgRsp(cmd.QuestionGcpAnotherAdvancedOpt, "n"),
+				msgRsp(cmd.QuestionRunTfPlan, "n"),
+			})
 			final, _ = c.ExpectEOF()
 		},
 		"cloud",
@@ -799,15 +786,12 @@ func TestGenerationCustomizedOutputLocationGcp(t *testing.T) {
 		"gcp",
 	)
 
-	// Ensure CLI ran correctly
-	assert.Contains(t, final, "Terraform code saved in")
+	assertTerraformSaved(t, final)
 
-	// Get result
 	result, _ := ioutil.ReadFile(filepath.FromSlash(fmt.Sprintf("%s/main.tf", dir)))
 
-	// Create the TF directly with lwgenerate and validate same result via CLI
 	buildTf, _ := gcp.NewTerraform(true, true,
-		gcp.WithProjectId("project-1"),
+		gcp.WithProjectId(projectId),
 	).Generate()
 	assert.Equal(t, buildTf, string(result))
 }
@@ -817,31 +801,22 @@ func TestGenerationAdvancedOptsDoneGcp(t *testing.T) {
 	os.Setenv("LW_NOCACHE", "true")
 	defer os.Setenv("LW_NOCACHE", "")
 	var final string
-	projectId := "project-1"
 
-	// Run CLI
 	tfResult := runGcpGenerateTest(t,
 		func(c *expect.Console) {
-			expectString(t, c, cmd.QuestionGcpEnableConfiguration)
-			c.SendLine("y")
-			expectString(t, c, cmd.QuestionGcpEnableAuditLog)
-			c.SendLine("y")
-			expectString(t, c, cmd.QuestionGcpProjectID)
-			c.SendLine(projectId)
-			expectString(t, c, cmd.QuestionGcpOrganizationIntegration)
-			c.SendLine("n")
-			expectString(t, c, cmd.QuestionGcpServiceAccountCredsPath)
-			c.SendLine("")
-			expectString(t, c, cmd.QuestionGcpConfigureAdvanced)
-			c.SendLine("y")
-			expectString(t, c, cmd.GcpAdvancedOptAuditLog)
-			// This is key down x3 in ANSI
-			c.Send("\x1B[B")
-			c.Send("\x1B[B")
-			c.Send("\x1B[B")
-			c.SendLine("\x1B[B")
-			expectString(t, c, cmd.QuestionRunTfPlan)
-			c.SendLine("n")
+			cliExpectations(t, c, []MsgRsp{
+				msgRsp(cmd.QuestionGcpEnableConfiguration, "y"),
+				msgRsp(cmd.QuestionGcpEnableAuditLog, "y"),
+				msgRsp(cmd.QuestionGcpProjectID, projectId),
+				msgRsp(cmd.QuestionGcpOrganizationIntegration, "n"),
+				msgRsp(cmd.QuestionGcpServiceAccountCredsPath, ""),
+				msgRsp(cmd.QuestionGcpConfigureAdvanced, "y"),
+				msgOnly(cmd.GcpAdvancedOptAuditLog),
+			})
+			menuSelect(t, c, 4)
+			cliExpectations(t, c, []MsgRsp{
+				msgRsp(cmd.QuestionRunTfPlan, "n"),
+			})
 			final, _ = c.ExpectEOF()
 		},
 		"cloud",
@@ -849,12 +824,45 @@ func TestGenerationAdvancedOptsDoneGcp(t *testing.T) {
 		"gcp",
 	)
 
-	// Ensure CLI ran correctly
-	assert.Contains(t, final, "Terraform code saved in")
+	assertTerraformSaved(t, final)
 
-	// Create the TF directly with lwgenerate and validate same result via CLI
 	buildTf, _ := gcp.NewTerraform(true, true,
-		gcp.WithProjectId("project-1"),
+		gcp.WithProjectId(projectId),
+	).Generate()
+	assert.Equal(t, buildTf, tfResult)
+}
+
+func TestGenerationAdvancedOptsDoneGcpConfiguration(t *testing.T) {
+	os.Setenv("LW_NOCACHE", "true")
+	defer os.Setenv("LW_NOCACHE", "")
+	var final string
+
+	tfResult := runGcpGenerateTest(t,
+		func(c *expect.Console) {
+			cliExpectations(t, c, []MsgRsp{
+				msgRsp(cmd.QuestionGcpEnableConfiguration, "y"),
+				msgRsp(cmd.QuestionGcpEnableAuditLog, "n"),
+				msgRsp(cmd.QuestionGcpProjectID, projectId),
+				msgRsp(cmd.QuestionGcpOrganizationIntegration, "n"),
+				msgRsp(cmd.QuestionGcpServiceAccountCredsPath, ""),
+				msgRsp(cmd.QuestionGcpConfigureAdvanced, "y"),
+				msgOnly(cmd.GcpAdvancedOptExistingServiceAccount),
+			})
+			menuSelect(t, c, 3)
+			cliExpectations(t, c, []MsgRsp{
+				msgRsp(cmd.QuestionRunTfPlan, "n"),
+			})
+			final, _ = c.ExpectEOF()
+		},
+		"cloud",
+		"iac",
+		"gcp",
+	)
+
+	assertTerraformSaved(t, final)
+
+	buildTf, _ := gcp.NewTerraform(true, false,
+		gcp.WithProjectId(projectId),
 	).Generate()
 	assert.Equal(t, buildTf, tfResult)
 }
@@ -863,7 +871,6 @@ func TestGenerationAdvancedOptsDoneGcp(t *testing.T) {
 func TestGenerationWithExistingTerraformGcp(t *testing.T) {
 	os.Setenv("LW_NOCACHE", "true")
 	defer os.Setenv("LW_NOCACHE", "")
-	projectId := "project-1"
 
 	// Tempdir for test
 	dir, err := ioutil.TempDir("", "lacework-cli")
@@ -877,32 +884,23 @@ func TestGenerationWithExistingTerraformGcp(t *testing.T) {
 		panic(err)
 	}
 
-	// Run CLI
 	runGcpGenerateTest(t,
 		func(c *expect.Console) {
-			expectString(t, c, cmd.QuestionGcpEnableConfiguration)
-			c.SendLine("y")
-			expectString(t, c, cmd.QuestionGcpEnableAuditLog)
-			c.SendLine("y")
-			expectString(t, c, cmd.QuestionGcpProjectID)
-			c.SendLine(projectId)
-			expectString(t, c, cmd.QuestionGcpOrganizationIntegration)
-			c.SendLine("n")
-			expectString(t, c, cmd.QuestionGcpServiceAccountCredsPath)
-			c.SendLine("")
-			expectString(t, c, cmd.QuestionGcpConfigureAdvanced)
-			c.SendLine("y")
-			expectString(t, c, cmd.GcpAdvancedOptAuditLog)
-			// This is key down x3 in ANSI
-			c.Send("\x1B[B")
-			c.Send("\x1B[B")
-			c.SendLine("\x1B[B")
-			expectString(t, c, cmd.QuestionGcpCustomizeOutputLocation)
-			c.SendLine(dir)
-			expectString(t, c, cmd.QuestionGcpAnotherAdvancedOpt)
-			c.SendLine("n")
-			expectString(t, c, fmt.Sprintf("%s/main.tf already exists, overwrite?", dir))
-			c.SendLine("n")
+			cliExpectations(t, c, []MsgRsp{
+				msgRsp(cmd.QuestionGcpEnableConfiguration, "y"),
+				msgRsp(cmd.QuestionGcpEnableAuditLog, "y"),
+				msgRsp(cmd.QuestionGcpProjectID, projectId),
+				msgRsp(cmd.QuestionGcpOrganizationIntegration, "n"),
+				msgRsp(cmd.QuestionGcpServiceAccountCredsPath, ""),
+				msgRsp(cmd.QuestionGcpConfigureAdvanced, "y"),
+				msgOnly(cmd.GcpAdvancedOptAuditLog),
+			})
+			menuSelect(t, c, 3)
+			cliExpectations(t, c, []MsgRsp{
+				msgRsp(cmd.QuestionGcpCustomizeOutputLocation, dir),
+				msgRsp(cmd.QuestionGcpAnotherAdvancedOpt, "n"),
+				msgRsp(fmt.Sprintf("%s/main.tf already exists, overwrite?", dir), "n"),
+			})
 		},
 		"cloud",
 		"iac",
@@ -916,6 +914,236 @@ func TestGenerationWithExistingTerraformGcp(t *testing.T) {
 	}
 
 	assert.Empty(t, data)
+}
+
+func TestGenerationFolders(t *testing.T) {
+	os.Setenv("LW_NOCACHE", "true")
+	defer os.Setenv("LW_NOCACHE", "")
+	var final string
+
+	tfResult := runGcpGenerateTest(t,
+		func(c *expect.Console) {
+			cliExpectations(t, c, []MsgRsp{
+				msgRsp(cmd.QuestionGcpEnableConfiguration, "y"),
+				msgRsp(cmd.QuestionGcpEnableAuditLog, "y"),
+				msgRsp(cmd.QuestionGcpProjectID, projectId),
+				msgRsp(cmd.QuestionGcpOrganizationIntegration, "y"),
+				msgRsp(cmd.QuestionGcpOrganizationID, organizationId),
+				msgRsp(cmd.QuestionGcpServiceAccountCredsPath, ""),
+				msgRsp(cmd.QuestionGcpConfigureAdvanced, "n"),
+				msgRsp(cmd.QuestionRunTfPlan, "n"),
+			})
+			final, _ = c.ExpectEOF()
+		},
+		"cloud",
+		"iac",
+		"gcp",
+		"--folders_to_include", "folder/abc",
+		"--folders_to_include", "folder/def",
+		"--folders_to_include", "folder/abc",
+		"--folders_to_exclude", "folder/abc",
+		"--folders_to_exclude", "folder/def",
+	)
+
+	assertTerraformSaved(t, final)
+
+	buildTf, _ := gcp.NewTerraform(true, true,
+		gcp.WithProjectId(projectId),
+		gcp.WithOrganizationIntegration(true),
+		gcp.WithOrganizationId(organizationId),
+		gcp.WithFoldersToExclude([]string{"folder/abc", "folder/def"}),
+		gcp.WithFoldersToInclude([]string{"folder/abc", "folder/abc", "folder/def"}),
+	).Generate()
+	assert.Equal(t, buildTf, tfResult)
+}
+
+func TestGenerationFoldersShorthand(t *testing.T) {
+	os.Setenv("LW_NOCACHE", "true")
+	defer os.Setenv("LW_NOCACHE", "")
+	var final string
+
+	tfResult := runGcpGenerateTest(t,
+		func(c *expect.Console) {
+			cliExpectations(t, c, []MsgRsp{
+				msgRsp(cmd.QuestionGcpEnableConfiguration, "y"),
+				msgRsp(cmd.QuestionGcpEnableAuditLog, "y"),
+				msgRsp(cmd.QuestionGcpProjectID, projectId),
+				msgRsp(cmd.QuestionGcpOrganizationIntegration, "y"),
+				msgRsp(cmd.QuestionGcpOrganizationID, organizationId),
+				msgRsp(cmd.QuestionGcpServiceAccountCredsPath, ""),
+				msgRsp(cmd.QuestionGcpConfigureAdvanced, "n"),
+				msgRsp(cmd.QuestionRunTfPlan, "n"),
+			})
+			final, _ = c.ExpectEOF()
+		},
+		"cloud",
+		"iac",
+		"gcp",
+		"-i", "folder/abc",
+		"-i", "folder/abc",
+		"-i", "folder/def",
+		"-e", "folder/abc",
+		"-e", "folder/def",
+	)
+
+	assertTerraformSaved(t, final)
+
+	buildTf, _ := gcp.NewTerraform(true, true,
+		gcp.WithProjectId(projectId),
+		gcp.WithOrganizationIntegration(true),
+		gcp.WithOrganizationId(organizationId),
+		gcp.WithFoldersToExclude([]string{"folder/abc", "folder/def"}),
+		gcp.WithFoldersToInclude([]string{"folder/abc", "folder/abc", "folder/def"}),
+	).Generate()
+	assert.Equal(t, buildTf, tfResult)
+}
+
+func TestGenerationIncludeRootProjects(t *testing.T) {
+	os.Setenv("LW_NOCACHE", "true")
+	defer os.Setenv("LW_NOCACHE", "")
+	var final string
+
+	tfResult := runGcpGenerateTest(t,
+		func(c *expect.Console) {
+			cliExpectations(t, c, []MsgRsp{
+				msgRsp(cmd.QuestionGcpEnableConfiguration, "y"),
+				msgRsp(cmd.QuestionGcpEnableAuditLog, "y"),
+				msgRsp(cmd.QuestionGcpProjectID, projectId),
+				msgRsp(cmd.QuestionGcpOrganizationIntegration, "y"),
+				msgRsp(cmd.QuestionGcpOrganizationID, organizationId),
+				msgRsp(cmd.QuestionGcpServiceAccountCredsPath, ""),
+				msgRsp(cmd.QuestionGcpConfigureAdvanced, "n"),
+				msgRsp(cmd.QuestionRunTfPlan, "n"),
+			})
+			final, _ = c.ExpectEOF()
+		},
+		"cloud",
+		"iac",
+		"gcp",
+		"--folders_to_exclude",
+		"folder/abc",
+		"--include_root_projects",
+	)
+
+	assertTerraformSaved(t, final)
+
+	buildTf, _ := gcp.NewTerraform(true, true,
+		gcp.WithProjectId(projectId),
+		gcp.WithOrganizationIntegration(true),
+		gcp.WithOrganizationId(organizationId),
+		gcp.WithFoldersToExclude([]string{"folder/abc"}),
+		gcp.WithIncludeRootProjects(true),
+	).Generate()
+	assert.Equal(t, buildTf, tfResult)
+}
+
+func TestGenerationIncludeRootProjectsFalse(t *testing.T) {
+	os.Setenv("LW_NOCACHE", "true")
+	defer os.Setenv("LW_NOCACHE", "")
+	var final string
+
+	tfResult := runGcpGenerateTest(t,
+		func(c *expect.Console) {
+			cliExpectations(t, c, []MsgRsp{
+				msgRsp(cmd.QuestionGcpEnableConfiguration, "y"),
+				msgRsp(cmd.QuestionGcpEnableAuditLog, "y"),
+				msgRsp(cmd.QuestionGcpProjectID, projectId),
+				msgRsp(cmd.QuestionGcpOrganizationIntegration, "y"),
+				msgRsp(cmd.QuestionGcpOrganizationID, organizationId),
+				msgRsp(cmd.QuestionGcpServiceAccountCredsPath, ""),
+				msgRsp(cmd.QuestionGcpConfigureAdvanced, "n"),
+				msgRsp(cmd.QuestionRunTfPlan, "n"),
+			})
+			final, _ = c.ExpectEOF()
+		},
+		"cloud",
+		"iac",
+		"gcp",
+		"--folders_to_exclude",
+		"folder/abc",
+		"--include_root_projects=false",
+	)
+
+	assertTerraformSaved(t, final)
+
+	buildTf, _ := gcp.NewTerraform(true, true,
+		gcp.WithProjectId(projectId),
+		gcp.WithOrganizationIntegration(true),
+		gcp.WithOrganizationId(organizationId),
+		gcp.WithFoldersToExclude([]string{"folder/abc"}),
+		gcp.WithIncludeRootProjects(false),
+	).Generate()
+	assert.Equal(t, buildTf, tfResult)
+}
+
+func TestGenerationAuditLogFiltersTrue(t *testing.T) {
+	os.Setenv("LW_NOCACHE", "true")
+	defer os.Setenv("LW_NOCACHE", "")
+	var final string
+
+	tfResult := runGcpGenerateTest(t,
+		func(c *expect.Console) {
+			cliExpectations(t, c, []MsgRsp{
+				msgRsp(cmd.QuestionGcpEnableConfiguration, "n"),
+				msgRsp(cmd.QuestionGcpEnableAuditLog, "y"),
+				msgRsp(cmd.QuestionGcpProjectID, projectId),
+				msgRsp(cmd.QuestionGcpOrganizationIntegration, "n"),
+				msgRsp(cmd.QuestionGcpServiceAccountCredsPath, ""),
+				msgRsp(cmd.QuestionGcpConfigureAdvanced, "n"),
+				msgRsp(cmd.QuestionRunTfPlan, "n"),
+			})
+			final, _ = c.ExpectEOF()
+		},
+		"cloud",
+		"iac",
+		"gcp",
+		"--google_workspace_filter",
+		"--k8s_filter",
+	)
+
+	assertTerraformSaved(t, final)
+
+	buildTf, _ := gcp.NewTerraform(false, true,
+		gcp.WithProjectId(projectId),
+		gcp.WithGoogleWorkspaceFilter(true),
+		gcp.WithK8sFilter(true),
+	).Generate()
+	assert.Equal(t, buildTf, tfResult)
+}
+
+func TestGenerationAuditlogFiltersFalse(t *testing.T) {
+	os.Setenv("LW_NOCACHE", "true")
+	defer os.Setenv("LW_NOCACHE", "")
+	var final string
+
+	tfResult := runGcpGenerateTest(t,
+		func(c *expect.Console) {
+			cliExpectations(t, c, []MsgRsp{
+				msgRsp(cmd.QuestionGcpEnableConfiguration, "n"),
+				msgRsp(cmd.QuestionGcpEnableAuditLog, "y"),
+				msgRsp(cmd.QuestionGcpProjectID, projectId),
+				msgRsp(cmd.QuestionGcpOrganizationIntegration, "n"),
+				msgRsp(cmd.QuestionGcpServiceAccountCredsPath, ""),
+				msgRsp(cmd.QuestionGcpConfigureAdvanced, "n"),
+				msgRsp(cmd.QuestionRunTfPlan, "n"),
+			})
+			final, _ = c.ExpectEOF()
+		},
+		"cloud",
+		"iac",
+		"gcp",
+		"--google_workspace_filter=false",
+		"--k8s_filter=false",
+	)
+
+	assertTerraformSaved(t, final)
+
+	buildTf, _ := gcp.NewTerraform(false, true,
+		gcp.WithProjectId(projectId),
+		gcp.WithGoogleWorkspaceFilter(false),
+		gcp.WithK8sFilter(false),
+	).Generate()
+	assert.Equal(t, buildTf, tfResult)
 }
 
 func runGcpGenerateTest(t *testing.T, conditions func(*expect.Console), args ...string) string {

--- a/integration/test_resources/help/cloud-account_iac-generate_gcp
+++ b/integration/test_resources/help/cloud-account_iac-generate_gcp
@@ -23,24 +23,30 @@ Flags:
       --audit_log                                     enable audit log integration
       --audit_log_integration_name string             specify a custom audit log integration name
       --bucket_lifecycle_rule_age int                 specify the lifecycle rule age (default -1)
-      --bucket_location string                        specify bucket location
-      --bucket_name string                            specify new bucket name
       --bucket_region string                          specify bucket region
-      --bucket_retention_days int                     specify the bucket retention days
       --configuration                                 enable configuration integration
       --configuration_integration_name string         specify a custom configuration integration name
+      --custom_bucket_name string                     override prefix based storage bucket name generation with a custom name
+      --custom_filter string                          customer defined Audit Log filter which will supersede all other filter options when defined
       --enable_force_destroy_bucket                   enable force bucket destroy
       --enable_ubla                                   enable universal bucket level access(ubla) (default true)
       --existing_bucket_name string                   specify existing bucket name
       --existing_service_account_name string          specify existing service account name
       --existing_service_account_private_key string   specify existing service account private key (base64 encoded)
       --existing_sink_name string                     specify existing sink name
+  -e, --folders_to_exclude stringArray                List of root folders to exclude in an organization-level integration
+  -i, --folders_to_include stringArray                list of root folders to include in an organization-level integration
+      --google_workspace_filter                       filter out Google Workspace login logs from GCP Audit Log sinks (default true)
   -h, --help                                          help for gcp
+      --include_root_projects                         Disables logic that includes root-level projects if excluding folders (default true)
+      --k8s_filter                                    filter out GKE logs from GCP Audit Log sinks (default true)
       --organization_id string                        specify the organization id (only set if organization_integration is set)
       --organization_integration                      enable organization integration
       --output string                                 location to write generated content (default is ~/lacework/gcp)
+      --prefix string                                 prefix that will be used at the beginning of every generated resource
       --project_id string                             specify the project id to be used to provision lacework resources (required)
       --service_account_credentials string            specify service account credentials JSON file path (leave blank to make use of google credential ENV vars)
+      --wait_time string                              amount of time to wait before the next resource is provisioned
 
 Global Flags:
   -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)

--- a/lwgenerate/_examples/azure/main.go
+++ b/lwgenerate/_examples/azure/main.go
@@ -43,7 +43,7 @@ func ConfigWithoutActivityLog() {
 func CustomActiveDirectory() {
 	hcl, err := azure.NewTerraform(true, true, false,
 		azure.WithConfigIntegrationName("Test Config Rename"),
-		azure.WithAuditLogIntegrationName("Test Activity Log Rename"),
+		azure.WithActivityLogIntegrationName("Test Activity Log Rename"),
 		azure.WithAdApplicationPassword("AD-Test-Password"),
 		azure.WithAdServicePrincipalId("AD-Test-Principal-ID"),
 		azure.WithAdApplicationId("AD-Test-Application-ID"),

--- a/lwgenerate/constants.go
+++ b/lwgenerate/constants.go
@@ -22,7 +22,7 @@ const (
 	HashAzureRMProviderVersion = "~> 2.91.0"
 
 	GcpConfigSource    = "lacework/config/gcp"
-	GcpConfigVersion   = "~> 2.0"
+	GcpConfigVersion   = "~> 2.3"
 	GcpAuditLogSource  = "lacework/audit-log/gcp"
-	GcpAuditLogVersion = "~> 2.0"
+	GcpAuditLogVersion = "~> 3.0"
 )

--- a/lwgenerate/gcp/gcp.go
+++ b/lwgenerate/gcp/gcp.go
@@ -1,6 +1,8 @@
 package gcp
 
 import (
+	"sort"
+
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/lacework/go-sdk/lwgenerate"
 	"github.com/pkg/errors"
@@ -78,14 +80,10 @@ type GenerateGcpTfConfigurationArgs struct {
 	// Set of labels which will be added to the topic
 	PubSubTopicLabels map[string]string
 
+	CustomBucketName string
+
 	// Supply a GCP region for the new bucket. EU/US/ASIA
 	BucketRegion string
-
-	// Supply a GCP location for the new bucket. Defaults to global
-	BucketLocation string
-
-	// Supply a name for the new bucket
-	BucketName string
 
 	// Existing Bucket Name
 	ExistingLogBucketName string
@@ -103,15 +101,27 @@ type GenerateGcpTfConfigurationArgs struct {
 	// If left empty the TF will default to -1
 	LogBucketLifecycleRuleAge int
 
-	// The number of days to keep logs before deleting.
-	// If left as 0 the TF will default to 30.
-	LogBucketRetentionDays int
-
 	// If AuditLog is true, give the user the opportunity to name their integration. Defaults to "TF audit_log"
 	AuditLogIntegrationName string
 
 	// Lacework Profile to use
 	LaceworkProfile string
+
+	FoldersToInclude []string
+
+	FoldersToExclude []string
+
+	IncludeRootProjects bool
+
+	CustomFilter string
+
+	GoogleWorkspaceFilter bool
+
+	K8sFilter bool
+
+	Prefix string
+
+	WaitTime string
 }
 
 // Ensure all combinations of inputs are valid for supported spec
@@ -156,7 +166,14 @@ type GcpTerraformModifier func(c *GenerateGcpTfConfigurationArgs)
 //     gcp.WithGcpServiceAccountCredentials("/path/to/sa/credentials.json")).Generate()
 //
 func NewTerraform(enableConfig bool, enableAuditLog bool, mods ...GcpTerraformModifier) *GenerateGcpTfConfigurationArgs {
-	config := &GenerateGcpTfConfigurationArgs{AuditLog: enableAuditLog, Configuration: enableConfig, EnableUBLA: true}
+	config := &GenerateGcpTfConfigurationArgs{
+		AuditLog:              enableAuditLog,
+		Configuration:         enableConfig,
+		IncludeRootProjects:   true,
+		EnableUBLA:            true,
+		GoogleWorkspaceFilter: true,
+		K8sFilter:             true,
+	}
 	// default LogBucketLifecycleRuleAge to -1. This helps us determine if the var has been set by the end user
 	config.LogBucketLifecycleRuleAge = -1
 	for _, m := range mods {
@@ -243,24 +260,16 @@ func WithPubSubTopicLabels(labels map[string]string) GcpTerraformModifier {
 	}
 }
 
+func WithCustomBucketName(name string) GcpTerraformModifier {
+	return func(c *GenerateGcpTfConfigurationArgs) {
+		c.CustomBucketName = name
+	}
+}
+
 // WithBucketRegion Set the Region in which the Bucket should be created
 func WithBucketRegion(region string) GcpTerraformModifier {
 	return func(c *GenerateGcpTfConfigurationArgs) {
 		c.BucketRegion = region
-	}
-}
-
-// WithBucketLocation Set the name of the bucket that will receive log objects
-func WithBucketLocation(location string) GcpTerraformModifier {
-	return func(c *GenerateGcpTfConfigurationArgs) {
-		c.BucketLocation = location
-	}
-}
-
-// WithBucketName Set the Location in which the Bucket should be created
-func WithBucketName(name string) GcpTerraformModifier {
-	return func(c *GenerateGcpTfConfigurationArgs) {
-		c.BucketName = name
 	}
 }
 
@@ -300,17 +309,58 @@ func WithLogBucketLifecycleRuleAge(ruleAge int) GcpTerraformModifier {
 	}
 }
 
-// WithLogBucketRetentionDays Set the number of days to keep logs before deleting. Default is 30
-func WithLogBucketRetentionDays(days int) GcpTerraformModifier {
-	return func(c *GenerateGcpTfConfigurationArgs) {
-		c.LogBucketRetentionDays = days
-	}
-}
-
 // WithAuditLogIntegrationName Set the Config Integration name to be displayed on the Lacework UI
 func WithAuditLogIntegrationName(name string) GcpTerraformModifier {
 	return func(c *GenerateGcpTfConfigurationArgs) {
 		c.AuditLogIntegrationName = name
+	}
+}
+
+func WithFoldersToInclude(folders []string) GcpTerraformModifier {
+	return func(c *GenerateGcpTfConfigurationArgs) {
+		c.FoldersToInclude = folders
+	}
+}
+
+func WithFoldersToExclude(folders []string) GcpTerraformModifier {
+	return func(c *GenerateGcpTfConfigurationArgs) {
+		c.FoldersToExclude = folders
+	}
+}
+
+func WithIncludeRootProjects(include bool) GcpTerraformModifier {
+	return func(c *GenerateGcpTfConfigurationArgs) {
+		c.IncludeRootProjects = include
+	}
+}
+
+func WithCustomFilter(filter string) GcpTerraformModifier {
+	return func(c *GenerateGcpTfConfigurationArgs) {
+		c.CustomFilter = filter
+	}
+}
+
+func WithGoogleWorkspaceFilter(filter bool) GcpTerraformModifier {
+	return func(c *GenerateGcpTfConfigurationArgs) {
+		c.GoogleWorkspaceFilter = filter
+	}
+}
+
+func WithK8sFilter(filter bool) GcpTerraformModifier {
+	return func(c *GenerateGcpTfConfigurationArgs) {
+		c.K8sFilter = filter
+	}
+}
+
+func WithPrefix(prefix string) GcpTerraformModifier {
+	return func(c *GenerateGcpTfConfigurationArgs) {
+		c.Prefix = prefix
+	}
+}
+
+func WithWaitTime(waitTime string) GcpTerraformModifier {
+	return func(c *GenerateGcpTfConfigurationArgs) {
+		c.WaitTime = waitTime
 	}
 }
 
@@ -404,6 +454,27 @@ func createLaceworkProvider(args *GenerateGcpTfConfigurationArgs) (*hclwrite.Blo
 	return nil, nil
 }
 
+func sortedStringSet(list []string) []string {
+	// TODO: Find me a home
+	_map := make(map[string]string)
+
+	for _, f := range list {
+		_map[f] = ""
+	}
+
+	set := make([]string, len(_map))
+
+	i := 0
+	for key := range _map {
+		set[i] = key
+		i++
+	}
+
+	sort.Strings(set)
+
+	return set
+}
+
 func createConfiguration(args *GenerateGcpTfConfigurationArgs) ([]*hclwrite.Block, error) {
 	blocks := []*hclwrite.Block{}
 	if args.Configuration {
@@ -417,6 +488,19 @@ func createConfiguration(args *GenerateGcpTfConfigurationArgs) ([]*hclwrite.Bloc
 			configurationModuleName = "gcp_organization_level_config"
 			attributes["org_integration"] = args.OrganizationIntegration
 			attributes["organization_id"] = args.GcpOrganizationId
+
+			if len(args.FoldersToInclude) > 0 {
+				attributes["folders_to_include"] = sortedStringSet(args.FoldersToInclude)
+			}
+
+			if len(args.FoldersToExclude) > 0 {
+				attributes["folders_to_exclude"] = sortedStringSet(args.FoldersToExclude)
+
+				// Default true in gcp-audit-log TF module
+				if args.IncludeRootProjects != true {
+					attributes["include_root_projects"] = args.IncludeRootProjects
+				}
+			}
 		}
 
 		if args.ExistingServiceAccount != nil {
@@ -427,6 +511,14 @@ func createConfiguration(args *GenerateGcpTfConfigurationArgs) ([]*hclwrite.Bloc
 
 		if args.ConfigurationIntegrationName != "" {
 			attributes["lacework_integration_name"] = args.ConfigurationIntegrationName
+		}
+
+		if args.Prefix != "" {
+			attributes["prefix"] = args.Prefix
+		}
+
+		if args.WaitTime != "" {
+			attributes["wait_time"] = args.WaitTime
 		}
 
 		moduleDetails = append(moduleDetails,
@@ -470,10 +562,6 @@ func createAuditLog(args *GenerateGcpTfConfigurationArgs) (*hclwrite.Block, erro
 				attributes["lifecycle_rule_age"] = args.LogBucketLifecycleRuleAge
 			}
 
-			if args.BucketName != "" {
-				attributes["log_bucket"] = args.BucketName
-			}
-
 			if args.AuditLogLabels != nil {
 				attributes["labels"] = args.AuditLogLabels
 			}
@@ -491,16 +579,12 @@ func createAuditLog(args *GenerateGcpTfConfigurationArgs) (*hclwrite.Block, erro
 				attributes["enable_ubla"] = args.EnableUBLA
 			}
 
+			if args.CustomBucketName != "" {
+				attributes["custom_bucket_name"] = args.CustomBucketName
+			}
+
 			if args.BucketRegion != "" {
 				attributes["bucket_region"] = args.BucketRegion
-			}
-
-			if args.BucketLocation != "" {
-				attributes["log_bucket_location"] = args.BucketLocation
-			}
-
-			if args.LogBucketRetentionDays != 0 {
-				attributes["log_bucket_retention_days"] = args.LogBucketRetentionDays
 			}
 		}
 
@@ -518,6 +602,19 @@ func createAuditLog(args *GenerateGcpTfConfigurationArgs) (*hclwrite.Block, erro
 			auditLogModuleName = "gcp_organization_level_audit_log"
 			attributes["org_integration"] = args.OrganizationIntegration
 			attributes["organization_id"] = args.GcpOrganizationId
+
+			if len(args.FoldersToInclude) > 0 {
+				attributes["folders_to_include"] = sortedStringSet(args.FoldersToInclude)
+			}
+
+			if len(args.FoldersToExclude) > 0 {
+				attributes["folders_to_exclude"] = sortedStringSet(args.FoldersToExclude)
+
+				// Default true in gcp-audit-log TF module
+				if args.IncludeRootProjects != true {
+					attributes["include_root_projects"] = args.IncludeRootProjects
+				}
+			}
 		}
 
 		if args.ExistingServiceAccount == nil && args.Configuration {
@@ -538,6 +635,28 @@ func createAuditLog(args *GenerateGcpTfConfigurationArgs) (*hclwrite.Block, erro
 
 		if args.AuditLogIntegrationName != "" {
 			attributes["lacework_integration_name"] = args.AuditLogIntegrationName
+		}
+
+		if args.CustomFilter != "" {
+			attributes["custom_filter"] = args.CustomFilter
+		}
+
+		// Default true in gcp-audit-log TF module
+		if args.GoogleWorkspaceFilter != true {
+			attributes["google_workspace_filter"] = args.GoogleWorkspaceFilter
+		}
+
+		// Default true in gcp-audit-log TF module
+		if args.K8sFilter != true {
+			attributes["k8s_filter"] = args.K8sFilter
+		}
+
+		if args.Prefix != "" {
+			attributes["prefix"] = args.Prefix
+		}
+
+		if args.WaitTime != "" {
+			attributes["wait_time"] = args.WaitTime
 		}
 
 		moduleDetails = append(moduleDetails,

--- a/lwgenerate/gcp/gcp_test.go
+++ b/lwgenerate/gcp/gcp_test.go
@@ -126,28 +126,6 @@ func TestGenerationProjectLevelAuditLogBucketRegion(t *testing.T) {
 	assert.Equal(t, reqProvider(moduleImportProjectLevelAuditLogBucketRegion), hcl)
 }
 
-func TestGenerationProjectLevelAuditLogBucketLocation(t *testing.T) {
-	hcl, err := gcp.NewTerraform(false, true,
-		gcp.WithGcpServiceAccountCredentials("/path/to/credentials"),
-		gcp.WithProjectId("project1"),
-		gcp.WithBucketLocation("us"),
-	).Generate()
-	assert.Nil(t, err)
-	assert.NotNil(t, hcl)
-	assert.Equal(t, reqProvider(moduleImportProjectLevelAuditLogBucketLocation), hcl)
-}
-
-func TestGenerationProjectLevelAuditLogBucketName(t *testing.T) {
-	hcl, err := gcp.NewTerraform(false, true,
-		gcp.WithGcpServiceAccountCredentials("/path/to/credentials"),
-		gcp.WithProjectId("project1"),
-		gcp.WithBucketName("foo"),
-	).Generate()
-	assert.Nil(t, err)
-	assert.NotNil(t, hcl)
-	assert.Equal(t, reqProvider(moduleImportProjectLevelAuditLogBucketName), hcl)
-}
-
 func TestGenerationProjectLevelAuditLogExistingBucketName(t *testing.T) {
 	hcl, err := gcp.NewTerraform(false, true,
 		gcp.WithGcpServiceAccountCredentials("/path/to/credentials"),
@@ -212,17 +190,6 @@ func TestGenerationProjectLevelAuditLogBucketLifecycleRuleAge(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, hcl)
 	assert.Equal(t, reqProvider(moduleImportProjectLevelAuditLogBucketLifecycleRuleAge), hcl)
-}
-
-func TestGenerationProjectLevelAuditLogBucketRetentionDays(t *testing.T) {
-	hcl, err := gcp.NewTerraform(false, true,
-		gcp.WithGcpServiceAccountCredentials("/path/to/credentials"),
-		gcp.WithProjectId("project1"),
-		gcp.WithLogBucketRetentionDays(420),
-	).Generate()
-	assert.Nil(t, err)
-	assert.NotNil(t, hcl)
-	assert.Equal(t, reqProvider(moduleImportProjectLevelAuditLogBucketRetentionDays), hcl)
 }
 
 func TestGenerationOrganizationLevelAuditLogWithoutConfig(t *testing.T) {
@@ -362,6 +329,401 @@ func TestGenerationOrganizationLevelConfigurationCustomIntegrationName(t *testin
 	assert.Equal(t, reqProvider(moduleImportOrganizationLevelConfigurationCustomIntegrationName), hcl)
 }
 
+func TestGenerationProjectLevelAuditLogCustomBucketName(t *testing.T) {
+	expect := `module "gcp_project_audit_log" {
+  source             = "lacework/audit-log/gcp"
+  version            = "~> 3.0"
+  custom_bucket_name = "bucket"
+}
+`
+
+	hcl, err := gcp.NewTerraform(false, true,
+		gcp.WithGcpServiceAccountCredentials("/path/to/credentials"),
+		gcp.WithProjectId("project1"),
+		gcp.WithCustomBucketName("bucket"),
+	).Generate()
+	assert.Nil(t, err)
+	assert.NotNil(t, hcl)
+	assert.Equal(t, reqProvider(expect), hcl)
+}
+
+func TestGenerationProjectLevelAuditLogCustomFilter(t *testing.T) {
+	expect := `module "gcp_project_audit_log" {
+  source        = "lacework/audit-log/gcp"
+  version       = "~> 3.0"
+  custom_filter = "custom-filter"
+}
+`
+
+	hcl, err := gcp.NewTerraform(false, true,
+		gcp.WithGcpServiceAccountCredentials("/path/to/credentials"),
+		gcp.WithProjectId("project1"),
+		gcp.WithCustomFilter("custom-filter"),
+	).Generate()
+	assert.Nil(t, err)
+	assert.NotNil(t, hcl)
+	assert.Equal(t, reqProvider(expect), hcl)
+}
+
+func TestGenerationProjectLevelAuditLogGoogleWorkspaceFilter(t *testing.T) {
+	expect := `module "gcp_project_audit_log" {
+  source  = "lacework/audit-log/gcp"
+  version = "~> 3.0"
+}
+`
+
+	hcl, err := gcp.NewTerraform(false, true,
+		gcp.WithGcpServiceAccountCredentials("/path/to/credentials"),
+		gcp.WithProjectId("project1"),
+		gcp.WithGoogleWorkspaceFilter(true),
+	).Generate()
+	assert.Nil(t, err)
+	assert.NotNil(t, hcl)
+	assert.Equal(t, reqProvider(expect), hcl)
+
+	expect = `module "gcp_project_audit_log" {
+  source                  = "lacework/audit-log/gcp"
+  version                 = "~> 3.0"
+  google_workspace_filter = false
+}
+`
+
+	hcl, err = gcp.NewTerraform(false, true,
+		gcp.WithGcpServiceAccountCredentials("/path/to/credentials"),
+		gcp.WithProjectId("project1"),
+		gcp.WithGoogleWorkspaceFilter(false),
+	).Generate()
+	assert.Nil(t, err)
+	assert.NotNil(t, hcl)
+	assert.Equal(t, reqProvider(expect), hcl)
+}
+
+func TestGenerationProjectLevelAuditLogK8sFilter(t *testing.T) {
+	expect := `module "gcp_project_audit_log" {
+  source  = "lacework/audit-log/gcp"
+  version = "~> 3.0"
+}
+`
+
+	hcl, err := gcp.NewTerraform(false, true,
+		gcp.WithGcpServiceAccountCredentials("/path/to/credentials"),
+		gcp.WithProjectId("project1"),
+		gcp.WithK8sFilter(true),
+	).Generate()
+	assert.Nil(t, err)
+	assert.NotNil(t, hcl)
+	assert.Equal(t, reqProvider(expect), hcl)
+
+	expect = `module "gcp_project_audit_log" {
+  source     = "lacework/audit-log/gcp"
+  version    = "~> 3.0"
+  k8s_filter = false
+}
+`
+
+	hcl, err = gcp.NewTerraform(false, true,
+		gcp.WithGcpServiceAccountCredentials("/path/to/credentials"),
+		gcp.WithProjectId("project1"),
+		gcp.WithK8sFilter(false),
+	).Generate()
+	assert.Nil(t, err)
+	assert.NotNil(t, hcl)
+	assert.Equal(t, reqProvider(expect), hcl)
+}
+
+func TestGenerationOrganizationLevelAuditLogFoldersToInclude(t *testing.T) {
+	expect := `module "gcp_organization_level_audit_log" {
+  source             = "lacework/audit-log/gcp"
+  version            = "~> 3.0"
+  folders_to_include = ["abc", "def"]
+  org_integration    = true
+  organization_id    = "123456789"
+}
+`
+	hcl, err := gcp.NewTerraform(false, true,
+		gcp.WithGcpServiceAccountCredentials("/path/to/credentials"),
+		gcp.WithProjectId("project1"),
+		gcp.WithOrganizationIntegration(true),
+		gcp.WithOrganizationId("123456789"),
+		gcp.WithFoldersToInclude([]string{"abc", "abc", "def", "def"}),
+	).Generate()
+	assert.Nil(t, err)
+	assert.NotNil(t, hcl)
+	assert.Equal(t, reqProvider(expect), hcl)
+}
+
+func TestGenerationOrganizationLevelAuditLogFoldersToExclude(t *testing.T) {
+	expect := `module "gcp_organization_level_audit_log" {
+  source             = "lacework/audit-log/gcp"
+  version            = "~> 3.0"
+  folders_to_exclude = ["abc", "def"]
+  org_integration    = true
+  organization_id    = "123456789"
+}
+`
+	hcl, err := gcp.NewTerraform(false, true,
+		gcp.WithGcpServiceAccountCredentials("/path/to/credentials"),
+		gcp.WithProjectId("project1"),
+		gcp.WithOrganizationIntegration(true),
+		gcp.WithOrganizationId("123456789"),
+		gcp.WithFoldersToExclude([]string{"abc", "def"}),
+	).Generate()
+	assert.Nil(t, err)
+	assert.NotNil(t, hcl)
+	assert.Equal(t, reqProvider(expect), hcl)
+}
+
+func TestGenerationOrganizationLevelAuditLogIncludeRootProjectsSolo(t *testing.T) {
+	expect := `module "gcp_organization_level_audit_log" {
+  source          = "lacework/audit-log/gcp"
+  version         = "~> 3.0"
+  org_integration = true
+  organization_id = "123456789"
+}
+`
+
+	hcl, err := gcp.NewTerraform(false, true,
+		gcp.WithGcpServiceAccountCredentials("/path/to/credentials"),
+		gcp.WithProjectId("project1"),
+		gcp.WithOrganizationIntegration(true),
+		gcp.WithOrganizationId("123456789"),
+		gcp.WithIncludeRootProjects(false),
+	).Generate()
+	assert.Nil(t, err)
+	assert.NotNil(t, hcl)
+	assert.Equal(t, reqProvider(expect), hcl)
+}
+
+func TestGenerationOrganizationLevelAuditLogIncludeRootProjectsFalse(t *testing.T) {
+	expect := `module "gcp_organization_level_audit_log" {
+  source                = "lacework/audit-log/gcp"
+  version               = "~> 3.0"
+  folders_to_exclude    = ["abc"]
+  include_root_projects = false
+  org_integration       = true
+  organization_id       = "123456789"
+}
+`
+
+	hcl, err := gcp.NewTerraform(false, true,
+		gcp.WithGcpServiceAccountCredentials("/path/to/credentials"),
+		gcp.WithProjectId("project1"),
+		gcp.WithOrganizationIntegration(true),
+		gcp.WithOrganizationId("123456789"),
+		gcp.WithIncludeRootProjects(false),
+		gcp.WithFoldersToExclude([]string{"abc"}),
+	).Generate()
+	assert.Nil(t, err)
+	assert.NotNil(t, hcl)
+	assert.Equal(t, reqProvider(expect), hcl)
+}
+
+func TestGenerationOrganizationLevelAuditLogIncludeRootProjectsTrue(t *testing.T) {
+	expect := `module "gcp_organization_level_audit_log" {
+  source             = "lacework/audit-log/gcp"
+  version            = "~> 3.0"
+  folders_to_exclude = ["abc"]
+  org_integration    = true
+  organization_id    = "123456789"
+}
+`
+
+	hcl, err := gcp.NewTerraform(false, true,
+		gcp.WithGcpServiceAccountCredentials("/path/to/credentials"),
+		gcp.WithProjectId("project1"),
+		gcp.WithOrganizationIntegration(true),
+		gcp.WithOrganizationId("123456789"),
+		gcp.WithIncludeRootProjects(true),
+		gcp.WithFoldersToExclude([]string{"abc"}),
+	).Generate()
+	assert.Nil(t, err)
+	assert.NotNil(t, hcl)
+	assert.Equal(t, reqProvider(expect), hcl)
+}
+
+func TestGenerationProjectLevelAuditLogPrefix(t *testing.T) {
+	expect := `module "gcp_project_audit_log" {
+  source  = "lacework/audit-log/gcp"
+  version = "~> 3.0"
+  prefix  = "rar"
+}
+`
+
+	hcl, err := gcp.NewTerraform(false, true,
+		gcp.WithGcpServiceAccountCredentials("/path/to/credentials"),
+		gcp.WithProjectId("project1"),
+		gcp.WithPrefix("rar"),
+	).Generate()
+	assert.Nil(t, err)
+	assert.NotNil(t, hcl)
+	assert.Equal(t, reqProvider(expect), hcl)
+}
+
+func TestGenerationProjectLevelAuditLogWaitTime(t *testing.T) {
+	expect := `module "gcp_project_audit_log" {
+  source    = "lacework/audit-log/gcp"
+  version   = "~> 3.0"
+  wait_time = "30s"
+}
+`
+
+	hcl, err := gcp.NewTerraform(false, true,
+		gcp.WithGcpServiceAccountCredentials("/path/to/credentials"),
+		gcp.WithProjectId("project1"),
+		gcp.WithWaitTime("30s"),
+	).Generate()
+	assert.Nil(t, err)
+	assert.NotNil(t, hcl)
+	assert.Equal(t, reqProvider(expect), hcl)
+}
+
+func TestGenerationOrganizationLevelConfigurationFoldersToInclude(t *testing.T) {
+	expect := `module "gcp_organization_level_config" {
+  source             = "lacework/config/gcp"
+  version            = "~> 2.3"
+  folders_to_include = ["abc", "def"]
+  org_integration    = true
+  organization_id    = "123456789"
+}
+`
+
+	hcl, err := gcp.NewTerraform(true, false,
+		gcp.WithGcpServiceAccountCredentials("/path/to/credentials"),
+		gcp.WithProjectId("project1"),
+		gcp.WithOrganizationIntegration(true),
+		gcp.WithOrganizationId("123456789"),
+		gcp.WithFoldersToInclude([]string{"abc", "abc", "def", "def"}),
+	).Generate()
+	assert.Nil(t, err)
+	assert.NotNil(t, hcl)
+	assert.Equal(t, reqProvider(expect), hcl)
+}
+
+func TestGenerationOrganizationLevelConfigurationFoldersToExclude(t *testing.T) {
+	expect := `module "gcp_organization_level_config" {
+  source             = "lacework/config/gcp"
+  version            = "~> 2.3"
+  folders_to_exclude = ["abc", "def"]
+  org_integration    = true
+  organization_id    = "123456789"
+}
+`
+
+	hcl, err := gcp.NewTerraform(true, false,
+		gcp.WithGcpServiceAccountCredentials("/path/to/credentials"),
+		gcp.WithProjectId("project1"),
+		gcp.WithOrganizationIntegration(true),
+		gcp.WithOrganizationId("123456789"),
+		gcp.WithFoldersToExclude([]string{"abc", "def"}),
+	).Generate()
+	assert.Nil(t, err)
+	assert.NotNil(t, hcl)
+	assert.Equal(t, reqProvider(expect), hcl)
+}
+
+func TestGenerationOrganizationLevelConfigurationIncludeRootProjectsSolo(t *testing.T) {
+	expect := `module "gcp_organization_level_config" {
+  source          = "lacework/config/gcp"
+  version         = "~> 2.3"
+  org_integration = true
+  organization_id = "123456789"
+}
+`
+
+	hcl, err := gcp.NewTerraform(true, false,
+		gcp.WithGcpServiceAccountCredentials("/path/to/credentials"),
+		gcp.WithProjectId("project1"),
+		gcp.WithOrganizationIntegration(true),
+		gcp.WithOrganizationId("123456789"),
+		gcp.WithIncludeRootProjects(false),
+	).Generate()
+	assert.Nil(t, err)
+	assert.NotNil(t, hcl)
+	assert.Equal(t, reqProvider(expect), hcl)
+}
+
+func TestGenerationOrganizationLevelConfigurationIncludeRootProjectsFalse(t *testing.T) {
+	expect := `module "gcp_organization_level_config" {
+  source                = "lacework/config/gcp"
+  version               = "~> 2.3"
+  folders_to_exclude    = ["abc"]
+  include_root_projects = false
+  org_integration       = true
+  organization_id       = "123456789"
+}
+`
+
+	hcl, err := gcp.NewTerraform(true, false,
+		gcp.WithGcpServiceAccountCredentials("/path/to/credentials"),
+		gcp.WithProjectId("project1"),
+		gcp.WithOrganizationIntegration(true),
+		gcp.WithOrganizationId("123456789"),
+		gcp.WithIncludeRootProjects(false),
+		gcp.WithFoldersToExclude([]string{"abc"}),
+	).Generate()
+	assert.Nil(t, err)
+	assert.NotNil(t, hcl)
+	assert.Equal(t, reqProvider(expect), hcl)
+}
+
+func TestGenerationOrganizationLevelConfigurationIncludeRootProjectsTrue(t *testing.T) {
+	expect := `module "gcp_organization_level_config" {
+  source             = "lacework/config/gcp"
+  version            = "~> 2.3"
+  folders_to_exclude = ["abc"]
+  org_integration    = true
+  organization_id    = "123456789"
+}
+`
+
+	hcl, err := gcp.NewTerraform(true, false,
+		gcp.WithGcpServiceAccountCredentials("/path/to/credentials"),
+		gcp.WithProjectId("project1"),
+		gcp.WithOrganizationIntegration(true),
+		gcp.WithOrganizationId("123456789"),
+		gcp.WithIncludeRootProjects(true),
+		gcp.WithFoldersToExclude([]string{"abc"}),
+	).Generate()
+	assert.Nil(t, err)
+	assert.NotNil(t, hcl)
+	assert.Equal(t, reqProvider(expect), hcl)
+}
+
+func TestGenerationProjectLevelConfigurationPrefix(t *testing.T) {
+	expect := `module "gcp_project_level_config" {
+  source  = "lacework/config/gcp"
+  version = "~> 2.3"
+  prefix  = "rar"
+}
+`
+
+	hcl, err := gcp.NewTerraform(true, false,
+		gcp.WithGcpServiceAccountCredentials("/path/to/credentials"),
+		gcp.WithProjectId("project1"),
+		gcp.WithPrefix("rar"),
+	).Generate()
+	assert.Nil(t, err)
+	assert.NotNil(t, hcl)
+	assert.Equal(t, reqProvider(expect), hcl)
+}
+
+func TestGenerationProjectConfigurationLogWaitTime(t *testing.T) {
+	expect := `module "gcp_project_level_config" {
+  source    = "lacework/config/gcp"
+  version   = "~> 2.3"
+  wait_time = "30s"
+}
+`
+	hcl, err := gcp.NewTerraform(true, false,
+		gcp.WithGcpServiceAccountCredentials("/path/to/credentials"),
+		gcp.WithProjectId("project1"),
+		gcp.WithWaitTime("30s"),
+	).Generate()
+	assert.Nil(t, err)
+	assert.NotNil(t, hcl)
+	assert.Equal(t, reqProvider(expect), hcl)
+}
+
 var requiredProviders = `terraform {
   required_providers {
     lacework = {
@@ -389,7 +751,7 @@ var laceworkProvider = `provider "lacework" {
 
 var moduleImportProjectLevelAuditLogWithConfiguration = `module "gcp_project_audit_log" {
   source                       = "lacework/audit-log/gcp"
-  version                      = "~> 2.0"
+  version                      = "~> 3.0"
   service_account_name         = module.gcp_project_level_config.service_account_name
   service_account_private_key  = module.gcp_project_level_config.service_account_private_key
   use_existing_service_account = true
@@ -398,20 +760,20 @@ var moduleImportProjectLevelAuditLogWithConfiguration = `module "gcp_project_aud
 
 var moduleImportProjectLevelAuditLogWithoutConfiguration = `module "gcp_project_audit_log" {
   source  = "lacework/audit-log/gcp"
-  version = "~> 2.0"
+  version = "~> 3.0"
 }
 `
 
 var moduleImportProjectLevelAuditLogCustomIntegrationName = `module "gcp_project_audit_log" {
   source                    = "lacework/audit-log/gcp"
-  version                   = "~> 2.0"
+  version                   = "~> 3.0"
   lacework_integration_name = "custom_integration_name"
 }
 `
 
 var moduleImportProjectLevelAuditLogLabels = `module "gcp_project_audit_log" {
   source  = "lacework/audit-log/gcp"
-  version = "~> 2.0"
+  version = "~> 3.0"
   labels = {
     key = "value"
   }
@@ -420,7 +782,7 @@ var moduleImportProjectLevelAuditLogLabels = `module "gcp_project_audit_log" {
 
 var moduleImportProjectLevelAuditLogBucketLabels = `module "gcp_project_audit_log" {
   source  = "lacework/audit-log/gcp"
-  version = "~> 2.0"
+  version = "~> 3.0"
   bucket_labels = {
     key = "value"
   }
@@ -429,7 +791,7 @@ var moduleImportProjectLevelAuditLogBucketLabels = `module "gcp_project_audit_lo
 
 var moduleImportProjectLevelAuditLogPubSubSubscriptionLabels = `module "gcp_project_audit_log" {
   source  = "lacework/audit-log/gcp"
-  version = "~> 2.0"
+  version = "~> 3.0"
   pubsub_subscription_labels = {
     key = "value"
   }
@@ -438,7 +800,7 @@ var moduleImportProjectLevelAuditLogPubSubSubscriptionLabels = `module "gcp_proj
 
 var moduleImportProjectLevelAuditLogPubSubTopicLabels = `module "gcp_project_audit_log" {
   source  = "lacework/audit-log/gcp"
-  version = "~> 2.0"
+  version = "~> 3.0"
   pubsub_topic_labels = {
     key = "value"
   }
@@ -447,76 +809,55 @@ var moduleImportProjectLevelAuditLogPubSubTopicLabels = `module "gcp_project_aud
 
 var moduleImportProjectLevelAuditLogBucketRegion = `module "gcp_project_audit_log" {
   source        = "lacework/audit-log/gcp"
-  version       = "~> 2.0"
+  version       = "~> 3.0"
   bucket_region = "us-west"
-}
-`
-
-var moduleImportProjectLevelAuditLogBucketLocation = `module "gcp_project_audit_log" {
-  source              = "lacework/audit-log/gcp"
-  version             = "~> 2.0"
-  log_bucket_location = "us"
-}
-`
-
-var moduleImportProjectLevelAuditLogBucketName = `module "gcp_project_audit_log" {
-  source     = "lacework/audit-log/gcp"
-  version    = "~> 2.0"
-  log_bucket = "foo"
 }
 `
 
 var moduleImportProjectLevelAuditLogExistingBucketName = `module "gcp_project_audit_log" {
   source               = "lacework/audit-log/gcp"
-  version              = "~> 2.0"
+  version              = "~> 3.0"
   existing_bucket_name = "foo"
 }
 `
 
 var moduleImportProjectLevelAuditLogExistingLogSinkName = `module "gcp_project_audit_log" {
   source             = "lacework/audit-log/gcp"
-  version            = "~> 2.0"
+  version            = "~> 3.0"
   existing_sink_name = "foo"
 }
 `
 
 var moduleImportProjectLevelAuditLogEnableForceDestroyBucket = `module "gcp_project_audit_log" {
   source               = "lacework/audit-log/gcp"
-  version              = "~> 2.0"
+  version              = "~> 3.0"
   bucket_force_destroy = true
 }
 `
 
 var moduleImportProjectLevelAuditLogEnableUBLA = `module "gcp_project_audit_log" {
   source  = "lacework/audit-log/gcp"
-  version = "~> 2.0"
+  version = "~> 3.0"
 }
 `
 
 var moduleImportProjectLevelAuditLogDisableUBLA = `module "gcp_project_audit_log" {
   source      = "lacework/audit-log/gcp"
-  version     = "~> 2.0"
+  version     = "~> 3.0"
   enable_ubla = false
 }
 `
 
 var moduleImportProjectLevelAuditLogBucketLifecycleRuleAge = `module "gcp_project_audit_log" {
   source             = "lacework/audit-log/gcp"
-  version            = "~> 2.0"
+  version            = "~> 3.0"
   lifecycle_rule_age = 420
-}
-`
-
-var moduleImportProjectLevelAuditLogBucketRetentionDays = `module "gcp_project_audit_log" {
-  source                    = "lacework/audit-log/gcp"
-  version                   = "~> 2.0"
-  log_bucket_retention_days = 420
 }
 `
 
 var moduleImportOrganizationLevelAuditLogWithConfiguration = `module "gcp_organization_level_audit_log" {
   source                       = "lacework/audit-log/gcp"
-  version                      = "~> 2.0"
+  version                      = "~> 3.0"
   org_integration              = true
   organization_id              = "123456789"
   service_account_name         = module.gcp_organization_level_config.service_account_name
@@ -527,14 +868,14 @@ var moduleImportOrganizationLevelAuditLogWithConfiguration = `module "gcp_organi
 
 var moduleImportOrganizationLevelAuditLogWithoutConfiguration = `module "gcp_organization_level_audit_log" {
   source          = "lacework/audit-log/gcp"
-  version         = "~> 2.0"
+  version         = "~> 3.0"
   org_integration = true
   organization_id = "123456789"
 }
 `
 var moduleImportOrganizationLevelAuditLogCustomIntegrationName = `module "gcp_organization_level_audit_log" {
   source                    = "lacework/audit-log/gcp"
-  version                   = "~> 2.0"
+  version                   = "~> 3.0"
   lacework_integration_name = "custom_integration_name"
   org_integration           = true
   organization_id           = "123456789"
@@ -543,13 +884,13 @@ var moduleImportOrganizationLevelAuditLogCustomIntegrationName = `module "gcp_or
 
 var moduleImportProjectLevelConfiguration = `module "gcp_project_level_config" {
   source  = "lacework/config/gcp"
-  version = "~> 2.0"
+  version = "~> 2.3"
 }
 `
 
 var moduleImportProjectLevelConfigurationExistingSA = `module "gcp_project_level_config" {
   source                       = "lacework/config/gcp"
-  version                      = "~> 2.0"
+  version                      = "~> 2.3"
   service_account_name         = "foo"
   service_account_private_key  = "123456789"
   use_existing_service_account = true
@@ -558,14 +899,14 @@ var moduleImportProjectLevelConfigurationExistingSA = `module "gcp_project_level
 
 var moduleImportProjectLevelConfigurationCustomIntegrationName = `module "gcp_project_level_config" {
   source                    = "lacework/config/gcp"
-  version                   = "~> 2.0"
+  version                   = "~> 2.3"
   lacework_integration_name = "custom_integration_name"
 }
 `
 
 var moduleImportOrganizationLevelConfiguration = `module "gcp_organization_level_config" {
   source          = "lacework/config/gcp"
-  version         = "~> 2.0"
+  version         = "~> 2.3"
   org_integration = true
   organization_id = "123456789"
 }
@@ -573,7 +914,7 @@ var moduleImportOrganizationLevelConfiguration = `module "gcp_organization_level
 
 var moduleImportOrganizationLevelConfigurationExistingSA = `module "gcp_organization_level_config" {
   source                       = "lacework/config/gcp"
-  version                      = "~> 2.0"
+  version                      = "~> 2.3"
   org_integration              = true
   organization_id              = "123456789"
   service_account_name         = "foo"
@@ -584,7 +925,7 @@ var moduleImportOrganizationLevelConfigurationExistingSA = `module "gcp_organiza
 
 var moduleImportOrganizationLevelConfigurationCustomIntegrationName = `module "gcp_organization_level_config" {
   source                    = "lacework/config/gcp"
-  version                   = "~> 2.0"
+  version                   = "~> 2.3"
   lacework_integration_name = "custom_integration_name"
   org_integration           = true
   organization_id           = "123456789"


### PR DESCRIPTION
## Summary

Version updates:
  - gcp-audit-log: v3
  - gcp-config: v2.3

Removing gcp-audit-log v2 TF parameters:
  - log_bucket
  - log_bucket_location
  - log_bucket_retention_days

New parameters:
  - folders_to_exclude
  - include_root_projects
  - folders_to_include
  - custom_bucket_name
  - custom_filter
  - google_workspace_filter
  - k8s_filter
  - prefix
  - wait_time

## How did you test this change?

Unit and integration testing

## Issue

[ALLY-923](https://lacework.atlassian.net/browse/ALLY-923)