### PR TITLE
fix(lql): fix handling of large numbers in json

### DIFF
--- a/api/lql_execute.go
+++ b/api/lql_execute.go
@@ -19,6 +19,8 @@
 package api
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"net/url"
 	"time"
@@ -59,10 +61,22 @@ type ExecuteQueryByIDRequest struct {
 	Arguments []ExecuteQueryArgument `json:"arguments"`
 }
 
+type ExecuteQueryData []interface{}
+
+func (d *ExecuteQueryData) UnmarshalJSON(data []byte) error {
+	type Alias ExecuteQueryData
+
+	temp := (*Alias)(d)
+	reader := bytes.NewReader(data)
+	decoder := json.NewDecoder(reader)
+	decoder.UseNumber()
+	return decoder.Decode(temp)
+}
+
 type ExecuteQueryResponse struct {
-	Data    []interface{} `json:"data"`
-	Ok      bool          `json:"ok"`
-	Message string        `json:"message"`
+	Data    ExecuteQueryData `json:"data"`
+	Ok      bool             `json:"ok"`
+	Message string           `json:"message"`
 }
 
 func validateQueryArguments(args []ExecuteQueryArgument) error {

--- a/api/lql_execute_test.go
+++ b/api/lql_execute_test.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strconv"
 	"testing"
 
 	"github.com/lacework/go-sdk/api"
@@ -72,11 +73,13 @@ var (
 		QueryID:   queryID,
 		Arguments: executeQueryArguments,
 	}
-	executeQueryData = `[
+	pidHash          = 5644915113269064637
+	executeQueryData = fmt.Sprintf(`[
 	{
-		"INSERT_ID": "35308423"
+		"INSERT_ID": "35308423",
+		"PID_HASH": %d
 	}
-]`
+]`, pidHash)
 	limitZero = 0
 	limitNeg  = -1
 	limitOne  = 1
@@ -131,6 +134,9 @@ func TestQueryExecuteOK(t *testing.T) {
 	assert.Nil(t, err)
 
 	assert.Equal(t, runExpected, runActual)
+	// test unmarshal of large integer
+	dataActual := runActual.Data[0].(map[string]interface{})
+	assert.Equal(t, json.Number(strconv.Itoa(pidHash)), dataActual["PID_HASH"])
 }
 
 func TestQueryExecuteBad(t *testing.T) {


### PR DESCRIPTION
## Summary
By default when unmarshaling JSON into an arbitrary Go `interface{}` it uses `float64` type for numbers.  When the number is large enough this causes irreversible damage to the values.

## How did you test this change?
Unit tests added

## Issue
https://lacework.atlassian.net/browse/ALLY-1194