### PR TITLE
fix(cli): rootCmd to intelligently PreRun components 

### DIFF
--- a/cli/cmd/component.go
+++ b/cli/cmd/component.go
@@ -34,6 +34,8 @@ import (
 	"github.com/lacework/go-sdk/lwcomponent"
 )
 
+const componentTypeAnnotation string = "component"
+
 var (
 	// componentsCmd represents the components command
 	componentsCmd = &cobra.Command{
@@ -117,7 +119,7 @@ func hasInstalledCommands() bool {
 // if the command was installed from the CDK
 func isComponent(annotations map[string]string) bool {
 	t, found := annotations["type"]
-	if found && t == "component" {
+	if found && t == componentTypeAnnotation {
 		return true
 	}
 	return false
@@ -158,7 +160,7 @@ func (c *cliState) LoadComponents() {
 					// @afiune strip `lw-` from component?
 					Use:                   component.Name,
 					Short:                 component.Description,
-					Annotations:           map[string]string{"type": "component"},
+					Annotations:           map[string]string{"type": componentTypeAnnotation},
 					Version:               ver.String(),
 					SilenceUsage:          true,
 					DisableFlagParsing:    true,
@@ -189,10 +191,9 @@ func (c *cliState) LoadComponents() {
 								"provided_flags", filteredCLIFlags, "error", err)
 						}
 
-						// The root command's persistent pre-run will have created a client
-						// without having parsed command line args.  So get it again with
-						// the correct configuration
-						if err := cli.NewClient(); err != nil {
+						// The root command's persistent pre-run will not have created
+						// a client or done migrations
+						if err := rootPersistentPreRunE(); err != nil {
 							return err
 						}
 


### PR DESCRIPTION
ALLY-1279

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/lacework/go-sdk) and create your branch from `main`
  2. Run `make prepare` in the repository root
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`make test`)
  5. Format your code (`make fmt`)
  6. Make sure your code lints (`make lint`)
  7. If you are updating the Lacework CLI, make sure it compiles (`make build-cli-cross-platform`)
  8. Follow the commit message standard (`type(scope): subject`) documented in [DEVELOPER_GUIDELINES.md](https://github.com/lacework/go-sdk/blob/main/DEVELOPER_GUIDELINES.md#commit-message-standard)
  9. If you haven't already, configure signed commits by [telling git about your signing key](https://docs.github.com/en/github/authenticating-to-github/managing-commit-signature-verification/telling-git-about-your-signing-key) and [signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)

  Learn more about contributing: https://github.com/lacework/go-sdk/blob/main/CONTRIBUTING.md
-->

## Summary
For CDK components which are type `CLI_COMMAND` the CLI automatically creates child commands for them.  The `RunE` portion of these child commands has special handling for global flags.  However, the `PersistentPreRunE` portion of the rootCmd performs tasks (i.e. establishes a NewClient or does Migration) without the knowledge of these flags.

Since `RunE` is essentially “pre run” for CDK components we should:

1. have the root command check if we’re running a component, and if so avoid certain tasks
2. perform the tasks avoided by the root command within the RunE of the component

## How did you test this change?
Manually

## Issue
https://lacework.atlassian.net/browse/ALLY-1279
