### PR TITLE
fix(cdk): Pass all global flags via env variables

### DIFF
--- a/cli/cmd/cli_state.go
+++ b/cli/cmd/cli_state.go
@@ -424,6 +424,11 @@ func (c *cliState) envs() []string {
 		fmt.Sprintf("LW_API_KEY=%s", c.KeyID),
 		fmt.Sprintf("LW_API_SECRET=%s", c.Secret),
 		fmt.Sprintf("LW_API_TOKEN=%s", c.Token),
+		fmt.Sprintf("LW_NONINTERACTIVE=%v", c.nonInteractive),
+		fmt.Sprintf("LW_NOCACHE=%v", c.noCache),
+		fmt.Sprintf("LW_NOCOLOR=%s", os.Getenv("NO_COLOR")),
+		fmt.Sprintf("LW_LOG=%s", c.LogLevel),
+		fmt.Sprintf("LW_JSON=%s", c.jsonOutput),
 	}
 }
 

--- a/cli/cmd/cli_state.go
+++ b/cli/cmd/cli_state.go
@@ -429,7 +429,7 @@ func (c *cliState) envs() []string {
 		fmt.Sprintf("LW_NOCACHE=%v", c.noCache),
 		fmt.Sprintf("LW_NOCOLOR=%s", os.Getenv("NO_COLOR")),
 		fmt.Sprintf("LW_LOG=%s", c.LogLevel),
-		fmt.Sprintf("LW_JSON=%s", c.jsonOutput),
+		fmt.Sprintf("LW_JSON=%v", c.jsonOutput),
 	}
 }
 

--- a/cli/cmd/cli_state.go
+++ b/cli/cmd/cli_state.go
@@ -424,6 +424,7 @@ func (c *cliState) envs() []string {
 		fmt.Sprintf("LW_API_KEY=%s", c.KeyID),
 		fmt.Sprintf("LW_API_SECRET=%s", c.Secret),
 		fmt.Sprintf("LW_API_TOKEN=%s", c.Token),
+		fmt.Sprintf("LW_ORGANIZATION=%v", c.OrgLevel),
 		fmt.Sprintf("LW_NONINTERACTIVE=%v", c.nonInteractive),
 		fmt.Sprintf("LW_NOCACHE=%v", c.noCache),
 		fmt.Sprintf("LW_NOCOLOR=%s", os.Getenv("NO_COLOR")),

--- a/cli/cmd/component.go
+++ b/cli/cmd/component.go
@@ -240,6 +240,10 @@ func filterCLIFlagsFromComponentArgs(args []string, globalFlags []*pflag.Flag) (
 				continue
 			}
 
+			if flag.Name == "help" || flag.Shorthand == "h" { // pass -h, --help flags as component arguments
+				continue
+			}
+
 			if flag.Name == argFlag || flag.Shorthand == argFlag {
 				// the argument is indeed a flag
 

--- a/cli/cmd/component_test.go
+++ b/cli/cmd/component_test.go
@@ -29,6 +29,7 @@ import (
 var mockedGlobalFlags = []*pflag.Flag{
 	&pflag.Flag{Name: "profile", Shorthand: "p", Value: &mockStringFlagValue{}},
 	&pflag.Flag{Name: "debug", Shorthand: "", Value: &mockBoolFlagValue{}},
+	&pflag.Flag{Name: "help", Shorthand: "-h", Value: &mockBoolFlagValue{}},
 	&pflag.Flag{Name: "nocolor", Shorthand: "", Value: &mockBoolFlagValue{}},
 	&pflag.Flag{Name: "nocache", Shorthand: "", Value: &mockBoolFlagValue{}},
 	&pflag.Flag{Name: "noninteractive", Shorthand: "", Value: &mockBoolFlagValue{}},
@@ -61,14 +62,20 @@ func TestComponentFilterCLIFlagsFromComponentArgs(t *testing.T) {
 			[]string(nil), []string{"--profile", "p2", "--debug"}},
 
 		{"args that have both arguments and global flags should split them correctly",
-			[]string{"--profile", "p2", "iac", "terraform-scan", "--verbose", "--debug"}, mockedGlobalFlags,
+			[]string{"--profile", "p2", "iac", "terraform-scan", "--verbose", "--debug"},
+			mockedGlobalFlags,
 			[]string{"iac", "terraform-scan", "--verbose"}, []string{"--profile", "p2", "--debug"}},
 
 		{"complex args and flags with component commands and flags should split them correctly",
-			[]string{"comp-cmd", "--nocolor", "--comp-flag", "comp-subcommand", "--comp-flag2", "-c", "-p", "foo"},
+			[]string{"comp-cmd", "--nocolor", "--comp-flag",
+				"comp-subcommand", "--comp-flag2", "-c", "-p", "foo"},
 			mockedGlobalFlags,
 			[]string{"comp-cmd", "--comp-flag", "comp-subcommand", "--comp-flag2", "-c"},
 			[]string{"--nocolor", "-p", "foo"}},
+
+		{"-h or --help should not be consider a flag but instead a component argument",
+			[]string{"iac", "terraform-scan", "--help"}, mockedGlobalFlags,
+			[]string{"iac", "terraform-scan", "--help"}, []string(nil)},
 	}
 
 	for _, kase := range cases {


### PR DESCRIPTION
## Summary

We were not passing a number of global flags via environment variables, this change adds them all.

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## How did you test this change?

Ran CDK commands

## Issue

https://lacework.atlassian.net/browse/ALLY-1243
