### PR TITLE
chore(ALLY-1275): bump lacework provider version

### DIFF
--- a/lwgenerate/aws/aws_test.go
+++ b/lwgenerate/aws/aws_test.go
@@ -311,7 +311,7 @@ var requiredProviders = `terraform {
   required_providers {
     lacework = {
       source  = "lacework/lacework"
-      version = "~> 0.26"
+      version = "~> 1.0"
     }
   }
 }

--- a/lwgenerate/aws_eks_audit/aws_eks_audit_test.go
+++ b/lwgenerate/aws_eks_audit/aws_eks_audit_test.go
@@ -389,7 +389,7 @@ var requiredProviders = `terraform {
   required_providers {
     lacework = {
       source  = "lacework/lacework"
-      version = "~> 0.26"
+      version = "~> 1.0"
     }
   }
 }

--- a/lwgenerate/azure/test-data/activity-log-with-all-subscriptions.tf
+++ b/lwgenerate/azure/test-data/activity-log-with-all-subscriptions.tf
@@ -10,7 +10,7 @@ terraform {
     }
     lacework = {
       source  = "lacework/lacework"
-      version = "~> 0.26"
+      version = "~> 1.0"
     }
   }
 }

--- a/lwgenerate/azure/test-data/activity-log-with-existing-storage.tf
+++ b/lwgenerate/azure/test-data/activity-log-with-existing-storage.tf
@@ -10,7 +10,7 @@ terraform {
     }
     lacework = {
       source  = "lacework/lacework"
-      version = "~> 0.26"
+      version = "~> 1.0"
     }
   }
 }

--- a/lwgenerate/azure/test-data/activity-log-with-lacework-profile.tf
+++ b/lwgenerate/azure/test-data/activity-log-with-lacework-profile.tf
@@ -10,7 +10,7 @@ terraform {
     }
     lacework = {
       source  = "lacework/lacework"
-      version = "~> 0.26"
+      version = "~> 1.0"
     }
   }
 }

--- a/lwgenerate/azure/test-data/activity-log-with-list-subscriptions.tf
+++ b/lwgenerate/azure/test-data/activity-log-with-list-subscriptions.tf
@@ -10,7 +10,7 @@ terraform {
     }
     lacework = {
       source  = "lacework/lacework"
-      version = "~> 0.26"
+      version = "~> 1.0"
     }
   }
 }

--- a/lwgenerate/azure/test-data/activity-log-with-location.tf
+++ b/lwgenerate/azure/test-data/activity-log-with-location.tf
@@ -10,7 +10,7 @@ terraform {
     }
     lacework = {
       source  = "lacework/lacework"
-      version = "~> 0.26"
+      version = "~> 1.0"
     }
   }
 }

--- a/lwgenerate/azure/test-data/activity_log_with_config.tf
+++ b/lwgenerate/azure/test-data/activity_log_with_config.tf
@@ -10,7 +10,7 @@ terraform {
     }
     lacework = {
       source  = "lacework/lacework"
-      version = "~> 0.26"
+      version = "~> 1.0"
     }
   }
 }

--- a/lwgenerate/azure/test-data/activity_log_without_config.tf
+++ b/lwgenerate/azure/test-data/activity_log_without_config.tf
@@ -10,7 +10,7 @@ terraform {
     }
     lacework = {
       source  = "lacework/lacework"
-      version = "~> 0.26"
+      version = "~> 1.0"
     }
   }
 }

--- a/lwgenerate/azure/test-data/config-log-with-list-subscriptions.tf
+++ b/lwgenerate/azure/test-data/config-log-with-list-subscriptions.tf
@@ -10,7 +10,7 @@ terraform {
     }
     lacework = {
       source  = "lacework/lacework"
-      version = "~> 0.26"
+      version = "~> 1.0"
     }
   }
 }

--- a/lwgenerate/azure/test-data/config-with-all-subscriptions.tf
+++ b/lwgenerate/azure/test-data/config-with-all-subscriptions.tf
@@ -10,7 +10,7 @@ terraform {
     }
     lacework = {
       source  = "lacework/lacework"
-      version = "~> 0.26"
+      version = "~> 1.0"
     }
   }
 }

--- a/lwgenerate/azure/test-data/config-with-management-group.tf
+++ b/lwgenerate/azure/test-data/config-with-management-group.tf
@@ -10,7 +10,7 @@ terraform {
     }
     lacework = {
       source  = "lacework/lacework"
-      version = "~> 0.26"
+      version = "~> 1.0"
     }
   }
 }

--- a/lwgenerate/azure/test-data/config-with-storage-account.tf
+++ b/lwgenerate/azure/test-data/config-with-storage-account.tf
@@ -10,7 +10,7 @@ terraform {
     }
     lacework = {
       source  = "lacework/lacework"
-      version = "~> 0.26"
+      version = "~> 1.0"
     }
   }
 }

--- a/lwgenerate/azure/test-data/config_without_activity_log.tf
+++ b/lwgenerate/azure/test-data/config_without_activity_log.tf
@@ -10,7 +10,7 @@ terraform {
     }
     lacework = {
       source  = "lacework/lacework"
-      version = "~> 0.26"
+      version = "~> 1.0"
     }
   }
 }

--- a/lwgenerate/azure/test-data/customer-ad-details.tf
+++ b/lwgenerate/azure/test-data/customer-ad-details.tf
@@ -10,7 +10,7 @@ terraform {
     }
     lacework = {
       source  = "lacework/lacework"
-      version = "~> 0.26"
+      version = "~> 1.0"
     }
   }
 }

--- a/lwgenerate/azure/test-data/renamed_activity_log.tf
+++ b/lwgenerate/azure/test-data/renamed_activity_log.tf
@@ -10,7 +10,7 @@ terraform {
     }
     lacework = {
       source  = "lacework/lacework"
-      version = "~> 0.26"
+      version = "~> 1.0"
     }
   }
 }

--- a/lwgenerate/azure/test-data/renamed_config.tf
+++ b/lwgenerate/azure/test-data/renamed_config.tf
@@ -10,7 +10,7 @@ terraform {
     }
     lacework = {
       source  = "lacework/lacework"
-      version = "~> 0.26"
+      version = "~> 1.0"
     }
   }
 }

--- a/lwgenerate/azure/test-data/renamed_config_and_activity_log.tf
+++ b/lwgenerate/azure/test-data/renamed_config_and_activity_log.tf
@@ -10,7 +10,7 @@ terraform {
     }
     lacework = {
       source  = "lacework/lacework"
-      version = "~> 0.26"
+      version = "~> 1.0"
     }
   }
 }

--- a/lwgenerate/constants.go
+++ b/lwgenerate/constants.go
@@ -2,7 +2,7 @@ package lwgenerate
 
 const (
 	LaceworkProviderSource  = "lacework/lacework"
-	LaceworkProviderVersion = "~> 0.26"
+	LaceworkProviderVersion = "~> 1.0"
 
 	AwsConfigSource      = "lacework/config/aws"
 	AwsConfigVersion     = "~> 0.5"

--- a/lwgenerate/gcp/gcp_test.go
+++ b/lwgenerate/gcp/gcp_test.go
@@ -640,7 +640,7 @@ var RequiredProviders = `terraform {
   required_providers {
     lacework = {
       source  = "lacework/lacework"
-      version = "~> 0.26"
+      version = "~> 1.0"
     }
   }
 }


### PR DESCRIPTION
## Summary

Terraform generated by Lacework CLI broken due to it using `v.0.26` and the TF modules using `v1.0` of [terraform-provider-lacework](https://github.com/lacework/terraform-provider-lacework).

Fix is to bump version of the lacework provider to `v1.0`.

## How did you test this change?

- unit
- integration
- manual `generate cloud-account ..` + terraform init & validate

## Issue

[ALLY-1275](https://lacework.atlassian.net/browse/ALLY-1275)
