### PR TITLE
feat: generate command rework

### DIFF
--- a/cli/cmd/generate.go
+++ b/cli/cmd/generate.go
@@ -5,100 +5,26 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
-	"time"
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
-type AwsGenerateCommandExtraState struct {
-	Output                string
-	UseExistingCloudtrail bool
-	UseExistingSNSTopic   bool
-	AwsSubAccounts        []string
-	TerraformApply        bool
-}
-
-func (a *AwsGenerateCommandExtraState) isEmpty() bool {
-	return a.Output == "" && !a.UseExistingCloudtrail && len(a.AwsSubAccounts) == 0 && !a.TerraformApply
-}
-
-// Flush current state of the struct to disk, provided it's not empty
-func (a *AwsGenerateCommandExtraState) writeCache() {
-	if !a.isEmpty() {
-		cli.WriteAssetToCache(CachedAssetAwsExtraState, time.Now().Add(time.Hour*1), a)
-	}
-}
-
-type GcpGenerateCommandExtraState struct {
-	AskAdvanced                bool
-	Output                     string
-	ConfigureNewBucketSettings bool
-	UseExistingServiceAccount  bool
-	UseExistingBucket          bool
-	UseExistingSink            bool
-	TerraformApply             bool
-}
-
-func (gcp *GcpGenerateCommandExtraState) isEmpty() bool {
-	return gcp.Output == "" &&
-		!gcp.AskAdvanced &&
-		!gcp.UseExistingServiceAccount &&
-		!gcp.UseExistingBucket &&
-		!gcp.UseExistingSink &&
-		!gcp.TerraformApply
-}
-
-// Flush current state of the struct to disk, provided it's not empty
-func (gcp *GcpGenerateCommandExtraState) writeCache() {
-	if !gcp.isEmpty() {
-		cli.WriteAssetToCache(CachedAssetGcpExtraState, time.Now().Add(time.Hour*1), gcp)
-	}
-}
-
-type AzureGenerateCommandExtraState struct {
-	Output         string
-	TerraformApply bool
-}
-
-func (a *AzureGenerateCommandExtraState) isEmpty() bool {
-	return a.Output == "" && !a.TerraformApply
-}
-
-// Flush current state of the struct to disk, provided it's not empty
-func (a *AzureGenerateCommandExtraState) writeCache() {
-	if !a.isEmpty() {
-		cli.WriteAssetToCache(CachedAzureAssetExtraState, time.Now().Add(time.Hour*1), a)
-	}
-}
-
 var (
 	QuestionRunTfPlan        = "Run Terraform plan now?"
 	QuestionUsePreviousCache = "Previous IaC generation detected, load cached values?"
 
-	// iac-generate command is used to create IaC code for various environments
 	generateTfCommand = &cobra.Command{
-		Use:     "iac-generate",
-		Aliases: []string{"iac"},
+		Use:     "generate",
+		Aliases: []string{"gen"},
 		Short:   "Create IaC code",
 		Long:    "Create IaC content for various different cloud environments and configurations",
 	}
 )
 
 func init() {
-	// add the iac-generate command
-	cloudAccountCommand.AddCommand(generateTfCommand)
-
-	// Add cloud specific command flags
-	initGenerateAwsTfCommandFlags()
-	initGenerateGcpTfCommandFlags()
-	initGenerateAzureTfCommandFlags()
-
-	// add sub-commands to the iac-generate command
-	generateTfCommand.AddCommand(generateAwsTfCommand)
-	generateTfCommand.AddCommand(generateGcpTfCommand)
-	generateTfCommand.AddCommand(generateAzureTfCommand)
+	rootCmd.AddCommand(generateTfCommand)
 }
 
 type SurveyQuestionWithValidationArgs struct {

--- a/cli/cmd/generate_aws.go
+++ b/cli/cmd/generate_aws.go
@@ -294,6 +294,25 @@ See help output for more details on the parameter value(s) required for Terrafor
 	}
 )
 
+type AwsGenerateCommandExtraState struct {
+	Output                string
+	UseExistingCloudtrail bool
+	UseExistingSNSTopic   bool
+	AwsSubAccounts        []string
+	TerraformApply        bool
+}
+
+func (a *AwsGenerateCommandExtraState) isEmpty() bool {
+	return a.Output == "" && !a.UseExistingCloudtrail && len(a.AwsSubAccounts) == 0 && !a.TerraformApply
+}
+
+// Flush current state of the struct to disk, provided it's not empty
+func (a *AwsGenerateCommandExtraState) writeCache() {
+	if !a.isEmpty() {
+		cli.WriteAssetToCache(CachedAssetAwsExtraState, time.Now().Add(time.Hour*1), a)
+	}
+}
+
 func initGenerateAwsTfCommandFlags() {
 	// add flags to sub commands
 	// TODO Share the help with the interactive generation

--- a/cli/cmd/generate_azure.go
+++ b/cli/cmd/generate_azure.go
@@ -318,6 +318,22 @@ By default, this command will function interactively, prompting for the required
 	}
 )
 
+type AzureGenerateCommandExtraState struct {
+	Output         string
+	TerraformApply bool
+}
+
+func (a *AzureGenerateCommandExtraState) isEmpty() bool {
+	return a.Output == "" && !a.TerraformApply
+}
+
+// Flush current state of the struct to disk, provided it's not empty
+func (a *AzureGenerateCommandExtraState) writeCache() {
+	if !a.isEmpty() {
+		cli.WriteAssetToCache(CachedAzureAssetExtraState, time.Now().Add(time.Hour*1), a)
+	}
+}
+
 func validateStorageLocation(location string) error {
 	if !validStorageLocations[location] {
 		return errors.New("invalid storage location supplied")

--- a/cli/cmd/generate_cloud_account.go
+++ b/cli/cmd/generate_cloud_account.go
@@ -1,0 +1,24 @@
+package cmd
+
+import "github.com/spf13/cobra"
+
+var (
+	generateCloudAccountCommand = &cobra.Command{
+		Use:     "cloud-account",
+		Aliases: []string{"cloud", "ca"},
+		Short:   "Create IaC code",
+		Long:    "Create IaC content for various different cloud environments",
+	}
+)
+
+func init() {
+	generateTfCommand.AddCommand(generateCloudAccountCommand)
+
+	initGenerateAwsTfCommandFlags()
+	initGenerateGcpTfCommandFlags()
+	initGenerateAzureTfCommandFlags()
+
+	generateCloudAccountCommand.AddCommand(generateAwsTfCommand)
+	generateCloudAccountCommand.AddCommand(generateGcpTfCommand)
+	generateCloudAccountCommand.AddCommand(generateAzureTfCommand)
+}

--- a/cli/cmd/generate_gcp.go
+++ b/cli/cmd/generate_gcp.go
@@ -267,6 +267,32 @@ See help output for more details on the parameter value(s) required for Terrafor
 	}
 )
 
+type GcpGenerateCommandExtraState struct {
+	AskAdvanced                bool
+	Output                     string
+	ConfigureNewBucketSettings bool
+	UseExistingServiceAccount  bool
+	UseExistingBucket          bool
+	UseExistingSink            bool
+	TerraformApply             bool
+}
+
+func (gcp *GcpGenerateCommandExtraState) isEmpty() bool {
+	return gcp.Output == "" &&
+		!gcp.AskAdvanced &&
+		!gcp.UseExistingServiceAccount &&
+		!gcp.UseExistingBucket &&
+		!gcp.UseExistingSink &&
+		!gcp.TerraformApply
+}
+
+// Flush current state of the struct to disk, provided it's not empty
+func (gcp *GcpGenerateCommandExtraState) writeCache() {
+	if !gcp.isEmpty() {
+		cli.WriteAssetToCache(CachedAssetGcpExtraState, time.Now().Add(time.Hour*1), gcp)
+	}
+}
+
 func initGenerateGcpTfCommandFlags() {
 	// add flags to sub commands
 	// TODO Share the help with the interactive generation

--- a/integration/aws_generation_test.go
+++ b/integration/aws_generation_test.go
@@ -29,8 +29,8 @@ func TestGenerationAwsErrorOnNoSelection(t *testing.T) {
 			c.SendLine("n")
 			expectString(t, c, "ERROR collecting/confirming parameters: must enable cloudtrail or config")
 		},
-		"cloud",
-		"iac",
+		"generate",
+		"cloud-account",
 		"aws",
 	)
 }
@@ -57,8 +57,8 @@ func TestGenerationAwsSimple(t *testing.T) {
 			c.SendLine("n")
 			final, _ = c.ExpectEOF()
 		},
-		"cloud",
-		"iac",
+		"generate",
+		"cloud-account",
 		"aws",
 	)
 
@@ -112,8 +112,8 @@ func TestGenerationAwsCustomizedOutputLocation(t *testing.T) {
 			c.SendLine("n")
 			final, _ = c.ExpectEOF()
 		},
-		"cloud",
-		"iac",
+		"generate",
+		"cloud-account",
 		"aws",
 	)
 
@@ -154,8 +154,8 @@ func TestGenerationAwsConfigOnly(t *testing.T) {
 			c.SendLine("n")
 			final, _ = c.ExpectEOF()
 		},
-		"cloud",
-		"iac",
+		"generate",
+		"cloud-account",
 		"aws",
 	)
 
@@ -199,8 +199,8 @@ func TestGenerationAwsAdvancedOptsDone(t *testing.T) {
 			c.SendLine("n")
 			final, _ = c.ExpectEOF()
 		},
-		"cloud",
-		"iac",
+		"generate",
+		"cloud-account",
 		"aws",
 	)
 
@@ -273,8 +273,8 @@ func TestGenerationAwsAdvancedOptsConsolidatedAndForceDestroy(t *testing.T) {
 			c.SendLine("n")
 			final, _ = c.ExpectEOF()
 		},
-		"cloud",
-		"iac",
+		"generate",
+		"cloud-account",
 		"aws",
 	)
 
@@ -343,8 +343,8 @@ func TestGenerationAwsAdvancedOptsUseExistingCloudtrail(t *testing.T) {
 			c.SendLine("n")
 			final, _ = c.ExpectEOF()
 		},
-		"cloud",
-		"iac",
+		"generate",
+		"cloud-account",
 		"aws",
 	)
 
@@ -437,8 +437,8 @@ func TestGenerationAwsAdvancedOptsConsolidatedWithSubAccounts(t *testing.T) {
 			c.SendLine("n")
 			final, _ = c.ExpectEOF()
 		},
-		"cloud",
-		"iac",
+		"generate",
+		"cloud-account",
 		"aws",
 	)
 
@@ -497,8 +497,8 @@ func TestGenerationAwsAdvancedOptsConfigWithSubAccounts(t *testing.T) {
 			c.SendLine("n")
 			final, _ = c.ExpectEOF()
 		},
-		"cloud",
-		"iac",
+		"generate",
+		"cloud-account",
 		"aws",
 	)
 
@@ -556,8 +556,8 @@ func TestGenerationAwsAdvancedOptsConsolidatedWithSubAccountsPassedByFlag(t *tes
 			c.SendLine("n")
 			final, _ = c.ExpectEOF()
 		},
-		"cloud",
-		"iac",
+		"generate",
+		"cloud-account",
 		"aws",
 		"--consolidated_cloudtrail",
 		"--aws_subaccount",
@@ -618,8 +618,8 @@ func TestGenerationAwsAdvancedOptsUseExistingIAM(t *testing.T) {
 			c.SendLine("n")
 			final, _ = c.ExpectEOF()
 		},
+		"generate",
 		"cloud-account",
-		"iac-generate",
 		"aws",
 	)
 
@@ -681,8 +681,8 @@ func TestGenerationAwsAdvancedOptsUseExistingElements(t *testing.T) {
 			c.SendLine("n")
 			final, _ = c.ExpectEOF()
 		},
+		"generate",
 		"cloud-account",
-		"iac-generate",
 		"aws",
 	)
 
@@ -762,8 +762,8 @@ func TestGenerationAwsAdvancedOptsCreateNewElements(t *testing.T) {
 			c.SendLine("n")
 			final, _ = c.ExpectEOF()
 		},
+		"generate",
 		"cloud-account",
-		"iac-generate",
 		"aws",
 	)
 
@@ -828,8 +828,8 @@ func TestGenerationAwsWithExistingTerraform(t *testing.T) {
 			expectString(t, c, fmt.Sprintf("%s/main.tf already exists, overwrite?", dir))
 			c.SendLine("n")
 		},
-		"cloud",
-		"iac",
+		"generate",
+		"cloud-account",
 		"aws",
 	)
 

--- a/integration/azure_generation_test.go
+++ b/integration/azure_generation_test.go
@@ -42,8 +42,8 @@ func TestGenerationAzureErrorOnNoSelection(t *testing.T) {
 			c.SendLine("n")
 			expectAzureString(c, "ERROR collecting/confirming parameters: must enable activity log or config", &runError)
 		},
-		"cloud",
-		"iac",
+		"generate",
+		"cloud-account",
 		"az",
 	)
 
@@ -73,8 +73,8 @@ func TestGenerationAzureSimple(t *testing.T) {
 			c.SendLine("n")
 			final, _ = c.ExpectEOF()
 		},
-		"cloud",
-		"iac",
+		"generate",
+		"cloud-account",
 		"az",
 	)
 
@@ -124,8 +124,8 @@ func TestGenerationAzureCustomizedOutputLocation(t *testing.T) {
 			c.SendLine("n")
 			final, _ = c.ExpectEOF()
 		},
-		"cloud",
-		"iac",
+		"generate",
+		"cloud-account",
 		"az",
 	)
 
@@ -163,8 +163,8 @@ func TestGenerationAzureConfigOnly(t *testing.T) {
 			c.SendLine("n")
 			final, _ = c.ExpectEOF()
 		},
-		"cloud",
-		"iac",
+		"generate",
+		"cloud-account",
 		"az",
 	)
 
@@ -199,8 +199,8 @@ func TestGenerationAzureActivityLogOnly(t *testing.T) {
 			c.SendLine("n")
 			final, _ = c.ExpectEOF()
 		},
-		"cloud",
-		"iac",
+		"generate",
+		"cloud-account",
 		"az",
 	)
 
@@ -252,8 +252,8 @@ func TestGenerationAzureNoADEnabled(t *testing.T) {
 			c.SendLine("n")
 			final, _ = c.ExpectEOF()
 		},
-		"cloud",
-		"iac",
+		"generate",
+		"cloud-account",
 		"az",
 	)
 
@@ -302,8 +302,8 @@ func TestGenerationAzureNamedConfig(t *testing.T) {
 			c.SendLine("n")
 			final, _ = c.ExpectEOF()
 		},
-		"cloud",
-		"iac",
+		"generate",
+		"cloud-account",
 		"az",
 	)
 
@@ -350,8 +350,8 @@ func TestGenerationAzureNamedActivityLog(t *testing.T) {
 			c.SendLine("n")
 			final, _ = c.ExpectEOF()
 		},
-		"cloud",
-		"iac",
+		"generate",
+		"cloud-account",
 		"az",
 	)
 
@@ -395,8 +395,8 @@ func TestGenerationAzureAdvancedOptsDone(t *testing.T) {
 			c.SendLine("n")
 			final, _ = c.ExpectEOF()
 		},
-		"cloud",
-		"iac",
+		"generate",
+		"cloud-account",
 		"az",
 	)
 
@@ -454,8 +454,8 @@ func TestGenerationAzureWithExistingTerraform(t *testing.T) {
 			c.SendLine("n")
 			_, _ = c.ExpectEOF()
 		},
-		"cloud",
-		"iac",
+		"generate",
+		"cloud-account",
 		"az",
 	)
 
@@ -500,8 +500,8 @@ func TestGenerationAzureConfigAllSubs(t *testing.T) {
 			c.SendLine("n")
 			final, _ = c.ExpectEOF()
 		},
-		"cloud",
-		"iac",
+		"generate",
+		"cloud-account",
 		"az",
 	)
 
@@ -551,8 +551,8 @@ func TestGenerationAzureConfigMgmntGroup(t *testing.T) {
 			c.SendLine("n")
 			final, _ = c.ExpectEOF()
 		},
-		"cloud",
-		"iac",
+		"generate",
+		"cloud-account",
 		"az",
 	)
 
@@ -603,8 +603,8 @@ func TestGenerationAzureConfigSubs(t *testing.T) {
 			c.SendLine("n")
 			final, _ = c.ExpectEOF()
 		},
-		"cloud",
-		"iac",
+		"generate",
+		"cloud-account",
 		"az",
 	)
 
@@ -654,8 +654,8 @@ func TestGenerationAzureActivityLogSubs(t *testing.T) {
 			c.SendLine("n")
 			final, _ = c.ExpectEOF()
 		},
-		"cloud",
-		"iac",
+		"generate",
+		"cloud-account",
 		"az",
 	)
 
@@ -710,8 +710,8 @@ func TestGenerationAzureActivityLogStorageAccount(t *testing.T) {
 			c.SendLine("n")
 			final, _ = c.ExpectEOF()
 		},
-		"cloud",
-		"iac",
+		"generate",
+		"cloud-account",
 		"az",
 	)
 
@@ -759,8 +759,8 @@ func TestGenerationAzureActivityLogAllSubs(t *testing.T) {
 			c.SendLine("n")
 			final, _ = c.ExpectEOF()
 		},
-		"cloud",
-		"iac",
+		"generate",
+		"cloud-account",
 		"az",
 	)
 
@@ -808,8 +808,8 @@ func TestGenerationAzureActivityLogLocation(t *testing.T) {
 			c.SendLine("n")
 			final, _ = c.ExpectEOF()
 		},
-		"cloud",
-		"iac",
+		"generate",
+		"cloud-account",
 		"az",
 	)
 

--- a/integration/gcp_generation_test.go
+++ b/integration/gcp_generation_test.go
@@ -38,8 +38,8 @@ func TestGenerationErrorOnNoSelectionGcp(t *testing.T) {
 				msgOnly("ERROR collecting/confirming parameters: must enable audit log or configuration"),
 			})
 		},
-		"cloud",
-		"iac",
+		"generate",
+		"cloud-account",
 		"gcp",
 	)
 }
@@ -64,8 +64,8 @@ func TestGenerationSimpleGcp(t *testing.T) {
 
 			final, _ = c.ExpectEOF()
 		},
-		"cloud",
-		"iac",
+		"generate",
+		"cloud-account",
 		"gcp",
 	)
 
@@ -97,8 +97,8 @@ func TestGenerationConfigOnlyGcp(t *testing.T) {
 
 			final, _ = c.ExpectEOF()
 		},
-		"cloud",
-		"iac",
+		"generate",
+		"cloud-account",
 		"gcp",
 	)
 
@@ -130,8 +130,8 @@ func TestGenerationAuditlogOnlyGcp(t *testing.T) {
 
 			final, _ = c.ExpectEOF()
 		},
-		"cloud",
-		"iac",
+		"generate",
+		"cloud-account",
 		"gcp",
 	)
 
@@ -162,8 +162,8 @@ func TestGenerationAuditlogEnableUBLA(t *testing.T) {
 			})
 			final, _ = c.ExpectEOF()
 		},
-		"cloud",
-		"iac",
+		"generate",
+		"cloud-account",
 		"gcp",
 		"--enable_ubla",
 	)
@@ -196,8 +196,8 @@ func TestGenerationAuditlogDisableUBLA(t *testing.T) {
 			})
 			final, _ = c.ExpectEOF()
 		},
-		"cloud",
-		"iac",
+		"generate",
+		"cloud-account",
 		"gcp",
 		"--enable_ubla=false",
 	)
@@ -232,8 +232,8 @@ func TestOrganizationIntegrationConfigAndAuditLogGcp(t *testing.T) {
 
 			final, _ = c.ExpectEOF()
 		},
-		"cloud",
-		"iac",
+		"generate",
+		"cloud-account",
 		"gcp",
 	)
 
@@ -268,8 +268,8 @@ func TestGeneratePrefixAndWait(t *testing.T) {
 
 			final, _ = c.ExpectEOF()
 		},
-		"cloud",
-		"iac",
+		"generate",
+		"cloud-account",
 		"gcp",
 		"--prefix",
 		prefix,
@@ -325,8 +325,8 @@ func TestGenerationSACredsGcp(t *testing.T) {
 
 			final, _ = c.ExpectEOF()
 		},
-		"cloud",
-		"iac",
+		"generate",
+		"cloud-account",
 		"gcp",
 	)
 
@@ -366,8 +366,8 @@ func TestGenerationAdvancedAuditLogOptsExistingBucketGcp(t *testing.T) {
 			final, _ = c.ExpectEOF()
 
 		},
-		"cloud",
-		"iac",
+		"generate",
+		"cloud-account",
 		"gcp",
 	)
 
@@ -406,8 +406,8 @@ func TestGenerationAdvancedAuditLogOptsNewBucketNotConfiguredGcp(t *testing.T) {
 
 			final, _ = c.ExpectEOF()
 		},
-		"cloud",
-		"iac",
+		"generate",
+		"cloud-account",
 		"gcp",
 	)
 
@@ -450,8 +450,8 @@ func TestGenerationAdvancedAuditLogOptsNewBucketConfiguredGcp(t *testing.T) {
 			})
 			final, _ = c.ExpectEOF()
 		},
-		"cloud",
-		"iac",
+		"generate",
+		"cloud-account",
 		"gcp",
 	)
 
@@ -499,8 +499,8 @@ func TestGenerationAdvancedAuditLogOptsExistingSinkGcp(t *testing.T) {
 			})
 			final, _ = c.ExpectEOF()
 		},
-		"cloud",
-		"iac",
+		"generate",
+		"cloud-account",
 		"gcp",
 	)
 
@@ -542,8 +542,8 @@ func TestGenerationAdvancedAuditLogOpts(t *testing.T) {
 			})
 			final, _ = c.ExpectEOF()
 		},
-		"cloud",
-		"iac",
+		"generate",
+		"cloud-account",
 		"gcp",
 	)
 
@@ -580,8 +580,8 @@ func TestGenerationAdvancedOptsUseExistingSA(t *testing.T) {
 			})
 			final, _ = c.ExpectEOF()
 		},
-		"cloud",
-		"iac",
+		"generate",
+		"cloud-account",
 		"gcp",
 	)
 
@@ -621,8 +621,8 @@ func TestGenerationCustomizedConfigurationIntegrationNameGcp(t *testing.T) {
 			})
 			final, _ = c.ExpectEOF()
 		},
-		"cloud",
-		"iac",
+		"generate",
+		"cloud-account",
 		"gcp",
 	)
 
@@ -668,8 +668,8 @@ func TestGenerationCustomizedAuditlogIntegrationNameGcp(t *testing.T) {
 			})
 			final, _ = c.ExpectEOF()
 		},
-		"cloud",
-		"iac",
+		"generate",
+		"cloud-account",
 		"gcp",
 	)
 
@@ -711,8 +711,8 @@ func TestGenerationCustomizedOutputLocationGcp(t *testing.T) {
 			})
 			final, _ = c.ExpectEOF()
 		},
-		"cloud",
-		"iac",
+		"generate",
+		"cloud-account",
 		"gcp",
 	)
 
@@ -746,8 +746,8 @@ func TestGenerationAdvancedOptsDoneGcp(t *testing.T) {
 			})
 			final, _ = c.ExpectEOF()
 		},
-		"cloud",
-		"iac",
+		"generate",
+		"cloud-account",
 		"gcp",
 	)
 
@@ -778,8 +778,8 @@ func TestGenerationAdvancedOptsDoneGcpConfiguration(t *testing.T) {
 			})
 			final, _ = c.ExpectEOF()
 		},
-		"cloud",
-		"iac",
+		"generate",
+		"cloud-account",
 		"gcp",
 	)
 
@@ -823,8 +823,8 @@ func TestGenerationWithExistingTerraformGcp(t *testing.T) {
 				msgRsp(fmt.Sprintf("%s/main.tf already exists, overwrite?", dir), "n"),
 			})
 		},
-		"cloud",
-		"iac",
+		"generate",
+		"cloud-account",
 		"gcp",
 	)
 
@@ -856,8 +856,8 @@ func TestGenerationFolders(t *testing.T) {
 			})
 			final, _ = c.ExpectEOF()
 		},
-		"cloud",
-		"iac",
+		"generate",
+		"cloud-account",
 		"gcp",
 		"--folders_to_include", "folder/abc",
 		"--folders_to_include", "folder/def",
@@ -897,8 +897,8 @@ func TestGenerationFoldersShorthand(t *testing.T) {
 			})
 			final, _ = c.ExpectEOF()
 		},
-		"cloud",
-		"iac",
+		"generate",
+		"cloud-account",
 		"gcp",
 		"-i", "folder/abc",
 		"-i", "folder/abc",
@@ -938,8 +938,8 @@ func TestGenerationIncludeRootProjects(t *testing.T) {
 			})
 			final, _ = c.ExpectEOF()
 		},
-		"cloud",
-		"iac",
+		"generate",
+		"cloud-account",
 		"gcp",
 		"--folders_to_exclude",
 		"folder/abc",
@@ -977,8 +977,8 @@ func TestGenerationIncludeRootProjectsFalse(t *testing.T) {
 			})
 			final, _ = c.ExpectEOF()
 		},
-		"cloud",
-		"iac",
+		"generate",
+		"cloud-account",
 		"gcp",
 		"--folders_to_exclude",
 		"folder/abc",
@@ -1015,8 +1015,8 @@ func TestGenerationAuditLogFiltersTrue(t *testing.T) {
 			})
 			final, _ = c.ExpectEOF()
 		},
-		"cloud",
-		"iac",
+		"generate",
+		"cloud-account",
 		"gcp",
 		"--google_workspace_filter",
 		"--k8s_filter",
@@ -1050,8 +1050,8 @@ func TestGenerationAuditlogFiltersFalse(t *testing.T) {
 			})
 			final, _ = c.ExpectEOF()
 		},
-		"cloud",
-		"iac",
+		"generate",
+		"cloud-account",
 		"gcp",
 		"--google_workspace_filter=false",
 		"--k8s_filter=false",

--- a/integration/test_resources/help/generate
+++ b/integration/test_resources/help/generate
@@ -1,19 +1,16 @@
-Manage cloud account integrations with Lacework
+Create IaC content for various different cloud environments and configurations
 
 Usage:
-  lacework cloud-account [command]
+  lacework generate [command]
 
 Aliases:
-  cloud-account, cloud-accounts, cloud, ca
+  generate, gen
 
 Available Commands:
-  create      Create a new cloud account integration
-  delete      Delete a cloud account integration
-  list        List all available cloud account integrations
-  show        Show a single cloud account integration
+  cloud-account Create IaC code
 
 Flags:
-  -h, --help   help for cloud-account
+  -h, --help   help for generate
 
 Global Flags:
   -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
@@ -29,4 +26,4 @@ Global Flags:
   -p, --profile string      switch between profiles configured at ~/.lacework.toml
       --subaccount string   sub-account name inside your organization (org admins only)
 
-Use "lacework cloud-account [command] --help" for more information about a command.
+Use "lacework generate [command] --help" for more information about a command.

--- a/integration/test_resources/help/generate_cloud-account
+++ b/integration/test_resources/help/generate_cloud-account
@@ -1,10 +1,10 @@
-Create IaC content for various different cloud environments and configurations
+Create IaC content for various different cloud environments
 
 Usage:
-  lacework cloud-account iac-generate [command]
+  lacework generate cloud-account [command]
 
 Aliases:
-  iac-generate, iac
+  cloud-account, cloud, ca
 
 Available Commands:
   aws         Generate and/or execute Terraform code for AWS integration
@@ -12,7 +12,7 @@ Available Commands:
   gcp         Generate and/or execute Terraform code for GCP integration
 
 Flags:
-  -h, --help   help for iac-generate
+  -h, --help   help for cloud-account
 
 Global Flags:
   -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
@@ -28,4 +28,4 @@ Global Flags:
   -p, --profile string      switch between profiles configured at ~/.lacework.toml
       --subaccount string   sub-account name inside your organization (org admins only)
 
-Use "lacework cloud-account iac-generate [command] --help" for more information about a command.
+Use "lacework generate cloud-account [command] --help" for more information about a command.

--- a/integration/test_resources/help/generate_cloud-account_aws
+++ b/integration/test_resources/help/generate_cloud-account_aws
@@ -16,7 +16,7 @@ This command can also be run in noninteractive mode.
 See help output for more details on the parameter value(s) required for Terraform code generation.
 
 Usage:
-  lacework cloud-account iac-generate aws [flags]
+  lacework generate cloud-account aws [flags]
 
 Flags:
       --apply                                 run terraform apply without executing plan or prompting

--- a/integration/test_resources/help/generate_cloud-account_azure
+++ b/integration/test_resources/help/generate_cloud-account_azure
@@ -12,7 +12,7 @@ By default, this command will function interactively, prompting for the required
 	* If confirmed, Terraform apply will be run, completing the setup of the cloud account
 
 Usage:
-  lacework cloud-account iac-generate azure [flags]
+  lacework generate cloud-account azure [flags]
 
 Aliases:
   azure, az

--- a/integration/test_resources/help/generate_cloud-account_gcp
+++ b/integration/test_resources/help/generate_cloud-account_gcp
@@ -16,7 +16,7 @@ This command can also be run in noninteractive mode.
 See help output for more details on the parameter value(s) required for Terraform code generation.
 
 Usage:
-  lacework cloud-account iac-generate gcp [flags]
+  lacework generate cloud-account gcp [flags]
 
 Flags:
       --apply                                         run terraform apply without executing plan or prompting

--- a/integration/test_resources/help/no-command-provided
+++ b/integration/test_resources/help/no-command-provided
@@ -24,6 +24,7 @@ Available Commands:
   configure               Configure the Lacework CLI
   container-registry      Manage container registries
   event                   Inspect Lacework events
+  generate                Create IaC code
   policy                  Manage policies
   policy-exception        Manage policy exceptions
   query                   Run and manage queries


### PR DESCRIPTION
## Summary

The subcommand `cloud-account iac-generate` is now top level `generate` command


## How did you test this change?

- unit test
- integration test
- manual test

## Issue

[ALLY-1201](https://lacework.atlassian.net/browse/ALLY-1201)
