### PR TITLE
style(cdk): detect lwcomponent error inside Execute() 

### DIFF
--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -29,6 +29,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
+	"github.com/lacework/go-sdk/lwcomponent"
 	"github.com/lacework/go-sdk/lwlogger"
 )
 
@@ -107,6 +108,11 @@ func Execute() (err error) {
 			exitwithCode(err, err.ExitCode)
 		case *queryFailonError:
 			exitwithCode(err, err.ExitCode)
+		case *lwcomponent.RunError:
+			// by default, all our components should display the error to
+			// the end user, which is why we don't output it, but we still
+			// exit the main program with the exit code from the component
+			os.Exit(err.ExitCode)
 		}
 	}()
 	defer cli.Wait()

--- a/cli/main.go
+++ b/cli/main.go
@@ -23,18 +23,10 @@ import (
 	"os"
 
 	"github.com/lacework/go-sdk/cli/cmd"
-	"github.com/lacework/go-sdk/lwcomponent"
 )
 
 func main() {
 	if err := cmd.Execute(); err != nil {
-		if componentError, ok := err.(*lwcomponent.RunError); ok {
-			// by default, all our components should display the error
-			// to the end user, which is why we don't output it, but we
-			// still exit the main program with the exit code from the component
-			os.Exit(componentError.ExitCode)
-		}
-
 		fmt.Fprintf(os.Stderr, "ERROR %s\n", err)
 		os.Exit(1)
 	}


### PR DESCRIPTION
This is just a style change since we should not check for error types inside our `main` package
but instead inside the `Execute()` function of the `cmd` package.