### PR TITLE
feat(api): introducing alertsv2 api

### DIFF
--- a/api/alerts.go
+++ b/api/alerts.go
@@ -1,0 +1,93 @@
+//
+// Author:: Salim Afiune Maya (<afiune@lacework.net>)
+// Copyright:: Copyright 2020, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package api
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/lacework/go-sdk/lwtime"
+)
+
+// AlertsService is a service that interacts with the Alerts
+// endpoints from the Lacework Server
+type AlertsService struct {
+	client *Client
+}
+
+type AlertInfo struct {
+	Subject     string `json:"subject"`
+	Description string `json:"description"`
+}
+
+type AlertSpec struct {
+	Profile string `json:"alertProfile"`
+	Name    string `json:"name"`
+}
+
+type AlertDerivedFields struct {
+	Category    string `json:"category"`
+	SubCategory string `json:"sub_category"`
+	Source      string `json:"source"`
+}
+
+type Alert struct {
+	ID            int                `json:"alertId"`
+	Name          string             `json:"alertName"`
+	Type          string             `json:"alertType"`
+	Severity      string             `json:"severity"`
+	Info          AlertInfo          `json:"alertInfo"`
+	Spec          AlertSpec          `json:"alertSpec"`
+	Status        string             `json:"status"`
+	StartTime     string             `json:"startTime"`
+	EndTime       string             `json:"endTime"`
+	UpdateTime    string             `json:"lastUserUpdateTime"`
+	PolicyID      string             `json:"policyId"`
+	DerivedFields AlertDerivedFields `json:"derivedFields"`
+	Reachability  string             `json:"reachability"`
+}
+
+type AlertsResponse struct {
+	Data []Alert `json:"data"`
+}
+
+func (svc *AlertsService) List() (
+	response AlertsResponse,
+	err error,
+) {
+	err = svc.client.RequestDecoder("GET", apiV2Alerts, nil, &response)
+	return
+}
+
+func (svc *AlertsService) ListByTime(start, end time.Time) (
+	response AlertsResponse,
+	err error,
+) {
+	err = svc.client.RequestDecoder(
+		"GET",
+		fmt.Sprintf(
+			apiV2AlertsByTime,
+			start.UTC().Format(lwtime.RFC3339Milli),
+			end.UTC().Format(lwtime.RFC3339Milli),
+		),
+		nil,
+		&response,
+	)
+	return
+}

--- a/api/alerts_close.go
+++ b/api/alerts_close.go
@@ -1,0 +1,70 @@
+//
+// Author:: Salim Afiune Maya (<afiune@lacework.net>)
+// Copyright:: Copyright 2020, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package api
+
+import (
+	"fmt"
+)
+
+type alertCloseReason int
+
+const (
+	AlertCloseReasonOther alertCloseReason = iota
+	AlertCloseReasonFalsePositive
+	AlertCloseReasonNotEnoughInfo
+	AlertCloseReasonMalicious
+	AlertCloseReasonExpected
+)
+
+// AlertCloseReasons is the list of available Alert closure reasons
+var AlertCloseReasons = map[alertCloseReason]string{
+	AlertCloseReasonOther:         "Other",
+	AlertCloseReasonFalsePositive: "False positive",
+	AlertCloseReasonNotEnoughInfo: "Not enough information",
+	AlertCloseReasonMalicious:     "Malicious and have resolution in place",
+	AlertCloseReasonExpected:      "Expected because of routine testing",
+}
+
+// String returns the string representation of an Alert closure reason
+func (i alertCloseReason) String() string {
+	return AlertCloseReasons[i]
+}
+
+type AlertCloseRequest struct {
+	AlertID int    `json:"-"`
+	Reason  int    `json:"reason"`
+	Comment string `json:"comment,omitempty"`
+}
+
+type AlertCloseResponse struct {
+	Message string `json:"message"`
+}
+
+func (svc *AlertsService) Close(request AlertCloseRequest) (
+	response AlertCloseResponse,
+	err error,
+) {
+	err = svc.client.RequestEncoderDecoder(
+		"POST",
+		fmt.Sprintf(apiV2AlertsClose, request.AlertID),
+		request,
+		&response,
+	)
+	return
+}

--- a/api/alerts_close_test.go
+++ b/api/alerts_close_test.go
@@ -1,0 +1,102 @@
+//
+// Author:: Salim Afiune Maya (<afiune@lacework.net>)
+// Copyright:: Copyright 2020, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package api_test
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/lacework/go-sdk/api"
+	"github.com/lacework/go-sdk/internal/lacework"
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	alertID           = 12345
+	alertCloseRequest = api.AlertCloseRequest{
+		AlertID: alertID,
+		Reason:  2,
+		Comment: "this is fine",
+	}
+)
+
+func TestAlertsCloseMethod(t *testing.T) {
+	fakeServer := lacework.MockServer()
+	fakeServer.UseApiV2()
+	fakeServer.MockAPI(
+		fmt.Sprintf("Alerts/%d/close", alertID),
+		func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "POST", r.Method, "Close should be a POST method")
+			fmt.Fprint(w, "{}")
+		},
+	)
+	defer fakeServer.Close()
+
+	c, err := api.NewClient("test",
+		api.WithToken("TOKEN"),
+		api.WithURL(fakeServer.URL()),
+	)
+	assert.Nil(t, err)
+
+	_, err = c.V2.Alerts.Close(alertCloseRequest)
+	assert.Nil(t, err)
+}
+
+func TestAlertsCloseOK(t *testing.T) {
+	fakeServer := lacework.MockServer()
+	fakeServer.UseApiV2()
+	fakeServer.MockAPI(
+		fmt.Sprintf("Alerts/%d/close", alertID),
+		func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNoContent)
+		},
+	)
+	defer fakeServer.Close()
+
+	c, err := api.NewClient("test",
+		api.WithToken("TOKEN"),
+		api.WithURL(fakeServer.URL()),
+	)
+	assert.Nil(t, err)
+
+	_, err = c.V2.Alerts.Close(alertCloseRequest)
+	assert.Nil(t, err)
+}
+
+func TestAlertsCloseError(t *testing.T) {
+	fakeServer := lacework.MockServer()
+	fakeServer.UseApiV2()
+	fakeServer.MockAPI(
+		fmt.Sprintf("Alerts/%d/close", alertID),
+		func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, lqlErrorReponse, http.StatusInternalServerError)
+		},
+	)
+	defer fakeServer.Close()
+
+	c, err := api.NewClient("test",
+		api.WithToken("TOKEN"),
+		api.WithURL(fakeServer.URL()),
+	)
+	assert.Nil(t, err)
+
+	_, err = c.V2.Alerts.Close(alertCloseRequest)
+	assert.NotNil(t, err)
+}

--- a/api/alerts_comment.go
+++ b/api/alerts_comment.go
@@ -1,0 +1,50 @@
+//
+// Author:: Salim Afiune Maya (<afiune@lacework.net>)
+// Copyright:: Copyright 2020, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package api
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+)
+
+type AlertsCommentRequest struct {
+	Comment string `json:"comment"`
+}
+
+type AlertsCommentResponse struct {
+	Data AlertTimeline `json:"data"`
+}
+
+func (svc *AlertsService) Comment(id int, comment string) (
+	response AlertsCommentResponse,
+	err error,
+) {
+	if comment == "" {
+		err = errors.New("alert comment must be provided")
+		return
+	}
+	err = svc.client.RequestEncoderDecoder(
+		"POST",
+		fmt.Sprintf(apiV2AlertsComment, id),
+		AlertsCommentRequest{Comment: comment},
+		&response,
+	)
+	return
+}

--- a/api/alerts_comment_test.go
+++ b/api/alerts_comment_test.go
@@ -1,0 +1,144 @@
+//
+// Author:: Salim Afiune Maya (<afiune@lacework.net>)
+// Copyright:: Copyright 2020, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package api_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/lacework/go-sdk/api"
+	"github.com/lacework/go-sdk/internal/lacework"
+	"github.com/stretchr/testify/assert"
+)
+
+var alertCommentJSON = `{
+    "data": {
+        "id": 38613065,
+        "alertId": 966883,
+        "entryType": "Comment",
+        "entryAuthorType": "UserUpdate",
+        "message": {
+            "value": "this is fine"
+        },
+        "externalTime": "0",
+        "user": {
+            "userGuid": "QAN6DB45_FFF67EEEEEEEEEBBDACD9",
+            "username": "david.hazekamp@lacework.net"
+        },
+        "updateContext": {}
+    }
+}`
+
+func TestAlertsCommentMethod(t *testing.T) {
+	fakeServer := lacework.MockServer()
+	fakeServer.UseApiV2()
+	fakeServer.MockAPI(
+		fmt.Sprintf("Alerts/%d/comment", alertID),
+		func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "POST", r.Method, "Comment should be a POST method")
+			fmt.Fprint(w, "{}")
+		},
+	)
+	defer fakeServer.Close()
+
+	c, err := api.NewClient("test",
+		api.WithToken("TOKEN"),
+		api.WithURL(fakeServer.URL()),
+	)
+	assert.Nil(t, err)
+
+	_, err = c.V2.Alerts.Comment(alertID, "this is a comment")
+	assert.Nil(t, err)
+}
+
+func TestAlertsCommentOK(t *testing.T) {
+	mockResponse := alertCommentJSON
+
+	fakeServer := lacework.MockServer()
+	fakeServer.UseApiV2()
+	fakeServer.MockAPI(
+		fmt.Sprintf("Alerts/%d/comment", alertID),
+		func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprint(w, mockResponse)
+		},
+	)
+	defer fakeServer.Close()
+
+	c, err := api.NewClient("test",
+		api.WithToken("TOKEN"),
+		api.WithURL(fakeServer.URL()),
+	)
+	assert.Nil(t, err)
+
+	commentExpected := api.AlertsCommentResponse{}
+	_ = json.Unmarshal([]byte(mockResponse), &commentExpected)
+
+	var commentActual api.AlertsCommentResponse
+	commentActual, err = c.V2.Alerts.Comment(alertID, "this is a comment")
+	assert.Nil(t, err)
+
+	assert.Equal(t, commentExpected, commentActual)
+}
+
+func TestAlertsCommentBad(t *testing.T) {
+	fakeServer := lacework.MockServer()
+	fakeServer.UseApiV2()
+	fakeServer.MockAPI(
+		fmt.Sprintf("Alerts/%d/comment", alertID),
+		func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprint(w, "{}")
+		},
+	)
+	defer fakeServer.Close()
+
+	c, err := api.NewClient("test",
+		api.WithToken("TOKEN"),
+		api.WithURL(fakeServer.URL()),
+	)
+	assert.Nil(t, err)
+
+	_, err = c.V2.Alerts.Comment(alertID, "")
+	if err == nil {
+		assert.FailNow(t, "expected error not thrown")
+	}
+	assert.Equal(t, "alert comment must be provided", err.Error())
+}
+
+func TestAlertsCommentError(t *testing.T) {
+	fakeServer := lacework.MockServer()
+	fakeServer.UseApiV2()
+	fakeServer.MockAPI(
+		fmt.Sprintf("Alerts/%d/comment", alertID),
+		func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, lqlErrorReponse, http.StatusInternalServerError)
+		},
+	)
+	defer fakeServer.Close()
+
+	c, err := api.NewClient("test",
+		api.WithToken("TOKEN"),
+		api.WithURL(fakeServer.URL()),
+	)
+	assert.Nil(t, err)
+
+	_, err = c.V2.Alerts.Comment(alertID, "")
+	assert.NotNil(t, err)
+}

--- a/api/alerts_details.go
+++ b/api/alerts_details.go
@@ -1,0 +1,90 @@
+//
+// Author:: Salim Afiune Maya (<afiune@lacework.net>)
+// Copyright:: Copyright 2020, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package api
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+)
+
+type alertScope int
+
+const (
+	AlertDetailsScope alertScope = iota
+	AlertInvestigationScope
+	AlertEventsScope
+	AlertRelatedAlertsScope
+	AlertIntegrationsScope
+	AlertTimelineScope
+)
+
+var AlertScopes = map[alertScope]string{
+	AlertDetailsScope:       "Details",
+	AlertInvestigationScope: "Investigation",
+	AlertEventsScope:        "Events",
+	AlertRelatedAlertsScope: "RelatedAlerts",
+	AlertIntegrationsScope:  "Integrations",
+	AlertTimelineScope:      "Timeline",
+}
+
+func (i alertScope) String() string {
+	return AlertScopes[i]
+}
+
+type AlertDetails struct {
+	Alert
+	EntityMap map[string]interface{} `json:"entityMap"` // @dhazekamp: this needs to be built out properly
+}
+
+type AlertDetailsResponse struct {
+	Data AlertDetails `json:"data"`
+}
+
+func (svc *AlertsService) Get(id int, scope alertScope) (interface{}, error) {
+	switch scope {
+	case AlertDetailsScope:
+		return svc.GetDetails(id)
+	case AlertInvestigationScope:
+		return svc.GetInvestigation(id)
+	case AlertEventsScope:
+		return svc.GetEvents(id)
+	case AlertRelatedAlertsScope:
+		return svc.GetRelatedAlerts(id)
+	case AlertIntegrationsScope:
+		return svc.GetIntegrations(id)
+	case AlertTimelineScope:
+		return svc.GetTimeline(id)
+	default:
+		return nil, errors.New(fmt.Sprintf("alert scope (%s) not recognized", scope))
+	}
+}
+
+func (svc *AlertsService) GetDetails(id int) (
+	response AlertDetailsResponse,
+	err error,
+) {
+	err = svc.client.RequestDecoder(
+		"GET",
+		fmt.Sprintf(apiV2AlertsDetails, id, AlertDetailsScope),
+		nil,
+		&response,
+	)
+	return
+}

--- a/api/alerts_details_events.go
+++ b/api/alerts_details_events.go
@@ -1,0 +1,44 @@
+//
+// Author:: Salim Afiune Maya (<afiune@lacework.net>)
+// Copyright:: Copyright 2020, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package api
+
+import (
+	"fmt"
+)
+
+// @dhazekamp: is this the same structure as v2/Events?
+// @dhazekamp: is this structure consistent across alerts (types)
+type AlertEvent map[string]interface{}
+
+type AlertEventsResponse struct {
+	Data []AlertEvent `json:"data"`
+}
+
+func (svc *AlertsService) GetEvents(id int) (
+	response AlertEventsResponse,
+	err error,
+) {
+	err = svc.client.RequestDecoder(
+		"GET",
+		fmt.Sprintf(apiV2AlertsDetails, id, AlertEventsScope),
+		nil,
+		&response,
+	)
+	return
+}

--- a/api/alerts_details_events_test.go
+++ b/api/alerts_details_events_test.go
@@ -1,0 +1,117 @@
+//
+// Author:: Salim Afiune Maya (<afiune@lacework.net>)
+// Copyright:: Copyright 2020, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package api_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/lacework/go-sdk/api"
+	"github.com/lacework/go-sdk/internal/lacework"
+	"github.com/stretchr/testify/assert"
+)
+
+var alertEventsJSON = `{
+    "data": [
+        {
+            "awsRegion": "eu-central-1",
+            "eventName": "DescribeAccountLimits",
+            "eventSource": "cloudformation.amazonaws.com",
+            "sourceIpAddress": "servicequotas.amazonaws.com",
+            "recipientAccountId": "287105300711",
+            "mfa": "false",
+            "eventTime": "2022-09-29T19:52:54Z",
+            "userIdentity": "{\"accessKeyId\":\"asdfasdf\",\"accountId\":\"287232303711\"}",
+            "additionalEventInfo": "{\"errorCode\": \"AccessDenied\"}"
+        }
+    ]
+}`
+
+func TestAlertsGetEventsMethod(t *testing.T) {
+	fakeServer := lacework.MockServer()
+	fakeServer.UseApiV2()
+	fakeServer.MockAPI(
+		fmt.Sprintf("Alerts/%d", alertID),
+		func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "GET", r.Method, "GetEvents should be a GET method")
+			fmt.Fprint(w, "{}")
+		},
+	)
+	defer fakeServer.Close()
+
+	c, err := api.NewClient("test",
+		api.WithToken("TOKEN"),
+		api.WithURL(fakeServer.URL()),
+	)
+	assert.Nil(t, err)
+
+	_, err = c.V2.Alerts.GetEvents(alertID)
+	assert.Nil(t, err)
+}
+
+func TestAlertsGetEventsOK(t *testing.T) {
+	mockResponse := alertInvestigationJSON
+
+	fakeServer := lacework.MockServer()
+	fakeServer.UseApiV2()
+	fakeServer.MockAPI(
+		fmt.Sprintf("Alerts/%d", alertID),
+		func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprint(w, mockResponse)
+		},
+	)
+	defer fakeServer.Close()
+
+	c, err := api.NewClient("test",
+		api.WithToken("TOKEN"),
+		api.WithURL(fakeServer.URL()),
+	)
+	assert.Nil(t, err)
+
+	eventsExpected := api.AlertEventsResponse{}
+	_ = json.Unmarshal([]byte(mockResponse), &eventsExpected)
+
+	var eventsActual api.AlertEventsResponse
+	eventsActual, err = c.V2.Alerts.GetEvents(alertID)
+	assert.Nil(t, err)
+	assert.Equal(t, eventsExpected, eventsActual)
+}
+
+func TestAlertsGetEventsError(t *testing.T) {
+	fakeServer := lacework.MockServer()
+	fakeServer.UseApiV2()
+	fakeServer.MockAPI(
+		fmt.Sprintf("Alerts/%d", alertID),
+		func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, lqlErrorReponse, http.StatusInternalServerError)
+		},
+	)
+	defer fakeServer.Close()
+
+	c, err := api.NewClient("test",
+		api.WithToken("TOKEN"),
+		api.WithURL(fakeServer.URL()),
+	)
+	assert.Nil(t, err)
+
+	_, err = c.V2.Alerts.GetEvents(alertID)
+	assert.NotNil(t, err)
+}

--- a/api/alerts_details_integrations.go
+++ b/api/alerts_details_integrations.go
@@ -1,0 +1,63 @@
+//
+// Author:: Salim Afiune Maya (<afiune@lacework.net>)
+// Copyright:: Copyright 2020, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package api
+
+import (
+	"fmt"
+)
+
+type AlertIntegrationChannel struct {
+	commonIntegrationData
+	EnvironmentGUID string                 `json:"ENV_GUID"`
+	Data            map[string]interface{} `json:"DATA"`
+}
+
+type AlertIntegrationContext struct {
+	ID   string `json:"id"`
+	Link string `json:"link"`
+}
+
+type AlertIntegration struct {
+	ID            string                  `json:"alertIntegrationId"`
+	AlertID       int                     `json:"alertId"`
+	Type          string                  `json:"integrationType"`
+	Channel       AlertIntegrationChannel `json:"alertChannel"`
+	Context       AlertIntegrationContext `json:"integrationContext"`
+	IntgGUID      string                  `json:"intgGuid"`
+	LastSyncTime  string                  `json:"lastSyncTime"`
+	Status        string                  `json:"status"`
+	Bidirectional bool                    `json:"isBidirectional"`
+}
+
+type AlertIntegrationsResponse struct {
+	Data []AlertIntegration `json:"data"`
+}
+
+func (svc *AlertsService) GetIntegrations(id int) (
+	response AlertIntegrationsResponse,
+	err error,
+) {
+	err = svc.client.RequestDecoder(
+		"GET",
+		fmt.Sprintf(apiV2AlertsDetails, id, AlertIntegrationsScope),
+		nil,
+		&response,
+	)
+	return
+}

--- a/api/alerts_details_integrations_test.go
+++ b/api/alerts_details_integrations_test.go
@@ -1,0 +1,147 @@
+//
+// Author:: Salim Afiune Maya (<afiune@lacework.net>)
+// Copyright:: Copyright 2020, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package api_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/lacework/go-sdk/api"
+	"github.com/lacework/go-sdk/internal/lacework"
+	"github.com/stretchr/testify/assert"
+)
+
+var alertIntegrationsJSON = `{
+    "data": [
+        {
+            "alertChannel": {
+                "INTG_GUID": "DEV7CE4D_6339B995C84CDBAEEEEEEC8EBA629CFDB5FB6",
+                "NAME": "LARS",
+                "CREATED_OR_UPDATED_TIME": "2022-05-02T20:44:56.612Z",
+                "CREATED_OR_UPDATED_BY": "david.hazekamp@lacework.net",
+                "ENV_GUID": "DEV7_A899511115596FC78BEEEEEEE8374DCD52A324B997BBCB97",
+                "TYPE": "Webhook",
+                "ENABLED": 1,
+                "STATE": {
+                    "ok": true,
+                    "lastUpdatedTime": 1664561511626,
+                    "lastSuccessfulTime": 1664561511626,
+                    "lastWebhookUpdateTime": 0,
+                    "details": {
+                        "errorMessage": "<html>\r\n<head><title>503 Service Temporarily Unavailable</title></head>\r\n<body>\r\n<center><h1>503 Service Temporarily Unavailable</h1></center>\r\n</body>\r\n</html>\r\n",
+                        "errorSubtitle": "Here is the response returned during the most recent channel failure:\n",
+                        "errorTitle": "HTTP 503",
+                        "message": "Could not send alert.  HTTP status code = 503 Channel Type: WEBHOOK integration name: LARS INTG_GUID: DEV7CE4D_6339B995C84CEEEEEEE3C8EBA629CFDB5FB6 response: <html>\r\n<head><title>503 Service Temporarily Unavailable</title></head>\r\n<body>\r\n<center><h1>503 Service Temporarily Unavailable</h1></center>\r\n</body>\r\n</html>\r\n",
+                        "statusCode": "503"
+                    }
+                },
+                "IS_ORG": 0,
+                "DATA": {
+                    "WEBHOOK_URL": "https://lars.run/alerts",
+                    "MIN_ALERT_SEVERITY": 3
+                }
+            },
+            "alertIntegrationId": "d7b76b0a-a9d6-e953-3asdf-53595515953f",
+            "alertId": 168155,
+            "integrationType": "WEBHOOK",
+            "integrationContext": {
+                "id": "",
+                "link": ""
+            },
+            "intgGuid": "DEV7CE4D_6339B995C8EEEEEEEE6C3C8EBA629CFDB5FB6",
+            "lastSyncTime": "2022-09-29T20:42:33.846Z",
+            "alertIntegrationStatus": "",
+            "status": "Open",
+            "isBidirectional": false
+        }
+    ]
+}`
+
+func TestAlertsGetIntegrationsMethod(t *testing.T) {
+	fakeServer := lacework.MockServer()
+	fakeServer.UseApiV2()
+	fakeServer.MockAPI(
+		fmt.Sprintf("Alerts/%d", alertID),
+		func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "GET", r.Method, "GetIntegrations should be a GET method")
+			fmt.Fprint(w, "{}")
+		},
+	)
+	defer fakeServer.Close()
+
+	c, err := api.NewClient("test",
+		api.WithToken("TOKEN"),
+		api.WithURL(fakeServer.URL()),
+	)
+	assert.Nil(t, err)
+
+	_, err = c.V2.Alerts.GetIntegrations(alertID)
+	assert.Nil(t, err)
+}
+
+func TestAlertsGetIntegrationsOK(t *testing.T) {
+	mockResponse := alertInvestigationJSON
+
+	fakeServer := lacework.MockServer()
+	fakeServer.UseApiV2()
+	fakeServer.MockAPI(
+		fmt.Sprintf("Alerts/%d", alertID),
+		func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprint(w, mockResponse)
+		},
+	)
+	defer fakeServer.Close()
+
+	c, err := api.NewClient("test",
+		api.WithToken("TOKEN"),
+		api.WithURL(fakeServer.URL()),
+	)
+	assert.Nil(t, err)
+
+	integrationsExpected := api.AlertIntegrationsResponse{}
+	_ = json.Unmarshal([]byte(mockResponse), &integrationsExpected)
+
+	var integrationsActual api.AlertIntegrationsResponse
+	integrationsActual, err = c.V2.Alerts.GetIntegrations(alertID)
+	assert.Nil(t, err)
+	assert.Equal(t, integrationsExpected, integrationsActual)
+}
+
+func TestAlertsGetIntegrationsError(t *testing.T) {
+	fakeServer := lacework.MockServer()
+	fakeServer.UseApiV2()
+	fakeServer.MockAPI(
+		fmt.Sprintf("Alerts/%d", alertID),
+		func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, lqlErrorReponse, http.StatusInternalServerError)
+		},
+	)
+	defer fakeServer.Close()
+
+	c, err := api.NewClient("test",
+		api.WithToken("TOKEN"),
+		api.WithURL(fakeServer.URL()),
+	)
+	assert.Nil(t, err)
+
+	_, err = c.V2.Alerts.GetIntegrations(alertID)
+	assert.NotNil(t, err)
+}

--- a/api/alerts_details_investigation.go
+++ b/api/alerts_details_investigation.go
@@ -1,0 +1,45 @@
+//
+// Author:: Salim Afiune Maya (<afiune@lacework.net>)
+// Copyright:: Copyright 2020, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package api
+
+import (
+	"fmt"
+)
+
+type AlertInvestigation struct {
+	Question string `json:"question"`
+	Answer   string `json:"answer"`
+}
+
+type AlertInvestigationResponse struct {
+	Data []AlertInvestigation `json:"data"`
+}
+
+func (svc *AlertsService) GetInvestigation(id int) (
+	response AlertInvestigationResponse,
+	err error,
+) {
+	err = svc.client.RequestDecoder(
+		"GET",
+		fmt.Sprintf(apiV2AlertsDetails, id, AlertInvestigationScope),
+		nil,
+		&response,
+	)
+	return
+}

--- a/api/alerts_details_investigation_test.go
+++ b/api/alerts_details_investigation_test.go
@@ -1,0 +1,118 @@
+//
+// Author:: Salim Afiune Maya (<afiune@lacework.net>)
+// Copyright:: Copyright 2020, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package api_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/lacework/go-sdk/api"
+	"github.com/lacework/go-sdk/internal/lacework"
+	"github.com/stretchr/testify/assert"
+)
+
+var alertInvestigationJSON = `{
+    "data": [
+        {
+            "question": "Has a new user been involved in the event in the last 60 days?",
+            "answer": "No"
+        },
+        {
+            "question": "Have the users involved in the event authenticated without MFA in the last 60 days?",
+            "answer": "No"
+        },
+        {
+            "question": "Have any of the users involved in the event used the Root account in the last 60 days?",
+            "answer": "No"
+        }
+    ]
+}`
+
+func TestAlertsGetInvestigationMethod(t *testing.T) {
+	fakeServer := lacework.MockServer()
+	fakeServer.UseApiV2()
+	fakeServer.MockAPI(
+		fmt.Sprintf("Alerts/%d", alertID),
+		func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "GET", r.Method, "GetInvestigation should be a GET method")
+			fmt.Fprint(w, "{}")
+		},
+	)
+	defer fakeServer.Close()
+
+	c, err := api.NewClient("test",
+		api.WithToken("TOKEN"),
+		api.WithURL(fakeServer.URL()),
+	)
+	assert.Nil(t, err)
+
+	_, err = c.V2.Alerts.GetInvestigation(alertID)
+	assert.Nil(t, err)
+}
+
+func TestAlertsGetInvestigationOK(t *testing.T) {
+	mockResponse := alertInvestigationJSON
+
+	fakeServer := lacework.MockServer()
+	fakeServer.UseApiV2()
+	fakeServer.MockAPI(
+		fmt.Sprintf("Alerts/%d", alertID),
+		func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprint(w, mockResponse)
+		},
+	)
+	defer fakeServer.Close()
+
+	c, err := api.NewClient("test",
+		api.WithToken("TOKEN"),
+		api.WithURL(fakeServer.URL()),
+	)
+	assert.Nil(t, err)
+
+	investigationExpected := api.AlertInvestigationResponse{}
+	_ = json.Unmarshal([]byte(mockResponse), &investigationExpected)
+
+	var investigationActual api.AlertInvestigationResponse
+	investigationActual, err = c.V2.Alerts.GetInvestigation(alertID)
+	assert.Nil(t, err)
+	assert.Equal(t, investigationExpected, investigationActual)
+}
+
+func TestAlertsGetInvestigationError(t *testing.T) {
+	fakeServer := lacework.MockServer()
+	fakeServer.UseApiV2()
+	fakeServer.MockAPI(
+		fmt.Sprintf("Alerts/%d", alertID),
+		func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, lqlErrorReponse, http.StatusInternalServerError)
+		},
+	)
+	defer fakeServer.Close()
+
+	c, err := api.NewClient("test",
+		api.WithToken("TOKEN"),
+		api.WithURL(fakeServer.URL()),
+	)
+	assert.Nil(t, err)
+
+	_, err = c.V2.Alerts.GetInvestigation(alertID)
+	assert.NotNil(t, err)
+}

--- a/api/alerts_details_related.go
+++ b/api/alerts_details_related.go
@@ -1,0 +1,51 @@
+//
+// Author:: Salim Afiune Maya (<afiune@lacework.net>)
+// Copyright:: Copyright 2020, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package api
+
+import (
+	"fmt"
+)
+
+type RelatedAlert struct {
+	ID        string    `json:"eventId"`
+	Name      string    `json:"eventName"`
+	Type      string    `json:"eventType"`
+	Severity  string    `json:"severity"`
+	Rank      int       `json:"rank"`
+	Info      AlertInfo `json:"eventInfo"`
+	StartTime string    `json:"startTime"`
+	EndTime   string    `json:"endTime"`
+}
+
+type RelatedAlertsResponse struct {
+	Data []RelatedAlert `json:"data"`
+}
+
+func (svc *AlertsService) GetRelatedAlerts(id int) (
+	response RelatedAlertsResponse,
+	err error,
+) {
+	err = svc.client.RequestDecoder(
+		"GET",
+		fmt.Sprintf(apiV2AlertsDetails, id, AlertRelatedAlertsScope),
+		nil,
+		&response,
+	)
+	return
+}

--- a/api/alerts_details_related_test.go
+++ b/api/alerts_details_related_test.go
@@ -1,0 +1,117 @@
+//
+// Author:: Salim Afiune Maya (<afiune@lacework.net>)
+// Copyright:: Copyright 2020, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package api_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/lacework/go-sdk/api"
+	"github.com/lacework/go-sdk/internal/lacework"
+	"github.com/stretchr/testify/assert"
+)
+
+var alertRelatedJSON = `{
+    "data": [
+        {
+            "awsRegion": "eu-central-1",
+            "eventName": "DescribeAccountLimits",
+            "eventSource": "cloudformation.amazonaws.com",
+            "sourceIpAddress": "servicequotas.amazonaws.com",
+            "recipientAccountId": "287105300711",
+            "mfa": "false",
+            "eventTime": "2022-09-29T19:52:54Z",
+            "userIdentity": "{\"accessKeyId\":\"asdfasdf\",\"accountId\":\"287232303711\"}",
+            "additionalEventInfo": "{\"errorCode\": \"AccessDenied\"}"
+        }
+    ]
+}`
+
+func TestAlertsGetRelatedAlertsMethod(t *testing.T) {
+	fakeServer := lacework.MockServer()
+	fakeServer.UseApiV2()
+	fakeServer.MockAPI(
+		fmt.Sprintf("Alerts/%d", alertID),
+		func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "GET", r.Method, "GetRelatedAlerts should be a GET method")
+			fmt.Fprint(w, "{}")
+		},
+	)
+	defer fakeServer.Close()
+
+	c, err := api.NewClient("test",
+		api.WithToken("TOKEN"),
+		api.WithURL(fakeServer.URL()),
+	)
+	assert.Nil(t, err)
+
+	_, err = c.V2.Alerts.GetRelatedAlerts(alertID)
+	assert.Nil(t, err)
+}
+
+func TestAlertsGetRelatedAlertsOK(t *testing.T) {
+	mockResponse := alertInvestigationJSON
+
+	fakeServer := lacework.MockServer()
+	fakeServer.UseApiV2()
+	fakeServer.MockAPI(
+		fmt.Sprintf("Alerts/%d", alertID),
+		func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprint(w, mockResponse)
+		},
+	)
+	defer fakeServer.Close()
+
+	c, err := api.NewClient("test",
+		api.WithToken("TOKEN"),
+		api.WithURL(fakeServer.URL()),
+	)
+	assert.Nil(t, err)
+
+	relatedExpected := api.RelatedAlertsResponse{}
+	_ = json.Unmarshal([]byte(mockResponse), &relatedExpected)
+
+	var relatedActual api.RelatedAlertsResponse
+	relatedActual, err = c.V2.Alerts.GetRelatedAlerts(alertID)
+	assert.Nil(t, err)
+	assert.Equal(t, relatedExpected, relatedActual)
+}
+
+func TestAlertsGetRelatedAlertsError(t *testing.T) {
+	fakeServer := lacework.MockServer()
+	fakeServer.UseApiV2()
+	fakeServer.MockAPI(
+		fmt.Sprintf("Alerts/%d", alertID),
+		func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, lqlErrorReponse, http.StatusInternalServerError)
+		},
+	)
+	defer fakeServer.Close()
+
+	c, err := api.NewClient("test",
+		api.WithToken("TOKEN"),
+		api.WithURL(fakeServer.URL()),
+	)
+	assert.Nil(t, err)
+
+	_, err = c.V2.Alerts.GetRelatedAlerts(alertID)
+	assert.NotNil(t, err)
+}

--- a/api/alerts_details_test.go
+++ b/api/alerts_details_test.go
@@ -1,0 +1,140 @@
+//
+// Author:: Salim Afiune Maya (<afiune@lacework.net>)
+// Copyright:: Copyright 2020, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package api_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/lacework/go-sdk/api"
+	"github.com/lacework/go-sdk/internal/lacework"
+	"github.com/stretchr/testify/assert"
+)
+
+var alertDetailsJSON = `{
+    "data": {
+        "alertId": 967272,
+        "startTime": "2022-09-29T15:00:00.000Z",
+        "alertType": "ChangedFile",
+        "severity": "Medium",
+        "reachability": "UnknownReachability",
+        "derivedFields": {
+            "category": "Policy",
+            "sub_category": "File",
+            "source": "Agent"
+        },
+        "endTime": "2022-09-29T16:00:00.000Z",
+        "lastUserUpdatedTime": "0",
+        "status": "Open",
+        "alertName": "Clone of Files Changed ",
+        "alertInfo": {
+            "subject": "Clone of Files Changed",
+            "description": "Custom Policy Violation"
+        },
+        "policyId": "CUSTOM_FIM_276",
+        "alertSource": "UnknownAlertSource",
+        "entityMap": {
+            "CustomRule": [
+                {
+                    "KEY": {
+                        "rule_guid": "OBJ_503B388C004E428E23D86397CD6DE818F307B3306143D7BB13E0"
+                    },
+                    "PROPS": {
+                        "display_filter": "'[{\"operator\":\"include\",\"field\":\"PATH\",\"values\":[\"*\"]},{\"operator\":\"include\",\"field\":\"HOSTNAME\",\"values\":[\"*\"]}]'",
+                        "lastupdated_time": "1654547359267",
+                        "lastupdated_user": "'Amanpreet Dhindsa'"
+                    }
+                }
+            ]
+        }
+    }
+}`
+
+func TestAlertsGetDetailsMethod(t *testing.T) {
+	fakeServer := lacework.MockServer()
+	fakeServer.UseApiV2()
+	fakeServer.MockAPI(
+		fmt.Sprintf("Alerts/%d", alertID),
+		func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "GET", r.Method, "GetDetails should be a GET method")
+			fmt.Fprint(w, "{}")
+		},
+	)
+	defer fakeServer.Close()
+
+	c, err := api.NewClient("test",
+		api.WithToken("TOKEN"),
+		api.WithURL(fakeServer.URL()),
+	)
+	assert.Nil(t, err)
+
+	_, err = c.V2.Alerts.GetDetails(alertID)
+	assert.Nil(t, err)
+}
+
+func TestAlertsGetDetailsOK(t *testing.T) {
+	mockResponse := alertDetailsJSON
+
+	fakeServer := lacework.MockServer()
+	fakeServer.UseApiV2()
+	fakeServer.MockAPI(
+		fmt.Sprintf("Alerts/%d", alertID),
+		func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprint(w, mockResponse)
+		},
+	)
+	defer fakeServer.Close()
+
+	c, err := api.NewClient("test",
+		api.WithToken("TOKEN"),
+		api.WithURL(fakeServer.URL()),
+	)
+	assert.Nil(t, err)
+
+	detailsExpected := api.AlertDetailsResponse{}
+	_ = json.Unmarshal([]byte(mockResponse), &detailsExpected)
+
+	var detailsActual api.AlertDetailsResponse
+	detailsActual, err = c.V2.Alerts.GetDetails(alertID)
+	assert.Nil(t, err)
+	assert.Equal(t, detailsExpected, detailsActual)
+}
+
+func TestAlertsGetDetailsError(t *testing.T) {
+	fakeServer := lacework.MockServer()
+	fakeServer.UseApiV2()
+	fakeServer.MockAPI(
+		fmt.Sprintf("Alerts/%d", alertID),
+		func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, lqlErrorReponse, http.StatusInternalServerError)
+		},
+	)
+	defer fakeServer.Close()
+
+	c, err := api.NewClient("test",
+		api.WithToken("TOKEN"),
+		api.WithURL(fakeServer.URL()),
+	)
+	assert.Nil(t, err)
+
+	_, err = c.V2.Alerts.GetDetails(alertID)
+	assert.NotNil(t, err)
+}

--- a/api/alerts_details_timeline.go
+++ b/api/alerts_details_timeline.go
@@ -1,0 +1,75 @@
+//
+// Author:: Salim Afiune Maya (<afiune@lacework.net>)
+// Copyright:: Copyright 2020, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package api
+
+import (
+	"fmt"
+)
+
+type AlertTimelineMessage struct {
+	Format string `json:"format"`
+	Value  string `json:"value"`
+}
+
+type AlertTimelineUser struct {
+	UserGUID string `json:"userGuid"`
+	Name     string `json:"username"`
+}
+
+type AlertTimelineNewIntegrationContext struct {
+	AlertID                string `json:"alertId"`
+	LastSyncTime           string `json:"lastSyncTime"`
+	AlertIntegrationStatus string `json:"alertIntegrationStatus"`
+	Status                 string `json:"status"`
+	Bidirectional          bool   `json:"isBidirectional"`
+}
+
+type AlertTimelineUpdateContext struct {
+	NewIntegration AlertTimelineNewIntegrationContext `json:"newIntegration"`
+}
+
+type AlertTimeline struct {
+	ID              int                        `json:"id"`
+	AlertID         int                        `json:"alertId"`
+	EntryType       string                     `json:"entryType"`
+	EntryAuthorType string                     `json:"entryAuthorType"`
+	IntgGUID        string                     `json:"intgGuid"`
+	Message         AlertTimelineMessage       `json:"message"`
+	ExternalTime    string                     `json:"externalTime"`
+	User            AlertTimelineUser          `json:"user"`
+	UpdateContext   AlertTimelineUpdateContext `json:"updateContext"`
+	Channel         AlertIntegrationChannel    `json:"alertChannel"`
+}
+
+type AlertTimelineResponse struct {
+	Data []AlertTimeline `json:"data"`
+}
+
+func (svc *AlertsService) GetTimeline(id int) (
+	response AlertTimelineResponse,
+	err error,
+) {
+	err = svc.client.RequestDecoder(
+		"GET",
+		fmt.Sprintf(apiV2AlertsDetails, id, AlertTimelineScope),
+		nil,
+		&response,
+	)
+	return
+}

--- a/api/alerts_details_timeline_test.go
+++ b/api/alerts_details_timeline_test.go
@@ -1,0 +1,121 @@
+//
+// Author:: Salim Afiune Maya (<afiune@lacework.net>)
+// Copyright:: Copyright 2020, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package api_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/lacework/go-sdk/api"
+	"github.com/lacework/go-sdk/internal/lacework"
+	"github.com/stretchr/testify/assert"
+)
+
+var alertTimelineJSON = `{
+    "data": [
+        {
+            "id": 129,
+            "alertId": 168155,
+            "entryType": "Comment",
+            "entryAuthorType": "UserUpdate",
+            "message": {
+                "value": "this is fine"
+            },
+            "externalTime": "0",
+            "user": {
+                "userGuid": "DEV7CE4D_76A94FE2C8D3EEEEEEEEED62EA6745D4A42DF777",
+                "username": "david.hazekamp@lacework.net"
+            },
+            "updateContext": {}
+        }
+    ]
+}`
+
+func TestAlertsGetTimelineMethod(t *testing.T) {
+	fakeServer := lacework.MockServer()
+	fakeServer.UseApiV2()
+	fakeServer.MockAPI(
+		fmt.Sprintf("Alerts/%d", alertID),
+		func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "GET", r.Method, "GetTimeline should be a GET method")
+			fmt.Fprint(w, "{}")
+		},
+	)
+	defer fakeServer.Close()
+
+	c, err := api.NewClient("test",
+		api.WithToken("TOKEN"),
+		api.WithURL(fakeServer.URL()),
+	)
+	assert.Nil(t, err)
+
+	_, err = c.V2.Alerts.GetTimeline(alertID)
+	assert.Nil(t, err)
+}
+
+func TestAlertsGetTimelineOK(t *testing.T) {
+	mockResponse := alertInvestigationJSON
+
+	fakeServer := lacework.MockServer()
+	fakeServer.UseApiV2()
+	fakeServer.MockAPI(
+		fmt.Sprintf("Alerts/%d", alertID),
+		func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprint(w, mockResponse)
+		},
+	)
+	defer fakeServer.Close()
+
+	c, err := api.NewClient("test",
+		api.WithToken("TOKEN"),
+		api.WithURL(fakeServer.URL()),
+	)
+	assert.Nil(t, err)
+
+	timelineExpected := api.AlertTimelineResponse{}
+	_ = json.Unmarshal([]byte(mockResponse), &timelineExpected)
+
+	var timelineActual api.AlertTimelineResponse
+	timelineActual, err = c.V2.Alerts.GetTimeline(alertID)
+	assert.Nil(t, err)
+	assert.Equal(t, timelineExpected, timelineActual)
+}
+
+func TestAlertsGetTimelineError(t *testing.T) {
+	fakeServer := lacework.MockServer()
+	fakeServer.UseApiV2()
+	fakeServer.MockAPI(
+		fmt.Sprintf("Alerts/%d", alertID),
+		func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, lqlErrorReponse, http.StatusInternalServerError)
+		},
+	)
+	defer fakeServer.Close()
+
+	c, err := api.NewClient("test",
+		api.WithToken("TOKEN"),
+		api.WithURL(fakeServer.URL()),
+	)
+	assert.Nil(t, err)
+
+	_, err = c.V2.Alerts.GetTimeline(alertID)
+	assert.NotNil(t, err)
+}

--- a/api/alerts_test.go
+++ b/api/alerts_test.go
@@ -1,0 +1,207 @@
+//
+// Author:: Salim Afiune Maya (<afiune@lacework.net>)
+// Copyright:: Copyright 2020, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package api_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/lacework/go-sdk/api"
+	"github.com/lacework/go-sdk/internal/lacework"
+	"github.com/stretchr/testify/assert"
+)
+
+var alertsJSON = `{
+    "paging": {
+        "rows": 412,
+        "totalRows": 412,
+        "urls": {
+            "nextPage": null
+        }
+    },
+    "data": [
+        {
+            "alertId": 967278,
+            "startTime": "2022-09-29T16:00:00.000Z",
+            "alertType": "CloudActivityLogIngestionFailed",
+            "severity": "High",
+            "reachability": "UnknownReachability",
+            "derivedFields": {
+                "category": "Policy",
+                "sub_category": "Platform",
+                "source": ""
+            },
+            "endTime": "2022-09-29T17:00:00.000Z",
+            "lastUserUpdatedTime": "0",
+            "status": "Open",
+            "alertName": "Clone of Cloud Activity log ingestion failure detected",
+            "alertInfo": {
+                "subject": "Clone of Cloud Activity log ingestion failure detected",
+                "description": "New integration failure detected for kiki-intg-2 (and 3 more)"
+            },
+            "policyId": "CUSTOM_PLATFORM_130",
+            "alertSource": "UnknownAlertSource"
+        }
+	]
+}`
+
+func TestAlertsListMethod(t *testing.T) {
+	fakeServer := lacework.MockServer()
+	fakeServer.UseApiV2()
+	fakeServer.MockAPI(
+		"Alerts",
+		func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "GET", r.Method, "List should be a GET method")
+			fmt.Fprint(w, "{}")
+		},
+	)
+	defer fakeServer.Close()
+
+	c, err := api.NewClient("test",
+		api.WithToken("TOKEN"),
+		api.WithURL(fakeServer.URL()),
+	)
+	assert.Nil(t, err)
+
+	_, err = c.V2.Alerts.List()
+	assert.Nil(t, err)
+}
+
+func TestAlertsListOK(t *testing.T) {
+	mockResponse := alertsJSON
+
+	fakeServer := lacework.MockServer()
+	fakeServer.UseApiV2()
+	fakeServer.MockAPI(
+		"Alerts",
+		func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprint(w, mockResponse)
+		},
+	)
+	defer fakeServer.Close()
+
+	c, err := api.NewClient("test",
+		api.WithToken("TOKEN"),
+		api.WithURL(fakeServer.URL()),
+	)
+	assert.Nil(t, err)
+
+	listExpected := api.AlertsResponse{}
+	_ = json.Unmarshal([]byte(mockResponse), &listExpected)
+
+	var listActual api.AlertsResponse
+	listActual, err = c.V2.Alerts.List()
+	assert.Nil(t, err)
+	assert.Equal(t, listExpected, listActual)
+}
+
+func TestAlertsListError(t *testing.T) {
+	fakeServer := lacework.MockServer()
+	fakeServer.UseApiV2()
+	fakeServer.MockAPI(
+		"Alerts",
+		func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, lqlErrorReponse, http.StatusInternalServerError)
+		},
+	)
+	defer fakeServer.Close()
+
+	c, err := api.NewClient("test",
+		api.WithToken("TOKEN"),
+		api.WithURL(fakeServer.URL()),
+	)
+	assert.Nil(t, err)
+
+	_, err = c.V2.Alerts.List()
+	assert.NotNil(t, err)
+}
+
+func TestAlertsListByTimeMethod(t *testing.T) {
+	fakeServer := lacework.MockServer()
+	fakeServer.UseApiV2()
+	fakeServer.MockAPI(
+		"Alerts",
+		func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "GET", r.Method, "ListByTime should be a GET method")
+			fmt.Fprint(w, "{}")
+		},
+	)
+	defer fakeServer.Close()
+
+	c, err := api.NewClient("test",
+		api.WithToken("TOKEN"),
+		api.WithURL(fakeServer.URL()),
+	)
+	assert.Nil(t, err)
+
+	_, err = c.V2.Alerts.ListByTime(time.Now(), time.Now())
+	assert.Nil(t, err)
+}
+
+func TestAlertsListByTimeOK(t *testing.T) {
+	mockResponse := alertsJSON
+
+	fakeServer := lacework.MockServer()
+	fakeServer.UseApiV2()
+	fakeServer.MockAPI(
+		"Alerts",
+		func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprint(w, mockResponse)
+		},
+	)
+	defer fakeServer.Close()
+
+	c, err := api.NewClient("test",
+		api.WithToken("TOKEN"),
+		api.WithURL(fakeServer.URL()),
+	)
+	assert.Nil(t, err)
+
+	listExpected := api.AlertsResponse{}
+	_ = json.Unmarshal([]byte(mockResponse), &listExpected)
+
+	var listActual api.AlertsResponse
+	listActual, err = c.V2.Alerts.ListByTime(time.Now(), time.Now())
+	assert.Nil(t, err)
+	assert.Equal(t, listExpected, listActual)
+}
+
+func TestAlertsListByTimeError(t *testing.T) {
+	fakeServer := lacework.MockServer()
+	fakeServer.UseApiV2()
+	fakeServer.MockAPI(
+		"Alerts",
+		func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, lqlErrorReponse, http.StatusInternalServerError)
+		},
+	)
+	defer fakeServer.Close()
+
+	c, err := api.NewClient("test",
+		api.WithToken("TOKEN"),
+		api.WithURL(fakeServer.URL()),
+	)
+	assert.Nil(t, err)
+
+	_, err = c.V2.Alerts.ListByTime(time.Now(), time.Now())
+	assert.NotNil(t, err)
+}

--- a/api/api.go
+++ b/api/api.go
@@ -145,6 +145,13 @@ const (
 	apiV2VulnerabilityExceptionFromGUID = "v2/VulnerabilityExceptions/%s"
 
 	apiV2EntitiesSearch = "v2/Entities/%s/search"
+
+	apiV2Alerts        = "v2/Alerts"
+	apiV2AlertsByTime  = "v2/Alerts?startTime=%s&endTime=%s"
+	apiV2AlertsSearch  = "v2/Alerts/search"
+	apiV2AlertsDetails = "v2/Alerts/%d?scope=%s"
+	apiV2AlertsComment = "v2/Alerts/%d/comment"
+	apiV2AlertsClose   = "v2/Alerts/%d/close"
 )
 
 // WithApiV2 configures the client to use the API version 2 (/api/v2)

--- a/api/api.go
+++ b/api/api.go
@@ -146,9 +146,9 @@ const (
 
 	apiV2EntitiesSearch = "v2/Entities/%s/search"
 
-	apiV2Alerts        = "v2/Alerts"
-	apiV2AlertsByTime  = "v2/Alerts?startTime=%s&endTime=%s"
-	apiV2AlertsSearch  = "v2/Alerts/search"
+	apiV2Alerts       = "v2/Alerts"
+	apiV2AlertsByTime = "v2/Alerts?startTime=%s&endTime=%s"
+	//apiV2AlertsSearch  = "v2/Alerts/search"
 	apiV2AlertsDetails = "v2/Alerts/%d?scope=%s"
 	apiV2AlertsComment = "v2/Alerts/%d/comment"
 	apiV2AlertsClose   = "v2/Alerts/%d/close"

--- a/api/v2.go
+++ b/api/v2.go
@@ -52,6 +52,7 @@ type V2Endpoints struct {
 	TeamMembers             *TeamMembersService
 	VulnerabilityExceptions *VulnerabilityExceptionsService
 	Vulnerabilities         *v2VulnerabilitiesService
+	Alerts                  *AlertsService
 }
 
 func NewV2Endpoints(c *Client) *V2Endpoints {
@@ -77,6 +78,7 @@ func NewV2Endpoints(c *Client) *V2Endpoints {
 		&TeamMembersService{c},
 		&VulnerabilityExceptionsService{c},
 		NewV2VulnerabilitiesService(c),
+		&AlertsService{c},
 	}
 
 	v2.Schemas.Services = map[integrationSchema]V2Service{


### PR DESCRIPTION

## Summary

Adds:
```
List()
ListByTime(start, end time.Time)
Get(id int, scope alertScope)
GetDetails(id int)
GetEvents(id int)
GetRelatedAlerts(id int)
GetInvestigation(id int)
GetIntegrations(id int)
GetTimeline(id int)
Comment(id int, comment string)
Close(request AlertCloseRequest)
```

...and corresponding data structures
...and tests!

## What's not included?
Alert search (https://lacework.atlassian.net/browse/ALLY-1206)
Alert entity map buildout (https://lacework.atlassian.net/browse/ALLY-1207)

## How did you test this change?
Comprehensive unit test coverage

## Issue
https://lacework.atlassian.net/browse/ALLY-1185
