### PR TITLE
Crioux/fix limit num scan

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@ circleci-artifacts/
 
 # for building binary files
 bin/
+# cli binary if built there
+cli/cli
 
 # vscode debug.test
 **/debug.test

--- a/api/container_registries_inline_scanner.go
+++ b/api/container_registries_inline_scanner.go
@@ -60,9 +60,7 @@ func (reg InlineScannerIntegration) ContainerRegistryType() containerRegistryTyp
 type InlineScannerData struct {
 	RegistryType  string              `json:"registryType"` // always "INLINE_SCANNER"
 	IdentifierTag []map[string]string `json:"identifierTag"`
-	// @afiune reported bug
-	// > https://lacework.atlassian.net/browse/RAIN-33574
-	LimitNumScan int `json:"limitNumScan,omitempty"`
+	LimitNumScan  string              `json:"limitNumScan,omitempty"`
 }
 
 func verifyInlineScannerContainerRegistry(data interface{}) interface{} {

--- a/cli/cmd/integration.go
+++ b/cli/cmd/integration.go
@@ -802,7 +802,7 @@ func reflectIntegrationData(raw api.RawIntegration) [][]string {
 			out = [][]string{
 				{"SERVER TOKEN", inlineScanner.Data.ServerToken.Token},
 				{"IDENTIFIER TAGS", castMapStringSliceToString(inlineScanner.Data.Data.IdentifierTag)},
-				{"LIMIT NUM SCANS", fmt.Sprintf("%d", inlineScanner.Data.Data.LimitNumScan)},
+				{"LIMIT NUM SCANS", inlineScanner.Data.Data.LimitNumScan},
 			}
 		case api.DockerHubRegistry.String():
 			out = append(out, []string{"USERNAME", iData.Credentials.Username})

--- a/cli/cmd/integration_inline_scanner.go
+++ b/cli/cmd/integration_inline_scanner.go
@@ -67,7 +67,7 @@ func createInlineScannerIntegration() error {
 		cli.Log.Warnw("unable to convert limit_num_scan, using default",
 			"error", err,
 			"input", answers.LimitNumScan,
-			"default", "5",
+			"default", "60",
 		)
 		limitNumScan = 60
 	}
@@ -76,7 +76,7 @@ func createInlineScannerIntegration() error {
 		api.InlineScannerContainerRegistry,
 		api.InlineScannerData{
 			IdentifierTag: castStringToLimitByLabel(answers.IdentifierTag),
-			LimitNumScan:  limitNumScan,
+			LimitNumScan:  strconv.Itoa(limitNumScan),
 		},
 	)
 


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/lacework/go-sdk) and create your branch from `main`
  2. Run `make prepare` in the repository root
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`make test`)
  5. Format your code (`make fmt`)
  6. Make sure your code lints (`make lint`)
  7. If you are updating the Lacework CLI, make sure it compiles (`make build-cli-cross-platform`)
  8. Follow the commit message standard (`type(scope): subject`) documented in [DEVELOPER_GUIDELINES.md](https://github.com/lacework/go-sdk/blob/main/DEVELOPER_GUIDELINES.md#commit-message-standard)
  9. If you haven't already, configure signed commits by [telling git about your signing key](https://docs.github.com/en/github/authenticating-to-github/managing-commit-signature-verification/telling-git-about-your-signing-key) and [signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)

  Learn more about contributing: https://github.com/lacework/go-sdk/blob/main/CONTRIBUTING.md
-->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

Was experiencing an inability to create inline container registries from the cli. The schema required LimitNumScan to be a string, and it was a number. 

`lacework container-registry create` was unable to create an 'inline scanner' container registry.

It was effectively doing this: 

```
lacework api post /api/v2/ContainerRegistries -d "{\"name\":\"foo\",\"type\":\"ContVulnCfg\",\"enabled\":1,\"data\":{\"registryType\":\"INLINE_SCANNER\",\"limitNumScan\":30}}"

ERROR unable to send the request:
  [POST] https://customerdemo.lacework.net/api/v2/ContainerRegistries
  [400] Error validating integration. Please verify the configuration details entered.
```

Where the 'limitNumScan' should have been the string "30" not the number 30.

## How did you test this change?

Verified the change allowed `lacework container-registry create` to operate correctly.

<!--
  How exactly did you verify that your PR solves the issue you wanted to solve?
  Include any other relevant information such as how to use the new functionality, screenshots, etc.
-->

![image](https://user-images.githubusercontent.com/819652/197275136-cf9e076f-4dcd-4f97-ad28-fd3dc4b91d42.png)

## Issue

<!--
  Include the link to a Jira/Github issue
-->
https://lacework.atlassian.net/browse/RAIN-38906
also should be able to close
https://lacework.atlassian.net/browse/RAIN-33574
now as well, as it is derived from the same underlying issue
