### PR TITLE
test: update error msg test

### DIFF
--- a/cli/cmd/package_manifest_test.go
+++ b/cli/cmd/package_manifest_test.go
@@ -162,7 +162,7 @@ func TestFanOutHostScans(t *testing.T) {
 	subject, err = fanOutHostScans(&api.PackageManifest{})
 	if assert.NotNil(t, err) {
 		assert.Contains(t, err.Error(),
-			"[403] Unauthorized Access", // intentional error since we are mocking the api token
+			"[403] User not authorized.", // intentional error since we are mocking the api token
 		)
 	}
 	assert.Equal(t, api.HostVulnScanPkgManifestResponse{}, subject)


### PR DESCRIPTION
Signed-off-by: Darren Murray <darren.murray@lacework.net>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/lacework/go-sdk) and create your branch from `main`
  2. Run `make prepare` in the repository root
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`make test`)
  5. Format your code (`make fmt`)
  6. Make sure your code lints (`make lint`)
  7. If you are updating the Lacework CLI, make sure it compiles (`make build-cli-cross-platform`)
  8. Follow the commit message standard (`type(scope): subject`) documented in [DEVELOPER_GUIDELINES.md](https://github.com/lacework/go-sdk/blob/main/DEVELOPER_GUIDELINES.md#commit-message-standard)
  9. If you haven't already, configure signed commits by [telling git about your signing key](https://docs.github.com/en/github/authenticating-to-github/managing-commit-signature-verification/telling-git-about-your-signing-key) and [signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)

  Learn more about contributing: https://github.com/lacework/go-sdk/blob/main/CONTRIBUTING.md
-->

## Summary

The error message for 'api/v1/external/vulnerabilities/scan' when user is not authorized has changed. Likely due to Rbac updates.
This is causing CI to fail. Updated with new error message

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## How did you test this change?
Run cli/cmd/package_manifest_test.go:134

<!--
  How exactly did you verify that your PR solves the issue you wanted to solve?
  Include any other relevant information such as how to use the new fuctionality, screenshots, etc.
-->