### PR TITLE
feat(api): New AwsSidekickOrg Cloud Account type

### DIFF
--- a/api/_examples/cloud-accounts/aws-agentless-scanning-org/main.go
+++ b/api/_examples/cloud-accounts/aws-agentless-scanning-org/main.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/lacework/go-sdk/api"
+)
+
+func main() {
+	lacework, err := api.NewClient(os.Getenv("LW_ACCOUNT"),
+		api.WithSubaccount(os.Getenv("LW_SUBACCOUNT")),
+		api.WithApiKeys(os.Getenv("LW_API_KEY"), os.Getenv("LW_API_SECRET")),
+		api.WithApiV2(),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	res, err := lacework.V2.CloudAccounts.List()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	for _, account := range res.Data {
+		support := "Unsupported"
+		switch account.Type {
+		case api.AwsSidekickOrgCloudAccount.String():
+			support = "Supported"
+		}
+
+		// Output: INTEGRATION-GUID:INTEGRATION-TYPE:[Supported|Unsupported]
+		fmt.Printf("%s:%s:%s\n", account.IntgGuid, account.Type, support)
+	}
+
+	awsSidekickOrgData := api.AwsSidekickOrgData{
+		ScanFrequency:           24,
+		ScanContainers:          true,
+		ScanHostVulnerabilities: true,
+		MonitoredAccounts:       "r-1234",
+		ManagementAccount:       "000123456789",
+		ScanningAccount:         "123456789000",
+	}
+
+	awsSidekickOrgAccount := api.NewCloudAccount(
+		fmt.Sprintf("%s-from-golang", api.AwsSidekickOrgCloudAccount.String()),
+		api.AwsSidekickOrgCloudAccount,
+		awsSidekickOrgData,
+	)
+
+	awsSidekickOrgResponse, err := lacework.V2.CloudAccounts.CreateAwsSidekickOrg(awsSidekickOrgAccount)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Output: AwsSidekickOrg Cloud Account created: THE-INTEGRATION-GUID
+	fmt.Printf("Cloud Account created: %s", awsSidekickOrgResponse.Data.IntgGuid)
+}

--- a/api/cloud_accounts.go
+++ b/api/cloud_accounts.go
@@ -88,6 +88,7 @@ const (
 	AwsCtSqsCloudAccount
 	AwsEksAuditCloudAccount
 	AwsSidekickCloudAccount
+	AwsSidekickOrgCloudAccount
 	AwsUsGovCfgCloudAccount
 	AwsUsGovCtSqsCloudAccount
 	AzureAlSeqCloudAccount
@@ -99,18 +100,19 @@ const (
 
 // CloudAccountTypes is the list of available Cloud Account integration types
 var CloudAccountTypes = map[cloudAccountType]string{
-	NoneCloudAccount:          "None",
-	AwsCfgCloudAccount:        "AwsCfg",
-	AwsCtSqsCloudAccount:      "AwsCtSqs",
-	AwsEksAuditCloudAccount:   "AwsEksAudit",
-	AwsSidekickCloudAccount:   "AwsSidekick",
-	AwsUsGovCfgCloudAccount:   "AwsUsGovCfg",
-	AwsUsGovCtSqsCloudAccount: "AwsUsGovCtSqs",
-	AzureAlSeqCloudAccount:    "AzureAlSeq",
-	AzureCfgCloudAccount:      "AzureCfg",
-	GcpAtSesCloudAccount:      "GcpAtSes",
-	GcpCfgCloudAccount:        "GcpCfg",
-	GcpGkeAuditCloudAccount:   "GcpGkeAudit",
+	NoneCloudAccount:           "None",
+	AwsCfgCloudAccount:         "AwsCfg",
+	AwsCtSqsCloudAccount:       "AwsCtSqs",
+	AwsEksAuditCloudAccount:    "AwsEksAudit",
+	AwsSidekickCloudAccount:    "AwsSidekick",
+	AwsSidekickOrgCloudAccount: "AwsSidekickOrg",
+	AwsUsGovCfgCloudAccount:    "AwsUsGovCfg",
+	AwsUsGovCtSqsCloudAccount:  "AwsUsGovCtSqs",
+	AzureAlSeqCloudAccount:     "AzureAlSeq",
+	AzureCfgCloudAccount:       "AzureCfg",
+	GcpAtSesCloudAccount:       "GcpAtSes",
+	GcpCfgCloudAccount:         "GcpCfg",
+	GcpGkeAuditCloudAccount:    "GcpGkeAudit",
 }
 
 // String returns the string representation of a Cloud Account integration type

--- a/api/cloud_accounts_aws_sidekick_org.go
+++ b/api/cloud_accounts_aws_sidekick_org.go
@@ -1,0 +1,76 @@
+//
+// Author:: Teddy Reed (<teddy.reed@lacework.net>)
+// Copyright:: Copyright 2022, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package api
+
+// GetAwsSidekickOrg gets a single AwsSidekickOrg integration matching the provided integration guid
+func (svc *CloudAccountsService) GetAwsSidekickOrg(guid string) (
+	response AwsSidekickOrgResponse,
+	err error,
+) {
+	err = svc.get(guid, &response)
+	return
+}
+
+// CreateAwsSidekickOrg creates an AwsSidekickOrg Cloud Account integration
+func (svc *CloudAccountsService) CreateAwsSidekickOrg(data CloudAccount) (
+	response AwsSidekickOrgResponse,
+	err error,
+) {
+	err = svc.create(data, &response)
+	return
+}
+
+// UpdateAwsSidekickOrg updates a single AwsSidekickOrg integration on the Lacework Server
+func (svc *CloudAccountsService) UpdateAwsSidekickOrg(data CloudAccount) (
+	response AwsSidekickOrgResponse,
+	err error,
+) {
+	err = svc.update(data.ID(), data, &response)
+	return
+}
+
+type AwsSidekickOrgResponse struct {
+	Data AwsSidekickOrg `json:"data"`
+}
+
+type AwsSidekickOrg struct {
+	v2CommonIntegrationData
+	awsSidekickToken `json:"serverToken"`
+	Data             AwsSidekickOrgData `json:"data"`
+}
+
+type AwsSidekickOrgData struct {
+	//QueryText represents an lql json string
+	QueryText string `json:"queryText,omitempty"`
+
+	//ScanFrequency in hours, 24 == 24 hours
+	ScanFrequency int `json:"scanFrequency"`
+
+	ScanContainers          bool `json:"scanContainers"`
+	ScanHostVulnerabilities bool `json:"scanHostVulnerabilities"`
+
+	//Properties specific to the AWS organization integration type
+	ScanningAccount   string `json:"scanningAccount"`
+	ManagementAccount string `json:"managementAccount,omitempty"`
+	MonitoredAccounts string `json:"monitoredAccounts"`
+
+	AccountID         string                             `json:"awsAccountId,omitempty"`
+	BucketArn         string                             `json:"bucketArn,omitempty"`
+	CrossAccountCreds AwsSidekickCrossAccountCredentials `json:"crossAccountCredentials"`
+}

--- a/api/cloud_accounts_aws_sidekick_org_test.go
+++ b/api/cloud_accounts_aws_sidekick_org_test.go
@@ -1,0 +1,185 @@
+//
+// Author:: Teddy Reed (<teddy.reed@lacework.net>)
+// Copyright:: Copyright 2022, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package api_test
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/lacework/go-sdk/api"
+	"github.com/lacework/go-sdk/internal/intgguid"
+	"github.com/lacework/go-sdk/internal/lacework"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCloudAccountsNewAwsSidekickOrgWithCustomTemplateFile(t *testing.T) {
+	awsSidekickOrgData := api.AwsSidekickOrgData{
+		CrossAccountCreds: api.AwsSidekickCrossAccountCredentials{
+			RoleArn:    "arn:foo:bar",
+			ExternalID: "0123456789",
+		},
+	}
+
+	subject := api.NewCloudAccount("integration_name", api.AwsSidekickOrgCloudAccount, awsSidekickOrgData)
+	assert.Equal(t, api.AwsSidekickOrgCloudAccount.String(), subject.Type)
+
+	// casting the data interface{} to type AwsCfgData
+	subjectData := subject.Data.(api.AwsSidekickOrgData)
+
+	assert.Equal(t, subjectData.CrossAccountCreds.RoleArn, "arn:foo:bar")
+	assert.Equal(t, subjectData.CrossAccountCreds.ExternalID, "0123456789")
+}
+
+func TestCloudAccountsAwsSidekickOrgGet(t *testing.T) {
+	var (
+		intgGUID   = intgguid.New()
+		apiPath    = fmt.Sprintf("CloudAccounts/%s", intgGUID)
+		fakeServer = lacework.MockServer()
+	)
+	fakeServer.UseApiV2()
+	fakeServer.MockToken("TOKEN")
+	defer fakeServer.Close()
+
+	fakeServer.MockAPI(apiPath, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method, "GetAwsSidekickOrg() should be a GET method")
+		fmt.Fprintf(w, generateCloudAccountResponse(singleAwsSidekickOrgCloudAccount(intgGUID)))
+	})
+
+	c, err := api.NewClient("test",
+		api.WithApiV2(),
+		api.WithToken("TOKEN"),
+		api.WithURL(fakeServer.URL()),
+	)
+	assert.Nil(t, err)
+
+	response, err := c.V2.CloudAccounts.GetAwsSidekickOrg(intgGUID)
+	assert.Nil(t, err)
+	assert.NotNil(t, response)
+	assert.Equal(t, intgGUID, response.Data.IntgGuid)
+	assert.Equal(t, "integration_name", response.Data.Name)
+	assert.True(t, response.Data.State.Ok)
+	assert.Equal(t, "arn:foo:bar", response.Data.Data.CrossAccountCreds.RoleArn)
+	assert.Equal(t, "0123456789", response.Data.Data.CrossAccountCreds.ExternalID)
+	assert.Equal(t, 24, response.Data.Data.ScanFrequency)
+	assert.True(t, response.Data.Data.ScanContainers)
+	assert.True(t, response.Data.Data.ScanHostVulnerabilities)
+	assert.Equal(t, "123456789000", response.Data.Data.ScanningAccount)
+	assert.Equal(t, "000123456789", response.Data.Data.ManagementAccount)
+	assert.Equal(t, "r-1234, ou-0987", response.Data.Data.MonitoredAccounts)
+
+}
+
+func TestCloudAccountsAwsSidekickOrgUpdate(t *testing.T) {
+	var (
+		intgGUID   = intgguid.New()
+		apiPath    = fmt.Sprintf("CloudAccounts/%s", intgGUID)
+		fakeServer = lacework.MockServer()
+	)
+	fakeServer.UseApiV2()
+	fakeServer.MockToken("TOKEN")
+	defer fakeServer.Close()
+
+	fakeServer.MockAPI(apiPath, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "PATCH", r.Method, "UpdateAwsSidekickOrg() should be a PATCH method")
+
+		if assert.NotNil(t, r.Body) {
+			body := httpBodySniffer(r)
+			assert.Contains(t, body, intgGUID, "INTG_GUID missing")
+			assert.Contains(t, body, "integration_name", "cloud account name is missing")
+			assert.Contains(t, body, "AwsSidekickOrg", "wrong cloud account type")
+			assert.Contains(t, body, "arn:foo:bar", "wrong role arn")
+			assert.Contains(t, body, "0123456789", "wrong external ID")
+			assert.Contains(t, body, "enabled\":1", "cloud account is not enabled")
+		}
+
+		fmt.Fprintf(w, generateCloudAccountResponse(singleAwsSidekickOrgCloudAccount(intgGUID)))
+	})
+
+	c, err := api.NewClient("test",
+		api.WithApiV2(),
+		api.WithToken("TOKEN"),
+		api.WithURL(fakeServer.URL()),
+	)
+	assert.Nil(t, err)
+
+	cloudAccount := api.NewCloudAccount("integration_name",
+		api.AwsSidekickOrgCloudAccount,
+		api.AwsSidekickOrgData{
+			CrossAccountCreds: api.AwsSidekickCrossAccountCredentials{
+				RoleArn:    "arn:foo:bar",
+				ExternalID: "0123456789",
+			},
+			ScanFrequency:     24,
+			MonitoredAccounts: "r-1234, ou-0987",
+			ScanningAccount:   "123456789000",
+			ManagementAccount: "000123456789",
+		},
+	)
+	assert.Equal(t, "integration_name", cloudAccount.Name, "AwsSidekickOrg cloud account name mismatch")
+	assert.Equal(t, "AwsSidekickOrg", cloudAccount.Type, "a new AwsSidekickOrg cloud account should match its type")
+	assert.Equal(t, 1, cloudAccount.Enabled, "a new AwsSidekickOrg cloud account should be enabled")
+	cloudAccount.IntgGuid = intgGUID
+
+	response, err := c.V2.CloudAccounts.UpdateAwsSidekickOrg(cloudAccount)
+	assert.Nil(t, err)
+	assert.NotNil(t, response)
+	assert.Equal(t, intgGUID, response.Data.IntgGuid)
+	assert.Equal(t, "arn:foo:bar", response.Data.Data.CrossAccountCreds.RoleArn)
+	assert.Equal(t, "0123456789", response.Data.Data.CrossAccountCreds.ExternalID)
+	assert.Equal(t, 24, response.Data.Data.ScanFrequency)
+	assert.True(t, response.Data.Data.ScanContainers)
+	assert.True(t, response.Data.Data.ScanHostVulnerabilities)
+	assert.Equal(t, "123456789000", response.Data.Data.ScanningAccount)
+	assert.Equal(t, "000123456789", response.Data.Data.ManagementAccount)
+	assert.Equal(t, "r-1234, ou-0987", response.Data.Data.MonitoredAccounts)
+}
+
+func singleAwsSidekickOrgCloudAccount(id string) string {
+	return `
+  {
+    "createdOrUpdatedBy": "teddy.reed@lacework.net",
+    "createdOrUpdatedTime": "2021-06-01T19:28:00.092Z",
+    "data": {
+      "awsAccountId": "123456789000",
+      "crossAccountCredentials": {
+        "externalId": "0123456789",
+        "roleArn": "arn:foo:bar"
+      },
+	  "scanFrequency": 24,
+	  "scanContainers": true,
+	  "scanHostVulnerabilities": true,
+	  "managementAccount": "000123456789",
+	  "monitoredAccounts": "r-1234, ou-0987",
+	  "scanningAccount": "123456789000"
+    },
+    "enabled": 1,
+    "intgGuid": "` + id + `",
+    "isOrg": 0,
+    "name": "integration_name",
+    "state": {
+      "details": {},
+      "lastSuccessfulTime": 1624456896915,
+      "lastUpdatedTime": 1624456896915,
+      "ok": true
+    },
+    "type": "AwsSidekickOrg"
+  }
+  `
+}

--- a/api/cloud_accounts_aws_sidekick_test.go
+++ b/api/cloud_accounts_aws_sidekick_test.go
@@ -1,0 +1,172 @@
+//
+// Author:: Teddy Reed (<teddy.reed@lacework.net>)
+// Copyright:: Copyright 2022, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package api_test
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/lacework/go-sdk/api"
+	"github.com/lacework/go-sdk/internal/intgguid"
+	"github.com/lacework/go-sdk/internal/lacework"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCloudAccountsNewAwsSidekickWithCustomTemplateFile(t *testing.T) {
+	awsCfgData := api.AwsSidekickData{
+		CrossAccountCreds: api.AwsSidekickCrossAccountCredentials{
+			RoleArn:    "arn:foo:bar",
+			ExternalID: "0123456789",
+		},
+	}
+
+	subject := api.NewCloudAccount("integration_name", api.AwsSidekickCloudAccount, awsCfgData)
+	assert.Equal(t, api.AwsSidekickCloudAccount.String(), subject.Type)
+
+	// casting the data interface{} to type AwsCfgData
+	subjectData := subject.Data.(api.AwsSidekickData)
+
+	assert.Equal(t, subjectData.CrossAccountCreds.RoleArn, "arn:foo:bar")
+	assert.Equal(t, subjectData.CrossAccountCreds.ExternalID, "0123456789")
+}
+
+func TestCloudAccountsAwsSidekickGet(t *testing.T) {
+	var (
+		intgGUID   = intgguid.New()
+		apiPath    = fmt.Sprintf("CloudAccounts/%s", intgGUID)
+		fakeServer = lacework.MockServer()
+	)
+	fakeServer.UseApiV2()
+	fakeServer.MockToken("TOKEN")
+	defer fakeServer.Close()
+
+	fakeServer.MockAPI(apiPath, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method, "GetAwsSidekick() should be a GET method")
+		fmt.Fprintf(w, generateCloudAccountResponse(singleAwsSidekickCloudAccount(intgGUID)))
+	})
+
+	c, err := api.NewClient("test",
+		api.WithApiV2(),
+		api.WithToken("TOKEN"),
+		api.WithURL(fakeServer.URL()),
+	)
+	assert.Nil(t, err)
+
+	response, err := c.V2.CloudAccounts.GetAwsSidekick(intgGUID)
+	assert.Nil(t, err)
+	assert.NotNil(t, response)
+	assert.Equal(t, intgGUID, response.Data.IntgGuid)
+	assert.Equal(t, "integration_name", response.Data.Name)
+	assert.True(t, response.Data.State.Ok)
+	assert.Equal(t, "arn:foo:bar", response.Data.Data.CrossAccountCreds.RoleArn)
+	assert.Equal(t, "0123456789", response.Data.Data.CrossAccountCreds.ExternalID)
+	assert.Equal(t, 24, response.Data.Data.ScanFrequency)
+	assert.True(t, response.Data.Data.ScanContainers)
+	assert.True(t, response.Data.Data.ScanHostVulnerabilities)
+}
+
+func TestCloudAccountsAwsSidekickUpdate(t *testing.T) {
+	var (
+		intgGUID   = intgguid.New()
+		apiPath    = fmt.Sprintf("CloudAccounts/%s", intgGUID)
+		fakeServer = lacework.MockServer()
+	)
+	fakeServer.UseApiV2()
+	fakeServer.MockToken("TOKEN")
+	defer fakeServer.Close()
+
+	fakeServer.MockAPI(apiPath, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "PATCH", r.Method, "UpdateAwsSidekick() should be a PATCH method")
+
+		if assert.NotNil(t, r.Body) {
+			body := httpBodySniffer(r)
+			assert.Contains(t, body, intgGUID, "INTG_GUID missing")
+			assert.Contains(t, body, "integration_name", "cloud account name is missing")
+			assert.Contains(t, body, "AwsSidekick", "wrong cloud account type")
+			assert.Contains(t, body, "arn:foo:bar", "wrong role arn")
+			assert.Contains(t, body, "0123456789", "wrong external ID")
+			assert.Contains(t, body, "enabled\":1", "cloud account is not enabled")
+		}
+
+		fmt.Fprintf(w, generateCloudAccountResponse(singleAwsSidekickCloudAccount(intgGUID)))
+	})
+
+	c, err := api.NewClient("test",
+		api.WithApiV2(),
+		api.WithToken("TOKEN"),
+		api.WithURL(fakeServer.URL()),
+	)
+	assert.Nil(t, err)
+
+	cloudAccount := api.NewCloudAccount("integration_name",
+		api.AwsSidekickCloudAccount,
+		api.AwsSidekickData{
+			CrossAccountCreds: api.AwsSidekickCrossAccountCredentials{
+				RoleArn:    "arn:foo:bar",
+				ExternalID: "0123456789",
+			},
+			ScanFrequency: 24,
+		},
+	)
+	assert.Equal(t, "integration_name", cloudAccount.Name, "AwsSidekick cloud account name mismatch")
+	assert.Equal(t, "AwsSidekick", cloudAccount.Type, "a new AwsSidekick cloud account should match its type")
+	assert.Equal(t, 1, cloudAccount.Enabled, "a new AwsSidekick cloud account should be enabled")
+	cloudAccount.IntgGuid = intgGUID
+
+	response, err := c.V2.CloudAccounts.UpdateAwsSidekick(cloudAccount)
+	assert.Nil(t, err)
+	assert.NotNil(t, response)
+	assert.Equal(t, intgGUID, response.Data.IntgGuid)
+	assert.Equal(t, "arn:foo:bar", response.Data.Data.CrossAccountCreds.RoleArn)
+	assert.Equal(t, "0123456789", response.Data.Data.CrossAccountCreds.ExternalID)
+	assert.Equal(t, 24, response.Data.Data.ScanFrequency)
+	assert.True(t, response.Data.Data.ScanContainers)
+	assert.True(t, response.Data.Data.ScanHostVulnerabilities)
+}
+
+func singleAwsSidekickCloudAccount(id string) string {
+	return `
+  {
+    "createdOrUpdatedBy": "teddy.reed@lacework.net",
+    "createdOrUpdatedTime": "2021-06-01T19:28:00.092Z",
+    "data": {
+      "awsAccountId": "123456789000",
+      "crossAccountCredentials": {
+        "externalId": "0123456789",
+        "roleArn": "arn:foo:bar"
+      },
+	  "scanFrequency": 24,
+	  "scanContainers": true,
+	  "scanHostVulnerabilities": true
+    },
+    "enabled": 1,
+    "intgGuid": "` + id + `",
+    "isOrg": 0,
+    "name": "integration_name",
+    "state": {
+      "details": {},
+      "lastSuccessfulTime": 1624456896915,
+      "lastUpdatedTime": 1624456896915,
+      "ok": true
+    },
+    "type": "AwsSidekick"
+  }
+  `
+}


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/lacework/go-sdk) and create your branch from `main`
  2. Run `make prepare` in the repository root
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`make test`)
  5. Format your code (`make fmt`)
  6. Make sure your code lints (`make lint`)
  7. If you are updating the Lacework CLI, make sure it compiles (`make build-cli-cross-platform`)
  8. Follow the commit message standard (`type(scope): subject`) documented in [DEVELOPER_GUIDELINES.md](https://github.com/lacework/go-sdk/blob/main/DEVELOPER_GUIDELINES.md#commit-message-standard)
  9. If you haven't already, configure signed commits by [telling git about your signing key](https://docs.github.com/en/github/authenticating-to-github/managing-commit-signature-verification/telling-git-about-your-signing-key) and [signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)

  Learn more about contributing: https://github.com/lacework/go-sdk/blob/main/CONTRIBUTING.md
-->

## Summary

This adds a new Cloud Account type `AwsSidekickOrg`, which is shorthand for Agentless Workload Scanning with AWS Organization integration. Or rather: multi-account AWS support. Previously with `AwsSidekick` it is single-account style integration.


## How did you test this change?

With unit tests and by adding this into the vendor directory for `lacework/terraform-provider-lacework` and running `make test` for that repo locally.

## Issue

RAIN-38397
