### PR TITLE
fix(cdk) pass valid LW_API_TOKEN to components

### DIFF
--- a/cli/cmd/cache.go
+++ b/cli/cmd/cache.go
@@ -43,7 +43,6 @@ const MaxCacheSize = 1024 * 1024 * 1024
 // cli.Cache.Write("data", []byte("cool update"))     // Update
 // cli.Cache.Erase("data")                            // Delete
 // ```
-//
 func (c *cliState) InitCache(d ...string) {
 	if len(d) == 0 {
 		dir, err := cache.CacheDir()
@@ -151,7 +150,7 @@ func (c *cliState) WriteCachedToken() error {
 		return nil
 	}
 
-	if c.Token == "" {
+	if c.Token == "" || c.tokenCache.ExpiresAt.Before(time.Now().Add(-10*time.Second)) {
 		response, err := c.LwApi.GenerateToken()
 		if err != nil {
 			return err
@@ -232,9 +231,11 @@ func (c *cliState) WriteAssetToCache(key string, expiresAt time.Time, data inter
 //
 // ```go
 // var report vulnReport
-// if expired := cli.ReadCachedAsset("my-report", &report); !expired {
-//     fmt.Printf("My report: %v\n", report)
-// }
+//
+//	if expired := cli.ReadCachedAsset("my-report", &report); !expired {
+//	    fmt.Printf("My report: %v\n", report)
+//	}
+//
 // ```
 func (c *cliState) ReadCachedAsset(key string, data interface{}) bool {
 	if c.noCache {

--- a/cli/cmd/component.go
+++ b/cli/cmd/component.go
@@ -180,10 +180,20 @@ func (c *cliState) LoadComponents() {
 						// Parse all global CLI flags provided (filtered) by the user, then run the global
 						// CLI init function to initialize our logger, api client, and other global config
 						err := cmd.Flags().Parse(filteredCLIFlags)
-						initConfig() // @afiune NOTE we purposely run this func first and then check the err
+
+						// We call initConfig() again after global flags have been parsed.
+						initConfig()
+
 						if err != nil {
 							cli.Log.Debugw("unable to parse global flags",
 								"provided_flags", filteredCLIFlags, "error", err)
+						}
+
+						// The root command's persistent pre-run will have created a client
+						// without having parsed command line args.  So get it again with
+						// the correct configuration
+						if err := cli.NewClient(); err != nil {
+							return err
 						}
 
 						cli.Log.Debugw("running component", "component", cmd.Use,


### PR DESCRIPTION
## Summary

When the cached token expires running `lacework iac ...` does not pass LW_API_TOKEN.

## How did you test this change?

With the iac component installed, I run `lacework access-token -d 10` to generate a very short lived token.

Initially a command like `lacework iac org list` will succeed.  But after ~10 seconds you will get:

```
samshen@Sams-Lacework-Laptop go-sdk % lacework iac org list
[Error] GET https://api.demo.soluble.cloud/api/v1/users/profile returned 401 in 463ms
[Error] {
  "ok" : false,
  "status" : 401,
  "error" : "Unauthorized",
  "timestamp" : "2022-11-07T17:21:12.923519Z",
  "message" : "401"
}
[ Info] Are you not logged in?  Use lacework iac auth profile to verify.
[ Info] See https://docs.lacework.com/iac/ for more information.
Error: https://api.demo.soluble.cloud/api/v1/users/profile returned 401
ERROR unable to run component: exit status 1
```

You can look under `~/.config/lacework/cache` to see that the token has not been refreshed.

## Issue

RAIN-42604