### PR TITLE
feat(generate): Add Terraform generation for AWS EKS Audit Log

### DIFF
--- a/cli/cmd/generate.go
+++ b/cli/cmd/generate.go
@@ -228,7 +228,7 @@ func validateAwsSubAccounts(subaccounts []string) error {
 	return nil
 }
 
-// create survey.Validator for string with regex
+// validateStringWithRegex create survey.Validator for string with regex
 func validateStringWithRegex(val interface{}, regex string, errorString string) error {
 	switch value := val.(type) {
 	case string:

--- a/cli/cmd/generate_aws_eks_audit.go
+++ b/cli/cmd/generate_aws_eks_audit.go
@@ -27,7 +27,7 @@ var (
 	QuestionEksAuditConfigureAdvanced = "Configure advanced integration options?"
 
 	// S3 Bucket Questions
-	EksAuditConfigureBucket              = "Configure bucket settings?"
+	EksAuditConfigureBucket              = "Configure bucket settings"
 	QuestionEksAuditBucketVersioning     = "Enable access versioning on the new bucket?"
 	QuestionEksAuditMfaDeleteS3Bucket    = "Should MFA object deletion be required for the new bucket?"
 	QuestionEksAuditForceDestroyS3Bucket = "Should force destroy be enabled for the new bucket?"

--- a/cli/cmd/generate_aws_eks_audit.go
+++ b/cli/cmd/generate_aws_eks_audit.go
@@ -17,11 +17,11 @@ import (
 
 var (
 	// Define question text here, so they can be reused in testing
-	QuestionEksAuditMultiRegion          = "Integrate cluster(s) in more than one region?"
-	QuestionEksAuditRegionClusterCurrent = "Currently configured regions & clusters: %s. " +
+	QuestionEksAuditMultiRegion          = "Integrate clusters in more than one region?"
+	QuestionEksAuditRegionClusterCurrent = "Currently configured regions and clusters: %s. " +
 		"Configure additional?"
 	QuestionEksAuditRegion         = "Specify AWS region:"
-	QuestionEksAuditRegionClusters = "Specify a comma seperated list of clusters in region" +
+	QuestionEksAuditRegionClusters = "Specify a comma-seperated list of clusters in region" +
 		" to ingest EKS Audit Logs:"
 	QuestionEksAuditAdditionalRegion = "Configure another AWS region?"
 
@@ -37,16 +37,16 @@ var (
 	QuestionEksAuditBucketSseAlgorithm   = "Specify the bucket SSE Algorithm: (optional)"
 	QuestionEksAuditBucketExistingKey    = "Use existing KMS key?"
 	QuestionEksAuditBucketKeyArn         = "Specify the bucket existing SSE KMS key ARN:"
-	QuestionEksAuditKmsKeyRotation       = "Should the kms key have rotation enabled?"
-	QuestionEksAuditKmsKeyDeletionDays   = "Specify the kms key deletion days: (optional)"
+	QuestionEksAuditKmsKeyRotation       = "Should the KMS key have rotation enabled?"
+	QuestionEksAuditKmsKeyDeletionDays   = "Specify the KMS key deletion days: (optional)"
 
 	// SNS Topic Questions
 	EksAuditConfigureSns                = "Configure SNS settings"
 	QuestionEksAuditSnsEncryption       = "Enable encryption on SNS topic when creating?"
-	QuestionEksAuditSnsEncryptionKeyArn = "Specify existing KMS encryption key arn for SNS topic (optional)"
+	QuestionEksAuditSnsEncryptionKeyArn = "Specify existing KMS encryption key ARN for SNS topic (optional)"
 
 	// Cloudwatch IAM Questions
-	EksAuditExistingCwIamRole        = "Configure & use existing Cloudwatch IAM role"
+	EksAuditExistingCwIamRole        = "Configure and use existing Cloudwatch IAM role"
 	QuestionEksAuditExistingCwIamArn = "Specify an existing Cloudwatch IAM role ARN:"
 
 	// Firehose Questions
@@ -54,10 +54,10 @@ var (
 	QuestionEksAuditExistingFhIamRole  = "Use existing Firehose IAM role?"
 	QuestionEksAuditExistingFhIamArn   = "Specify an existing Firehose IAM role ARN:"
 	QuestionEksAuditFhEncryption       = "Enable encryption on Firehose when creating?"
-	QuestionEksAuditFhEncryptionKeyArn = "Specify existing KMS encryption key arn for Firehose (optional)"
+	QuestionEksAuditFhEncryptionKeyArn = "Specify existing KMS encryption key ARN for Firehose (optional)"
 
 	// Cross Account IAM Questions
-	EksAuditExistingCaIamRole          = "Configure & use existing Cross Account IAM role"
+	EksAuditExistingCaIamRole          = "Configure and use existing Cross Account IAM role"
 	QuestionEksAuditExistingCaIamArn   = "Specify an existing Cross Account IAM role ARN:"
 	QuestionEksAuditExistingCaIamExtID = "Specify the external ID to be used with the existing IAM role:"
 
@@ -88,20 +88,20 @@ var (
 		Long: `Use this command to generate Terraform code for deploying Lacework into an EKS
 environment.
 
-By default, this command interactively prompts for the required information to setup the new cloud account.
+By default, this command interactively prompts for the required information to set up the new cloud account.
 In interactive mode, this command will:
 
-* Prompt for the required information to setup the integration
+* Prompt for the required information to set up the integration
 * Generate new Terraform code using the inputs
 * Optionally, run the generated Terraform code:
   * If Terraform is already installed, the version is verified as compatible for use
-	* If Terraform is not installed, or the version installed is not compatible, a new version will be installed into a temporary location
-	* Once Terraform is detected or installed, Terraform plan will be executed
-	* The command will prompt with the outcome of the plan and allow to view more details or continue with Terraform apply
-	* If confirmed, Terraform apply will be run, completing the setup of the cloud account
+  * If Terraform is not installed, or the version installed is not compatible, a new version will be installed into a temporary location
+  * Once Terraform is detected or installed, the Terraform plan is executed
+  * The command prompts you with the outcome of the plan and allows you to view more details or continue with Terraform apply
+  * If confirmed, Terraform apply runs, completing the setup of the cloud account
 
 This command can also be run in noninteractive mode.
-See help output for more details on the parameter value(s) required for Terraform code generation.
+See help output for more details on the parameter values required for Terraform code generation.
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Generate TF Code
@@ -208,7 +208,7 @@ See help output for more details on the parameter value(s) required for Terrafor
 				return err
 			}
 
-			// Validate bucket sse key arn, if passed
+			// Validate bucket sse key ARN, if passed
 			bucketSseKeyArn, err := cmd.Flags().GetString("bucket_sse_key_arn")
 			if err != nil {
 				return errors.Wrap(err, "failed to load command flags")
@@ -217,7 +217,7 @@ See help output for more details on the parameter value(s) required for Terrafor
 				return err
 			}
 
-			// Validate firehose key arn, if passed
+			// Validate firehose key ARN, if passed
 			firehoseKeyArn, err := cmd.Flags().GetString("firehose_encryption_key_arn")
 			if err != nil {
 				return errors.Wrap(err, "failed to load command flags")
@@ -226,7 +226,7 @@ See help output for more details on the parameter value(s) required for Terrafor
 				return err
 			}
 
-			// Validate sns topic key arn, if passed
+			// Validate sns topic key ARN, if passed
 			snsKeyArn, err := cmd.Flags().GetString("sns_topic_encryption_key_arn")
 			if err != nil {
 				return errors.Wrap(err, "failed to load command flags")
@@ -240,13 +240,13 @@ See help output for more details on the parameter value(s) required for Terrafor
 				cachedOptions := &aws_eks_audit.GenerateAwsEksAuditTfConfigurationArgs{}
 				iacParamsExpired := cli.ReadCachedAsset(CachedAssetAwsEksAuditIacParams, &cachedOptions)
 				if iacParamsExpired {
-					cli.Log.Debug("loaded previously set values for AWS EKS Audit iac generation")
+					cli.Log.Debug("loaded previously set values for AWS EKS Audit IAC generation")
 				}
 
 				extraState := &AwsEksAuditGenerateCommandExtraState{}
 				extraStateParamsExpired := cli.ReadCachedAsset(CachedAssetAwsEksAuditExtraState, &extraState)
 				if extraStateParamsExpired {
-					cli.Log.Debug("loaded previously set values for AWS EKS Audit iac generation (extra state)")
+					cli.Log.Debug("loaded previously set values for AWS EKS Audit IAC generation (extra state)")
 				}
 
 				// Determine if previously cached options exists; prompt user if they'd like to continue
@@ -285,7 +285,7 @@ See help output for more details on the parameter value(s) required for Terrafor
 						"invalid region name supplied"); err != nil {
 						return err
 					}
-					// parse the cluster comma seperated string into a list of clusters
+					// parse the cluster comma-seperated string into a list of clusters
 					parsedClusters := strings.Split(clusters, ",")
 					awsParsedRegionClusterMap[region] = append(awsParsedRegionClusterMap[region], parsedClusters...)
 				}
@@ -412,7 +412,7 @@ func initGenerateAwsEksAuditTfCommandFlags() {
 		&GenerateAwsEksAuditCommandState.KmsKeyDeletionDays,
 		"kms_key_deletion_days",
 		0,
-		"specify the waiting period, specified in number of days")
+		"specify the kms waiting period before deletion, in number of days")
 	generateAwsEksAuditTfCommand.PersistentFlags().BoolVar(
 		&GenerateAwsEksAuditCommandState.KmsKeyRotation,
 		"enable_kms_key_rotation",
@@ -427,7 +427,7 @@ func initGenerateAwsEksAuditTfCommandFlags() {
 		&GenerateAwsEksAuditCommandState.RegionClusterMap,
 		"region_clusters",
 		map[string]string{},
-		"configure eks clusters per aws region; To configure multiple regions pass the flag"+
+		"configure eks clusters per aws region. To configure multiple regions pass the flag"+
 			" multiple times. Example format:  --region_clusters <region>=\"cluster,list\"")
 	generateAwsEksAuditTfCommand.PersistentFlags().BoolVar(
 		&GenerateAwsEksAuditCommandState.SnsTopicEncryptionEnabled,

--- a/cli/cmd/generate_aws_eks_audit.go
+++ b/cli/cmd/generate_aws_eks_audit.go
@@ -2,10 +2,11 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/lacework/go-sdk/lwgenerate/aws_eks_audit"
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/lacework/go-sdk/lwgenerate/aws_eks_audit"
 
 	"github.com/imdario/mergo"
 	"github.com/spf13/cobra"

--- a/cli/cmd/generate_aws_eks_audit.go
+++ b/cli/cmd/generate_aws_eks_audit.go
@@ -253,14 +253,12 @@ See help output for more details on the parameter value(s) required for Terrafor
 			if cli.InteractiveMode() {
 				cachedOptions := &aws_eks_audit.GenerateAwsEksAuditTfConfigurationArgs{}
 				iacParamsExpired := cli.ReadCachedAsset(CachedAssetAwsEksAuditIacParams, &cachedOptions)
-				cli.Log.Debug(fmt.Sprintf("iacParamsExpired: %s", iacParamsExpired))
 				if iacParamsExpired {
 					cli.Log.Debug("loaded previously set values for AWS EKS Audit iac generation")
 				}
 
 				extraState := &AwsEksAuditGenerateCommandExtraState{}
 				extraStateParamsExpired := cli.ReadCachedAsset(CachedAssetAwsEksAuditExtraState, &extraState)
-				cli.Log.Debug(fmt.Sprintf("extraStateParamsExpired: %s", extraStateParamsExpired))
 				if extraStateParamsExpired {
 					cli.Log.Debug("loaded previously set values for AWS EKS Audit iac generation (extra state)")
 				}
@@ -294,7 +292,7 @@ See help output for more details on the parameter value(s) required for Terrafor
 			if len(GenerateAwsEksAuditCommandState.RegionClusterMap) > 0 {
 				// validate the format of supplied values is correct
 
-				var awsParsedRegionClusterMap map[string][]string
+				awsParsedRegionClusterMap := make(map[string][]string)
 				for region, clusters := range GenerateAwsEksAuditCommandState.RegionClusterMap {
 					// verify each region is a valid aws region
 					if err := validateStringWithRegex(region, AwsEksAuditRegionRegex,
@@ -542,7 +540,7 @@ func promptAwsEksAuditBucketQuestions(config *aws_eks_audit.GenerateAwsEksAuditT
 }
 
 func promptAwsEksAuditExistingCrossAccountIamQuestions(input *aws_eks_audit.
-GenerateAwsEksAuditTfConfigurationArgs) error {
+	GenerateAwsEksAuditTfConfigurationArgs) error {
 	// ensure struct is initialized
 	if input.ExistingCrossAccountIamRole == nil {
 		input.ExistingCrossAccountIamRole = &aws_eks_audit.ExistingCrossAccountIamRoleDetails{}
@@ -563,7 +561,7 @@ GenerateAwsEksAuditTfConfigurationArgs) error {
 }
 
 func promptAwsEksAuditFirehoseQuestions(input *aws_eks_audit.
-GenerateAwsEksAuditTfConfigurationArgs) error {
+	GenerateAwsEksAuditTfConfigurationArgs) error {
 
 	if err := SurveyQuestionInteractiveOnly(SurveyQuestionWithValidationArgs{
 		Prompt: &survey.Confirm{
@@ -614,7 +612,7 @@ GenerateAwsEksAuditTfConfigurationArgs) error {
 }
 
 func promptAwsEksAuditExistingCloudwatchIamQuestions(input *aws_eks_audit.
-GenerateAwsEksAuditTfConfigurationArgs) error {
+	GenerateAwsEksAuditTfConfigurationArgs) error {
 
 	err := SurveyQuestionInteractiveOnly(SurveyQuestionWithValidationArgs{
 		Prompt: &survey.Input{
@@ -629,7 +627,7 @@ GenerateAwsEksAuditTfConfigurationArgs) error {
 }
 
 func promptAwsEksAuditSnsQuestions(input *aws_eks_audit.
-GenerateAwsEksAuditTfConfigurationArgs) error {
+	GenerateAwsEksAuditTfConfigurationArgs) error {
 
 	if err := SurveyQuestionInteractiveOnly(SurveyQuestionWithValidationArgs{
 		Prompt: &survey.Confirm{
@@ -656,7 +654,7 @@ GenerateAwsEksAuditTfConfigurationArgs) error {
 }
 
 func promptAwsEksAuditCustomIntegrationName(input *aws_eks_audit.
-GenerateAwsEksAuditTfConfigurationArgs) error {
+	GenerateAwsEksAuditTfConfigurationArgs) error {
 
 	err := SurveyQuestionInteractiveOnly(SurveyQuestionWithValidationArgs{
 		Prompt: &survey.Input{

--- a/cli/cmd/generate_aws_eks_audit.go
+++ b/cli/cmd/generate_aws_eks_audit.go
@@ -143,8 +143,8 @@ See help output for more details on the parameter value(s) required for Terrafor
 				mods = append(mods, aws_eks_audit.EnableBucketVersioning())
 			}
 
-			if GenerateAwsEksAuditCommandState.FirehoseEncryptionEnabled {
-				mods = append(mods, aws_eks_audit.EnableFirehoseEncryption())
+			if GenerateAwsEksAuditCommandState.FirehoseEncryptionDisabled {
+				mods = append(mods, aws_eks_audit.DisableFirehoseEncryption())
 			}
 
 			if GenerateAwsEksAuditCommandState.KmsKeyMultiRegion {
@@ -155,8 +155,8 @@ See help output for more details on the parameter value(s) required for Terrafor
 				mods = append(mods, aws_eks_audit.EnableKmsKeyRotation())
 			}
 
-			if GenerateAwsEksAuditCommandState.SnsTopicEncryptionEnabled {
-				mods = append(mods, aws_eks_audit.EnableSnsTopicEncryption())
+			if GenerateAwsEksAuditCommandState.SnsTopicEncryptionDisabled {
+				mods = append(mods, aws_eks_audit.DisableSnsTopicEncryption())
 			}
 
 			// Create new struct

--- a/cli/cmd/generate_aws_eks_audit.go
+++ b/cli/cmd/generate_aws_eks_audit.go
@@ -289,10 +289,6 @@ See help output for more details on the parameter value(s) required for Terrafor
 				GenerateAwsEksAuditCommandState.ParsedRegionClusterMap = awsParsedRegionClusterMap
 			}
 
-			if len(GenerateAwsEksAuditCommandState.ParsedRegionClusterMap) <= 1 {
-				GenerateAwsEksAuditCommandState.KmsKeyMultiRegion = false
-			}
-
 			// Collect and/or confirm parameters
 			err = promptAwsEksAuditGenerate(GenerateAwsEksAuditCommandState, GenerateAwsEksAuditExistingRoleState,
 				GenerateAwsEksAuditCommandExtraState)
@@ -412,7 +408,7 @@ func initGenerateAwsEksAuditTfCommandFlags() {
 	generateAwsEksAuditTfCommand.PersistentFlags().IntVar(
 		&GenerateAwsEksAuditCommandState.KmsKeyDeletionDays,
 		"kms_key_deletion_days",
-		30,
+		0,
 		"specify the waiting period, specified in number of days")
 	generateAwsEksAuditTfCommand.PersistentFlags().BoolVar(
 		&GenerateAwsEksAuditCommandState.KmsKeyRotation,
@@ -511,7 +507,7 @@ func promptAwsEksAuditBucketQuestions(config *aws_eks_audit.GenerateAwsEksAuditT
 			Response: &config.KmsKeyRotation,
 		},
 		{
-			Prompt:   &survey.Input{Message: QuestionEksAuditKmsKeyDeletionDays, Default: "30"},
+			Prompt:   &survey.Input{Message: QuestionEksAuditKmsKeyDeletionDays, Default: "0"},
 			Checks:   []*bool{&config.BucketEnableEncryption, &newKmsKey},
 			Opts:     []survey.AskOpt{},
 			Response: &config.KmsKeyDeletionDays,

--- a/cli/cmd/generate_aws_eks_audit.go
+++ b/cli/cmd/generate_aws_eks_audit.go
@@ -130,7 +130,6 @@ See help output for more details on the parameter value(s) required for Terrafor
 				aws_eks_audit.EnableFirehoseEncryption(GenerateAwsEksAuditCommandState.FirehoseEncryptionEnabled),
 				aws_eks_audit.EnableSnsTopicEncryption(GenerateAwsEksAuditCommandState.SnsTopicEncryptionEnabled),
 				aws_eks_audit.EnableBucketVersioning(GenerateAwsEksAuditCommandState.BucketVersioning),
-				aws_eks_audit.EnableKmsKeyMultiRegion(GenerateAwsEksAuditCommandState.KmsKeyMultiRegion),
 				aws_eks_audit.EnableKmsKeyRotation(GenerateAwsEksAuditCommandState.KmsKeyRotation),
 			}
 

--- a/cli/cmd/generate_aws_eks_audit.go
+++ b/cli/cmd/generate_aws_eks_audit.go
@@ -28,10 +28,10 @@ var (
 
 	// S3 Bucket Questions
 	EksAuditConfigureBucket              = "Configure bucket settings?"
-	QuestionEksAuditBucketVersioning     = "Should access versioning be enabled for the new bucket?"
+	QuestionEksAuditBucketVersioning     = "Disable access versioning on the new bucket?"
 	QuestionEksAuditMfaDeleteS3Bucket    = "Should MFA object deletion be required for the new bucket?"
 	QuestionEksAuditForceDestroyS3Bucket = "Should force destroy be enabled for the new bucket?"
-	QuestionEksAuditBucketEncryption     = "Should encryption be enabled for the new bucket?"
+	QuestionEksAuditBucketEncryption     = "Disable encryption for the new bucket?"
 	QuestionEksAuditBucketSseAlgorithm   = "Specify the bucket SSE Algorithm: (optional)"
 	QuestionEksAuditBucketKeyArn         = "Specify the bucket existing SSE KMS key ARN:"
 	QuestionEksAuditBucketLifecycle      = "Specify the bucket lifecycle expiration days: (optional)"
@@ -39,20 +39,20 @@ var (
 	QuestionEksAuditKmsKeyDeletionDays   = "Specify the kms key deletion days: (optional)"
 
 	// SNS Topic Questions
-	QuestionEksAuditConfigureSns        = "Configure SNS settings"
-	QuestionEksAuditSnsEnableEncryption = "Enable encryption on SNS topic when creating?"
-	QuestionEksAuditSnsEncryptionKeyArn = "Specify existing KMS encryption key arn for SNS topic (optional)"
+	QuestionEksAuditConfigureSns         = "Configure SNS settings"
+	QuestionEksAuditSnsDisableEncryption = "Disable encryption on SNS topic when creating?"
+	QuestionEksAuditSnsEncryptionKeyArn  = "Specify existing KMS encryption key arn for SNS topic (optional)"
 
 	// Cloudwatch IAM Questions
 	EksAuditExistingCwIamRole        = "Configure & use existing Cloudwatch IAM role"
 	QuestionEksAuditExistingCwIamArn = "Specify an existing Cloudwatch IAM role ARN:"
 
 	// Firehose Questions
-	EksAuditConfigureFh                = "Configure Firehose settings"
-	QuestionEksAuditExistingFhIamRole  = "Use existing Firehose IAM role?"
-	QuestionEksAuditExistingFhIamArn   = "Specify an existing Firehose IAM role ARN:"
-	QuestionEksAuditFhEnableEncryption = "Enable encryption on Firehose when creating?"
-	QuestionEksAuditFhEncryptionKeyArn = "Specify existing KMS encryption key arn for Firehose (optional)"
+	EksAuditConfigureFh                 = "Configure Firehose settings"
+	QuestionEksAuditExistingFhIamRole   = "Use existing Firehose IAM role?"
+	QuestionEksAuditExistingFhIamArn    = "Specify an existing Firehose IAM role ARN:"
+	QuestionEksAuditFhDisableEncryption = "Disable encryption on Firehose when creating?"
+	QuestionEksAuditFhEncryptionKeyArn  = "Specify existing KMS encryption key arn for Firehose (optional)"
 
 	// Cross Account IAM Questions
 	EksAuditExistingCaIamRole          = "Configure & use existing Cross Account IAM role"
@@ -127,8 +127,8 @@ See help output for more details on the parameter value(s) required for Terrafor
 				aws_eks_audit.WithLaceworkProfile(GenerateAwsEksAuditCommandState.LaceworkProfile),
 			}
 
-			if GenerateAwsEksAuditCommandState.BucketEnableEncryption {
-				mods = append(mods, aws_eks_audit.EnableBucketEncryption())
+			if GenerateAwsEksAuditCommandState.BucketDisableEncryption {
+				mods = append(mods, aws_eks_audit.DisableBucketEncryption())
 			}
 
 			if GenerateAwsEksAuditCommandState.BucketEnableMfaDelete {
@@ -139,8 +139,8 @@ See help output for more details on the parameter value(s) required for Terrafor
 				mods = append(mods, aws_eks_audit.EnableBucketForceDestroy())
 			}
 
-			if GenerateAwsEksAuditCommandState.BucketVersioning {
-				mods = append(mods, aws_eks_audit.EnableBucketVersioning())
+			if GenerateAwsEksAuditCommandState.DisableBucketVersioning {
+				mods = append(mods, aws_eks_audit.DisableBucketVersioning())
 			}
 
 			if GenerateAwsEksAuditCommandState.FirehoseEncryptionDisabled {
@@ -355,11 +355,11 @@ func initGenerateAwsEksAuditTfCommandFlags() {
 		&GenerateAwsEksAuditCommandState.BucketEnableMfaDelete,
 		"enable_mfa_delete_s3",
 		false,
-		"enable mfa delete on s3 bucket")
+		"enable mfa delete on s3 bucket. Requires bucket versioning.")
 	generateAwsEksAuditTfCommand.PersistentFlags().BoolVar(
-		&GenerateAwsEksAuditCommandState.BucketEnableEncryption,
+		&GenerateAwsEksAuditCommandState.BucketDisableEncryption,
 		"disable_encryption_s3",
-		false,
+		true,
 		"disable encryption on s3 bucket")
 	generateAwsEksAuditTfCommand.PersistentFlags().BoolVar(
 		&GenerateAwsEksAuditCommandState.BucketForceDestroy,
@@ -382,7 +382,7 @@ func initGenerateAwsEksAuditTfCommandFlags() {
 		"",
 		"specify the kms key arn to be used for s3. (required when bucket_sse_algorithm is aws:kms & using an existing kms key)")
 	generateAwsEksAuditTfCommand.PersistentFlags().BoolVar(
-		&GenerateAwsEksAuditCommandState.BucketVersioning,
+		&GenerateAwsEksAuditCommandState.DisableBucketVersioning,
 		"disable_bucket_versioning",
 		false,
 		"disable s3 bucket versioning")
@@ -417,9 +417,9 @@ func initGenerateAwsEksAuditTfCommandFlags() {
 		"",
 		"specify a custom cloudwatch log filter pattern")
 	generateAwsEksAuditTfCommand.PersistentFlags().BoolVar(
-		&GenerateAwsEksAuditCommandState.FirehoseEncryptionEnabled,
+		&GenerateAwsEksAuditCommandState.FirehoseEncryptionDisabled,
 		"disable_firehose_encryption",
-		false,
+		true,
 		"disable firehose encryption")
 	generateAwsEksAuditTfCommand.PersistentFlags().StringVar(
 		&GenerateAwsEksAuditCommandState.FirehoseEncryptionKeyArn,
@@ -447,9 +447,9 @@ func initGenerateAwsEksAuditTfCommandFlags() {
 		map[string]string{},
 		"configure aws regions and eks clusters; value format must be <region>:\"cluster,list\",<region>:\"cluster,list\"")
 	generateAwsEksAuditTfCommand.PersistentFlags().BoolVar(
-		&GenerateAwsEksAuditCommandState.SnsTopicEncryptionEnabled,
+		&GenerateAwsEksAuditCommandState.SnsTopicEncryptionDisabled,
 		"disable_sns_topic_encryption",
-		false,
+		true,
 		"disable encryption on the sns topic")
 	generateAwsEksAuditTfCommand.PersistentFlags().StringVar(
 		&GenerateAwsEksAuditCommandState.SnsTopicEncryptionKeyArn,
@@ -475,8 +475,8 @@ func promptAwsEksAuditBucketQuestions(config *aws_eks_audit.GenerateAwsEksAuditT
 	// Only ask these questions if configure bucket is true
 	if err := SurveyMultipleQuestionWithValidation([]SurveyQuestionWithValidationArgs{
 		{
-			Prompt:   &survey.Confirm{Message: QuestionEksAuditBucketVersioning, Default: config.BucketVersioning},
-			Response: &config.BucketVersioning,
+			Prompt:   &survey.Confirm{Message: QuestionEksAuditBucketVersioning, Default: config.DisableBucketVersioning},
+			Response: &config.DisableBucketVersioning,
 		},
 		{
 			Prompt:   &survey.Confirm{Message: QuestionEksAuditMfaDeleteS3Bucket, Default: config.BucketEnableMfaDelete},
@@ -492,16 +492,18 @@ func promptAwsEksAuditBucketQuestions(config *aws_eks_audit.GenerateAwsEksAuditT
 			Response: &config.BucketLifecycleExpirationDays,
 		},
 		{
-			Prompt:   &survey.Confirm{Message: QuestionEksAuditBucketEncryption, Default: config.BucketEnableEncryption},
-			Response: &config.BucketEnableEncryption,
+			Prompt: &survey.Confirm{Message: QuestionEksAuditBucketEncryption,
+				Default: config.BucketDisableEncryption},
+			Response: &config.BucketDisableEncryption,
 		},
 	}); err != nil {
 		return err
 	}
 
+	bucketEnableEncryption := !config.BucketDisableEncryption
 	if err := SurveyQuestionInteractiveOnly(SurveyQuestionWithValidationArgs{
 		Prompt:   &survey.Input{Message: QuestionEksAuditBucketSseAlgorithm},
-		Checks:   []*bool{&config.BucketEnableEncryption},
+		Checks:   []*bool{&bucketEnableEncryption},
 		Opts:     []survey.AskOpt{},
 		Response: &config.BucketSseAlgorithm,
 	}); err != nil {
@@ -510,25 +512,25 @@ func promptAwsEksAuditBucketQuestions(config *aws_eks_audit.GenerateAwsEksAuditT
 
 	if err := SurveyQuestionInteractiveOnly(SurveyQuestionWithValidationArgs{
 		Prompt:   &survey.Input{Message: QuestionEksAuditBucketKeyArn},
-		Checks:   []*bool{&config.BucketEnableEncryption},
+		Checks:   []*bool{&bucketEnableEncryption},
 		Opts:     []survey.AskOpt{},
 		Response: &config.BucketSseKeyArn,
 	}); err != nil {
 		return err
 	}
 
-	newKmsKey := config.BucketEnableEncryption && len(config.BucketSseKeyArn) == 0
+	newKmsKey := bucketEnableEncryption && len(config.BucketSseKeyArn) == 0
 	if err := SurveyMultipleQuestionWithValidation([]SurveyQuestionWithValidationArgs{
 		{
 			Prompt:   &survey.Confirm{Message: QuestionEksAuditKmsKeyRotation},
-			Checks:   []*bool{&config.BucketEnableEncryption, &newKmsKey},
+			Checks:   []*bool{&bucketEnableEncryption, &newKmsKey},
 			Required: true,
 			Opts:     []survey.AskOpt{},
 			Response: &config.KmsKeyRotation,
 		},
 		{
 			Prompt:   &survey.Input{Message: QuestionEksAuditKmsKeyDeletionDays, Default: "30"},
-			Checks:   []*bool{&config.BucketEnableEncryption, &newKmsKey},
+			Checks:   []*bool{&bucketEnableEncryption, &newKmsKey},
 			Opts:     []survey.AskOpt{},
 			Response: &config.KmsKeyDeletionDays,
 		},
@@ -588,23 +590,24 @@ func promptAwsEksAuditFirehoseQuestions(input *aws_eks_audit.
 		},
 		{
 			Prompt: &survey.Confirm{
-				Message: QuestionEksAuditFhEnableEncryption,
-				Default: input.FirehoseEncryptionEnabled,
+				Message: QuestionEksAuditFhDisableEncryption,
+				Default: input.FirehoseEncryptionDisabled,
 			},
 			Opts:     []survey.AskOpt{},
-			Response: &input.FirehoseEncryptionEnabled,
+			Response: &input.FirehoseEncryptionDisabled,
 			Required: true,
 		},
 	}); err != nil {
 		return err
 	}
 
+	firehoseEncryptionEnabled := !input.FirehoseEncryptionDisabled
 	err := SurveyQuestionInteractiveOnly(SurveyQuestionWithValidationArgs{
 		Prompt: &survey.Input{
 			Message: QuestionEksAuditFhEncryptionKeyArn,
 			Default: input.FirehoseEncryptionKeyArn,
 		},
-		Checks:   []*bool{&input.FirehoseEncryptionEnabled},
+		Checks:   []*bool{&firehoseEncryptionEnabled},
 		Opts:     []survey.AskOpt{},
 		Response: &input.FirehoseEncryptionKeyArn,
 	})
@@ -631,22 +634,23 @@ func promptAwsEksAuditSnsQuestions(input *aws_eks_audit.
 
 	if err := SurveyQuestionInteractiveOnly(SurveyQuestionWithValidationArgs{
 		Prompt: &survey.Confirm{
-			Message: QuestionEksAuditSnsEnableEncryption,
-			Default: input.SnsTopicEncryptionEnabled,
+			Message: QuestionEksAuditSnsDisableEncryption,
+			Default: input.SnsTopicEncryptionDisabled,
 		},
 		Opts:     []survey.AskOpt{},
-		Response: &input.SnsTopicEncryptionEnabled,
+		Response: &input.SnsTopicEncryptionDisabled,
 		Required: true,
 	}); err != nil {
 		return err
 	}
 
+	snsTopicEncryptionEnabled := !input.SnsTopicEncryptionDisabled
 	err := SurveyQuestionInteractiveOnly(SurveyQuestionWithValidationArgs{
 		Prompt: &survey.Input{
 			Message: QuestionEksAuditSnsEncryptionKeyArn,
 			Default: input.SnsTopicEncryptionKeyArn,
 		},
-		Checks:   []*bool{&input.SnsTopicEncryptionEnabled},
+		Checks:   []*bool{&snsTopicEncryptionEnabled},
 		Opts:     []survey.AskOpt{},
 		Response: &input.SnsTopicEncryptionKeyArn,
 	})

--- a/cli/cmd/generate_aws_eks_audit.go
+++ b/cli/cmd/generate_aws_eks_audit.go
@@ -425,9 +425,10 @@ func initGenerateAwsEksAuditTfCommandFlags() {
 		"specify the prefix that will be used at the beginning of every generated resource")
 	generateAwsEksAuditTfCommand.PersistentFlags().StringToStringVar(
 		&GenerateAwsEksAuditCommandState.RegionClusterMap,
-		"region_cluster_map",
+		"region_clusters",
 		map[string]string{},
-		"configure aws regions and eks clusters; value format must be <region>:\"cluster,list\",<region>:\"cluster,list\"")
+		"configure eks clusters per aws region; To configure multiple regions pass the flag"+
+			" multiple times. Example format:  --region_clusters <region>=\"cluster,list\"")
 	generateAwsEksAuditTfCommand.PersistentFlags().BoolVar(
 		&GenerateAwsEksAuditCommandState.SnsTopicEncryptionEnabled,
 		"enable_sns_topic_encryption",

--- a/cli/cmd/generate_aws_eks_audit_test.go
+++ b/cli/cmd/generate_aws_eks_audit_test.go
@@ -1,0 +1,119 @@
+package cmd
+
+import (
+	"fmt"
+	"github.com/lacework/go-sdk/lwgenerate/aws_eks_audit"
+	"os"
+	"path/filepath"
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func toggleEksNonInteractive() {
+	cli.noCache = !cli.noCache
+	cli.nonInteractive = !cli.nonInteractive
+}
+
+func TestGenerateMostBasicEksArgs(t *testing.T) {
+	toggleEksNonInteractive()
+	defer toggleEksNonInteractive()
+
+	data := aws_eks_audit.GenerateAwsEksAuditTfConfigurationArgs{}
+	err := promptAwsEksAuditGenerate(
+		&data,
+		&aws_eks_audit.ExistingCrossAccountIamRoleDetails{},
+		&AwsEksAuditGenerateCommandExtraState{Output: "/tmp"},
+	)
+
+	assert.Nil(t, err)
+}
+
+func TestAwsEksAuditRegionRegex(t *testing.T) {
+	ok, _ := regexp.MatchString(AwsEksAuditRegionRegex, "invalidarnstring")
+	assert.False(t, ok, "aws region cannot be an arbitrary string")
+
+	ok, _ = regexp.MatchString(AwsEksAuditRegionRegex, "us-gov-east-1")
+	assert.False(t, ok, "aws gov cloud regions not currently supported")
+
+	ok, _ = regexp.MatchString(AwsEksAuditRegionRegex, "us-east-1")
+	assert.True(t, ok, "aws region us-east-1 is valid")
+
+	ok, _ = regexp.MatchString(AwsEksAuditRegionRegex, "ap-northeast-1")
+	assert.True(t, ok, "aws region ap-norteast-1 is valid")
+}
+
+func TestEksGenerationCache(t *testing.T) {
+	t.Run("extra state shouldn't be written if empty", func(t *testing.T) {
+
+		dir, err := os.MkdirTemp("", "lacework-cli-cache")
+		if err != nil {
+			panic(err)
+		}
+		defer func(path string) {
+			err := os.RemoveAll(path)
+			if err != nil {
+
+			}
+		}(dir)
+		cli.InitCache(dir)
+
+		extraState := &AwsEksAuditGenerateCommandExtraState{}
+		extraState.writeCache()
+		assert.NoFileExists(t, filepath.FromSlash(fmt.Sprintf("%s/cache/standalone/%s", dir,
+			CachedAssetAwsEksAuditExtraState)))
+	})
+	t.Run("extra state should be written if not empty", func(t *testing.T) {
+		dir, err := os.MkdirTemp("", "lacework-cli-cache")
+		if err != nil {
+			panic(err)
+		}
+		defer func(path string) {
+			err := os.RemoveAll(path)
+			if err != nil {
+
+			}
+		}(dir)
+		cli.InitCache(dir)
+
+		extraState := AwsEksAuditGenerateCommandExtraState{Output: "/tmp"}
+		extraState.writeCache()
+		assert.FileExists(t, filepath.FromSlash(fmt.Sprintf("%s/cache/standalone/%s", dir, CachedAssetAwsEksAuditExtraState)))
+	})
+	t.Run("iac params should not be cached when empty", func(t *testing.T) {
+		dir, err := os.MkdirTemp("", "lacework-cli-cache")
+		if err != nil {
+			panic(err)
+		}
+		defer func(path string) {
+			err := os.RemoveAll(path)
+			if err != nil {
+
+			}
+		}(dir)
+		cli.InitCache(dir)
+
+		args := aws_eks_audit.GenerateAwsEksAuditTfConfigurationArgs{}
+		writeAwsEksAuditGenerationArgsCache(&args)
+		assert.NoFileExists(t, filepath.FromSlash(fmt.Sprintf("%s/cache/standalone/%s", dir,
+			CachedAssetAwsEksAuditIacParams)))
+	})
+	t.Run("iac params should be cached when not empty", func(t *testing.T) {
+		dir, err := os.MkdirTemp("", "lacework-cli-cache")
+		if err != nil {
+			panic(err)
+		}
+		defer func(path string) {
+			err := os.RemoveAll(path)
+			if err != nil {
+
+			}
+		}(dir)
+		cli.InitCache(dir)
+
+		args := aws_eks_audit.GenerateAwsEksAuditTfConfigurationArgs{LaceworkProfile: "default"}
+		writeAwsEksAuditGenerationArgsCache(&args)
+		assert.FileExists(t, filepath.FromSlash(fmt.Sprintf("%s/cache/standalone/%s", dir, CachedAssetAwsEksAuditIacParams)))
+	})
+}

--- a/cli/cmd/generate_aws_eks_audit_test.go
+++ b/cli/cmd/generate_aws_eks_audit_test.go
@@ -2,11 +2,12 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/lacework/go-sdk/lwgenerate/aws_eks_audit"
 	"os"
 	"path/filepath"
 	"regexp"
 	"testing"
+
+	"github.com/lacework/go-sdk/lwgenerate/aws_eks_audit"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/cli/cmd/generate_aws_test.go
+++ b/cli/cmd/generate_aws_test.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -90,7 +89,7 @@ func TestAwsSubAccountValidation(t *testing.T) {
 
 func TestGenerationCache(t *testing.T) {
 	t.Run("extra state shouldn't be written if empty", func(t *testing.T) {
-		dir, err := ioutil.TempDir("", "lacework-cli-cache")
+		dir, err := os.MkdirTemp("", "lacework-cli-cache")
 		if err != nil {
 			panic(err)
 		}
@@ -102,7 +101,7 @@ func TestGenerationCache(t *testing.T) {
 		assert.NoFileExists(t, filepath.FromSlash(fmt.Sprintf("%s/cache/standalone/%s", dir, CachedAssetAwsExtraState)))
 	})
 	t.Run("extra state should be written if not empty", func(t *testing.T) {
-		dir, err := ioutil.TempDir("", "lacework-cli-cache")
+		dir, err := os.MkdirTemp("", "lacework-cli-cache")
 		if err != nil {
 			panic(err)
 		}
@@ -114,7 +113,7 @@ func TestGenerationCache(t *testing.T) {
 		assert.FileExists(t, filepath.FromSlash(fmt.Sprintf("%s/cache/standalone/%s", dir, CachedAssetAwsExtraState)))
 	})
 	t.Run("iac params should not be cached when empty", func(t *testing.T) {
-		dir, err := ioutil.TempDir("", "lacework-cli-cache")
+		dir, err := os.MkdirTemp("", "lacework-cli-cache")
 		if err != nil {
 			panic(err)
 		}
@@ -126,7 +125,7 @@ func TestGenerationCache(t *testing.T) {
 		assert.NoFileExists(t, filepath.FromSlash(fmt.Sprintf("%s/cache/standalone/%s", dir, CachedAwsAssetIacParams)))
 	})
 	t.Run("iac params should be cached when not empty", func(t *testing.T) {
-		dir, err := ioutil.TempDir("", "lacework-cli-cache")
+		dir, err := os.MkdirTemp("", "lacework-cli-cache")
 		if err != nil {
 			panic(err)
 		}

--- a/cli/cmd/generate_k8s.go
+++ b/cli/cmd/generate_k8s.go
@@ -18,5 +18,7 @@ func init() {
 	generateTfCommand.AddCommand(generateK8sCommand)
 
 	initGenerateGkeTfCommandFlags()
+	initGenerateAwsEksAuditTfCommandFlags()
 	generateK8sCommand.AddCommand(generateGkeTfCommand)
+	generateK8sCommand.AddCommand(generateAwsEksAuditTfCommand)
 }

--- a/integration/aws_eks_audit_generation_test.go
+++ b/integration/aws_eks_audit_generation_test.go
@@ -1,0 +1,575 @@
+//go:build !windows && generation
+
+package integration
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/lacework/go-sdk/lwgenerate/aws_eks_audit"
+
+	"github.com/Netflix/go-expect"
+	"github.com/lacework/go-sdk/cli/cmd"
+	"github.com/stretchr/testify/assert"
+)
+
+func assertEksAuditTerraformSaved(t *testing.T, message string) {
+	assert.Contains(t, message, "Terraform code saved in")
+}
+
+func runEksAuditGenerateTest(t *testing.T, conditions func(*expect.Console), args ...string) string {
+	dir := createDummyTOMLConfig()
+	homeCache := os.Getenv("HOME")
+	os.Setenv("HOME", dir)
+	defer os.Setenv("HOME", homeCache)
+	defer os.RemoveAll(dir)
+
+	runFakeTerminalTestFromDir(t, dir, conditions, args...)
+	out, err := ioutil.ReadFile(filepath.FromSlash(fmt.Sprintf("%s/lacework/aws_eks_audit/main.tf", dir)))
+	if err != nil {
+		return ""
+	}
+
+	return string(out)
+}
+
+func TestGenerationEksSingleRegion(t *testing.T) {
+	os.Setenv("LW_NOCACHE", "true")
+	defer os.Setenv("LW_NOCACHE", "")
+	var final string
+
+	tfResult := runEksAuditGenerateTest(t,
+		func(c *expect.Console) {
+			expectsCliOutput(t, c, []MsgRspHandler{
+				MsgRsp{cmd.QuestionEksAuditMultiRegion, "n"},
+				MsgRsp{cmd.QuestionEksAuditRegion, "us-west-1"},
+				MsgRsp{cmd.QuestionEksAuditRegionClusters, "cluster1,cluster2"},
+				MsgRsp{cmd.QuestionEksAuditConfigureAdvanced, "n"},
+				MsgRsp{cmd.QuestionRunTfPlan, "n"},
+			})
+
+			final, _ = c.ExpectEOF()
+		},
+		"generate",
+		"k8s",
+		"eks",
+	)
+
+	assertEksAuditTerraformSaved(t, final)
+
+	regionClusterMap := make(map[string][]string)
+	regionClusterMap["us-west-1"] = []string{"cluster1", "cluster2"}
+	buildTf, _ := aws_eks_audit.NewTerraform(aws_eks_audit.WithParsedRegionClusterMap(regionClusterMap)).Generate()
+	assert.Equal(t, buildTf, tfResult)
+}
+
+func TestGenerationEksSingleRegionAdvancedBucket(t *testing.T) {
+	os.Setenv("LW_NOCACHE", "true")
+	defer os.Setenv("LW_NOCACHE", "")
+	var final string
+
+	tfResult := runEksAuditGenerateTest(t,
+		func(c *expect.Console) {
+			expectsCliOutput(t, c, []MsgRspHandler{
+				MsgRsp{cmd.QuestionEksAuditMultiRegion, "n"},
+				MsgRsp{cmd.QuestionEksAuditRegion, "us-west-1"},
+				MsgRsp{cmd.QuestionEksAuditRegionClusters, "cluster1,cluster2"},
+				MsgRsp{cmd.QuestionEksAuditConfigureAdvanced, "y"},
+				MsgMenu{cmd.EksAuditConfigureBucket, 0},
+				MsgRsp{cmd.QuestionEksAuditBucketVersioning, "y"},
+				MsgRsp{cmd.QuestionEksAuditMfaDeleteS3Bucket, "y"},
+				MsgRsp{cmd.QuestionEksAuditForceDestroyS3Bucket, "y"},
+				MsgRsp{cmd.QuestionEksAuditBucketEncryption, "y"},
+				MsgRsp{cmd.QuestionEksAuditBucketExistingKey, "n"},
+				MsgRsp{cmd.QuestionEksAuditBucketSseAlgorithm, ""},
+				MsgRsp{cmd.QuestionEksAuditKmsKeyRotation, "y"},
+				MsgRsp{cmd.QuestionEksAuditKmsKeyDeletionDays, "30"},
+				MsgRsp{cmd.QuestionEksAuditBucketLifecycle, "30"},
+				MsgRsp{cmd.QuestionEksAuditAnotherAdvancedOpt, "n"},
+				MsgRsp{cmd.QuestionRunTfPlan, "n"},
+			})
+
+			final, _ = c.ExpectEOF()
+		},
+		"generate",
+		"k8s",
+		"eks",
+	)
+
+	assertEksAuditTerraformSaved(t, final)
+
+	regionClusterMap := make(map[string][]string)
+	regionClusterMap["us-west-1"] = []string{"cluster1", "cluster2"}
+	buildTf, _ := aws_eks_audit.NewTerraform(
+		aws_eks_audit.WithParsedRegionClusterMap(regionClusterMap),
+		aws_eks_audit.EnableBucketVersioning(true),
+		aws_eks_audit.EnableBucketMfaDelete(),
+		aws_eks_audit.EnableBucketForceDestroy(),
+		aws_eks_audit.EnableBucketEncryption(true),
+		aws_eks_audit.EnableKmsKeyRotation(true),
+		aws_eks_audit.WithKmsKeyDeletionDays(30),
+		aws_eks_audit.WithBucketLifecycleExpirationDays(30),
+	).Generate()
+	assert.Equal(t, buildTf, tfResult)
+}
+
+func TestGenerationEksSingleRegionAdvancedBucketExistingKey(t *testing.T) {
+	os.Setenv("LW_NOCACHE", "true")
+	defer os.Setenv("LW_NOCACHE", "")
+	var final string
+
+	tfResult := runEksAuditGenerateTest(t,
+		func(c *expect.Console) {
+			expectsCliOutput(t, c, []MsgRspHandler{
+				MsgRsp{cmd.QuestionEksAuditMultiRegion, "n"},
+				MsgRsp{cmd.QuestionEksAuditRegion, "us-west-1"},
+				MsgRsp{cmd.QuestionEksAuditRegionClusters, "cluster1,cluster2"},
+				MsgRsp{cmd.QuestionEksAuditConfigureAdvanced, "y"},
+				MsgMenu{cmd.EksAuditConfigureBucket, 0},
+				MsgRsp{cmd.QuestionEksAuditBucketVersioning, "y"},
+				MsgRsp{cmd.QuestionEksAuditMfaDeleteS3Bucket, "y"},
+				MsgRsp{cmd.QuestionEksAuditForceDestroyS3Bucket, "y"},
+				MsgRsp{cmd.QuestionEksAuditBucketEncryption, "y"},
+				MsgRsp{cmd.QuestionEksAuditBucketExistingKey, "y"},
+				MsgRsp{cmd.QuestionEksAuditBucketSseAlgorithm, ""},
+				MsgRsp{cmd.QuestionEksAuditBucketKeyArn, "arn:aws:kms:us-west-2:249446771485:key/2537e820-be82-4ded-8dca-504e199b0903"},
+				MsgRsp{cmd.QuestionEksAuditBucketLifecycle, "30"},
+				MsgRsp{cmd.QuestionEksAuditAnotherAdvancedOpt, "n"},
+				MsgRsp{cmd.QuestionRunTfPlan, "n"},
+			})
+
+			final, _ = c.ExpectEOF()
+		},
+		"generate",
+		"k8s",
+		"eks",
+	)
+
+	assertEksAuditTerraformSaved(t, final)
+
+	regionClusterMap := make(map[string][]string)
+	regionClusterMap["us-west-1"] = []string{"cluster1", "cluster2"}
+	buildTf, _ := aws_eks_audit.NewTerraform(
+		aws_eks_audit.WithParsedRegionClusterMap(regionClusterMap),
+		aws_eks_audit.EnableBucketVersioning(true),
+		aws_eks_audit.EnableBucketMfaDelete(),
+		aws_eks_audit.EnableBucketForceDestroy(),
+		aws_eks_audit.EnableBucketEncryption(true),
+		aws_eks_audit.WithBucketSseKeyArn("arn:aws:kms:us-west-2:249446771485:key/2537e820-be82-4ded-8dca-504e199b0903"),
+		aws_eks_audit.WithBucketLifecycleExpirationDays(30),
+	).Generate()
+	assert.Equal(t, buildTf, tfResult)
+}
+
+func TestGenerationEksSingleRegionAdvancedCrossAccountIam(t *testing.T) {
+	os.Setenv("LW_NOCACHE", "true")
+	defer os.Setenv("LW_NOCACHE", "")
+	var final string
+
+	tfResult := runEksAuditGenerateTest(t,
+		func(c *expect.Console) {
+			expectsCliOutput(t, c, []MsgRspHandler{
+				MsgRsp{cmd.QuestionEksAuditMultiRegion, "n"},
+				MsgRsp{cmd.QuestionEksAuditRegion, "us-west-1"},
+				MsgRsp{cmd.QuestionEksAuditRegionClusters, "cluster1,cluster2"},
+				MsgRsp{cmd.QuestionEksAuditConfigureAdvanced, "y"},
+				MsgMenu{cmd.EksAuditExistingCaIamRole, 1},
+				MsgRsp{cmd.QuestionEksAuditExistingCaIamArn, "arn:aws:iam::249446771485:role/2537e820-ca-role"},
+				MsgRsp{cmd.QuestionEksAuditExistingCaIamExtID, "123456789"},
+				MsgRsp{cmd.QuestionEksAuditAnotherAdvancedOpt, "n"},
+				MsgRsp{cmd.QuestionRunTfPlan, "n"},
+			})
+
+			final, _ = c.ExpectEOF()
+		},
+		"generate",
+		"k8s",
+		"eks",
+	)
+
+	assertEksAuditTerraformSaved(t, final)
+
+	regionClusterMap := make(map[string][]string)
+	regionClusterMap["us-west-1"] = []string{"cluster1", "cluster2"}
+	buildTf, _ := aws_eks_audit.NewTerraform(
+		aws_eks_audit.WithParsedRegionClusterMap(regionClusterMap),
+		aws_eks_audit.WithExistingCrossAccountIamRole(
+			&aws_eks_audit.ExistingCrossAccountIamRoleDetails{
+				Arn:        "arn:aws:iam::249446771485:role/2537e820-ca-role",
+				ExternalId: "123456789",
+			}),
+	).Generate()
+	assert.Equal(t, buildTf, tfResult)
+}
+
+func TestGenerationEksSingleRegionAdvancedFirehoseSettings(t *testing.T) {
+	os.Setenv("LW_NOCACHE", "true")
+	defer os.Setenv("LW_NOCACHE", "")
+	var final string
+
+	tfResult := runEksAuditGenerateTest(t,
+		func(c *expect.Console) {
+			expectsCliOutput(t, c, []MsgRspHandler{
+				MsgRsp{cmd.QuestionEksAuditMultiRegion, "n"},
+				MsgRsp{cmd.QuestionEksAuditRegion, "us-west-1"},
+				MsgRsp{cmd.QuestionEksAuditRegionClusters, "cluster1,cluster2"},
+				MsgRsp{cmd.QuestionEksAuditConfigureAdvanced, "y"},
+				MsgMenu{cmd.EksAuditConfigureFh, 2},
+				MsgRsp{cmd.QuestionEksAuditExistingFhIamRole, "y"},
+				MsgRsp{cmd.QuestionEksAuditExistingFhIamArn, "arn:aws:iam::249446771485:role/2537e820-fh-role"},
+				MsgRsp{cmd.QuestionEksAuditFhEncryption, "y"},
+				MsgRsp{cmd.QuestionEksAuditFhEncryptionKeyArn, ""},
+				MsgRsp{cmd.QuestionEksAuditAnotherAdvancedOpt, "n"},
+				MsgRsp{cmd.QuestionRunTfPlan, "n"},
+			})
+
+			final, _ = c.ExpectEOF()
+		},
+		"generate",
+		"k8s",
+		"eks",
+	)
+
+	assertEksAuditTerraformSaved(t, final)
+
+	regionClusterMap := make(map[string][]string)
+	regionClusterMap["us-west-1"] = []string{"cluster1", "cluster2"}
+	buildTf, _ := aws_eks_audit.NewTerraform(
+		aws_eks_audit.WithParsedRegionClusterMap(regionClusterMap),
+		aws_eks_audit.WithExistingFirehoseIamRoleArn(
+			"arn:aws:iam::249446771485:role/2537e820-fh-role",
+		),
+		aws_eks_audit.EnableFirehoseEncryption(true),
+	).Generate()
+	assert.Equal(t, buildTf, tfResult)
+}
+
+func TestGenerationEksSingleRegionAdvancedExistingCloudwatchRole(t *testing.T) {
+	os.Setenv("LW_NOCACHE", "true")
+	defer os.Setenv("LW_NOCACHE", "")
+	var final string
+
+	tfResult := runEksAuditGenerateTest(t,
+		func(c *expect.Console) {
+			expectsCliOutput(t, c, []MsgRspHandler{
+				MsgRsp{cmd.QuestionEksAuditMultiRegion, "n"},
+				MsgRsp{cmd.QuestionEksAuditRegion, "us-west-1"},
+				MsgRsp{cmd.QuestionEksAuditRegionClusters, "cluster1,cluster2"},
+				MsgRsp{cmd.QuestionEksAuditConfigureAdvanced, "y"},
+				MsgMenu{cmd.EksAuditExistingCwIamRole, 3},
+				MsgRsp{cmd.QuestionEksAuditExistingCwIamArn, "arn:aws:iam::249446771485:role/2537e820-cw-role"},
+				MsgRsp{cmd.QuestionEksAuditAnotherAdvancedOpt, "n"},
+				MsgRsp{cmd.QuestionRunTfPlan, "n"},
+			})
+
+			final, _ = c.ExpectEOF()
+		},
+		"generate",
+		"k8s",
+		"eks",
+	)
+
+	assertEksAuditTerraformSaved(t, final)
+
+	regionClusterMap := make(map[string][]string)
+	regionClusterMap["us-west-1"] = []string{"cluster1", "cluster2"}
+	buildTf, _ := aws_eks_audit.NewTerraform(
+		aws_eks_audit.WithParsedRegionClusterMap(regionClusterMap),
+		aws_eks_audit.WithExistingCloudWatchIamRoleArn(
+			"arn:aws:iam::249446771485:role/2537e820-cw-role",
+		),
+	).Generate()
+	assert.Equal(t, buildTf, tfResult)
+}
+
+func TestGenerationEksSingleRegionAdvancedSnsSettings(t *testing.T) {
+	os.Setenv("LW_NOCACHE", "true")
+	defer os.Setenv("LW_NOCACHE", "")
+	var final string
+
+	tfResult := runEksAuditGenerateTest(t,
+		func(c *expect.Console) {
+			expectsCliOutput(t, c, []MsgRspHandler{
+				MsgRsp{cmd.QuestionEksAuditMultiRegion, "n"},
+				MsgRsp{cmd.QuestionEksAuditRegion, "us-west-1"},
+				MsgRsp{cmd.QuestionEksAuditRegionClusters, "cluster1,cluster2"},
+				MsgRsp{cmd.QuestionEksAuditConfigureAdvanced, "y"},
+				MsgMenu{cmd.EksAuditConfigureSns, 4},
+				MsgRsp{cmd.QuestionEksAuditSnsEncryption, "y"},
+				MsgRsp{cmd.QuestionEksAuditSnsEncryptionKeyArn, "arn:aws:kms:us-west-2:249446771485:key/2537e820-be82-4ded-8dca-504e199b0903"},
+				MsgRsp{cmd.QuestionEksAuditAnotherAdvancedOpt, "n"},
+				MsgRsp{cmd.QuestionRunTfPlan, "n"},
+			})
+
+			final, _ = c.ExpectEOF()
+		},
+		"generate",
+		"k8s",
+		"eks",
+	)
+
+	assertEksAuditTerraformSaved(t, final)
+
+	regionClusterMap := make(map[string][]string)
+	regionClusterMap["us-west-1"] = []string{"cluster1", "cluster2"}
+	buildTf, _ := aws_eks_audit.NewTerraform(
+		aws_eks_audit.WithParsedRegionClusterMap(regionClusterMap),
+		aws_eks_audit.EnableSnsTopicEncryption(true),
+		aws_eks_audit.WithSnsTopicEncryptionKeyArn(
+			"arn:aws:kms:us-west-2:249446771485:key/2537e820-be82-4ded-8dca-504e199b0903",
+		),
+	).Generate()
+	assert.Equal(t, buildTf, tfResult)
+}
+
+func TestGenerationEksSingleRegionAdvancedCustomIntegrationName(t *testing.T) {
+	os.Setenv("LW_NOCACHE", "true")
+	defer os.Setenv("LW_NOCACHE", "")
+	var final string
+
+	tfResult := runEksAuditGenerateTest(t,
+		func(c *expect.Console) {
+			expectsCliOutput(t, c, []MsgRspHandler{
+				MsgRsp{cmd.QuestionEksAuditMultiRegion, "n"},
+				MsgRsp{cmd.QuestionEksAuditRegion, "us-west-1"},
+				MsgRsp{cmd.QuestionEksAuditRegionClusters, "cluster1,cluster2"},
+				MsgRsp{cmd.QuestionEksAuditConfigureAdvanced, "y"},
+				MsgMenu{cmd.EksAuditIntegrationNameOpt, 5},
+				MsgRsp{cmd.QuestionEksAuditCustomIntegrationName,
+					"custom eks audit integration name"},
+				MsgRsp{cmd.QuestionEksAuditAnotherAdvancedOpt, "n"},
+				MsgRsp{cmd.QuestionRunTfPlan, "n"},
+			})
+
+			final, _ = c.ExpectEOF()
+		},
+		"generate",
+		"k8s",
+		"eks",
+	)
+
+	assertEksAuditTerraformSaved(t, final)
+
+	regionClusterMap := make(map[string][]string)
+	regionClusterMap["us-west-1"] = []string{"cluster1", "cluster2"}
+	buildTf, _ := aws_eks_audit.NewTerraform(
+		aws_eks_audit.WithParsedRegionClusterMap(regionClusterMap),
+		aws_eks_audit.WithEksAuditIntegrationName("custom eks audit integration name"),
+	).Generate()
+	assert.Equal(t, buildTf, tfResult)
+}
+
+func TestGenerationEksSingleRegionAdvancedCustomOutputLocation(t *testing.T) {
+	os.Setenv("LW_NOCACHE", "true")
+	defer os.Setenv("LW_NOCACHE", "")
+	var final string
+
+	dir, err := ioutil.TempDir("", "lacework-cli")
+	if err != nil {
+		panic(err)
+	}
+	defer os.RemoveAll(dir)
+
+	runEksAuditGenerateTest(t,
+		func(c *expect.Console) {
+			expectsCliOutput(t, c, []MsgRspHandler{
+				MsgRsp{cmd.QuestionEksAuditMultiRegion, "n"},
+				MsgRsp{cmd.QuestionEksAuditRegion, "us-west-1"},
+				MsgRsp{cmd.QuestionEksAuditRegionClusters, "cluster1,cluster2"},
+				MsgRsp{cmd.QuestionEksAuditConfigureAdvanced, "y"},
+				MsgMenu{cmd.EksAuditAdvancedOptLocation, 6},
+				MsgRsp{cmd.QuestionEksAuditCustomizeOutputLocation, dir},
+				MsgRsp{cmd.QuestionEksAuditAnotherAdvancedOpt, "n"},
+				MsgRsp{cmd.QuestionRunTfPlan, "n"},
+			})
+
+			final, _ = c.ExpectEOF()
+		},
+		"generate",
+		"k8s",
+		"eks",
+	)
+
+	assertEksAuditTerraformSaved(t, final)
+
+	result, _ := ioutil.ReadFile(filepath.FromSlash(fmt.Sprintf("%s/main.tf", dir)))
+
+	regionClusterMap := make(map[string][]string)
+	regionClusterMap["us-west-1"] = []string{"cluster1", "cluster2"}
+	buildTf, _ := aws_eks_audit.NewTerraform(
+		aws_eks_audit.WithParsedRegionClusterMap(regionClusterMap),
+	).Generate()
+	assert.Equal(t, buildTf, string(result))
+}
+
+func TestGenerationEksSingleRegionExistingTerraform(t *testing.T) {
+	os.Setenv("LW_NOCACHE", "true")
+	defer os.Setenv("LW_NOCACHE", "")
+
+	dir, err := ioutil.TempDir("", "lacework-cli")
+	if err != nil {
+		panic(err)
+	}
+	defer os.RemoveAll(dir)
+
+	if err := os.WriteFile(filepath.FromSlash(fmt.Sprintf("%s/main.tf", dir)), []byte{}, 0644); err != nil {
+		panic(err)
+	}
+
+	runEksAuditGenerateTest(t,
+		func(c *expect.Console) {
+			expectsCliOutput(t, c, []MsgRspHandler{
+				MsgRsp{cmd.QuestionEksAuditMultiRegion, "n"},
+				MsgRsp{cmd.QuestionEksAuditRegion, "us-west-1"},
+				MsgRsp{cmd.QuestionEksAuditRegionClusters, "cluster1,cluster2"},
+				MsgRsp{cmd.QuestionEksAuditConfigureAdvanced, "y"},
+				MsgMenu{cmd.EksAuditAdvancedOptLocation, 6},
+				MsgRsp{cmd.QuestionEksAuditCustomizeOutputLocation, dir},
+				MsgRsp{cmd.QuestionEksAuditAnotherAdvancedOpt, "n"},
+				MsgRsp{fmt.Sprintf("%s/main.tf already exists, overwrite?", dir), "n"},
+			})
+		},
+		"generate",
+		"k8s",
+		"eks",
+	)
+
+	// Ensure CLI ran correctly
+	data, err := os.ReadFile(fmt.Sprintf("%s/main.tf", dir))
+	if err != nil {
+		panic(err)
+	}
+
+	assert.Empty(t, data)
+}
+
+func TestGenerateEksPrefix(t *testing.T) {
+	os.Setenv("LW_NOCACHE", "true")
+	defer os.Setenv("LW_NOCACHE", "")
+	var final string
+	prefix := "prefix-"
+
+	tfResult := runEksAuditGenerateTest(t,
+		func(c *expect.Console) {
+			expectsCliOutput(t, c, []MsgRspHandler{
+				MsgRsp{cmd.QuestionEksAuditMultiRegion, "n"},
+				MsgRsp{cmd.QuestionEksAuditRegion, "us-west-1"},
+				MsgRsp{cmd.QuestionEksAuditRegionClusters, "cluster1,cluster2"},
+				MsgRsp{cmd.QuestionEksAuditConfigureAdvanced, "n"},
+				MsgRsp{cmd.QuestionRunTfPlan, "n"},
+			})
+
+			final, _ = c.ExpectEOF()
+		},
+		"generate",
+		"k8s",
+		"eks",
+		"--prefix",
+		prefix,
+	)
+
+	assertGkeTerraformSaved(t, final)
+
+	regionClusterMap := make(map[string][]string)
+	regionClusterMap["us-west-1"] = []string{"cluster1", "cluster2"}
+	buildTf, _ := aws_eks_audit.NewTerraform(
+		aws_eks_audit.WithParsedRegionClusterMap(regionClusterMap),
+		aws_eks_audit.WithPrefix(prefix),
+	).Generate()
+	assert.Equal(t, buildTf, tfResult)
+}
+
+func TestGenerationEksOverwriteOutput(t *testing.T) {
+	os.Setenv("LW_NOCACHE", "true")
+	defer os.Setenv("LW_NOCACHE", "")
+	var final string
+
+	dir := createDummyTOMLConfig()
+	defer os.RemoveAll(dir)
+
+	homeCache := os.Getenv("HOME")
+	os.Setenv("HOME", dir)
+	defer os.Setenv("HOME", homeCache)
+
+	output_dir := createDummyTOMLConfig()
+	defer os.RemoveAll(output_dir)
+
+	runFakeTerminalTestFromDir(t, dir,
+		func(c *expect.Console) {
+			expectsCliOutput(t, c, []MsgRspHandler{
+				MsgRsp{cmd.QuestionEksAuditMultiRegion, "n"},
+				MsgRsp{cmd.QuestionEksAuditRegion, "us-west-1"},
+				MsgRsp{cmd.QuestionEksAuditRegionClusters, "cluster1,cluster2"},
+				MsgRsp{cmd.QuestionEksAuditConfigureAdvanced, "n"},
+				MsgRsp{cmd.QuestionRunTfPlan, "n"},
+			})
+			final, _ = c.ExpectEOF()
+		},
+		"generate",
+		"k8s",
+		"eks",
+		"--output",
+		output_dir,
+	)
+
+	assert.Contains(t, final, fmt.Sprintf("cd %s", output_dir))
+
+	runFakeTerminalTestFromDir(t, dir,
+		func(c *expect.Console) {
+			expectsCliOutput(t, c, []MsgRspHandler{
+				MsgRsp{cmd.QuestionEksAuditMultiRegion, "n"},
+				MsgRsp{cmd.QuestionEksAuditRegion, "us-west-1"},
+				MsgRsp{cmd.QuestionEksAuditRegionClusters, "cluster1,cluster2"},
+				MsgRsp{cmd.QuestionEksAuditConfigureAdvanced, "n"},
+				MsgRsp{"already exists, overwrite?", "n"},
+				MsgRsp{cmd.QuestionRunTfPlan, "n"},
+			})
+			final, _ = c.ExpectEOF()
+		},
+		"generate",
+		"k8s",
+		"eks",
+		"--output",
+		output_dir,
+	)
+
+	assert.Contains(t, final, fmt.Sprintf("cd %s", output_dir))
+}
+
+func TestGenerationEksMultiRegion(t *testing.T) {
+	os.Setenv("LW_NOCACHE", "true")
+	defer os.Setenv("LW_NOCACHE", "")
+	var final string
+
+	tfResult := runEksAuditGenerateTest(t,
+		func(c *expect.Console) {
+			expectsCliOutput(t, c, []MsgRspHandler{
+				MsgRsp{cmd.QuestionEksAuditMultiRegion, "y"},
+				MsgRsp{cmd.QuestionEksAuditRegion, "us-west-1"},
+				MsgRsp{cmd.QuestionEksAuditRegionClusters, "cluster1,cluster2"},
+				MsgRsp{cmd.QuestionEksAuditAdditionalRegion, "y"},
+				MsgRsp{cmd.QuestionEksAuditRegion, "us-east-1"},
+				MsgRsp{cmd.QuestionEksAuditRegionClusters, "cluster3"},
+				MsgRsp{cmd.QuestionEksAuditAdditionalRegion, "n"},
+				MsgRsp{cmd.QuestionEksAuditConfigureAdvanced, "n"},
+				MsgRsp{cmd.QuestionRunTfPlan, "n"},
+			})
+
+			final, _ = c.ExpectEOF()
+		},
+		"generate",
+		"k8s",
+		"eks",
+	)
+
+	assertEksAuditTerraformSaved(t, final)
+
+	regionClusterMap := make(map[string][]string)
+	regionClusterMap["us-west-1"] = []string{"cluster1", "cluster2"}
+	regionClusterMap["us-east-1"] = []string{"cluster3"}
+	buildTf, _ := aws_eks_audit.NewTerraform(aws_eks_audit.WithParsedRegionClusterMap(regionClusterMap)).Generate()
+	assert.Equal(t, buildTf, tfResult)
+}

--- a/integration/framework_test.go
+++ b/integration/framework_test.go
@@ -49,20 +49,19 @@ var expectStringTimeout = time.Second * 3
 //
 // example:
 //
-//  func TestHelpCommand(t *testing.T) {
-//    out, err, exitcode := LaceworkCLI("help")
+//	func TestHelpCommand(t *testing.T) {
+//	  out, err, exitcode := LaceworkCLI("help")
 //
-//    assert.Contains(t,
-//      out.String(),
-//      "Use \"lacework [command] --help\" for more information about a command.",
-//      "STDOUT doesn't match")
-//    assert.Empty(t,
-//      err.String(),
-//      "STDERR should be empty")
-//    assert.Equal(t, 0, exitcode,
-//      "EXITCODE is not the expected one")
-//  }
-//
+//	  assert.Contains(t,
+//	    out.String(),
+//	    "Use \"lacework [command] --help\" for more information about a command.",
+//	    "STDOUT doesn't match")
+//	  assert.Empty(t,
+//	    err.String(),
+//	    "STDERR should be empty")
+//	  assert.Equal(t, 0, exitcode,
+//	    "EXITCODE is not the expected one")
+//	}
 func LaceworkCLI(args ...string) (bytes.Buffer, bytes.Buffer, int) {
 	dir, err := ioutil.TempDir("", "lacework-cli")
 	if err != nil {
@@ -113,12 +112,12 @@ func NewLaceworkCLI(workingDir string, stdin io.Reader, args ...string) *exec.Cm
 //
 // Example:
 //
-// func TestUpdaterExample(t *testing.T) {
-//   enableTestingUpdaterEnv()
-//   defer disableTestingUpdaterEnv()
+//	func TestUpdaterExample(t *testing.T) {
+//	  enableTestingUpdaterEnv()
+//	  defer disableTestingUpdaterEnv()
 //
-//   // exacute an updater test
-// }
+//	  // exacute an updater test
+//	}
 var ciTestingUpdaterEnv = "CI_TEST_LWUPDATER"
 
 func enableTestingUpdaterEnv() {

--- a/integration/test_resources/help/generate_k8s
+++ b/integration/test_resources/help/generate_k8s
@@ -7,6 +7,7 @@ Usage:
   lacework generate k8s [command]
 
 Available Commands:
+  eks         Generate and/or execute Terraform code for EKS integration
   gke         Generate and/or execute Terraform code for GKE integration
 
 Flags:

--- a/integration/test_resources/help/generate_k8s_eks
+++ b/integration/test_resources/help/generate_k8s_eks
@@ -43,7 +43,7 @@ Flags:
       --kms_key_deletion_days int                 specify the waiting period, specified in number of days
       --output string                             location to write generated content
       --prefix string                             specify the prefix that will be used at the beginning of every generated resource
-      --region_cluster_map stringToString         configure aws regions and eks clusters; value format must be <region>:"cluster,list",<region>:"cluster,list" (default [])
+      --region_clusters stringToString            configure eks clusters per aws region; To configure multiple regions pass the flag multiple times. Example format:  --region_clusters <region>="cluster,list" (default [])
       --sns_topic_encryption_key_arn string       specify the kms key arn to be used with the sns topic
 
 Global Flags:

--- a/integration/test_resources/help/generate_k8s_eks
+++ b/integration/test_resources/help/generate_k8s_eks
@@ -40,7 +40,7 @@ Flags:
       --firehose_encryption_key_arn string        specify the kms key arn to be used with the Firehose
   -h, --help                                      help for eks
       --integration_name string                   specify the name of the eks audit integration
-      --kms_key_deletion_days int                 specify the waiting period, specified in number of days (default 30)
+      --kms_key_deletion_days int                 specify the waiting period, specified in number of days
       --output string                             location to write generated content
       --prefix string                             specify the prefix that will be used at the beginning of every generated resource
       --region_cluster_map stringToString         configure aws regions and eks clusters; value format must be <region>:"cluster,list",<region>:"cluster,list" (default [])

--- a/integration/test_resources/help/generate_k8s_eks
+++ b/integration/test_resources/help/generate_k8s_eks
@@ -1,0 +1,61 @@
+Use this command to generate Terraform code for deploying Lacework into an EKS
+environment.
+
+By default, this command interactively prompts for the required information to setup the new cloud account.
+In interactive mode, this command will:
+
+* Prompt for the required information to setup the integration
+* Generate new Terraform code using the inputs
+* Optionally, run the generated Terraform code:
+  * If Terraform is already installed, the version is verified as compatible for use
+	* If Terraform is not installed, or the version installed is not compatible, a new version will be installed into a temporary location
+	* Once Terraform is detected or installed, Terraform plan will be executed
+	* The command will prompt with the outcome of the plan and allow to view more details or continue with Terraform apply
+	* If confirmed, Terraform apply will be run, completing the setup of the cloud account
+
+This command can also be run in noninteractive mode.
+See help output for more details on the parameter value(s) required for Terraform code generation.
+
+Usage:
+  lacework generate k8s eks [flags]
+
+Flags:
+      --apply                                     run terraform apply without executing plan or prompting
+      --aws_profile string                        specify aws profile
+      --bucket_lifecycle_exp_days int             specify the s3 bucket lifecycle expiration days
+      --bucket_sse_algorithm string               specify the encryption algorithm to use for S3 bucket server-side encryption
+      --bucket_sse_key_arn string                 specify the kms key arn to be used for s3. (required when bucket_sse_algorithm is aws:kms & using an existing kms key)
+      --custom_filter_pattern string              specify a custom cloudwatch log filter pattern
+      --disable_bucket_versioning                 disable s3 bucket versioning
+      --disable_encryption_s3                     disable encryption on s3 bucket (default true)
+      --disable_firehose_encryption               disable firehose encryption (default true)
+      --disable_kms_key_rotation                  disable automatic kms key rotation
+      --disable_sns_topic_encryption              disable encryption on the sns topic (default true)
+      --enable_force_destroy                      enable force destroy s3 bucket
+      --enable_mfa_delete_s3                      enable mfa delete on s3 bucket. Requires bucket versioning.
+      --existing_ca_iam_role_arn string           specify existing cross account iam role arn to use
+      --existing_ca_iam_role_external_id string   specify existing cross account iam role external_id to use
+      --existing_cw_iam_role_arn string           specify existing cloudwatch iam role arn to use
+      --existing_firehose_iam_role_arn string     specify existing firehose iam role arn to use
+      --firehose_encryption_key_arn string        specify the kms key arn to be used with the Firehose
+  -h, --help                                      help for eks
+      --integration_name string                   specify the name of the eks audit integration
+      --kms_key_deletion_days int                 specify the waiting period, specified in number of days (default 30)
+      --output string                             location to write generated content
+      --prefix string                             specify the prefix that will be used at the beginning of every generated resource
+      --region_cluster_map stringToString         configure aws regions and eks clusters; value format must be <region>:"cluster,list",<region>:"cluster,list" (default [])
+      --sns_topic_encryption_key_arn string       specify the kms key arn to be used with the sns topic
+
+Global Flags:
+  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -k, --api_key string      access key id
+  -s, --api_secret string   secret access key
+      --api_token string    access token (replaces the use of api_key and api_secret)
+      --debug               turn on debug logging
+      --json                switch commands output from human-readable to json format
+      --nocache             turn off caching
+      --nocolor             turn off colors
+      --noninteractive      turn off interactive mode (disable spinners, prompts, etc.)
+      --organization        access organization level data sets (org admins only)
+  -p, --profile string      switch between profiles configured at ~/.lacework.toml
+      --subaccount string   sub-account name inside your organization (org admins only)

--- a/integration/test_resources/help/generate_k8s_eks
+++ b/integration/test_resources/help/generate_k8s_eks
@@ -26,13 +26,13 @@ Flags:
       --bucket_sse_algorithm string               specify the encryption algorithm to use for S3 bucket server-side encryption
       --bucket_sse_key_arn string                 specify the kms key arn to be used for s3. (required when bucket_sse_algorithm is aws:kms & using an existing kms key)
       --custom_filter_pattern string              specify a custom cloudwatch log filter pattern
-      --disable_bucket_versioning                 disable s3 bucket versioning
-      --disable_encryption_s3                     disable encryption on s3 bucket (default true)
-      --disable_firehose_encryption               disable firehose encryption (default true)
-      --disable_kms_key_rotation                  disable automatic kms key rotation
-      --disable_sns_topic_encryption              disable encryption on the sns topic (default true)
+      --enable_bucket_versioning                  enable s3 bucket versioning (default true)
+      --enable_encryption_s3                      enable encryption on s3 bucket (default true)
+      --enable_firehose_encryption                enable firehose encryption (default true)
       --enable_force_destroy                      enable force destroy s3 bucket
+      --enable_kms_key_rotation                   enable automatic kms key rotation (default true)
       --enable_mfa_delete_s3                      enable mfa delete on s3 bucket. Requires bucket versioning.
+      --enable_sns_topic_encryption               enable encryption on the sns topic (default true)
       --existing_ca_iam_role_arn string           specify existing cross account iam role arn to use
       --existing_ca_iam_role_external_id string   specify existing cross account iam role external_id to use
       --existing_cw_iam_role_arn string           specify existing cloudwatch iam role arn to use

--- a/integration/test_resources/help/generate_k8s_eks
+++ b/integration/test_resources/help/generate_k8s_eks
@@ -1,20 +1,20 @@
 Use this command to generate Terraform code for deploying Lacework into an EKS
 environment.
 
-By default, this command interactively prompts for the required information to setup the new cloud account.
+By default, this command interactively prompts for the required information to set up the new cloud account.
 In interactive mode, this command will:
 
-* Prompt for the required information to setup the integration
+* Prompt for the required information to set up the integration
 * Generate new Terraform code using the inputs
 * Optionally, run the generated Terraform code:
   * If Terraform is already installed, the version is verified as compatible for use
-	* If Terraform is not installed, or the version installed is not compatible, a new version will be installed into a temporary location
-	* Once Terraform is detected or installed, Terraform plan will be executed
-	* The command will prompt with the outcome of the plan and allow to view more details or continue with Terraform apply
-	* If confirmed, Terraform apply will be run, completing the setup of the cloud account
+  * If Terraform is not installed, or the version installed is not compatible, a new version will be installed into a temporary location
+  * Once Terraform is detected or installed, the Terraform plan is executed
+  * The command prompts you with the outcome of the plan and allows you to view more details or continue with Terraform apply
+  * If confirmed, Terraform apply runs, completing the setup of the cloud account
 
 This command can also be run in noninteractive mode.
-See help output for more details on the parameter value(s) required for Terraform code generation.
+See help output for more details on the parameter values required for Terraform code generation.
 
 Usage:
   lacework generate k8s eks [flags]
@@ -40,10 +40,10 @@ Flags:
       --firehose_encryption_key_arn string        specify the kms key arn to be used with the Firehose
   -h, --help                                      help for eks
       --integration_name string                   specify the name of the eks audit integration
-      --kms_key_deletion_days int                 specify the waiting period, specified in number of days
+      --kms_key_deletion_days int                 specify the kms waiting period before deletion, in number of days
       --output string                             location to write generated content
       --prefix string                             specify the prefix that will be used at the beginning of every generated resource
-      --region_clusters stringToString            configure eks clusters per aws region; To configure multiple regions pass the flag multiple times. Example format:  --region_clusters <region>="cluster,list" (default [])
+      --region_clusters stringToString            configure eks clusters per aws region. To configure multiple regions pass the flag multiple times. Example format:  --region_clusters <region>="cluster,list" (default [])
       --sns_topic_encryption_key_arn string       specify the kms key arn to be used with the sns topic
 
 Global Flags:

--- a/lwgenerate/aws/aws.go
+++ b/lwgenerate/aws/aws.go
@@ -39,7 +39,7 @@ func (e *ExistingIamRoleDetails) IsPartial() bool {
 	return true
 }
 
-// Create new existing IAM role details
+// NewExistingIamRoleDetails Create new existing IAM role details
 func NewExistingIamRoleDetails(name string, arn string, externalId string) *ExistingIamRoleDetails {
 	return &ExistingIamRoleDetails{
 		Arn:        arn,
@@ -181,11 +181,11 @@ type AwsTerraformModifier func(c *GenerateAwsTfConfigurationArgs)
 // Note: Additional configuration details may be set using modifiers of the AwsTerraformModifier type
 //
 // Basic usage: Initialize a new AwsTerraformModifier struct, with a non-default AWS profile set. Then use generate to
-//              create a string output of the required HCL.
 //
-//   hcl, err := aws.NewTerraform("us-east-1", true, true,
-//     aws.WithAwsProfile("mycorp-profile")).Generate()
+//	           create a string output of the required HCL.
 //
+//	hcl, err := aws.NewTerraform("us-east-1", true, true,
+//	  aws.WithAwsProfile("mycorp-profile")).Generate()
 func NewTerraform(region string, enableConfig bool, enableCloudtrail bool, mods ...AwsTerraformModifier) *GenerateAwsTfConfigurationArgs {
 	config := &GenerateAwsTfConfigurationArgs{AwsRegion: region, Cloudtrail: enableCloudtrail, Config: enableConfig}
 	for _, m := range mods {
@@ -257,7 +257,7 @@ func WithCloudtrailName(cloudtrailName string) AwsTerraformModifier {
 	}
 }
 
-// WithConfigName add optional name for Config intergration
+// WithConfigName add optional name for Config integration
 func WithConfigName(configName string) AwsTerraformModifier {
 	return func(c *GenerateAwsTfConfigurationArgs) {
 		c.ConfigName = configName
@@ -308,7 +308,7 @@ func WithSnsTopicEncryptionKeyArn(snsTopicEncryptionKeyArn string) AwsTerraformM
 	}
 }
 
-//WithSqsQueueName Set SQS Queue Name if creating new one
+// WithSqsQueueName Set SQS Queue Name if creating new one
 func WithSqsQueueName(sqsQueueName string) AwsTerraformModifier {
 	return func(c *GenerateAwsTfConfigurationArgs) {
 		c.SqsQueueName = sqsQueueName

--- a/lwgenerate/aws_eks_audit/aws_eks_audit.go
+++ b/lwgenerate/aws_eks_audit/aws_eks_audit.go
@@ -386,6 +386,8 @@ func createRequiredProviders() (*hclwrite.Block, error) {
 
 func createAwsProvider(args *GenerateAwsEksAuditTfConfigurationArgs) ([]*hclwrite.Block, error) {
 	var blocks []*hclwrite.Block
+	// if more than 1 region has been supplied we need to add an aws provider with
+	// an alias for each region
 	if len(args.ParsedRegionClusterMap) > 1 {
 		for region := range args.ParsedRegionClusterMap {
 			attrs := map[string]interface{}{
@@ -403,7 +405,12 @@ func createAwsProvider(args *GenerateAwsEksAuditTfConfigurationArgs) ([]*hclwrit
 
 			blocks = append(blocks, providerBlock)
 		}
-	} else if len(args.ParsedRegionClusterMap) == 1 {
+
+	}
+
+	// if only 1 region has been supplied we only need to create a single aws provider
+	// this provider shouldn't have an alias
+	if len(args.ParsedRegionClusterMap) == 1 {
 		for region := range args.ParsedRegionClusterMap {
 			attrs := map[string]interface{}{
 				"region": region,

--- a/lwgenerate/aws_eks_audit/aws_eks_audit.go
+++ b/lwgenerate/aws_eks_audit/aws_eks_audit.go
@@ -455,7 +455,7 @@ func createEksAudit(args *GenerateAwsEksAuditTfConfigurationArgs) ([]*hclwrite.B
 		moduleAttrs["bucket_enable_mfa_delete"] = true
 	}
 
-	if args.BucketEnableEncryption != true {
+	if !args.BucketEnableEncryption {
 		moduleAttrs["bucket_encryption_enabled"] = args.BucketEnableEncryption
 	}
 
@@ -471,7 +471,7 @@ func createEksAudit(args *GenerateAwsEksAuditTfConfigurationArgs) ([]*hclwrite.B
 		moduleAttrs["bucket_sse_algorithm"] = args.BucketSseAlgorithm
 	}
 
-	if args.BucketVersioning != true {
+	if !args.BucketVersioning {
 		moduleAttrs["bucket_versioning_enabled"] = args.BucketVersioning
 	}
 
@@ -499,7 +499,7 @@ func createEksAudit(args *GenerateAwsEksAuditTfConfigurationArgs) ([]*hclwrite.B
 		moduleAttrs["filter_pattern"] = args.FilterPattern
 	}
 
-	if args.FirehoseEncryptionEnabled != true {
+	if !args.FirehoseEncryptionEnabled {
 		moduleAttrs["kinesis_firehose_encryption_enabled"] = args.FirehoseEncryptionEnabled
 	}
 
@@ -511,15 +511,15 @@ func createEksAudit(args *GenerateAwsEksAuditTfConfigurationArgs) ([]*hclwrite.B
 		moduleAttrs["kms_key_deletion_days"] = args.KmsKeyDeletionDays
 	}
 
-	if args.KmsKeyMultiRegion != true {
+	if !args.KmsKeyMultiRegion {
 		moduleAttrs["kms_key_multi_region"] = args.KmsKeyMultiRegion
 	}
 
-	if args.KmsKeyRotation != true {
+	if !args.KmsKeyRotation {
 		moduleAttrs["kms_key_rotation"] = args.KmsKeyRotation
 	}
 
-	if args.SnsTopicEncryptionEnabled != true {
+	if !args.SnsTopicEncryptionEnabled {
 		moduleAttrs["sns_topic_encryption_enabled"] = args.SnsTopicEncryptionEnabled
 	}
 

--- a/lwgenerate/aws_eks_audit/aws_eks_audit.go
+++ b/lwgenerate/aws_eks_audit/aws_eks_audit.go
@@ -2,12 +2,13 @@ package aws_eks_audit
 
 import (
 	"fmt"
+	"sort"
+
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/lacework/go-sdk/lwgenerate"
 	"github.com/pkg/errors"
 	"github.com/zclconf/go-cty/cty"
-	"sort"
 )
 
 type ExistingCrossAccountIamRoleDetails struct {
@@ -65,6 +66,9 @@ type GenerateAwsEksAuditTfConfigurationArgs struct {
 	// The encryption algorithm to use for S3 bucket server-side encryption
 	BucketSseAlgorithm string
 
+	// Should we use an existing KMS key for the bucket?
+	ExistingBucketKmsKey bool
+
 	// The ARN of the KMS encryption key to be used for S3
 	// (Required when bucket_sse_algorithm is aws:kms and using an existing kms key)
 	BucketSseKeyArn string
@@ -92,6 +96,7 @@ type GenerateAwsEksAuditTfConfigurationArgs struct {
 
 	// Should encryption be enabled on the created firehose? Defaults to true.
 	FirehoseEncryptionEnabled bool
+
 	// The ARN of an existing KMS encryption key to be used for the Kinesis Firehose
 	FirehoseEncryptionKeyArn string
 

--- a/lwgenerate/aws_eks_audit/aws_eks_audit.go
+++ b/lwgenerate/aws_eks_audit/aws_eks_audit.go
@@ -415,6 +415,8 @@ func createAwsProvider(args *GenerateAwsEksAuditTfConfigurationArgs) ([]*hclwrit
 	// if only 1 region has been supplied we only need to create a single aws provider
 	// this provider shouldn't have an alias
 	if len(args.ParsedRegionClusterMap) == 1 {
+		// set kms key multi region to false if only 1 region is supplied
+		args.KmsKeyMultiRegion = false
 		for region := range args.ParsedRegionClusterMap {
 			attrs := map[string]interface{}{
 				"region": region,

--- a/lwgenerate/aws_eks_audit/aws_eks_audit.go
+++ b/lwgenerate/aws_eks_audit/aws_eks_audit.go
@@ -2,6 +2,7 @@ package aws_eks_audit
 
 import (
 	"fmt"
+
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/lacework/go-sdk/lwgenerate"

--- a/lwgenerate/aws_eks_audit/aws_eks_audit.go
+++ b/lwgenerate/aws_eks_audit/aws_eks_audit.go
@@ -136,7 +136,7 @@ func (args *GenerateAwsEksAuditTfConfigurationArgs) validate() error {
 
 	// Validate that at least one region with clusters was set
 	if len(args.ParsedRegionClusterMap) == 0 {
-		return errors.New("At least one region with a list of cluster(s) must be set")
+		return errors.New("At least one region with a list of clusters must be set")
 	}
 
 	// Validate, at least 1 cluster must be supplied per region

--- a/lwgenerate/aws_eks_audit/aws_eks_audit.go
+++ b/lwgenerate/aws_eks_audit/aws_eks_audit.go
@@ -1,0 +1,606 @@
+package aws_eks_audit
+
+import (
+	"fmt"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/lacework/go-sdk/lwgenerate"
+	"github.com/pkg/errors"
+	"github.com/zclconf/go-cty/cty"
+)
+
+type ExistingCrossAccountIamRoleDetails struct {
+	// Existing IAM Role ARN
+	Arn string
+
+	// Existing IAM Role External ID
+	ExternalId string
+}
+
+func (e *ExistingCrossAccountIamRoleDetails) IsPartial() bool {
+	// If nil, return false
+	if e == nil {
+		return false
+	}
+
+	// If all values are empty, return false
+	if e.Arn == "" && e.ExternalId == "" {
+		return false
+	}
+
+	// If all values are populated, return false
+	if e.Arn != "" && e.ExternalId != "" {
+		return false
+	}
+
+	return true
+}
+
+// NewExistingCrossAccountIamRoleDetails Create new existing IAM role details
+func NewExistingCrossAccountIamRoleDetails(arn string, externalId string) *ExistingCrossAccountIamRoleDetails {
+	return &ExistingCrossAccountIamRoleDetails{
+		Arn:        arn,
+		ExternalId: externalId,
+	}
+}
+
+type GenerateAwsEksAuditTfConfigurationArgs struct {
+
+	// Supply an AWS Profile name
+	AwsProfile string
+
+	// Should we require MFA for object deletion?
+	BucketEnableMfaDelete bool
+
+	// Should we enable bucket encryption?
+	BucketEnableEncryption bool
+
+	// Should we force destroy the bucket if it has stuff in it?
+	BucketForceDestroy bool
+
+	// The lifetime, in days, of the bucket objects. The value must be a non-zero positive integer
+	BucketLifecycleExpirationDays int
+
+	// The encryption algorithm to use for S3 bucket server-side encryption
+	BucketSseAlgorithm string
+
+	// The ARN of the KMS encryption key to be used for S3
+	// (Required when bucket_sse_algorithm is aws:kms and using an existing kms key)
+	BucketSseKeyArn string
+
+	// Should we enable bucket versioning?
+	BucketVersioning bool
+
+	// The name of the AWS EKS Audit Log integration in Lacework. Defaults to "TF AWS EKS Audit Log"
+	EksAuditIntegrationName string
+
+	// Optionally supply existing cloudwatch IAM role ARN
+	ExistingCloudWatchIamRoleArn string
+
+	// Optionally supply existing cross account IAM role details
+	ExistingCrossAccountIamRole *ExistingCrossAccountIamRoleDetails
+
+	// Should we allow the user to configure an existing Firehose IAM role?
+	ExistingFirehoseIam bool
+
+	// Optionally supply existing firehose role ARN if ExistingFirehoseIam is true
+	ExistingFirehoseIamRoleArn string
+
+	// The Cloudwatch Log Subscription Filter pattern
+	FilterPattern string
+
+	// Should encryption be enabled on the created firehose? Defaults to true.
+	FirehoseEncryptionEnabled bool
+
+	// The ARN of an existing KMS encryption key to be used for the Kinesis Firehose
+	FirehoseEncryptionKeyArn string
+
+	// The waiting period, specified in number of days. Defaults to 30.
+	KmsKeyDeletionDays int
+
+	// Whether the KMS key is a multi-region or regional key
+	KmsKeyMultiRegion bool
+
+	// Enable KMS automatic key rotation
+	KmsKeyRotation bool
+
+	// The prefix that will be used at the beginning of every generated resource. Defaults to "lw-eks-al"
+	Prefix string
+
+	// Parsed version of RegionClusterMap
+	RegionClusterMap map[string]string
+
+	// Parsed version of RegionClusterMap
+	ParsedRegionClusterMap map[string][]string
+
+	// Parsed list of Regions passed in by the user from RegionClusterMap
+	ParsedRegionList []string
+
+	// Should encryption be enabled for the sns topic? Defaults to true
+	SnsTopicEncryptionEnabled bool
+
+	// The ARN of an existing KMS encryption key to be used for the SNS topic
+	SnsTopicEncryptionKeyArn string
+
+	// Lacework Profile to use
+	LaceworkProfile string
+}
+
+// Ensure all combinations of inputs our valid for supported spec
+func (args *GenerateAwsEksAuditTfConfigurationArgs) validate() error {
+
+	// Validate that at least one region with clusters was set
+	if len(args.ParsedRegionClusterMap) == 0 {
+		return errors.New("At least one region with a list of cluster(s) must be set")
+	}
+
+	// Validate existing role IAM values, if set
+	if args.ExistingCrossAccountIamRole != nil {
+		if args.ExistingCrossAccountIamRole.Arn == "" ||
+			args.ExistingCrossAccountIamRole.ExternalId == "" {
+			return errors.New("when using an existing cross account IAM role, existing role ARN and external ID all must be set")
+		}
+	}
+
+	return nil
+}
+
+type AwsEksAuditTerraformModifier func(c *GenerateAwsEksAuditTfConfigurationArgs)
+
+// NewTerraform returns an instance of the GenerateAwsEksAuditTfConfigurationArgs struct.
+//
+// Note: Additional configuration details may be set using modifiers of the AwsEksAuditTerraformModifier type
+//
+// Basic usage: Initialize a new AwsEksAuditTerraformModifier struct, with a non-default AWS profile set. Then use generate to
+//
+//	           create a string output of the required HCL.
+//
+//	hcl, err := aws.NewTerraform({"us-east-1": ["cluster1", "cluster2"], "us-east-2": ["cluster3"]}
+//	  aws.WithAwsProfile("mycorp-profile")).Generate()
+func NewTerraform(mods ...AwsEksAuditTerraformModifier) *GenerateAwsEksAuditTfConfigurationArgs {
+	config := &GenerateAwsEksAuditTfConfigurationArgs{}
+	for _, m := range mods {
+		m(config)
+	}
+	return config
+}
+
+// WithAwsProfile Set the AWS Profile to utilize when integrating
+func WithAwsProfile(name string) AwsEksAuditTerraformModifier {
+	return func(c *GenerateAwsEksAuditTfConfigurationArgs) {
+		c.AwsProfile = name
+	}
+}
+
+// EnableBucketMfaDelete Set the S3 MfaDelete parameter to true for newly created buckets
+func EnableBucketMfaDelete() AwsEksAuditTerraformModifier {
+	return func(c *GenerateAwsEksAuditTfConfigurationArgs) {
+		c.BucketEnableMfaDelete = true
+	}
+}
+
+// EnableBucketEncryption Set the S3 Encryption parameter to true for newly created buckets
+func EnableBucketEncryption() AwsEksAuditTerraformModifier {
+	return func(c *GenerateAwsEksAuditTfConfigurationArgs) {
+		c.BucketEnableEncryption = true
+	}
+}
+
+// EnableBucketForceDestroy Set the S3 ForceDestroy parameter to true for newly created buckets
+func EnableBucketForceDestroy() AwsEksAuditTerraformModifier {
+	return func(c *GenerateAwsEksAuditTfConfigurationArgs) {
+		c.BucketForceDestroy = true
+	}
+}
+
+// WithBucketLifecycleExpirationDays Set the S3 Lifecycle Expiration Days parameter for newly created buckets
+func WithBucketLifecycleExpirationDays(days int) AwsEksAuditTerraformModifier {
+	return func(c *GenerateAwsEksAuditTfConfigurationArgs) {
+		c.BucketLifecycleExpirationDays = days
+	}
+}
+
+// WithBucketSseAlgorithm Set the encryption algorithm to use for S3 bucket server-side encryption
+func WithBucketSseAlgorithm(algorithm string) AwsEksAuditTerraformModifier {
+	return func(c *GenerateAwsEksAuditTfConfigurationArgs) {
+		c.BucketSseAlgorithm = algorithm
+	}
+}
+
+// WithBucketSseKeyArn Set the ARN of the KMS encryption key to be used for S3
+// (Required when bucket_sse_algorithm is aws:kms and using an existing aws_kms_key)
+func WithBucketSseKeyArn(arn string) AwsEksAuditTerraformModifier {
+	return func(c *GenerateAwsEksAuditTfConfigurationArgs) {
+		c.BucketSseKeyArn = arn
+	}
+}
+
+// EnableBucketVersioning Set the S3 Bucket versioning parameter to true for newly created buckets
+func EnableBucketVersioning() AwsEksAuditTerraformModifier {
+	return func(c *GenerateAwsEksAuditTfConfigurationArgs) {
+		c.BucketVersioning = true
+	}
+}
+
+// WithEksAuditIntegrationName Set the name of the EKS audit integration
+func WithEksAuditIntegrationName(name string) AwsEksAuditTerraformModifier {
+	return func(c *GenerateAwsEksAuditTfConfigurationArgs) {
+		c.EksAuditIntegrationName = name
+	}
+}
+
+// WithExistingCloudWatchIamRoleArn  Set an existing cloudwatch IAM role ARN
+func WithExistingCloudWatchIamRoleArn(arn string) AwsEksAuditTerraformModifier {
+	return func(c *GenerateAwsEksAuditTfConfigurationArgs) {
+		c.ExistingCloudWatchIamRoleArn = arn
+	}
+}
+
+// WithExistingCrossAccountIamRole Set an existing cross account IAM role configuration to use with
+// the created Terraform code
+func WithExistingCrossAccountIamRole(iamDetails *ExistingCrossAccountIamRoleDetails) AwsEksAuditTerraformModifier {
+	return func(c *GenerateAwsEksAuditTfConfigurationArgs) {
+		c.ExistingCrossAccountIamRole = iamDetails
+	}
+}
+
+// WithExistingFirehoseIamRoleArn  Set an existing firehose IAM role ARN
+func WithExistingFirehoseIamRoleArn(arn string) AwsEksAuditTerraformModifier {
+	return func(c *GenerateAwsEksAuditTfConfigurationArgs) {
+		c.ExistingFirehoseIamRoleArn = arn
+	}
+}
+
+// WithFilterPattern Set the filter pattern for the Cloudwatch subscription filter
+func WithFilterPattern(pattern string) AwsEksAuditTerraformModifier {
+	return func(c *GenerateAwsEksAuditTfConfigurationArgs) {
+		c.FilterPattern = pattern
+	}
+}
+
+// EnableFirehoseEncryption Set the firehose encryption parameter to true for newly created firehose
+func EnableFirehoseEncryption() AwsEksAuditTerraformModifier {
+	return func(c *GenerateAwsEksAuditTfConfigurationArgs) {
+		c.FirehoseEncryptionEnabled = true
+	}
+}
+
+// WithFirehoseEncryptionKeyArn Set the ARN of an existing KMS encryption key to be used
+// with the Kinesis Firehose
+func WithFirehoseEncryptionKeyArn(arn string) AwsEksAuditTerraformModifier {
+	return func(c *GenerateAwsEksAuditTfConfigurationArgs) {
+		c.FirehoseEncryptionKeyArn = arn
+	}
+}
+
+// WithKmsKeyDeletionDays Set the KMS deletion waiting period, specified in number of days
+func WithKmsKeyDeletionDays(days int) AwsEksAuditTerraformModifier {
+	return func(c *GenerateAwsEksAuditTfConfigurationArgs) {
+		c.KmsKeyDeletionDays = days
+	}
+}
+
+// EnableKmsKeyMultiRegion Set whether the KMS key is a multi-region or regional key
+func EnableKmsKeyMultiRegion() AwsEksAuditTerraformModifier {
+	return func(c *GenerateAwsEksAuditTfConfigurationArgs) {
+		c.KmsKeyMultiRegion = true
+	}
+}
+
+// EnableKmsKeyRotation Set KMS automatic key rotation to true
+func EnableKmsKeyRotation() AwsEksAuditTerraformModifier {
+	return func(c *GenerateAwsEksAuditTfConfigurationArgs) {
+		c.KmsKeyRotation = true
+	}
+}
+
+// WithPrefix Set the prefix that will be used at the beginning of every generated resource
+func WithPrefix(prefix string) AwsEksAuditTerraformModifier {
+	return func(c *GenerateAwsEksAuditTfConfigurationArgs) {
+		c.Prefix = prefix
+	}
+}
+
+// WithRegionClusterMap Set the region cluster map.
+// This is a list of clusters per AWS region
+func WithRegionClusterMap(regionClusterMap map[string][]string) AwsEksAuditTerraformModifier {
+	return func(c *GenerateAwsEksAuditTfConfigurationArgs) {
+		c.ParsedRegionClusterMap = regionClusterMap
+	}
+}
+
+// WithClusterRegionList Set the cluster region list.
+// This is a list of all the aws regions
+func WithClusterRegionList(regionClusterList []string) AwsEksAuditTerraformModifier {
+	return func(c *GenerateAwsEksAuditTfConfigurationArgs) {
+		c.ParsedRegionList = regionClusterList
+	}
+}
+
+// EnableSnsTopicEncryption Set whether encryption should be enabled for the sns topic
+func EnableSnsTopicEncryption() AwsEksAuditTerraformModifier {
+	return func(c *GenerateAwsEksAuditTfConfigurationArgs) {
+		c.SnsTopicEncryptionEnabled = true
+	}
+}
+
+// WithSnsTopicEncryptionKeyArn Set the ARN of an existing KMS encryption key to be used
+// with the SNS Topic
+func WithSnsTopicEncryptionKeyArn(arn string) AwsEksAuditTerraformModifier {
+	return func(c *GenerateAwsEksAuditTfConfigurationArgs) {
+		c.SnsTopicEncryptionKeyArn = arn
+	}
+}
+
+// WithLaceworkProfile Set the Lacework Profile to utilize when integrating
+func WithLaceworkProfile(name string) AwsEksAuditTerraformModifier {
+	return func(c *GenerateAwsEksAuditTfConfigurationArgs) {
+		c.LaceworkProfile = name
+	}
+}
+
+// Generate new Terraform code based on the supplied args.
+func (args *GenerateAwsEksAuditTfConfigurationArgs) Generate() (string, error) {
+	// Validate inputs
+	if err := args.validate(); err != nil {
+		return "", errors.Wrap(err, "invalid inputs")
+	}
+
+	// Create blocks
+	requiredProviders, err := createRequiredProviders()
+	if err != nil {
+		return "", errors.Wrap(err, "failed to generate required providers")
+	}
+
+	awsProvider, err := createAwsProvider(args)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to generate aws provider")
+	}
+
+	laceworkProvider, err := createLaceworkProvider(args)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to generate lacework provider")
+	}
+
+	eksAuditModule, err := createEksAudit(args)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to generate aws eks audit module & resources")
+	}
+
+	// Render
+	hclBlocks := lwgenerate.CreateHclStringOutput(
+		lwgenerate.CombineHclBlocks(
+			requiredProviders,
+			awsProvider,
+			laceworkProvider,
+			eksAuditModule),
+	)
+	return hclBlocks, nil
+}
+
+func createRequiredProviders() (*hclwrite.Block, error) {
+	return lwgenerate.CreateRequiredProviders(
+		lwgenerate.NewRequiredProvider("lacework",
+			lwgenerate.HclRequiredProviderWithSource(lwgenerate.LaceworkProviderSource),
+			lwgenerate.HclRequiredProviderWithVersion(lwgenerate.LaceworkProviderVersion)))
+}
+
+func createAwsProvider(args *GenerateAwsEksAuditTfConfigurationArgs) ([]*hclwrite.Block, error) {
+	var blocks []*hclwrite.Block
+	if len(args.ParsedRegionList) >= 1 {
+		for _, region := range args.ParsedRegionList {
+			attrs := map[string]interface{}{
+				"alias":  region,
+				"region": region,
+			}
+			providerBlock, err := lwgenerate.NewProvider(
+				"aws",
+				lwgenerate.HclProviderWithAttributes(attrs),
+			).ToBlock()
+
+			if err != nil {
+				return nil, err
+			}
+
+			blocks = append(blocks, providerBlock)
+		}
+	} else if len(args.ParsedRegionList) == 1 {
+		for _, region := range args.ParsedRegionList {
+			attrs := map[string]interface{}{
+				"region": region,
+			}
+			providerBlock, err := lwgenerate.NewProvider(
+				"aws",
+				lwgenerate.HclProviderWithAttributes(attrs),
+			).ToBlock()
+
+			if err != nil {
+				return nil, err
+			}
+
+			blocks = append(blocks, providerBlock)
+		}
+	}
+
+	return blocks, nil
+}
+
+func createLaceworkProvider(args *GenerateAwsEksAuditTfConfigurationArgs) (*hclwrite.Block, error) {
+	if args.LaceworkProfile != "" {
+		return lwgenerate.NewProvider(
+			"lacework",
+			lwgenerate.HclProviderWithAttributes(map[string]interface{}{"profile": args.LaceworkProfile}),
+		).ToBlock()
+	}
+	return nil, nil
+}
+
+func createEksAudit(args *GenerateAwsEksAuditTfConfigurationArgs) ([]*hclwrite.Block, error) {
+	var blocks []*hclwrite.Block
+	moduleAttrs := map[string]interface{}{}
+	resourceAttrs := map[string]interface{}{}
+	moduleDetails := []lwgenerate.HclModuleModifier{lwgenerate.HclModuleWithVersion(lwgenerate.AwsEksAuditVersion)}
+
+	if args.BucketEnableMfaDelete {
+		moduleAttrs["bucket_enable_mfa_delete"] = true
+	}
+
+	if args.BucketEnableEncryption {
+		moduleAttrs["bucket_encryption_enabled"] = true
+	}
+
+	if args.BucketForceDestroy {
+		moduleAttrs["bucket_force_destroy"] = true
+	}
+
+	if args.BucketLifecycleExpirationDays > 0 {
+		moduleAttrs["bucket_lifecycle_expiration_days"] = args.BucketLifecycleExpirationDays
+	}
+
+	if args.BucketSseAlgorithm != "" && args.BucketEnableEncryption {
+		moduleAttrs["bucket_sse_algorithm"] = args.BucketSseAlgorithm
+	}
+
+	if args.BucketSseKeyArn != "" && args.BucketEnableEncryption {
+		moduleAttrs["bucket_key_arn"] = args.BucketSseAlgorithm
+	}
+
+	if args.ExistingCloudWatchIamRoleArn != "" {
+		moduleAttrs["use_existing_cloudwatch_iam_role"] = true
+		moduleAttrs["cloudwatch_iam_role_arn"] = args.ExistingCloudWatchIamRoleArn
+	}
+
+	if args.ExistingCrossAccountIamRole != nil {
+		moduleAttrs["use_existing_cross_account_iam_role"] = true
+		moduleAttrs["iam_role_arn"] = args.ExistingCrossAccountIamRole.Arn
+		moduleAttrs["iam_role_external_id"] = args.ExistingCrossAccountIamRole.ExternalId
+	}
+
+	if args.ExistingFirehoseIamRoleArn != "" {
+		moduleAttrs["use_existing_firehose_iam_role"] = true
+		moduleAttrs["firehose_iam_role_arn"] = args.ExistingFirehoseIamRoleArn
+	}
+
+	if args.FilterPattern != "" {
+		moduleAttrs["filter_pattern"] = args.FilterPattern
+	}
+
+	if args.FirehoseEncryptionEnabled {
+		moduleAttrs["kinesis_firehose_encryption_enabled"] = true
+	}
+
+	if args.FirehoseEncryptionKeyArn != "" && args.FirehoseEncryptionEnabled {
+		moduleAttrs["kinesis_firehose_key_arn"] = args.FirehoseEncryptionKeyArn
+	}
+
+	if args.KmsKeyDeletionDays >= 7 && args.KmsKeyDeletionDays <= 30 {
+		moduleAttrs["kms_key_deletion_days"] = args.KmsKeyDeletionDays
+	}
+
+	if args.KmsKeyMultiRegion {
+		moduleAttrs["kms_key_multi_region"] = true
+	}
+
+	if args.KmsKeyRotation {
+		moduleAttrs["kms_key_rotation"] = true
+	}
+
+	if args.SnsTopicEncryptionEnabled {
+		moduleAttrs["sns_topic_encryption_enabled"] = true
+	}
+
+	if args.SnsTopicEncryptionKeyArn != "" && args.SnsTopicEncryptionEnabled {
+		moduleAttrs["sns_topic_key_arn"] = args.SnsTopicEncryptionKeyArn
+	}
+
+	var regionList []string
+
+	if len(args.ParsedRegionClusterMap) > 1 {
+		// set no_cw_subscription_filter if we have more than 1 region in the ParsedRegionClusterMap
+		moduleAttrs["no_cw_subscription_filter"] = true
+
+		// Add aws_cloudwatch_log_subscription_filter(s) resource per region
+		for region, clusters := range args.ParsedRegionClusterMap {
+			regionList = append(regionList, region)
+
+			// create hcl tokens for each cluster and create a token array to be added to our hcl
+			//tuple. (we are unable to add the for loop inside the call to TokensForTuple)
+			var tokens []hclwrite.Tokens
+			for _, cluster := range clusters {
+				tokens = append(tokens, hclwrite.TokensForValue(cty.StringVal(cluster)))
+			}
+
+			// the for_each input must be in the following format toset(["", ""])
+			// In order to achieve this we can use TokensForTuple to build the tuple `[]`
+			// then TokensForFunctionCall to wrap this with our call to the `toset()` function
+			resourceAttrs["for_each"] = hclwrite.TokensForFunctionCall(
+				"toset",
+				hclwrite.TokensForTuple(tokens),
+			)
+			// Using hclwrite.Tokens as $ is not supported as part of string expression.
+			// Adding a single "$" would result in "$$"
+			resourceAttrs["name"] = hclwrite.Tokens{
+				{Type: hclsyntax.TokenOQuote, Bytes: []byte(`"`)},
+				{Type: hclsyntax.TokenIdent, Bytes: []byte(`${module.aws_eks_audit_log.filter_prefix}-${each.value}`)},
+				{Type: hclsyntax.TokenCQuote, Bytes: []byte(`"`)},
+			}
+			resourceAttrs["log_group_name"] = hclwrite.Tokens{
+				{Type: hclsyntax.TokenOQuote, Bytes: []byte(`"`)},
+				{Type: hclsyntax.TokenIdent, Bytes: []byte(`/aws/eks/${each.value}/cluster`)},
+				{Type: hclsyntax.TokenCQuote, Bytes: []byte(`"`)},
+			}
+
+			resourceAttrs["role_arn"] = lwgenerate.CreateSimpleTraversal([]string{"module", "aws_eks_audit_log", "cloudwatch_iam_role_arn"})
+			resourceAttrs["filter_pattern"] = lwgenerate.CreateSimpleTraversal([]string{"module", "aws_eks_audit_log", "filter_pattern"})
+			resourceAttrs["destination_arn"] = lwgenerate.CreateSimpleTraversal([]string{"module", "aws_eks_audit_log", "firehose_arn"})
+
+			// the depends_on input must be in the following format [""]
+			// In order to achieve this we can use TokensForTuple to build the tuple `[]`
+			resourceAttrs["depends_on"] = hclwrite.TokensForTuple([]hclwrite.Tokens{
+				hclwrite.TokensForTraversal(
+					lwgenerate.CreateSimpleTraversal([]string{"module", "aws_eks_audit_log"}),
+				),
+			})
+
+			lwCwSubscriptionFilter, err := lwgenerate.NewResource(
+				fmt.Sprintf(
+					"lw_cw_subscription_filter_%s",
+					region),
+				lwgenerate.HclResourceWithAttributesAndProviderDetails(resourceAttrs, map[string]string{
+					"aws": fmt.Sprintf("aws.%s", region),
+				}),
+			).ToResourceBlock()
+
+			if err != nil {
+				return nil, err
+			}
+
+			blocks = append(blocks, lwCwSubscriptionFilter)
+		}
+	} else if len(args.ParsedRegionClusterMap) > 0 {
+		// set no_cw_subscription_filter to false if we have only 1 region in the ParsedRegionClusterMap
+		moduleAttrs["no_cw_subscription_filter"] = false
+		for _, clusters := range args.ParsedRegionClusterMap {
+			moduleAttrs["cluster_names"] = clusters
+		}
+	}
+
+	moduleAttrs["cloudwatch_regions"] = regionList
+
+	moduleDetails = append(moduleDetails,
+		lwgenerate.HclModuleWithAttributes(moduleAttrs),
+	)
+
+	modDetails, err := lwgenerate.NewModule(
+		"aws_eks_audit_log",
+		lwgenerate.AwsEksAuditSource,
+		moduleDetails...,
+	).ToBlock()
+
+	if err != nil {
+		return nil, err
+	}
+	blocks = append(blocks, modDetails)
+
+	return blocks, nil
+}

--- a/lwgenerate/aws_eks_audit/aws_eks_audit_test.go
+++ b/lwgenerate/aws_eks_audit/aws_eks_audit_test.go
@@ -1,0 +1,35 @@
+package aws_eks_audit
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Helper for combining string expected values
+//func reqProviderAndRegion(extraInputs ...string) string {
+//	base := requiredProviders + "\n" + awsProvider
+//	countInputs := len(extraInputs)
+//	for i, e := range extraInputs {
+//		if i < countInputs {
+//			base = base + "\n" + e
+//		}
+//
+//		if i >= countInputs {
+//			base = base + e
+//		}
+//	}
+//	return base
+//}
+
+func TestGenerationCloudTrail(t *testing.T) {
+	clusterMap := make(map[string][]string)
+	regionOne := []string{"cluster1", "cluster2"}
+	regionTwo := []string{"cluster3"}
+	clusterMap["us-east-1"] = regionOne
+	clusterMap["us-east-2"] = regionTwo
+	hcl, err := NewTerraform(WithRegionClusterMap(clusterMap)).Generate()
+	print(hcl)
+	assert.Nil(t, err)
+
+}

--- a/lwgenerate/aws_eks_audit/aws_eks_audit_test.go
+++ b/lwgenerate/aws_eks_audit/aws_eks_audit_test.go
@@ -326,9 +326,22 @@ func TestGenerationEksWithInvalidKmsKeyDeletionDays(t *testing.T) {
 	assert.NotContains(t, hcl, "kms_key_deletion_days")
 }
 
-func TestGenerationEksEnableKmsKeyMultiRegionTrue(t *testing.T) {
+func TestGenerationEksEnableKmsKeyMultiRegionTrueWithSingleRegion(t *testing.T) {
 	clusterMap := make(map[string][]string)
 	clusterMap["us-east-1"] = []string{"cluster1", "cluster2"}
+	hcl, err := NewTerraform(WithParsedRegionClusterMap(clusterMap),
+		EnableKmsKeyMultiRegion(true),
+	).Generate()
+	assert.Nil(t, err)
+	assert.NotNil(t, hcl)
+	strippedHcl := strings.ReplaceAll(hcl, " ", "")
+	assert.Contains(t, strippedHcl, "kms_key_multi_region=false")
+}
+
+func TestGenerationEksEnableKmsKeyMultiRegionTrueWithMultiRegion(t *testing.T) {
+	clusterMap := make(map[string][]string)
+	clusterMap["us-east-1"] = []string{"cluster1", "cluster2"}
+	clusterMap["us-east-2"] = []string{"cluster3"}
 	hcl, err := NewTerraform(WithParsedRegionClusterMap(clusterMap),
 		EnableKmsKeyMultiRegion(true),
 	).Generate()
@@ -391,6 +404,7 @@ module "aws_eks_audit_log" {
   version                   = "~> 0.4"
   cloudwatch_regions        = ["us-east-1"]
   cluster_names             = ["cluster1", "cluster2"]
+  kms_key_multi_region      = false
   no_cw_subscription_filter = false
 }
 `

--- a/lwgenerate/aws_eks_audit/aws_eks_audit_test.go
+++ b/lwgenerate/aws_eks_audit/aws_eks_audit_test.go
@@ -46,7 +46,7 @@ func TestGenerationEksFailureWithNoOptionsSet(t *testing.T) {
 	data := &GenerateAwsEksAuditTfConfigurationArgs{}
 	_, err := data.Generate()
 	assert.Error(t, err)
-	assert.Equal(t, "invalid inputs: At least one region with a list of cluster(s) must be set", err.Error())
+	assert.Equal(t, "invalid inputs: At least one region with a list of clusters must be set", err.Error())
 }
 
 func TestGenerationEksFailureSingleRegionNoClusters(t *testing.T) {

--- a/lwgenerate/aws_eks_audit/aws_eks_audit_test.go
+++ b/lwgenerate/aws_eks_audit/aws_eks_audit_test.go
@@ -96,7 +96,7 @@ func TestGenerationEksBucketWithNoBucketVersioning(t *testing.T) {
 	clusterMap := make(map[string][]string)
 	clusterMap["us-east-1"] = []string{"cluster1", "cluster2"}
 	hcl, err := NewTerraform(WithParsedRegionClusterMap(clusterMap),
-		DisableBucketVersioning(),
+		EnableBucketVersioning(false),
 	).Generate()
 	assert.Nil(t, err)
 	assert.NotNil(t, hcl)
@@ -108,7 +108,7 @@ func TestGenerationEksBucketWithNoBucketVersioningMfaDeleteEnabled(t *testing.T)
 	clusterMap := make(map[string][]string)
 	clusterMap["us-east-1"] = []string{"cluster1", "cluster2"}
 	hcl, err := NewTerraform(WithParsedRegionClusterMap(clusterMap),
-		DisableBucketVersioning(),
+		EnableBucketVersioning(false),
 		EnableBucketMfaDelete(),
 	).Generate()
 	assert.Nil(t, err)
@@ -122,7 +122,7 @@ func TestGenerationEksBucketWithNoEncryption(t *testing.T) {
 	clusterMap := make(map[string][]string)
 	clusterMap["us-east-1"] = []string{"cluster1", "cluster2"}
 	hcl, err := NewTerraform(WithParsedRegionClusterMap(clusterMap),
-		DisableBucketEncryption(),
+		EnableBucketEncryption(false),
 	).Generate()
 	assert.Nil(t, err)
 	assert.NotNil(t, hcl)
@@ -134,7 +134,7 @@ func TestGenerationEksBucketWithNoEncryptionAndKeyArn(t *testing.T) {
 	clusterMap := make(map[string][]string)
 	clusterMap["us-east-1"] = []string{"cluster1", "cluster2"}
 	hcl, err := NewTerraform(WithParsedRegionClusterMap(clusterMap),
-		DisableBucketEncryption(),
+		EnableBucketEncryption(false),
 		WithBucketSseKeyArn("arn:aws:kms:us-west-2:249446771485:key/2537e820-be82-4ded-8dca-504e199b0903"),
 	).Generate()
 	assert.Nil(t, err)
@@ -163,7 +163,7 @@ func TestGenerationEksFirehoseWithNoEncryption(t *testing.T) {
 	clusterMap := make(map[string][]string)
 	clusterMap["us-east-1"] = []string{"cluster1", "cluster2"}
 	hcl, err := NewTerraform(WithParsedRegionClusterMap(clusterMap),
-		DisableFirehoseEncryption(),
+		EnableFirehoseEncryption(false),
 	).Generate()
 	assert.Nil(t, err)
 	assert.NotNil(t, hcl)
@@ -175,7 +175,7 @@ func TestGenerationEksFirehoseWithNoEncryptionAndKeyArn(t *testing.T) {
 	clusterMap := make(map[string][]string)
 	clusterMap["us-east-1"] = []string{"cluster1", "cluster2"}
 	hcl, err := NewTerraform(WithParsedRegionClusterMap(clusterMap),
-		DisableFirehoseEncryption(),
+		EnableFirehoseEncryption(false),
 		WithFirehoseEncryptionKeyArn("arn:aws:kms:us-west-2:249446771485:key/2537e820-be82-4ded-8dca-504e199b0903"),
 	).Generate()
 	assert.Nil(t, err)
@@ -202,7 +202,7 @@ func TestGenerationEksSnsWithNoEncryption(t *testing.T) {
 	clusterMap := make(map[string][]string)
 	clusterMap["us-east-1"] = []string{"cluster1", "cluster2"}
 	hcl, err := NewTerraform(WithParsedRegionClusterMap(clusterMap),
-		DisableSnsTopicEncryption(),
+		EnableSnsTopicEncryption(false),
 	).Generate()
 	assert.Nil(t, err)
 	assert.NotNil(t, hcl)
@@ -214,7 +214,7 @@ func TestGenerationEksSnsWithNoEncryptionAndKeyArn(t *testing.T) {
 	clusterMap := make(map[string][]string)
 	clusterMap["us-east-1"] = []string{"cluster1", "cluster2"}
 	hcl, err := NewTerraform(WithParsedRegionClusterMap(clusterMap),
-		DisableSnsTopicEncryption(),
+		EnableSnsTopicEncryption(false),
 		WithSnsTopicEncryptionKeyArn("arn:aws:kms:us-west-2:249446771485:key/2537e820-be82-4ded-8dca-504e199b0903"),
 	).Generate()
 	assert.Nil(t, err)
@@ -326,28 +326,50 @@ func TestGenerationEksWithInvalidKmsKeyDeletionDays(t *testing.T) {
 	assert.NotContains(t, hcl, "kms_key_deletion_days")
 }
 
-func TestGenerationEksEnableKmsKeyMultiRegion(t *testing.T) {
+func TestGenerationEksEnableKmsKeyMultiRegionTrue(t *testing.T) {
 	clusterMap := make(map[string][]string)
 	clusterMap["us-east-1"] = []string{"cluster1", "cluster2"}
 	hcl, err := NewTerraform(WithParsedRegionClusterMap(clusterMap),
-		EnableKmsKeyMultiRegion(),
+		EnableKmsKeyMultiRegion(true),
 	).Generate()
 	assert.Nil(t, err)
 	assert.NotNil(t, hcl)
-	strippedHcl := strings.ReplaceAll(hcl, " ", "")
-	assert.Contains(t, strippedHcl, "kms_key_multi_region=true")
+	assert.NotContains(t, hcl, "kms_key_multi_region")
 }
 
-func TestGenerationEksEnableKmsKeyRotation(t *testing.T) {
+func TestGenerationEksEnableKmsKeyMultiRegionFalse(t *testing.T) {
 	clusterMap := make(map[string][]string)
 	clusterMap["us-east-1"] = []string{"cluster1", "cluster2"}
 	hcl, err := NewTerraform(WithParsedRegionClusterMap(clusterMap),
-		EnableKmsKeyRotation(),
+		EnableKmsKeyMultiRegion(false),
 	).Generate()
 	assert.Nil(t, err)
 	assert.NotNil(t, hcl)
 	strippedHcl := strings.ReplaceAll(hcl, " ", "")
-	assert.Contains(t, strippedHcl, "kms_key_rotation=true")
+	assert.Contains(t, strippedHcl, "kms_key_multi_region=false")
+}
+
+func TestGenerationEksEnableKmsKeyRotationTrue(t *testing.T) {
+	clusterMap := make(map[string][]string)
+	clusterMap["us-east-1"] = []string{"cluster1", "cluster2"}
+	hcl, err := NewTerraform(WithParsedRegionClusterMap(clusterMap),
+		EnableKmsKeyRotation(true),
+	).Generate()
+	assert.Nil(t, err)
+	assert.NotNil(t, hcl)
+	assert.NotContains(t, hcl, "kms_key_rotation")
+}
+
+func TestGenerationEksEnableKmsKeyRotationFalse(t *testing.T) {
+	clusterMap := make(map[string][]string)
+	clusterMap["us-east-1"] = []string{"cluster1", "cluster2"}
+	hcl, err := NewTerraform(WithParsedRegionClusterMap(clusterMap),
+		EnableKmsKeyRotation(false),
+	).Generate()
+	assert.Nil(t, err)
+	assert.NotNil(t, hcl)
+	strippedHcl := strings.ReplaceAll(hcl, " ", "")
+	assert.Contains(t, strippedHcl, "kms_key_rotation=false")
 }
 
 var requiredProviders = `terraform {

--- a/lwgenerate/aws_eks_audit/aws_eks_audit_test.go
+++ b/lwgenerate/aws_eks_audit/aws_eks_audit_test.go
@@ -57,6 +57,41 @@ func TestGenerationEksFailureSingleRegionNoClusters(t *testing.T) {
 	assert.Equal(t, "invalid inputs: At least one cluster must be supplied per region", err.Error())
 }
 
+func TestGenerationEksEnableBucketForceDestroy(t *testing.T) {
+	clusterMap := make(map[string][]string)
+	clusterMap["us-east-1"] = []string{"cluster1", "cluster2"}
+	hcl, err := NewTerraform(WithParsedRegionClusterMap(clusterMap),
+		EnableBucketForceDestroy(),
+	).Generate()
+	assert.Nil(t, err)
+	assert.NotNil(t, hcl)
+	strippedHcl := strings.ReplaceAll(hcl, " ", "")
+	assert.Contains(t, strippedHcl, "bucket_force_destroy=true")
+}
+
+func TestGenerationEksWithValidBucketLifecycleExpirationDays(t *testing.T) {
+	clusterMap := make(map[string][]string)
+	clusterMap["us-east-1"] = []string{"cluster1", "cluster2"}
+	hcl, err := NewTerraform(WithParsedRegionClusterMap(clusterMap),
+		WithBucketLifecycleExpirationDays(10),
+	).Generate()
+	assert.Nil(t, err)
+	assert.NotNil(t, hcl)
+	strippedHcl := strings.ReplaceAll(hcl, " ", "")
+	assert.Contains(t, strippedHcl, "bucket_lifecycle_expiration_days=10")
+}
+
+func TestGenerationEksWithInvalidBucketLifecycleExpirationDays(t *testing.T) {
+	clusterMap := make(map[string][]string)
+	clusterMap["us-east-1"] = []string{"cluster1", "cluster2"}
+	hcl, err := NewTerraform(WithParsedRegionClusterMap(clusterMap),
+		WithBucketLifecycleExpirationDays(-1),
+	).Generate()
+	assert.Nil(t, err)
+	assert.NotNil(t, hcl)
+	assert.NotContains(t, hcl, "bucket_lifecycle_expiration_days")
+}
+
 func TestGenerationEksBucketWithNoBucketVersioning(t *testing.T) {
 	clusterMap := make(map[string][]string)
 	clusterMap["us-east-1"] = []string{"cluster1", "cluster2"}
@@ -268,6 +303,53 @@ func TestGenerationPartialExistingCrossAccountIamValues(t *testing.T) {
 	})
 }
 
+func TestGenerationEksWithValidKmsKeyDeletionDays(t *testing.T) {
+	clusterMap := make(map[string][]string)
+	clusterMap["us-east-1"] = []string{"cluster1", "cluster2"}
+	hcl, err := NewTerraform(WithParsedRegionClusterMap(clusterMap),
+		WithKmsKeyDeletionDays(10),
+	).Generate()
+	assert.Nil(t, err)
+	assert.NotNil(t, hcl)
+	strippedHcl := strings.ReplaceAll(hcl, " ", "")
+	assert.Contains(t, strippedHcl, "kms_key_deletion_days=10")
+}
+
+func TestGenerationEksWithInvalidKmsKeyDeletionDays(t *testing.T) {
+	clusterMap := make(map[string][]string)
+	clusterMap["us-east-1"] = []string{"cluster1", "cluster2"}
+	hcl, err := NewTerraform(WithParsedRegionClusterMap(clusterMap),
+		WithKmsKeyDeletionDays(6),
+	).Generate()
+	assert.Nil(t, err)
+	assert.NotNil(t, hcl)
+	assert.NotContains(t, hcl, "kms_key_deletion_days")
+}
+
+func TestGenerationEksEnableKmsKeyMultiRegion(t *testing.T) {
+	clusterMap := make(map[string][]string)
+	clusterMap["us-east-1"] = []string{"cluster1", "cluster2"}
+	hcl, err := NewTerraform(WithParsedRegionClusterMap(clusterMap),
+		EnableKmsKeyMultiRegion(),
+	).Generate()
+	assert.Nil(t, err)
+	assert.NotNil(t, hcl)
+	strippedHcl := strings.ReplaceAll(hcl, " ", "")
+	assert.Contains(t, strippedHcl, "kms_key_multi_region=true")
+}
+
+func TestGenerationEksEnableKmsKeyRotation(t *testing.T) {
+	clusterMap := make(map[string][]string)
+	clusterMap["us-east-1"] = []string{"cluster1", "cluster2"}
+	hcl, err := NewTerraform(WithParsedRegionClusterMap(clusterMap),
+		EnableKmsKeyRotation(),
+	).Generate()
+	assert.Nil(t, err)
+	assert.NotNil(t, hcl)
+	strippedHcl := strings.ReplaceAll(hcl, " ", "")
+	assert.Contains(t, strippedHcl, "kms_key_rotation=true")
+}
+
 var requiredProviders = `terraform {
   required_providers {
     lacework = {
@@ -275,16 +357,6 @@ var requiredProviders = `terraform {
       version = "~> 0.26"
     }
   }
-}
-`
-
-var awsProvider = `provider "aws" {
-  region = "us-east-1"
-}
-`
-
-var laceworkProvider = `provider "lacework" {
-  profile = "test-profile"
 }
 `
 

--- a/lwgenerate/constants.go
+++ b/lwgenerate/constants.go
@@ -8,6 +8,8 @@ const (
 	AwsConfigVersion     = "~> 0.5"
 	AwsCloudTrailSource  = "lacework/cloudtrail/aws"
 	AwsCloudTrailVersion = "~> 2.0"
+	AwsEksAuditSource    = "lacework/eks-audit-log/aws"
+	AwsEksAuditVersion   = "~> 0.4"
 
 	LWAzureConfigSource       = "lacework/config/azure"
 	LWAzureConfigVersion      = "~> 1.0"

--- a/lwgenerate/hcl.go
+++ b/lwgenerate/hcl.go
@@ -359,7 +359,7 @@ func HclCreateGenericBlock(hcltype string, labels []string, attr map[string]inte
 
 // Create tokens for map of traversals.  Used as a workaround for writing complex types where the built-in
 // SetAttributeValue won't work
-func createMapTraversalTokens(input map[string]string) hclwrite.Tokens { //nolint:unused
+func createMapTraversalTokens(input map[string]string) hclwrite.Tokens {
 	// Sort input
 	var keys []string
 	for k := range input {

--- a/lwgenerate/hcl.go
+++ b/lwgenerate/hcl.go
@@ -156,6 +156,11 @@ func (m *HclModule) ToBlock() (*hclwrite.Block, error) {
 		return nil, err
 	}
 
+	if m.providerDetails != nil {
+		block.Body().AppendNewline()
+		block.Body().SetAttributeRaw("providers", createMapTraversalTokens(m.providerDetails))
+	}
+
 	return block, nil
 }
 

--- a/lwgenerate/hcl.go
+++ b/lwgenerate/hcl.go
@@ -302,7 +302,7 @@ func setBlockAttributeValue(block *hclwrite.Block, key string, val interface{}) 
 	case hclwrite.Tokens:
 		block.Body().SetAttributeRaw(key, v)
 	default:
-		return errors.New(fmt.Sprintf("setBlockAttributeValue: unknown type for key: %s", key))
+		return fmt.Errorf("setBlockAttributeValue: unknown type for key: %s", key)
 	}
 
 	return nil
@@ -354,7 +354,7 @@ func HclCreateGenericBlock(hcltype string, labels []string, attr map[string]inte
 
 // Create tokens for map of traversals.  Used as a workaround for writing complex types where the built-in
 // SetAttributeValue won't work
-func createMapTraversalTokens(input map[string]string) hclwrite.Tokens {
+func createMapTraversalTokens(input map[string]string) hclwrite.Tokens { //nolint:unused
 	// Sort input
 	var keys []string
 	for k := range input {


### PR DESCRIPTION
Signed-off-by: Ross <ross.moles@lacework.net>


## Summary

Lacework CLI extension to include menus and generation of TF for EKS Audit Log


## How did you test this change?

Manually ✅ 
Unit tests ✅ 
Integration tests ✅

## Issue

https://lacework.atlassian.net/browse/RAIN-30917