### PR TITLE
fix: gke integration test flags

### DIFF
--- a/integration/gke_generation_test.go
+++ b/integration/gke_generation_test.go
@@ -1,3 +1,5 @@
+//go:build !windows && generation
+
 package integration
 
 import (


### PR DESCRIPTION

## Summary

Nightly builds failing at windows testing stage - GKE integration tests missing flags to exclude from windows.  Adding this.

