### PR TITLE
fix: aws terraform sns variables

### DIFF
--- a/cli/cmd/generate_aws.go
+++ b/cli/cmd/generate_aws.go
@@ -414,12 +414,12 @@ func initGenerateAwsTfCommandFlags() {
 	)
 	generateAwsTfCommand.PersistentFlags().BoolVar(
 		&GenerateAwsCommandState.SnsEncryptionEnabled,
-		"sns_encryption_enabled",
+		"sns_topic_encryption_enabled",
 		true,
 		"enable encryption on SNS topic when creating one")
 	generateAwsTfCommand.PersistentFlags().StringVar(
 		&GenerateAwsCommandState.SnsEncryptionKeyArn,
-		"sns_encryption_key_arn",
+		"sns_topic_encryption_key_arn",
 		"",
 		"specify existing KMS encryption key arn for SNS topic")
 	generateAwsTfCommand.PersistentFlags().StringVar(

--- a/cli/cmd/generate_aws.go
+++ b/cli/cmd/generate_aws.go
@@ -119,8 +119,8 @@ See help output for more details on the parameter value(s) required for Terrafor
 				aws.WithBucketEncryptionEnabled(GenerateAwsCommandState.BucketEncryptionEnabled),
 				aws.WithBucketSSEKeyArn(GenerateAwsCommandState.BucketSseKeyArn),
 				aws.WithSnsTopicName(GenerateAwsCommandState.SnsTopicName),
-				aws.WithSnsEncryptionEnabled(GenerateAwsCommandState.SnsEncryptionEnabled),
-				aws.WithSnsEncryptionKeyArn(GenerateAwsCommandState.SnsEncryptionKeyArn),
+				aws.WithSnsTopicEncryptionEnabled(GenerateAwsCommandState.SnsTopicEncryptionEnabled),
+				aws.WithSnsTopicEncryptionKeyArn(GenerateAwsCommandState.SnsTopicEncryptionKeyArn),
 				aws.WithSqsQueueName(GenerateAwsCommandState.SqsQueueName),
 				aws.WithSqsEncryptionEnabled(GenerateAwsCommandState.SqsEncryptionEnabled),
 				aws.WithSqsEncryptionKeyArn(GenerateAwsCommandState.SqsEncryptionKeyArn),
@@ -413,12 +413,12 @@ func initGenerateAwsTfCommandFlags() {
 		"location to write generated content (default is ~/lacework/aws)",
 	)
 	generateAwsTfCommand.PersistentFlags().BoolVar(
-		&GenerateAwsCommandState.SnsEncryptionEnabled,
+		&GenerateAwsCommandState.SnsTopicEncryptionEnabled,
 		"sns_topic_encryption_enabled",
 		true,
 		"enable encryption on SNS topic when creating one")
 	generateAwsTfCommand.PersistentFlags().StringVar(
-		&GenerateAwsCommandState.SnsEncryptionKeyArn,
+		&GenerateAwsCommandState.SnsTopicEncryptionKeyArn,
 		"sns_topic_encryption_key_arn",
 		"",
 		"specify existing KMS encryption key arn for SNS topic")
@@ -557,16 +557,16 @@ func promptAwsCtQuestions(config *aws.GenerateAwsTfConfigurationArgs, extraState
 		},
 		// If new bucket created, should this have encryption enabled
 		{
-			Prompt:   &survey.Confirm{Message: QuestionSnsEnableEncryption, Default: config.SnsEncryptionEnabled},
-			Response: &config.SnsEncryptionEnabled,
+			Prompt:   &survey.Confirm{Message: QuestionSnsEnableEncryption, Default: config.SnsTopicEncryptionEnabled},
+			Response: &config.SnsTopicEncryptionEnabled,
 			Checks:   []*bool{&config.Cloudtrail, &newTopic},
 		},
 		// Allow the user to set the SSE Key ARN if required
 		{
-			Prompt:   &survey.Input{Message: QuestionSnsEncryptionKeyArn, Default: config.SnsEncryptionKeyArn},
-			Response: &config.SnsEncryptionKeyArn,
+			Prompt:   &survey.Input{Message: QuestionSnsEncryptionKeyArn, Default: config.SnsTopicEncryptionKeyArn},
+			Response: &config.SnsTopicEncryptionKeyArn,
 			Opts:     []survey.AskOpt{survey.WithValidator(validateOptionalAwsArnFormat)},
-			Checks:   []*bool{&config.Cloudtrail, &newTopic, &config.SnsEncryptionEnabled},
+			Checks:   []*bool{&config.Cloudtrail, &newTopic, &config.SnsTopicEncryptionEnabled},
 		},
 	}, config.Cloudtrail); err != nil {
 		return err

--- a/integration/aws_generation_test.go
+++ b/integration/aws_generation_test.go
@@ -68,7 +68,7 @@ func TestGenerationAwsSimple(t *testing.T) {
 	// Create the TF directly with lwgenerate and validate same result via CLI
 	buildTf, _ := aws.NewTerraform(region, true, true,
 		aws.WithBucketEncryptionEnabled(true),
-		aws.WithSnsEncryptionEnabled(true),
+		aws.WithSnsTopicEncryptionEnabled(true),
 		aws.WithSqsEncryptionEnabled(true),
 	).Generate()
 	assert.Equal(t, buildTf, tfResult)
@@ -126,7 +126,7 @@ func TestGenerationAwsCustomizedOutputLocation(t *testing.T) {
 	// Create the TF directly with lwgenerate and validate same result via CLI
 	buildTf, _ := aws.NewTerraform(region, true, true,
 		aws.WithBucketEncryptionEnabled(true),
-		aws.WithSnsEncryptionEnabled(true),
+		aws.WithSnsTopicEncryptionEnabled(true),
 		aws.WithSqsEncryptionEnabled(true),
 	).Generate()
 	assert.Equal(t, buildTf, string(result))
@@ -165,7 +165,7 @@ func TestGenerationAwsConfigOnly(t *testing.T) {
 	// Create the TF directly with lwgenerate and validate same result via CLI
 	buildTf, _ := aws.NewTerraform(region, true, false,
 		aws.WithBucketEncryptionEnabled(true),
-		aws.WithSnsEncryptionEnabled(true),
+		aws.WithSnsTopicEncryptionEnabled(true),
 		aws.WithSqsEncryptionEnabled(true),
 	).Generate()
 	assert.Equal(t, buildTf, tfResult)
@@ -210,7 +210,7 @@ func TestGenerationAwsAdvancedOptsDone(t *testing.T) {
 	// Create the TF directly with lwgenerate and validate same result via CLI
 	buildTf, _ := aws.NewTerraform(region, true, true,
 		aws.WithBucketEncryptionEnabled(true),
-		aws.WithSnsEncryptionEnabled(true),
+		aws.WithSnsTopicEncryptionEnabled(true),
 		aws.WithSqsEncryptionEnabled(true),
 	).Generate()
 	assert.Equal(t, buildTf, tfResult)
@@ -286,7 +286,7 @@ func TestGenerationAwsAdvancedOptsConsolidatedAndForceDestroy(t *testing.T) {
 		aws.UseConsolidatedCloudtrail(),
 		aws.EnableForceDestroyS3Bucket(),
 		aws.WithBucketEncryptionEnabled(true),
-		aws.WithSnsEncryptionEnabled(true),
+		aws.WithSnsTopicEncryptionEnabled(true),
 		aws.WithSqsEncryptionEnabled(true),
 	).Generate()
 	assert.Equal(t, buildTf, tfResult)
@@ -355,7 +355,7 @@ func TestGenerationAwsAdvancedOptsUseExistingCloudtrail(t *testing.T) {
 	buildTf, _ := aws.NewTerraform(region, true, true,
 		aws.ExistingCloudtrailBucketArn("arn:aws:s3:::bucket_name"),
 		aws.WithBucketEncryptionEnabled(true),
-		aws.WithSnsEncryptionEnabled(true),
+		aws.WithSnsTopicEncryptionEnabled(true),
 		aws.WithSqsEncryptionEnabled(true),
 	).Generate()
 	assert.Equal(t, buildTf, tfResult)
@@ -451,7 +451,7 @@ func TestGenerationAwsAdvancedOptsConsolidatedWithSubAccounts(t *testing.T) {
 		aws.WithAwsProfile("default"),
 		aws.WithSubaccounts(aws.NewAwsSubAccount("account1", "us-east-1"), aws.NewAwsSubAccount("account2", "us-east-2")),
 		aws.WithBucketEncryptionEnabled(true),
-		aws.WithSnsEncryptionEnabled(true),
+		aws.WithSnsTopicEncryptionEnabled(true),
 		aws.WithSqsEncryptionEnabled(true),
 	).Generate()
 	assert.Equal(t, buildTf, tfResult)
@@ -575,7 +575,7 @@ func TestGenerationAwsAdvancedOptsConsolidatedWithSubAccountsPassedByFlag(t *tes
 		aws.WithAwsProfile("default"),
 		aws.WithSubaccounts(aws.NewAwsSubAccount("account1", "us-east-1"), aws.NewAwsSubAccount("account2", "us-east-2")),
 		aws.WithBucketEncryptionEnabled(true),
-		aws.WithSnsEncryptionEnabled(true),
+		aws.WithSnsTopicEncryptionEnabled(true),
 		aws.WithSqsEncryptionEnabled(true),
 	).Generate()
 	assert.Equal(t, buildTf, tfResult)
@@ -630,7 +630,7 @@ func TestGenerationAwsAdvancedOptsUseExistingIAM(t *testing.T) {
 	buildTf, _ := aws.NewTerraform(region, true, true,
 		aws.UseExistingIamRole(aws.NewExistingIamRoleDetails(roleName, roleArn, roleExtId)),
 		aws.WithBucketEncryptionEnabled(true),
-		aws.WithSnsEncryptionEnabled(true),
+		aws.WithSnsTopicEncryptionEnabled(true),
 		aws.WithSqsEncryptionEnabled(true),
 	).Generate()
 	assert.Equal(t, buildTf, tfResult)
@@ -778,8 +778,8 @@ func TestGenerationAwsAdvancedOptsCreateNewElements(t *testing.T) {
 		aws.WithBucketEncryptionEnabled(true),
 		aws.WithBucketSSEKeyArn(kmsArn),
 		aws.WithSnsTopicName(topicName),
-		aws.WithSnsEncryptionEnabled(true),
-		aws.WithSnsEncryptionKeyArn(kmsArn),
+		aws.WithSnsTopicEncryptionEnabled(true),
+		aws.WithSnsTopicEncryptionKeyArn(kmsArn),
 		aws.WithSqsQueueName(queueName),
 		aws.WithSqsEncryptionEnabled(true),
 		aws.WithSqsEncryptionKeyArn(kmsArn),

--- a/integration/test_resources/help/generate_cloud-account_aws
+++ b/integration/test_resources/help/generate_cloud-account_aws
@@ -39,8 +39,8 @@ Flags:
       --force_destroy_s3                      enable force destroy S3 bucket
   -h, --help                                  help for aws
       --output string                         location to write generated content (default is ~/lacework/aws)
-      --sns_encryption_enabled                enable encryption on SNS topic when creating one (default true)
-      --sns_encryption_key_arn string         specify existing KMS encryption key arn for SNS topic
+      --sns_topic_encryption_enabled          enable encryption on SNS topic when creating one (default true)
+      --sns_topic_encryption_key_arn string   specify existing KMS encryption key arn for SNS topic
       --sns_topic_name string                 specify SNS topic name if creating new one
       --sqs_encryption_enabled                enable encryption on SQS queue when creating (default true)
       --sqs_encryption_key_arn string         specify existing KMS encryption key arn for SQS queue

--- a/lwgenerate/aws/aws.go
+++ b/lwgenerate/aws/aws.go
@@ -117,7 +117,7 @@ type GenerateAwsTfConfigurationArgs struct {
 	SnsTopicName string
 
 	// Enable encryption of SNS if it is created
-	SnsEncryptionEnabled bool
+	SnsTopicEncryptionEnabled bool
 
 	// Indicates that the SNS Encryption flag has been actively set
 	// this is needed to show this it was set actively to false, rather
@@ -125,7 +125,7 @@ type GenerateAwsTfConfigurationArgs struct {
 	SnsEncryptionEnabledSet bool
 
 	// Arn of the KMS encryption key for SNS, required when SNS encryption in enabled
-	SnsEncryptionKeyArn string
+	SnsTopicEncryptionKeyArn string
 
 	// SSQ Queue name if creating one and not using an existing one
 	SqsQueueName string
@@ -293,18 +293,18 @@ func WithSnsTopicName(snsTopicName string) AwsTerraformModifier {
 	}
 }
 
-// WithSnsEncryptionEnabled Enable encryption on SNS Topic when created
-func WithSnsEncryptionEnabled(snsEncryptionEnabled bool) AwsTerraformModifier {
+// WithSnsTopicEncryptionEnabled Enable encryption on SNS Topic when created
+func WithSnsTopicEncryptionEnabled(snsTopicEncryptionEnabled bool) AwsTerraformModifier {
 	return func(c *GenerateAwsTfConfigurationArgs) {
-		c.SnsEncryptionEnabled = snsEncryptionEnabled
+		c.SnsTopicEncryptionEnabled = snsTopicEncryptionEnabled
 		c.SnsEncryptionEnabledSet = true
 	}
 }
 
-// WithSnsEncryptionKeyArn Set existing KMS encryption key arn for SNS topic
-func WithSnsEncryptionKeyArn(snsEncryptionKeyArn string) AwsTerraformModifier {
+// WithSnsTopicEncryptionKeyArn Set existing KMS encryption key arn for SNS topic
+func WithSnsTopicEncryptionKeyArn(snsTopicEncryptionKeyArn string) AwsTerraformModifier {
 	return func(c *GenerateAwsTfConfigurationArgs) {
-		c.SnsEncryptionKeyArn = snsEncryptionKeyArn
+		c.SnsTopicEncryptionKeyArn = snsTopicEncryptionKeyArn
 	}
 }
 
@@ -525,9 +525,9 @@ func createCloudtrail(args *GenerateAwsTfConfigurationArgs) (*hclwrite.Block, er
 				attributes["sns_topic_name"] = args.SnsTopicName
 			}
 			if args.SnsEncryptionEnabledSet {
-				if args.SnsEncryptionEnabled {
-					if args.SnsEncryptionKeyArn != "" {
-						attributes["sns_topic_encryption_key_arn"] = args.SnsEncryptionKeyArn
+				if args.SnsTopicEncryptionEnabled {
+					if args.SnsTopicEncryptionKeyArn != "" {
+						attributes["sns_topic_encryption_key_arn"] = args.SnsTopicEncryptionKeyArn
 					}
 				} else {
 					attributes["sns_topic_encryption_enabled "] = false

--- a/lwgenerate/aws/aws.go
+++ b/lwgenerate/aws/aws.go
@@ -527,10 +527,10 @@ func createCloudtrail(args *GenerateAwsTfConfigurationArgs) (*hclwrite.Block, er
 			if args.SnsEncryptionEnabledSet {
 				if args.SnsEncryptionEnabled {
 					if args.SnsEncryptionKeyArn != "" {
-						attributes["sns_encryption_key_arn"] = args.SnsEncryptionKeyArn
+						attributes["sns_topic_encryption_key_arn"] = args.SnsEncryptionKeyArn
 					}
 				} else {
-					attributes["sns_encryption_enabled "] = false
+					attributes["sns_topic_encryption_enabled "] = false
 				}
 			}
 		}

--- a/lwgenerate/aws/aws_test.go
+++ b/lwgenerate/aws/aws_test.go
@@ -106,8 +106,8 @@ func TestGenerationCloudtrailSnsWithEncryption(t *testing.T) {
 	snsEncryptionArn := "arn:aws:kms:us-west-2:249446771485:key/2537e820-be82-4ded-8dca-504e199b0903"
 	hcl, err := NewTerraform("us-east-2", false, true,
 		WithSnsTopicName(snsTopicName),
-		WithSnsEncryptionEnabled(true),
-		WithSnsEncryptionKeyArn(snsEncryptionArn),
+		WithSnsTopicEncryptionEnabled(true),
+		WithSnsTopicEncryptionKeyArn(snsEncryptionArn),
 	).Generate()
 	assert.Nil(t, err)
 	assert.NotNil(t, hcl)
@@ -118,7 +118,7 @@ func TestGenerationCloudtrailSnsWithNoEncryption(t *testing.T) {
 	snsTopicName := "sns-topic-name"
 	hcl, err := NewTerraform("us-east-2", false, true,
 		WithSnsTopicName(snsTopicName),
-		WithSnsEncryptionEnabled(false),
+		WithSnsTopicEncryptionEnabled(false),
 	).Generate()
 	assert.Nil(t, err)
 	assert.NotNil(t, hcl)
@@ -181,8 +181,8 @@ func TestGenerationCloudtrailAllEncryptionElementsSet(t *testing.T) {
 		WithBucketEncryptionEnabled(true),
 		WithBucketSSEKeyArn(encryptionArn),
 		WithSnsTopicName(snsTopicName),
-		WithSnsEncryptionEnabled(true),
-		WithSnsEncryptionKeyArn(encryptionArn),
+		WithSnsTopicEncryptionEnabled(true),
+		WithSnsTopicEncryptionKeyArn(encryptionArn),
 		WithSqsQueueName(ssqQueueName),
 		WithSqsEncryptionEnabled(true),
 		WithSqsEncryptionKeyArn(encryptionArn),

--- a/lwgenerate/aws/aws_test.go
+++ b/lwgenerate/aws/aws_test.go
@@ -344,18 +344,18 @@ var moduleImportCtWithConfig = `module "main_cloudtrail" {
 `
 
 var moduleImportCtWithSnsWithoutConfig = `module "main_cloudtrail" {
-  source                 = "lacework/cloudtrail/aws"
-  version                = "~> 2.0"
-  sns_encryption_key_arn = "arn:aws:kms:us-west-2:249446771485:key/2537e820-be82-4ded-8dca-504e199b0903"
-  sns_topic_name         = "sns-topic-name"
+  source                       = "lacework/cloudtrail/aws"
+  version                      = "~> 2.0"
+  sns_topic_encryption_key_arn = "arn:aws:kms:us-west-2:249446771485:key/2537e820-be82-4ded-8dca-504e199b0903"
+  sns_topic_name               = "sns-topic-name"
 }
 `
 
 var moduleImportCtWithSnsNoConfigNoEncryption = `module "main_cloudtrail" {
-  source                  = "lacework/cloudtrail/aws"
-  version                 = "~> 2.0"
-  sns_encryption_enabled  = false
-  sns_topic_name          = "sns-topic-name"
+  source                        = "lacework/cloudtrail/aws"
+  version                       = "~> 2.0"
+  sns_topic_encryption_enabled  = false
+  sns_topic_name                = "sns-topic-name"
 }
 `
 var moduleImportCtWithSnsNoConfigEncryptionNotSet = `module "main_cloudtrail" {
@@ -389,15 +389,15 @@ var moduleImportCtWithSqsNoConfigEncryptionNotSet = `module "main_cloudtrail" {
 `
 
 var moduleImportCtWithAllEncryptionSet = `module "main_cloudtrail" {
-  source                 = "lacework/cloudtrail/aws"
-  version                = "~> 2.0"
-  bucket_name            = "s3-bucket-name"
-  bucket_sse_key_arn     = "arn:aws:kms:us-west-2:249446771485:key/2537e820-be82-4ded-8dca-504e199b0903"
-  cloudtrail_name        = "cloudtrail-name"
-  sns_encryption_key_arn = "arn:aws:kms:us-west-2:249446771485:key/2537e820-be82-4ded-8dca-504e199b0903"
-  sns_topic_name         = "sns-topic-name"
-  sqs_encryption_key_arn = "arn:aws:kms:us-west-2:249446771485:key/2537e820-be82-4ded-8dca-504e199b0903"
-  sqs_queue_name         = "sqs-queue-name"
+  source                       = "lacework/cloudtrail/aws"
+  version                      = "~> 2.0"
+  bucket_name                  = "s3-bucket-name"
+  bucket_sse_key_arn           = "arn:aws:kms:us-west-2:249446771485:key/2537e820-be82-4ded-8dca-504e199b0903"
+  cloudtrail_name              = "cloudtrail-name"
+  sns_topic_encryption_key_arn = "arn:aws:kms:us-west-2:249446771485:key/2537e820-be82-4ded-8dca-504e199b0903"
+  sns_topic_name               = "sns-topic-name"
+  sqs_encryption_key_arn       = "arn:aws:kms:us-west-2:249446771485:key/2537e820-be82-4ded-8dca-504e199b0903"
+  sqs_queue_name               = "sqs-queue-name"
 }
 `
 


### PR DESCRIPTION
## Summary

[AWS cloud-trail](https://github.com/lacework/terraform-aws-cloudtrail#inputs) module expects `sns_topic_encryption` for encryption variables.

## How did you test this change?

- unit
- integration
- manual

## Issue

[RAIN-38110](https://lacework.atlassian.net/browse/RAIN-38110)
