### PR TITLE
build: fix install-cli Makefile target to account for ARM builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -165,6 +165,8 @@ test-resources: ## *CI ONLY* Prepares CI test containers
 install-cli: build-cli-cross-platform ## Build and install the Lacework CLI binary at /usr/local/bin/lacework
 ifeq (x86_64, $(shell uname -m))
 	mv bin/$(PACKAGENAME)-$(shell uname -s | tr '[:upper:]' '[:lower:]')-amd64 /usr/local/bin/$(CLINAME)
+else ifeq (arm64, $(shell uname -m))
+	mv bin/$(PACKAGENAME)-$(shell uname -s | tr '[:upper:]' '[:lower:]')-arm64 /usr/local/bin/$(CLINAME)
 else
 	mv bin/$(PACKAGENAME)-$(shell uname -s | tr '[:upper:]' '[:lower:]')-386 /usr/local/bin/$(CLINAME)
 endif


### PR DESCRIPTION
## Summary
Running `make install-cli` continually fails on ARM architecture environments. Further investigation revealed that the `mv` command sequence in the Makefile's `install-cli` target only accounts for x64 and x86 environments. 

```bash
mv bin/lacework-cli-darwin-386 /usr/local/bin/lacework-dev
mv: rename bin/lacework-cli-darwin-386 to /usr/local/bin/lacework-dev: No such file or directory
make: *** [install-cli] Error 1
```

## How did you test this change?
Ran `make install-cli` locally on an M1

## Issue
* https://lacework.atlassian.net/browse/ALLY-1230
