### PR TITLE
fix: azure Lacework provider & profile flag

### DIFF
--- a/cli/cmd/generate_azure.go
+++ b/cli/cmd/generate_azure.go
@@ -162,8 +162,13 @@ By default, this command will function interactively, prompting for the required
 			// Generate TF Code
 			cli.StartProgress("Generating Azure Terraform Code...")
 
+			if cli.Profile != "default" {
+				GenerateAzureCommandState.LaceworkProfile = cli.Profile
+			}
+
 			// Setup modifiers for NewTerraform constructor
 			mods := []azure.AzureTerraformModifier{
+				azure.WithLaceworkProfile(GenerateAzureCommandState.LaceworkProfile),
 				azure.WithAllSubscriptions(GenerateAzureCommandState.AllSubscriptions),
 				azure.WithManagementGroup(GenerateAzureCommandState.ManagementGroup),
 				azure.WithExistingStorageAccount(GenerateAzureCommandState.ExistingStorageAccount),
@@ -687,7 +692,7 @@ func askAdvancedAzureOptions(config *azure.GenerateAzureTfConfigurationArgs, ext
 }
 
 func azureConfigIsEmpty(config *azure.GenerateAzureTfConfigurationArgs) bool {
-	return !config.Config && !config.ActivityLog
+	return !config.Config && !config.ActivityLog && config.LaceworkProfile == ""
 }
 
 func allSubscriptionsDisabled(config *azure.GenerateAzureTfConfigurationArgs) *bool {

--- a/integration/gcp_generation_test.go
+++ b/integration/gcp_generation_test.go
@@ -1209,6 +1209,42 @@ func TestGenerationGcpOverwriteOutput(t *testing.T) {
 	assert.Contains(t, final, fmt.Sprintf("cd %s", output_dir))
 }
 
+func TestGenerationGcpLaceworkProfile(t *testing.T) {
+	os.Setenv("LW_NOCACHE", "true")
+	defer os.Setenv("LW_NOCACHE", "")
+	var final string
+	gcpProfile := "v2"
+
+	tfResult := runGcpGenerateTest(t,
+		func(c *expect.Console) {
+			expectsCliOutput(t, c, []MsgRsp{
+				msgRsp(cmd.QuestionGcpEnableConfiguration, "y"),
+				msgRsp(cmd.QuestionGcpEnableAuditLog, "y"),
+				msgRsp(cmd.QuestionGcpProjectID, projectId),
+				msgRsp(cmd.QuestionGcpOrganizationIntegration, "n"),
+				msgRsp(cmd.QuestionGcpServiceAccountCredsPath, ""),
+				msgRsp(cmd.QuestionGcpConfigureAdvanced, "n"),
+				msgRsp(cmd.QuestionRunTfPlan, "n"),
+			})
+
+			final, _ = c.ExpectEOF()
+		},
+		"generate",
+		"cloud-account",
+		"gcp",
+		"--profile",
+		gcpProfile,
+	)
+
+	assertTerraformSaved(t, final)
+
+	buildTf, _ := gcp.NewTerraform(true, true,
+		gcp.WithProjectId(projectId),
+		gcp.WithLaceworkProfile(gcpProfile),
+	).Generate()
+	assert.Equal(t, buildTf, tfResult)
+}
+
 func runGcpGenerateTest(t *testing.T, conditions func(*expect.Console), args ...string) string {
 	// create a temporal directory where we will check that the
 	// configuration file is deployed (.lacework.toml)

--- a/integration/gcp_generation_test.go
+++ b/integration/gcp_generation_test.go
@@ -1217,14 +1217,14 @@ func TestGenerationGcpLaceworkProfile(t *testing.T) {
 
 	tfResult := runGcpGenerateTest(t,
 		func(c *expect.Console) {
-			expectsCliOutput(t, c, []MsgRsp{
-				msgRsp(cmd.QuestionGcpEnableConfiguration, "y"),
-				msgRsp(cmd.QuestionGcpEnableAuditLog, "y"),
-				msgRsp(cmd.QuestionGcpProjectID, projectId),
-				msgRsp(cmd.QuestionGcpOrganizationIntegration, "n"),
-				msgRsp(cmd.QuestionGcpServiceAccountCredsPath, ""),
-				msgRsp(cmd.QuestionGcpConfigureAdvanced, "n"),
-				msgRsp(cmd.QuestionRunTfPlan, "n"),
+			expectsCliOutput(t, c, []MsgRspHandler{
+				MsgRsp{cmd.QuestionGcpEnableConfiguration, "y"},
+				MsgRsp{cmd.QuestionGcpEnableAuditLog, "y"},
+				MsgRsp{cmd.QuestionGcpProjectID, projectId},
+				MsgRsp{cmd.QuestionGcpOrganizationIntegration, "n"},
+				MsgRsp{cmd.QuestionGcpServiceAccountCredsPath, ""},
+				MsgRsp{cmd.QuestionGcpConfigureAdvanced, "n"},
+				MsgRsp{cmd.QuestionRunTfPlan, "n"},
 			})
 
 			final, _ = c.ExpectEOF()

--- a/lwgenerate/aws/aws_test.go
+++ b/lwgenerate/aws/aws_test.go
@@ -311,7 +311,7 @@ var requiredProviders = `terraform {
   required_providers {
     lacework = {
       source  = "lacework/lacework"
-      version = "~> 0.16"
+      version = "~> 0.26"
     }
   }
 }

--- a/lwgenerate/azure/azure_test.go
+++ b/lwgenerate/azure/azure_test.go
@@ -221,3 +221,13 @@ func TestGenerationLocation(t *testing.T) {
 	assert.NotNil(t, hcl)
 	assert.Equal(t, ActivityLogLocation, hcl)
 }
+
+func TestGenerationWithLaceworkProvider(t *testing.T) {
+	laceworkProfile, fileErr := getFileContent("test-data/activity-log-with-lacework-profile.tf")
+	assert.Nil(t, fileErr)
+
+	hcl, err := azure.NewTerraform(false, true, true, azure.WithLaceworkProfile("test-profile")).Generate()
+	assert.Nil(t, err)
+	assert.NotNil(t, hcl)
+	assert.Equal(t, laceworkProfile, hcl)
+}

--- a/lwgenerate/azure/test-data/activity-log-with-all-subscriptions.tf
+++ b/lwgenerate/azure/test-data/activity-log-with-all-subscriptions.tf
@@ -8,6 +8,10 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 2.91.0"
     }
+    lacework = {
+      source  = "lacework/lacework"
+      version = "~> 0.26"
+    }
   }
 }
 

--- a/lwgenerate/azure/test-data/activity-log-with-existing-storage.tf
+++ b/lwgenerate/azure/test-data/activity-log-with-existing-storage.tf
@@ -8,6 +8,10 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 2.91.0"
     }
+    lacework = {
+      source  = "lacework/lacework"
+      version = "~> 0.26"
+    }
   }
 }
 

--- a/lwgenerate/azure/test-data/activity-log-with-lacework-profile.tf
+++ b/lwgenerate/azure/test-data/activity-log-with-lacework-profile.tf
@@ -15,6 +15,10 @@ terraform {
   }
 }
 
+provider "lacework" {
+  profile = "test-profile"
+}
+
 provider "azuread" {
 }
 
@@ -28,22 +32,11 @@ module "az_ad_application" {
   version = "~> 1.0"
 }
 
-module "az_config" {
-  source                      = "lacework/config/azure"
-  version                     = "~> 1.0"
-  application_id              = module.az_ad_application.application_id
-  application_password        = module.az_ad_application.application_password
-  lacework_integration_name   = "Test Config Rename"
-  service_principal_id        = module.az_ad_application.service_principal_id
-  use_existing_ad_application = true
-}
-
 module "az_activity_log" {
   source                      = "lacework/activity-log/azure"
   version                     = "~> 1.0"
   application_id              = module.az_ad_application.application_id
   application_password        = module.az_ad_application.application_password
-  lacework_integration_name   = "Test Activity Log Rename"
   service_principal_id        = module.az_ad_application.service_principal_id
   use_existing_ad_application = true
 }

--- a/lwgenerate/azure/test-data/activity-log-with-list-subscriptions.tf
+++ b/lwgenerate/azure/test-data/activity-log-with-list-subscriptions.tf
@@ -8,6 +8,10 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 2.91.0"
     }
+    lacework = {
+      source  = "lacework/lacework"
+      version = "~> 0.26"
+    }
   }
 }
 

--- a/lwgenerate/azure/test-data/activity-log-with-location.tf
+++ b/lwgenerate/azure/test-data/activity-log-with-location.tf
@@ -8,6 +8,10 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 2.91.0"
     }
+    lacework = {
+      source  = "lacework/lacework"
+      version = "~> 0.26"
+    }
   }
 }
 

--- a/lwgenerate/azure/test-data/activity_log_with_config.tf
+++ b/lwgenerate/azure/test-data/activity_log_with_config.tf
@@ -8,6 +8,10 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 2.91.0"
     }
+    lacework = {
+      source  = "lacework/lacework"
+      version = "~> 0.26"
+    }
   }
 }
 

--- a/lwgenerate/azure/test-data/activity_log_without_config.tf
+++ b/lwgenerate/azure/test-data/activity_log_without_config.tf
@@ -8,6 +8,10 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 2.91.0"
     }
+    lacework = {
+      source  = "lacework/lacework"
+      version = "~> 0.26"
+    }
   }
 }
 

--- a/lwgenerate/azure/test-data/config-log-with-list-subscriptions.tf
+++ b/lwgenerate/azure/test-data/config-log-with-list-subscriptions.tf
@@ -8,6 +8,10 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 2.91.0"
     }
+    lacework = {
+      source  = "lacework/lacework"
+      version = "~> 0.26"
+    }
   }
 }
 

--- a/lwgenerate/azure/test-data/config-with-all-subscriptions.tf
+++ b/lwgenerate/azure/test-data/config-with-all-subscriptions.tf
@@ -8,6 +8,10 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 2.91.0"
     }
+    lacework = {
+      source  = "lacework/lacework"
+      version = "~> 0.26"
+    }
   }
 }
 

--- a/lwgenerate/azure/test-data/config-with-management-group.tf
+++ b/lwgenerate/azure/test-data/config-with-management-group.tf
@@ -8,6 +8,10 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 2.91.0"
     }
+    lacework = {
+      source  = "lacework/lacework"
+      version = "~> 0.26"
+    }
   }
 }
 

--- a/lwgenerate/azure/test-data/config-with-storage-account.tf
+++ b/lwgenerate/azure/test-data/config-with-storage-account.tf
@@ -8,6 +8,10 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 2.91.0"
     }
+    lacework = {
+      source  = "lacework/lacework"
+      version = "~> 0.26"
+    }
   }
 }
 

--- a/lwgenerate/azure/test-data/config_without_activity_log.tf
+++ b/lwgenerate/azure/test-data/config_without_activity_log.tf
@@ -8,6 +8,10 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 2.91.0"
     }
+    lacework = {
+      source  = "lacework/lacework"
+      version = "~> 0.26"
+    }
   }
 }
 

--- a/lwgenerate/azure/test-data/customer-ad-details.tf
+++ b/lwgenerate/azure/test-data/customer-ad-details.tf
@@ -8,6 +8,10 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 2.91.0"
     }
+    lacework = {
+      source  = "lacework/lacework"
+      version = "~> 0.26"
+    }
   }
 }
 

--- a/lwgenerate/azure/test-data/renamed_activity_log.tf
+++ b/lwgenerate/azure/test-data/renamed_activity_log.tf
@@ -8,6 +8,10 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 2.91.0"
     }
+    lacework = {
+      source  = "lacework/lacework"
+      version = "~> 0.26"
+    }
   }
 }
 

--- a/lwgenerate/azure/test-data/renamed_config.tf
+++ b/lwgenerate/azure/test-data/renamed_config.tf
@@ -8,6 +8,10 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 2.91.0"
     }
+    lacework = {
+      source  = "lacework/lacework"
+      version = "~> 0.26"
+    }
   }
 }
 

--- a/lwgenerate/constants.go
+++ b/lwgenerate/constants.go
@@ -2,7 +2,7 @@ package lwgenerate
 
 const (
 	LaceworkProviderSource  = "lacework/lacework"
-	LaceworkProviderVersion = "~> 0.16"
+	LaceworkProviderVersion = "~> 0.26"
 
 	AwsConfigSource      = "lacework/config/aws"
 	AwsConfigVersion     = "~> 0.5"

--- a/lwgenerate/gcp/gcp_test.go
+++ b/lwgenerate/gcp/gcp_test.go
@@ -640,7 +640,7 @@ var RequiredProviders = `terraform {
   required_providers {
     lacework = {
       source  = "lacework/lacework"
-      version = "~> 0.16"
+      version = "~> 0.26"
     }
   }
 }


### PR DESCRIPTION
## Summary

Azure TF requires the Lacework provider and the Lacework API profile defined, if a default profile hasn't been configured.

```
> terraform plan
╷
│ Error: Invalid provider configuration
│
│ Provider "registry.terraform.io/lacework/lacework" requires explicit configuration. Add a provider block to the root module and configure the provider's required arguments as described in
│ the provider documentation.
│
╵
╷
│ Error: Unable to create Lacework API client
│
│   with provider["registry.terraform.io/lacework/lacework"],
│   on <empty> line 0:
│   (source code not available)
│
│ profile 'default' not found.
│
│ Try using the Lacework CLI command 'lacework configure --profile default'
```

This error doesn't occur if `.lacework.toml` contains a default block.  It is a problem for the onboarding service as the bundle (bash script) doesn't configure a default profile, it configures a profile called 'onboarding'.

## How did you test this change?

- unit
- integration
- manual

## Issue

[RAIN-38163](https://lacework.atlassian.net/browse/RAIN-38163)
