### PR TITLE
fix(cdk): parse global flags when running components

### DIFF
--- a/cli/cmd/component.go
+++ b/cli/cmd/component.go
@@ -22,12 +22,14 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/fatih/color"
 	"github.com/olekukonko/tablewriter"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 
 	"github.com/lacework/go-sdk/lwcomponent"
 )
@@ -158,16 +160,40 @@ func (c *cliState) LoadComponents() {
 					Short:                 component.Description,
 					Annotations:           map[string]string{"type": "component"},
 					Version:               ver.String(),
+					SilenceUsage:          true,
 					DisableFlagParsing:    true,
 					DisableFlagsInUseLine: true,
 					RunE: func(cmd *cobra.Command, args []string) error {
-						cli.Log.Debugw("running component", "component", cmd.Use, "args", args)
+						globalFlags := []*pflag.Flag{}
+						cmd.Flags().VisitAll(func(f *pflag.Flag) {
+							// At runtime, we visit all global flags defined at the root command
+							// and we essentially make a slice of the flag names with their shorthand
+							// so that we can remove them all from the raw arguments (`args`)
+							globalFlags = append(globalFlags, f)
+						})
+
+						// Use the list of global CLI flags to filter the provided arguments and return
+						// the filteres arguments to pass to the underlying component and the real list
+						// of CLI flags. The later is used to parse and then run the global CLI init func
+						filteredArgs, filteredCLIFlags := filterCLIFlagsFromComponentArgs(args, globalFlags)
+
+						// Parse all global CLI flags provided (filtered) by the user, then run the global
+						// CLI init function to initialize our logger, api client, and other global config
+						err := cmd.Flags().Parse(filteredCLIFlags)
+						initConfig() // @afiune NOTE we purposely run this func first and then check the err
+						if err != nil {
+							cli.Log.Debugw("unable to parse global flags",
+								"provided_flags", filteredCLIFlags, "error", err)
+						}
+
+						cli.Log.Debugw("running component", "component", cmd.Use,
+							"args", filteredArgs, "cli_flags", filteredCLIFlags)
 						f, ok := cli.LwComponents.GetComponent(cmd.Use)
 						if ok {
 							// @afiune what if the component needs other env variables
 							envs := []string{fmt.Sprintf("LW_COMPONENT_NAME=%s", cmd.Use)}
 							envs = append(envs, c.envs()...)
-							return f.RunAndOutput(args, envs...)
+							return f.RunAndOutput(filteredArgs, envs...)
 						}
 
 						// We will land here only if we couldn't run the component, which is not
@@ -180,6 +206,69 @@ func (c *cliState) LoadComponents() {
 		}
 	}
 }
+
+// filterCLIFlagsFromComponentArgs uses the arguments provided by the user and
+// the list of global CLI flags to return the real list of component arguments
+// and the real list of CLI flags provided as arguments
+func filterCLIFlagsFromComponentArgs(args []string, globalFlags []*pflag.Flag) (
+	componentArgs []string, cliFlags []string,
+) {
+
+	// this variable is used to store a flag of type `string` so that we can check
+	// the next argument and pass it as the value of the flag
+	stringFlag := ""
+
+	for _, arg := range args {
+
+		// if the stringFlag variable is not empty it means that the current argument
+		// is the value of the provided string flag, add it, empty it and move on
+		if stringFlag != "" {
+			cliFlags = append(cliFlags, stringFlag, arg) // add the flag and value
+			stringFlag = ""                              // empty the flag
+			continue                                     // move to the next argument
+		}
+
+		// assume the argument is an argument unless it is a flag
+		isArg := true
+
+		// flags must have a prefix of `--` or `-`, if the argument has that prefix it
+		// means that it could be a flag, strip it and compare it with all global flags
+		argFlag := strings.TrimPrefix(strings.TrimPrefix(arg, "--"), "-")
+
+		for _, flag := range globalFlags {
+			if flag == nil { // avoid panics trying to access pointer
+				continue
+			}
+
+			if flag.Name == argFlag || flag.Shorthand == argFlag {
+				// the argument is indeed a flag
+
+				if flag.Value == nil { // avoid panics trying to access interface
+					continue
+				}
+
+				switch flag.Value.Type() { // check the type
+				case "bool":
+					isArg = false
+					cliFlags = append(cliFlags, arg)
+					break
+				case "string":
+					isArg = false
+					stringFlag = arg
+					break
+				}
+			}
+		}
+
+		if isArg {
+			// the argument is actually an argument
+			componentArgs = append(componentArgs, arg)
+		}
+	}
+
+	return
+}
+
 func runComponentsList(_ *cobra.Command, _ []string) (err error) {
 	cli.StartProgress("Loading components state...")
 	cli.LwComponents, err = lwcomponent.LoadState(cli.LwApi)

--- a/cli/cmd/component_test.go
+++ b/cli/cmd/component_test.go
@@ -1,0 +1,123 @@
+//
+// Author:: Salim Afiune Maya (<afiune@lacework.net>)
+// Copyright:: Copyright 2022, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+)
+
+// NOTE these flags will be automatically generated at runtime by cobra
+var mockedGlobalFlags = []*pflag.Flag{
+	&pflag.Flag{Name: "profile", Shorthand: "p", Value: &mockStringFlagValue{}},
+	&pflag.Flag{Name: "debug", Shorthand: "", Value: &mockBoolFlagValue{}},
+	&pflag.Flag{Name: "nocolor", Shorthand: "", Value: &mockBoolFlagValue{}},
+	&pflag.Flag{Name: "nocache", Shorthand: "", Value: &mockBoolFlagValue{}},
+	&pflag.Flag{Name: "noninteractive", Shorthand: "", Value: &mockBoolFlagValue{}},
+}
+
+func TestComponentFilterCLIFlagsFromComponentArgs(t *testing.T) {
+	cases := []struct {
+		Text string
+
+		Args        []string
+		GlobalFlags []*pflag.Flag
+
+		expectedArgs  []string
+		expectedFlags []string
+	}{
+		{"empty args and flags",
+			[]string(nil), []*pflag.Flag(nil),
+			[]string(nil), []string(nil)},
+
+		{"only args without flags returns all args",
+			[]string{"iac", "terraform-scan", "--verbose"}, []*pflag.Flag(nil),
+			[]string{"iac", "terraform-scan", "--verbose"}, []string(nil)},
+
+		{"only args with global flags returns args",
+			[]string{"iac", "terraform-scan", "--verbose"}, mockedGlobalFlags,
+			[]string{"iac", "terraform-scan", "--verbose"}, []string(nil)},
+
+		{"args that only have global flags returns all flags",
+			[]string{"--profile", "p2", "--debug"}, mockedGlobalFlags,
+			[]string(nil), []string{"--profile", "p2", "--debug"}},
+
+		{"args that have both arguments and global flags should split them correctly",
+			[]string{"--profile", "p2", "iac", "terraform-scan", "--verbose", "--debug"}, mockedGlobalFlags,
+			[]string{"iac", "terraform-scan", "--verbose"}, []string{"--profile", "p2", "--debug"}},
+
+		{"complex args and flags with component commands and flags should split them correctly",
+			[]string{"comp-cmd", "--nocolor", "--comp-flag", "comp-subcommand", "--comp-flag2", "-c", "-p", "foo"},
+			mockedGlobalFlags,
+			[]string{"comp-cmd", "--comp-flag", "comp-subcommand", "--comp-flag2", "-c"},
+			[]string{"--nocolor", "-p", "foo"}},
+	}
+
+	for _, kase := range cases {
+		t.Run(kase.Text, func(t *testing.T) {
+			subjectArgs, subjectFlags := filterCLIFlagsFromComponentArgs(kase.Args, kase.GlobalFlags)
+			if assert.Equal(t, len(subjectArgs), len(kase.expectedArgs)) {
+				assert.Equal(t, kase.expectedArgs, subjectArgs)
+			}
+			if assert.Equal(t, len(subjectFlags), len(kase.expectedFlags)) {
+				assert.Equal(t, kase.expectedFlags, subjectFlags)
+			}
+		})
+	}
+}
+
+type mockStringFlagValue struct {
+	value string
+}
+
+func (m *mockStringFlagValue) String() string {
+	return m.value
+}
+func (m *mockStringFlagValue) Type() string {
+	return "string"
+}
+func (m *mockStringFlagValue) Set(v string) error {
+	m.value = v
+	return nil
+}
+
+type mockBoolFlagValue struct {
+	value bool
+}
+
+func (m *mockBoolFlagValue) String() string {
+	if m.value {
+		return "true"
+	}
+	return "false"
+}
+func (m *mockBoolFlagValue) Type() string {
+	return "bool"
+}
+func (m *mockBoolFlagValue) Set(v string) error {
+	if v == "true" {
+		m.value = true
+	}
+	if v == "false" {
+		m.value = false
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

Before this change, when someone would try to use global flags such as `--profile`, `--debug`, etc. while running a component, the CLI would bypass the parsing of all flags and it would send all arguments directly to the underlying component. This caused problems when switching profiles, activating debug logs, etc. (no global flag was working)

This change is implementing a parsing mechanism that will filter all real global flags from the provided arguments and pass the rest as arguments to the component. The filtered global flags are also parsed and applied.

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>


<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## How did you test this change?

Wrote unit tests for the filter function, note that I mocked a few things such as a couple structs and global
flags that will be generated at runtime by the underlying [Go package we use named cobra.](https://github.com/spf13/cobra)

## Issue

https://lacework.atlassian.net/browse/ALLY-1243