### PR TITLE
fix(lwrunner): create ~/.ssh directory if not exist

### DIFF
--- a/lwrunner/runner.go
+++ b/lwrunner/runner.go
@@ -28,6 +28,7 @@ import (
 	"os"
 	"path"
 
+	"github.com/lacework/go-sdk/internal/file"
 	homedir "github.com/mitchellh/go-homedir"
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/knownhosts"
@@ -126,6 +127,12 @@ func AddKnownHost(host string, remote net.Addr, key ssh.PublicKey, knownFile str
 		}
 
 		knownFile = path
+	}
+
+	if !file.FileExists(knownFile) {
+		if err := os.MkdirAll(path.Dir(knownFile), 0700); err != nil {
+			return err
+		}
 	}
 
 	f, err := os.OpenFile(knownFile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0600)

--- a/lwrunner/runner_test.go
+++ b/lwrunner/runner_test.go
@@ -113,13 +113,14 @@ func TestDefaultIdentityFilePathEnvVariable(t *testing.T) {
 	}
 }
 
-func TestLwRunnerAddKnownHost(t *testing.T) {
+func TestLwRunnerAddKnownHostNoSSHDir(t *testing.T) {
 	mockHome, err := ioutil.TempDir("", "lwrunner")
 	if err != nil {
 		panic(err)
 	}
 	defer os.RemoveAll(mockHome)
 
+	knownFile := path.Join(mockHome, ".ssh", "known_hosts")
 	netAddr := mockNetAddr{}
 	// generate test RSA keypair in SSH format
 	priv, err := rsa.GenerateKey(rand.Reader, 2048)
@@ -127,9 +128,57 @@ func TestLwRunnerAddKnownHost(t *testing.T) {
 	rsaPub := priv.PublicKey
 	sshPub, err := ssh.NewPublicKey(&rsaPub)
 	assert.NoError(t, err)
-	subject := lwrunner.AddKnownHost("mock-test", netAddr, sshPub,
-		path.Join(mockHome, ".ssh", "known_hosts"))
+
+	// Add known host to mocked home directory
+	subject := lwrunner.AddKnownHost("mock-test", netAddr, sshPub, knownFile)
 	assert.NoError(t, subject)
+
+	// Check the known host file
+	content, err := ioutil.ReadFile(knownFile)
+	assert.NoError(t, err)
+	assert.Contains(t, string(content), "mock-test")
+
+	// Try again, it should work
+	// Add known host to mocked home directory
+	subject = lwrunner.AddKnownHost("second-time", netAddr, sshPub, knownFile)
+	assert.NoError(t, subject)
+
+	// Check the known host file
+	content, err = ioutil.ReadFile(knownFile)
+	assert.NoError(t, err)
+	assert.Contains(t, string(content), "second-time")
+}
+
+func TestLwRunnerAddKnownWithSSHDir(t *testing.T) {
+	mockHome, err := ioutil.TempDir("", "lwrunner")
+	if err != nil {
+		panic(err)
+	}
+	defer os.RemoveAll(mockHome)
+
+	// Mock that the ~/.ssh dir exists
+	err = os.Mkdir(path.Join(mockHome, ".ssh"), 0700)
+	if err != nil {
+		panic(err)
+	}
+
+	knownFile := path.Join(mockHome, ".ssh", "known_hosts")
+	netAddr := mockNetAddr{}
+	// generate test RSA keypair in SSH format
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	assert.NoError(t, err)
+	rsaPub := priv.PublicKey
+	sshPub, err := ssh.NewPublicKey(&rsaPub)
+	assert.NoError(t, err)
+
+	// Add known host to mocked home directory
+	subject := lwrunner.AddKnownHost("mock-test", netAddr, sshPub, knownFile)
+	assert.NoError(t, subject)
+
+	// Check the known host file
+	content, err := ioutil.ReadFile(knownFile)
+	assert.NoError(t, err)
+	assert.Contains(t, string(content), "mock-test")
 }
 
 type mockNetAddr struct{}


### PR DESCRIPTION

## Summary

This change fixes the issue where we try to add a known host to the
known_hosts file but the directory ~/.ssh does not exist.

Now we are creating that directory first.

## How did you test this change?
Replicated the issue inside our unit tests:
```
    === Failed
    === FAIL: lwrunner TestLwRunnerAddKnownHost (0.19s)
        runner_test.go:132:
                    Error Trace:    /Users/afiune/github/go-sdk/lwrunner/runner_test.go:132
                    Error:          Received unexpected error:
                                    open /var/folders/pn/rtky3yx17fx60dc03njhm_fw0000gn/T/lwrunner1052124622/.ssh/known_hosts: no such file or directory
                    Test:           TestLwRunnerAddKnownHost
```


## Issue

Closes https://github.com/lacework/go-sdk/issues/915
Jira https://lacework.atlassian.net/browse/ALLY-1195


