### PR TITLE
fix: compliance evaluation search cmd, searches greater than last 7 days

### DIFF
--- a/api/inventory.go
+++ b/api/inventory.go
@@ -56,3 +56,30 @@ type InventorySearch struct {
 	Csp     inventoryType    `json:"csp"`
 	Dataset inventoryDataset `json:"dataset"`
 }
+
+// WindowedSearch performs a new search of a specific time frame size,
+// until response data is found or the max searchable days is reached
+func (svc *InventoryService) WindowedSearch(response *InventoryAwsResponse, filter InventorySearch, size int, max int) error {
+	for i := 0; i < max; i += size {
+		err := svc.Search(&response, filter)
+		if err != nil {
+			return err
+		}
+		if len(response.Data) != 0 {
+			return nil
+		}
+
+		//adjust window
+		newStart := filter.StartTime.AddDate(0, 0, -size)
+		newEnd := filter.EndTime.AddDate(0, 0, -size)
+
+		// ensure we do not go over the max allowed searchable days
+		rem := (i - max) % size
+		if rem > 0 {
+			newEnd = filter.EndTime.AddDate(0, 0, -rem)
+		}
+		filter.TimeFilter.StartTime = &newStart
+		filter.TimeFilter.EndTime = &newEnd
+	}
+	return nil
+}

--- a/cli/cmd/compliance_aws.go
+++ b/cli/cmd/compliance_aws.go
@@ -448,7 +448,7 @@ The output from status with the --json flag can be used in the body of PATCH api
 					Csp:     api.AwsInventoryType,
 				}
 			)
-			err := cli.LwApi.V2.Inventory.Search(&awsInventorySearchResponse, filter)
+			err := cli.LwApi.V2.Inventory.WindowedSearch(&awsInventorySearchResponse, filter, 7, 92)
 			cli.StopProgress()
 
 			if len(awsInventorySearchResponse.Data) == 0 {
@@ -479,7 +479,7 @@ The output from status with the --json flag can be used in the body of PATCH api
 					Dataset: api.AwsComplianceEvaluationDataset,
 				}
 			)
-			err = cli.LwApi.V2.ComplianceEvaluations.Search(&awsComplianceEvaluationSearchResponse, complianceFilter)
+			err = cli.LwApi.V2.ComplianceEvaluations.WindowedSearch(&awsComplianceEvaluationSearchResponse, complianceFilter, 7, 92)
 			cli.StopProgress()
 			if err != nil {
 				return err


### PR DESCRIPTION
## Summary

The compliance evaluation search cmd was only searching the last 7 days. The max amount of days allowed for this search is 92, with a window of 7 days. 

This change adds a new windowedSearch func to perform a new search of a specific time frame size until response data is found or the max searchable days is reached

## How did you test this change?

Run `lacework aws comp search <resource_arn>` with  the resource arn from JIRA acceptance criteria

## Issue

https://lacework.atlassian.net/browse/ALLY-1196
