### PR TITLE
fix(cdk): Avoid double component error messages

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -23,10 +23,18 @@ import (
 	"os"
 
 	"github.com/lacework/go-sdk/cli/cmd"
+	"github.com/lacework/go-sdk/lwcomponent"
 )
 
 func main() {
 	if err := cmd.Execute(); err != nil {
+		if componentError, ok := err.(*lwcomponent.RunError); ok {
+			// by default, all our components should display the error
+			// to the end user, which is why we don't output it, but we
+			// still exit the main program with the exit code from the component
+			os.Exit(componentError.ExitCode)
+		}
+
 		fmt.Fprintf(os.Stderr, "ERROR %s\n", err)
 		os.Exit(1)
 	}

--- a/lwcomponent/error.go
+++ b/lwcomponent/error.go
@@ -1,6 +1,10 @@
 package lwcomponent
 
-import "github.com/pkg/errors"
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+)
 
 var (
 	ErrComponentNotFound = errors.New("component not found on disk")
@@ -12,4 +16,24 @@ var (
 //
 func IsNotFound(err error) bool {
 	return errors.Is(err, ErrComponentNotFound)
+}
+
+// RunError is a struct used to pass an error when a component tries to run and
+// it fails, a few functions will return this error so that callers (upstream
+// packages) can unwrap and identify that the error comes from this package
+type RunError struct {
+	ExitCode int
+	Message  string
+	Err      error
+}
+
+func (e *RunError) Error() string {
+	if e.ExitCode == 0 {
+		return ""
+	}
+	return fmt.Sprintf("%s: %s", e.Message, e.Err.Error())
+}
+
+func (e *RunError) Unwrap() error {
+	return e.Err
 }

--- a/lwcomponent/executable.go
+++ b/lwcomponent/executable.go
@@ -82,8 +82,17 @@ func (c Component) run(cmd *exec.Cmd) error {
 		}
 
 		if err := cmd.Run(); err != nil {
-			return errors.Wrap(err, baseRunErr)
+			// default to -1 in case we can't get the actual exit code, which
+			// is better than returning an error with exit code 0 (default int)
+			exitCode := -1
+
+			if exitError, ok := err.(*exec.ExitError); ok {
+				exitCode = exitError.ExitCode()
+			}
+
+			return &RunError{Err: err, Message: baseRunErr, ExitCode: exitCode}
 		}
+
 		return nil
 	}
 


### PR DESCRIPTION
## Summary

**Current Behavior:**

When running a component, if the component fails, we print two error messages:
```
$ lacework iac fdsasd
Error: unknown command "fdsasd" for "iac"
ERROR unable to run component: exit status 1
```

**New Behavior:**

We detect that the error is a component failing to run and we avoid outputting two error messages:
```
$ lacework iac fdsasd
Error: unknown command "fdsasd" for "iac"
```

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/lacework/go-sdk) and create your branch from `main`
  2. Run `make prepare` in the repository root
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`make test`)
  5. Format your code (`make fmt`)
  6. Make sure your code lints (`make lint`)
  7. If you are updating the Lacework CLI, make sure it compiles (`make build-cli-cross-platform`)
  8. Follow the commit message standard (`type(scope): subject`) documented in [DEVELOPER_GUIDELINES.md](https://github.com/lacework/go-sdk/blob/main/DEVELOPER_GUIDELINES.md#commit-message-standard)
  9. If you haven't already, configure signed commits by [telling git about your signing key](https://docs.github.com/en/github/authenticating-to-github/managing-commit-signature-verification/telling-git-about-your-signing-key) and [signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)

  Learn more about contributing: https://github.com/lacework/go-sdk/blob/main/CONTRIBUTING.md
-->


## How did you test this change?

Ran manually both, component and non-component commands.

## Issue

https://lacework.atlassian.net/browse/ALLY-1259