### PR TITLE
fix(cli): do not `aws-install` on nil runners

### DIFF
--- a/cli/cmd/aws.go
+++ b/cli/cmd/aws.go
@@ -142,7 +142,6 @@ func awsRegionDescribeInstances(region string) ([]*lwrunner.AWSRunner, error) {
 
 	runners := []*lwrunner.AWSRunner{}
 	producerWg := new(sync.WaitGroup)
-	// cl := limiter.NewConcurrencyLimiter(agentCmdState.InstallMaxParallelism)
 	wp := workerpool.New(agentCmdState.InstallMaxParallelism)
 	runnerCh := make(chan *lwrunner.AWSRunner)
 
@@ -174,7 +173,7 @@ func awsRegionDescribeInstances(region string) ([]*lwrunner.AWSRunner, error) {
 
 				producerWg.Add(1)
 
-				// In order to use `cl.Execute()`, the input func() must not take any arguments.
+				// In order to use `wp.Submit()`, the input func() must not take any arguments.
 				// Copy the runner info to dedicated variable in the goroutine
 				instanceCopyWg := new(sync.WaitGroup)
 				instanceCopyWg.Add(1)
@@ -197,9 +196,10 @@ func awsRegionDescribeInstances(region string) ([]*lwrunner.AWSRunner, error) {
 					)
 					if err != nil {
 						cli.Log.Debugw("error identifying runner", "error", err, "instance_id", *threadInstance.InstanceId)
+					} else {
+						runnerCh <- runner
 					}
 
-					runnerCh <- runner
 					producerWg.Done()
 				})
 				instanceCopyWg.Wait()

--- a/lwrunner/awsrunner.go
+++ b/lwrunner/awsrunner.go
@@ -63,7 +63,8 @@ func NewAWSRunner(amiImageId, host, region, availabilityZone, instanceID string,
 	var user string
 	if strings.Contains(*result.Images[0].Name, "ubuntu") {
 		user = "ubuntu"
-	} else if strings.Contains(*result.Images[0].Name, "amazon_linux") {
+	} else if strings.Contains(*result.Images[0].Name, "amazon_linux") ||
+		strings.Contains(*result.Images[0].Name, "amzn2-ami") {
 		user = "ec2-user"
 	} else {
 		return nil, fmt.Errorf("expected either Ubuntu or Amazon Linux 2 AMI, got AMI %s", *result.Images[0].Name)


### PR DESCRIPTION
Currently, if the CLI can find an instance but is not able to connect to
it and create a `lwrunner.AWSRunner` struct to represent it, it will
still try to install an agent on that instance.

This commit:
* Changes the parallelism code to not add the runner if it does not
successfully initialize
* Addresses the root cause that triggered this problem by adjusting the
AMI username heuristic for Amazon Linux 2
* Removes outdated comments around the parallelism code area

Fixes RAIN-39248
Fixes RAIN-39251

Signed-off-by: nschmeller <nick.schmeller@lacework.net>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/lacework/go-sdk) and create your branch from `main`
  2. Run `make prepare` in the repository root
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`make test`)
  5. Format your code (`make fmt`)
  6. Make sure your code lints (`make lint`)
  7. If you are updating the Lacework CLI, make sure it compiles (`make build-cli-cross-platform`)
  8. Follow the commit message standard (`type(scope): subject`) documented in [DEVELOPER_GUIDELINES.md](https://github.com/lacework/go-sdk/blob/main/DEVELOPER_GUIDELINES.md#commit-message-standard)
  9. If you haven't already, configure signed commits by [telling git about your signing key](https://docs.github.com/en/github/authenticating-to-github/managing-commit-signature-verification/telling-git-about-your-signing-key) and [signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)

  Learn more about contributing: https://github.com/lacework/go-sdk/blob/main/CONTRIBUTING.md
-->

## How did you test this change?

<!--
  How exactly did you verify that your PR solves the issue you wanted to solve?
  Include any other relevant information such as how to use the new functionality, screenshots, etc.
-->
Updating integration tests to add runners across OSes.

## Issue

<!--
  Include the link to a Jira/Github issue
-->

https://lacework.atlassian.net/browse/RAIN-39248
https://lacework.atlassian.net/browse/RAIN-39251
