### PR TITLE
feat(cli)!: pass agent token as flag for `aws-install`

### DIFF
--- a/cli/cmd/agent_aws-install_ec2ssh.go
+++ b/cli/cmd/agent_aws-install_ec2ssh.go
@@ -128,7 +128,7 @@ func installAWSSSH(_ *cobra.Command, args []string) error {
 				return err
 			}
 		} else {
-			return errors.New("user did not provide or interactively select an agent token")
+			return errors.New("--token flag is required when --noninteractive flag is set")
 		}
 	}
 

--- a/cli/cmd/agent_aws-install_ec2ssh.go
+++ b/cli/cmd/agent_aws-install_ec2ssh.go
@@ -48,8 +48,8 @@ To filter by instance tag key:
     lacework agent aws-install ec2ssh --tag_key TagName
 
 To provide an existing access token, use the '--token' flag. This flag is required
-when running non-interactively (`--noninteractive` flag). The interactive command
-`lacework agent token list` can be used to query existing tokens.
+when running non-interactively ('--noninteractive' flag). The interactive command
+'lacework agent token list' can be used to query existing tokens.
 
     lacework agent aws-install ec2ic --token <token>
 

--- a/cli/cmd/agent_aws-install_ec2ssh.go
+++ b/cli/cmd/agent_aws-install_ec2ssh.go
@@ -47,9 +47,9 @@ To filter by instance tag key:
 
     lacework agent aws-install ec2ssh --tag_key TagName
 
-To provide an agent access token of your choice, use the command 'lacework agent token list',
-select a token and pass it to the '--token' flag. This flag must be selected if the
-'--noninteractive' flag is set.
+To provide an existing access token, use the '--token' flag. This flag is required
+when running non-interactively (`--noninteractive` flag). The interactive command
+`lacework agent token list` can be used to query existing tokens.
 
     lacework agent aws-install ec2ic --token <token>
 

--- a/integration/test_resources/help/agent_aws-install_ec2ic
+++ b/integration/test_resources/help/agent_aws-install_ec2ic
@@ -2,19 +2,25 @@ This command installs the agent on all EC2 instances in an AWS account using EC2
 
 To filter by one or more regions:
 
-    lacework agent aws-install ec2ic <token> --include_regions us-west-2,us-east-2
+    lacework agent aws-install ec2ic --include_regions us-west-2,us-east-2
 
 To filter by instance tag:
 
-    lacework agent aws-install ec2ic <token> --tag TagName,TagValue
+    lacework agent aws-install ec2ic --tag TagName,TagValue
 
 To filter by instance tag key:
 
-    lacework agent aws-install ec2ic <token> --tag_key TagName
+    lacework agent aws-install ec2ic --tag_key TagName
 
 To explicitly specify the username for all SSH logins:
 
-    lacework agent aws-install ec2ic <token> --ssh_username <your-user>
+    lacework agent aws-install ec2ic --ssh_username <your-user>
+
+To provide an agent access token of your choice, use the command 'lacework agent token list',
+select a token and pass it to the '--token' flag. This flag must be selected if the
+'--noninteractive' flag is set.
+
+    lacework agent aws-install ec2ic --token <token>
 
 AWS credentials are read from the following environment variables:
 - AWS_ACCESS_KEY_ID
@@ -26,7 +32,7 @@ This command will automatically add hosts with successful connections to
 '~/.ssh/known_hosts' unless specified with '--trust_host_key=false'.
 
 Usage:
-  lacework agent aws-install ec2ic <token> [flags]
+  lacework agent aws-install ec2ic [flags]
 
 Flags:
   -h, --help                      help for ec2ic
@@ -35,6 +41,7 @@ Flags:
       --ssh_username string       username to login with
       --tag strings               only install agents on infra with this tag
       --tag_key string            only install agents on infra with this tag key set
+      --token string              agent access token
       --trust_host_key            automatically add host keys to the ~/.ssh/known_hosts file (default true)
 
 Global Flags:

--- a/integration/test_resources/help/agent_aws-install_ec2ssh
+++ b/integration/test_resources/help/agent_aws-install_ec2ssh
@@ -13,9 +13,9 @@ To filter by instance tag key:
 
     lacework agent aws-install ec2ssh --tag_key TagName
 
-To provide an agent access token of your choice, use the command 'lacework agent token list',
-select a token and pass it to the '--token' flag. This flag must be selected if the
-'--noninteractive' flag is set.
+To provide an existing access token, use the '--token' flag. This flag is required
+when running non-interactively (`--noninteractive` flag). The interactive command
+`lacework agent token list` can be used to query existing tokens.
 
     lacework agent aws-install ec2ic --token <token>
 

--- a/integration/test_resources/help/agent_aws-install_ec2ssh
+++ b/integration/test_resources/help/agent_aws-install_ec2ssh
@@ -14,8 +14,8 @@ To filter by instance tag key:
     lacework agent aws-install ec2ssh --tag_key TagName
 
 To provide an existing access token, use the '--token' flag. This flag is required
-when running non-interactively (`--noninteractive` flag). The interactive command
-`lacework agent token list` can be used to query existing tokens.
+when running non-interactively ('--noninteractive' flag). The interactive command
+'lacework agent token list' can be used to query existing tokens.
 
     lacework agent aws-install ec2ic --token <token>
 

--- a/integration/test_resources/help/agent_aws-install_ec2ssh
+++ b/integration/test_resources/help/agent_aws-install_ec2ssh
@@ -3,15 +3,21 @@ using SSH.
 
 To filter by one or more regions:
 
-    lacework agent aws-install ec2ssh <token> --include_regions us-west-2,us-east-2
+    lacework agent aws-install ec2ssh --include_regions us-west-2,us-east-2
 
 To filter by instance tag:
 
-    lacework agent aws-install ec2ssh <token> --tag TagName,TagValue
+    lacework agent aws-install ec2ssh --tag TagName,TagValue
 
 To filter by instance tag key:
 
-    lacework agent aws-install ec2ssh <token> --tag_key TagName
+    lacework agent aws-install ec2ssh --tag_key TagName
+
+To provide an agent access token of your choice, use the command 'lacework agent token list',
+select a token and pass it to the '--token' flag. This flag must be selected if the
+'--noninteractive' flag is set.
+
+    lacework agent aws-install ec2ic --token <token>
 
 You will need to provide an SSH authentication method. This authentication method
 should work for all instances that your tag or region filters select. Instances must
@@ -19,11 +25,11 @@ be routable from your local host.
 
 To authenticate using username and password:
 
-    lacework agent aws-install ec2ssh <token> --ssh_username <your-user> --ssh_password <secret>
+    lacework agent aws-install ec2ssh --ssh_username <your-user> --ssh_password <secret>
 
 To authenticate using an identity file:
 
-    lacework agent aws-install ec2ssh <token> -i /path/to/your/key
+    lacework agent aws-install ec2ssh -i /path/to/your/key
 
 The environment should contain AWS credentials in the following variables:
 - AWS_ACCESS_KEY_ID
@@ -35,7 +41,7 @@ This command will automatically add hosts with successful connections to
 '~/.ssh/known_hosts' unless specified with '--trust_host_key=false'.
 
 Usage:
-  lacework agent aws-install ec2ssh <token> [flags]
+  lacework agent aws-install ec2ssh [flags]
 
 Flags:
   -h, --help                      help for ec2ssh
@@ -47,6 +53,7 @@ Flags:
       --ssh_username string       username to login with
       --tag strings               only select instances with this tag
       --tag_key string            only install agents on infra with this tag key
+      --token string              agent access token
       --trust_host_key            automatically add host keys to the ~/.ssh/known_hosts file (default true)
 
 Global Flags:


### PR DESCRIPTION
This commit switches the method of passing the agent token to
`aws-install`, and is a breaking change for the CLI.

The old method that was released in `v0.43.0` was to pass it as
a required arg. The new method in this PR will rely on passing the
token as an optional flag (`--token`) and asking the user to provide
it interactively if that flag is not present.

Fixes RAIN-42457

Signed-off-by: nschmeller <nick.schmeller@lacework.net>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/lacework/go-sdk) and create your branch from `main`
  2. Run `make prepare` in the repository root
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`make test`)
  5. Format your code (`make fmt`)
  6. Make sure your code lints (`make lint`)
  7. If you are updating the Lacework CLI, make sure it compiles (`make build-cli-cross-platform`)
  8. Follow the commit message standard (`type(scope): subject`) documented in [DEVELOPER_GUIDELINES.md](https://github.com/lacework/go-sdk/blob/main/DEVELOPER_GUIDELINES.md#commit-message-standard)
  9. If you haven't already, configure signed commits by [telling git about your signing key](https://docs.github.com/en/github/authenticating-to-github/managing-commit-signature-verification/telling-git-about-your-signing-key) and [signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)

  Learn more about contributing: https://github.com/lacework/go-sdk/blob/main/CONTRIBUTING.md
-->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->
We initially decided to release the `aws-install` subcommand with the agent token as a required arg. We've changed our minds on this and have decided that it's better to ask the customer interactively (once) to select an agent token, or to explicitly pass it as a flag. The initial rationale to pass the agent token as a required arg was based on a poor design decision around initializing AWS runners.

This is a breaking change, and we'd like to get it released before v1.0.0 ships.

## How did you test this change?

<!--
  How exactly did you verify that your PR solves the issue you wanted to solve?
  Include any other relevant information such as how to use the new functionality, screenshots, etc.
-->
Updating CTF integration tests in the agent repo

## Issue

<!--
  Include the link to a Jira/Github issue
-->
https://lacework.atlassian.net/browse/RAIN-42457
