### PR TITLE
Jon stewart/ally 1189/tf validate

### DIFF
--- a/integration/aws_generation_test.go
+++ b/integration/aws_generation_test.go
@@ -23,11 +23,11 @@ func TestGenerationAwsErrorOnNoSelection(t *testing.T) {
 	// Run CLI
 	runGenerateTest(t,
 		func(c *expect.Console) {
-			expectString(t, c, cmd.QuestionAwsEnableConfig)
-			c.SendLine("n")
-			expectString(t, c, cmd.QuestionEnableCloudtrail)
-			c.SendLine("n")
-			expectString(t, c, "ERROR collecting/confirming parameters: must enable cloudtrail or config")
+			expectsCliOutput(t, c, []MsgRspHandler{
+				MsgRsp{cmd.QuestionAwsEnableConfig, "n"},
+				MsgRsp{cmd.QuestionEnableCloudtrail, "n"},
+				MsgOnly{"ERROR collecting/confirming parameters: must enable cloudtrail or config"},
+			})
 		},
 		"generate",
 		"cloud-account",
@@ -45,16 +45,13 @@ func TestGenerationAwsSimple(t *testing.T) {
 	// Run CLI
 	tfResult := runGenerateTest(t,
 		func(c *expect.Console) {
-			expectString(t, c, cmd.QuestionAwsEnableConfig)
-			c.SendLine("y")
-			expectString(t, c, cmd.QuestionEnableCloudtrail)
-			c.SendLine("y")
-			expectString(t, c, cmd.QuestionAwsRegion)
-			c.SendLine(region)
-			expectString(t, c, cmd.QuestionAwsConfigAdvanced)
-			c.SendLine("n")
-			expectString(t, c, cmd.QuestionRunTfPlan)
-			c.SendLine("n")
+			expectsCliOutput(t, c, []MsgRspHandler{
+				MsgRsp{cmd.QuestionAwsEnableConfig, "y"},
+				MsgRsp{cmd.QuestionEnableCloudtrail, "y"},
+				MsgRsp{cmd.QuestionAwsRegion, region},
+				MsgRsp{cmd.QuestionAwsConfigAdvanced, "n"},
+				MsgRsp{cmd.QuestionRunTfPlan, "n"},
+			})
 			final, _ = c.ExpectEOF()
 		},
 		"generate",
@@ -91,25 +88,16 @@ func TestGenerationAwsCustomizedOutputLocation(t *testing.T) {
 	// Run CLI
 	runGenerateTest(t,
 		func(c *expect.Console) {
-			expectString(t, c, cmd.QuestionAwsEnableConfig)
-			c.SendLine("y")
-			expectString(t, c, cmd.QuestionEnableCloudtrail)
-			c.SendLine("y")
-			expectString(t, c, cmd.QuestionAwsRegion)
-			c.SendLine(region)
-			expectString(t, c, cmd.QuestionAwsConfigAdvanced)
-			c.SendLine("y")
-			expectString(t, c, cmd.AwsAdvancedOptDone)
-			c.Send("\x1B[B")
-			c.Send("\x1B[B")
-			c.Send("\x1B[B")
-			c.SendLine("\x1B[B")
-			expectString(t, c, cmd.QuestionAwsCustomizeOutputLocation)
-			c.SendLine(dir)
-			expectString(t, c, cmd.QuestionAwsAnotherAdvancedOpt)
-			c.SendLine("n")
-			expectString(t, c, cmd.QuestionRunTfPlan)
-			c.SendLine("n")
+			expectsCliOutput(t, c, []MsgRspHandler{
+				MsgRsp{cmd.QuestionAwsEnableConfig, "y"},
+				MsgRsp{cmd.QuestionEnableCloudtrail, "y"},
+				MsgRsp{cmd.QuestionAwsRegion, region},
+				MsgRsp{cmd.QuestionAwsConfigAdvanced, "y"},
+				MsgMenu{cmd.AwsAdvancedOptDone, 4},
+				MsgRsp{cmd.QuestionAwsCustomizeOutputLocation, dir},
+				MsgRsp{cmd.QuestionAwsAnotherAdvancedOpt, "n"},
+				MsgRsp{cmd.QuestionRunTfPlan, "n"},
+			})
 			final, _ = c.ExpectEOF()
 		},
 		"generate",
@@ -142,16 +130,13 @@ func TestGenerationAwsConfigOnly(t *testing.T) {
 	// Run CLI
 	tfResult := runGenerateTest(t,
 		func(c *expect.Console) {
-			expectString(t, c, cmd.QuestionAwsEnableConfig)
-			c.SendLine("y")
-			expectString(t, c, cmd.QuestionEnableCloudtrail)
-			c.SendLine("n")
-			expectString(t, c, cmd.QuestionAwsRegion)
-			c.SendLine(region)
-			expectString(t, c, cmd.QuestionAwsConfigAdvanced)
-			c.SendLine("n")
-			expectString(t, c, cmd.QuestionRunTfPlan)
-			c.SendLine("n")
+			expectsCliOutput(t, c, []MsgRspHandler{
+				MsgRsp{cmd.QuestionAwsEnableConfig, "y"},
+				MsgRsp{cmd.QuestionEnableCloudtrail, "n"},
+				MsgRsp{cmd.QuestionAwsRegion, region},
+				MsgRsp{cmd.QuestionAwsConfigAdvanced, "n"},
+				MsgRsp{cmd.QuestionRunTfPlan, "n"},
+			})
 			final, _ = c.ExpectEOF()
 		},
 		"generate",
@@ -181,22 +166,14 @@ func TestGenerationAwsAdvancedOptsDone(t *testing.T) {
 	// Run CLI
 	tfResult := runGenerateTest(t,
 		func(c *expect.Console) {
-			expectString(t, c, cmd.QuestionAwsEnableConfig)
-			c.SendLine("y")
-			expectString(t, c, cmd.QuestionEnableCloudtrail)
-			c.SendLine("y")
-			expectString(t, c, cmd.QuestionAwsRegion)
-			c.SendLine(region)
-			expectString(t, c, cmd.QuestionAwsConfigAdvanced)
-			c.SendLine("y")
-			expectString(t, c, cmd.AwsAdvancedOptDone)
-			c.Send("\x1B[B")
-			c.Send("\x1B[B")
-			c.Send("\x1B[B")
-			c.Send("\x1B[B")
-			c.SendLine("\x1B[B")
-			expectString(t, c, cmd.QuestionRunTfPlan)
-			c.SendLine("n")
+			expectsCliOutput(t, c, []MsgRspHandler{
+				MsgRsp{cmd.QuestionAwsEnableConfig, "y"},
+				MsgRsp{cmd.QuestionEnableCloudtrail, "y"},
+				MsgRsp{cmd.QuestionAwsRegion, region},
+				MsgRsp{cmd.QuestionAwsConfigAdvanced, "y"},
+				MsgMenu{cmd.AwsAdvancedOptDone, 5},
+				MsgRsp{cmd.QuestionRunTfPlan, "n"},
+			})
 			final, _ = c.ExpectEOF()
 		},
 		"generate",
@@ -226,51 +203,32 @@ func TestGenerationAwsAdvancedOptsConsolidatedAndForceDestroy(t *testing.T) {
 	// Run CLI
 	tfResult := runGenerateTest(t,
 		func(c *expect.Console) {
-			expectString(t, c, cmd.QuestionAwsEnableConfig)
-			c.SendLine("y")
-			expectString(t, c, cmd.QuestionEnableCloudtrail)
-			c.SendLine("y")
-			expectString(t, c, cmd.QuestionAwsRegion)
-			c.SendLine(region)
-			expectString(t, c, cmd.QuestionAwsConfigAdvanced)
-			c.SendLine("y")
-			expectString(t, c, cmd.AwsAdvancedOptDone)
-			c.SendLine("\x1B[B")
-			expectString(t, c, cmd.QuestionConsolidatedCloudtrail)
-			c.SendLine("y")
-			expectString(t, c, cmd.QuestionUseExistingCloudtrail)
-			c.SendLine("n")
-			expectString(t, c, cmd.QuestionCloudtrailName)
-			c.SendLine("")
-			// S3 Bucket Questions
-			expectString(t, c, cmd.QuestionForceDestroyS3Bucket)
-			c.SendLine("y")
-			expectString(t, c, cmd.QuestionBucketName)
-			c.SendLine("")
-			expectString(t, c, cmd.QuestionBucketEnableEncryption)
-			c.SendLine("y")
-			expectString(t, c, cmd.QuestionBucketSseKeyArn)
-			c.SendLine("")
-			// SNS Topic Questions
-			expectString(t, c, cmd.QuestionsUseExistingSNSTopic)
-			c.SendLine("n")
-			expectString(t, c, cmd.QuestionSnsTopicName)
-			c.SendLine("")
-			expectString(t, c, cmd.QuestionSnsEnableEncryption)
-			c.SendLine("y")
-			expectString(t, c, cmd.QuestionSnsEncryptionKeyArn)
-			c.SendLine("")
-			// SQS Questions
-			expectString(t, c, cmd.QuestionSqsQueueName)
-			c.SendLine("")
-			expectString(t, c, cmd.QuestionSqsEnableEncryption)
-			c.SendLine("y")
-			expectString(t, c, cmd.QuestionSqsEncryptionKeyArn)
-			c.SendLine("")
-			expectString(t, c, cmd.QuestionAwsAnotherAdvancedOpt)
-			c.SendLine("n")
-			expectString(t, c, cmd.QuestionRunTfPlan)
-			c.SendLine("n")
+			expectsCliOutput(t, c, []MsgRspHandler{
+				MsgRsp{cmd.QuestionAwsEnableConfig, "y"},
+				MsgRsp{cmd.QuestionEnableCloudtrail, "y"},
+				MsgRsp{cmd.QuestionAwsRegion, region},
+				MsgRsp{cmd.QuestionAwsConfigAdvanced, "y"},
+				MsgMenu{cmd.AwsAdvancedOptDone, 1},
+				MsgRsp{cmd.QuestionConsolidatedCloudtrail, "y"},
+				MsgRsp{cmd.QuestionUseExistingCloudtrail, "n"},
+				MsgRsp{cmd.QuestionCloudtrailName, ""},
+				// S3 Bucket Questions
+				MsgRsp{cmd.QuestionForceDestroyS3Bucket, "y"},
+				MsgRsp{cmd.QuestionBucketName, ""},
+				MsgRsp{cmd.QuestionBucketEnableEncryption, "y"},
+				MsgRsp{cmd.QuestionBucketSseKeyArn, ""},
+				// SNS Topic Questions
+				MsgRsp{cmd.QuestionsUseExistingSNSTopic, "n"},
+				MsgRsp{cmd.QuestionSnsTopicName, ""},
+				MsgRsp{cmd.QuestionSnsEnableEncryption, "y"},
+				MsgRsp{cmd.QuestionSnsEncryptionKeyArn, ""},
+				// SQS Questions
+				MsgRsp{cmd.QuestionSqsQueueName, ""},
+				MsgRsp{cmd.QuestionSqsEnableEncryption, "y"},
+				MsgRsp{cmd.QuestionSqsEncryptionKeyArn, ""},
+				MsgRsp{cmd.QuestionAwsAnotherAdvancedOpt, "n"},
+				MsgRsp{cmd.QuestionRunTfPlan, "n"},
+			})
 			final, _ = c.ExpectEOF()
 		},
 		"generate",
@@ -302,45 +260,28 @@ func TestGenerationAwsAdvancedOptsUseExistingCloudtrail(t *testing.T) {
 	// Run CLI
 	tfResult := runGenerateTest(t,
 		func(c *expect.Console) {
-			expectString(t, c, cmd.QuestionAwsEnableConfig)
-			c.SendLine("y")
-			expectString(t, c, cmd.QuestionEnableCloudtrail)
-			c.SendLine("y")
-			expectString(t, c, cmd.QuestionAwsRegion)
-			c.SendLine(region)
-			expectString(t, c, cmd.QuestionAwsConfigAdvanced)
-			c.SendLine("y")
-			expectString(t, c, cmd.AwsAdvancedOptDone)
-			c.SendLine("\x1B[B")
-			expectString(t, c, cmd.QuestionConsolidatedCloudtrail)
-			c.SendLine("n")
-			expectString(t, c, cmd.QuestionUseExistingCloudtrail)
-			c.SendLine("y")
-			expectString(t, c, cmd.QuestionCloudtrailExistingBucketArn)
-			c.SendLine("notright") // test our validator is working
-			expectString(t, c, "invalid arn supplied")
-			c.SendLine("arn:aws:s3:::bucket_name")
-			// SNS Topic Questions
-			expectString(t, c, cmd.QuestionsUseExistingSNSTopic)
-			c.SendLine("n")
-			expectString(t, c, cmd.QuestionSnsTopicName)
-			c.SendLine("")
-			expectString(t, c, cmd.QuestionSnsEnableEncryption)
-			c.SendLine("y")
-			expectString(t, c, cmd.QuestionSnsEncryptionKeyArn)
-			c.SendLine("")
-			// SQS Questions
-			expectString(t, c, cmd.QuestionSqsQueueName)
-			c.SendLine("")
-			expectString(t, c, cmd.QuestionSqsEnableEncryption)
-			c.SendLine("y")
-			expectString(t, c, cmd.QuestionSqsEncryptionKeyArn)
-			c.SendLine("")
-			//
-			expectString(t, c, cmd.QuestionAwsAnotherAdvancedOpt)
-			c.SendLine("n")
-			expectString(t, c, cmd.QuestionRunTfPlan)
-			c.SendLine("n")
+			expectsCliOutput(t, c, []MsgRspHandler{
+				MsgRsp{cmd.QuestionAwsEnableConfig, "y"},
+				MsgRsp{cmd.QuestionEnableCloudtrail, "y"},
+				MsgRsp{cmd.QuestionAwsRegion, region},
+				MsgRsp{cmd.QuestionAwsConfigAdvanced, "y"},
+				MsgMenu{cmd.AwsAdvancedOptDone, 1},
+				MsgRsp{cmd.QuestionConsolidatedCloudtrail, "n"},
+				MsgRsp{cmd.QuestionUseExistingCloudtrail, "y"},
+				MsgRsp{cmd.QuestionCloudtrailExistingBucketArn, "notright"},
+				MsgRsp{"invalid arn supplied", "arn:aws:s3:::bucket_name"},
+				// SNS Topic Questions
+				MsgRsp{cmd.QuestionsUseExistingSNSTopic, "n"},
+				MsgRsp{cmd.QuestionSnsTopicName, ""},
+				MsgRsp{cmd.QuestionSnsEnableEncryption, "y"},
+				MsgRsp{cmd.QuestionSnsEncryptionKeyArn, ""},
+				// SQS Questions
+				MsgRsp{cmd.QuestionSqsQueueName, ""},
+				MsgRsp{cmd.QuestionSqsEnableEncryption, "y"},
+				MsgRsp{cmd.QuestionSqsEncryptionKeyArn, ""},
+				MsgRsp{cmd.QuestionAwsAnotherAdvancedOpt, "n"},
+				MsgRsp{cmd.QuestionRunTfPlan, "n"},
+			})
 			final, _ = c.ExpectEOF()
 		},
 		"generate",
@@ -371,70 +312,40 @@ func TestGenerationAwsAdvancedOptsConsolidatedWithSubAccounts(t *testing.T) {
 	// Run CLI
 	tfResult := runGenerateTest(t,
 		func(c *expect.Console) {
-			expectString(t, c, cmd.QuestionAwsEnableConfig)
-			c.SendLine("y")
-			expectString(t, c, cmd.QuestionEnableCloudtrail)
-			c.SendLine("y")
-			expectString(t, c, cmd.QuestionAwsRegion)
-			c.SendLine(region)
-			expectString(t, c, cmd.QuestionAwsConfigAdvanced)
-			c.SendLine("y")
-			expectString(t, c, cmd.AwsAdvancedOptDone)
-			c.SendLine("\x1B[B")
-			expectString(t, c, cmd.QuestionConsolidatedCloudtrail)
-			c.SendLine("y")
-			expectString(t, c, cmd.QuestionUseExistingCloudtrail)
-			c.SendLine("n")
-			expectString(t, c, cmd.QuestionCloudtrailName)
-			c.SendLine("")
-			expectString(t, c, cmd.QuestionForceDestroyS3Bucket)
-			c.SendLine("n")
-			expectString(t, c, cmd.QuestionBucketName)
-			c.SendLine("")
-			expectString(t, c, cmd.QuestionBucketEnableEncryption)
-			c.SendLine("y")
-			expectString(t, c, cmd.QuestionBucketSseKeyArn)
-			c.SendLine("")
-			// SNS Topic Questions
-			expectString(t, c, cmd.QuestionsUseExistingSNSTopic)
-			c.SendLine("n")
-			expectString(t, c, cmd.QuestionSnsTopicName)
-			c.SendLine("")
-			expectString(t, c, cmd.QuestionSnsEnableEncryption)
-			c.SendLine("y")
-			expectString(t, c, cmd.QuestionSnsEncryptionKeyArn)
-			c.SendLine("")
-			// SQS Questions
-			expectString(t, c, cmd.QuestionSqsQueueName)
-			c.SendLine("")
-			expectString(t, c, cmd.QuestionSqsEnableEncryption)
-			c.SendLine("y")
-			expectString(t, c, cmd.QuestionSqsEncryptionKeyArn)
-			c.SendLine("")
-			//
-			expectString(t, c, cmd.QuestionAwsAnotherAdvancedOpt)
-			c.SendLine("y")
-			expectString(t, c, cmd.AwsAdvancedOptDone)
-			c.Send("\x1B[B")
-			c.SendLine("\x1B[B") // Down arrow twice and enter on the submenu to add subaccounts
-			expectString(t, c, cmd.QuestionPrimaryAwsAccountProfile)
-			c.SendLine("default")
-			expectString(t, c, cmd.QuestionSubAccountProfileName)
-			c.SendLine("account1")
-			expectString(t, c, cmd.QuestionSubAccountRegion)
-			c.SendLine("us-east-1")
-			expectString(t, c, cmd.QuestionSubAccountAddMore)
-			c.SendLine("y")
-			expectString(t, c, cmd.QuestionSubAccountProfileName)
-			c.SendLine("account2")
-			expectString(t, c, cmd.QuestionSubAccountRegion)
-			c.SendLine("us-east-2")
-			expectString(t, c, cmd.QuestionSubAccountAddMore)
-			c.SendLine("n")
-			expectString(t, c, cmd.QuestionAwsAnotherAdvancedOpt)
-			c.SendLine("n")
-			expectString(t, c, cmd.QuestionRunTfPlan)
-			c.SendLine("n")
+			expectsCliOutput(t, c, []MsgRspHandler{
+				MsgRsp{cmd.QuestionAwsEnableConfig, "y"},
+				MsgRsp{cmd.QuestionEnableCloudtrail, "y"},
+				MsgRsp{cmd.QuestionAwsRegion, region},
+				MsgRsp{cmd.QuestionAwsConfigAdvanced, "y"},
+				MsgMenu{cmd.AwsAdvancedOptDone, 1},
+				MsgRsp{cmd.QuestionConsolidatedCloudtrail, "y"},
+				MsgRsp{cmd.QuestionUseExistingCloudtrail, "n"},
+				MsgRsp{cmd.QuestionCloudtrailName, ""},
+				MsgRsp{cmd.QuestionForceDestroyS3Bucket, "n"},
+				MsgRsp{cmd.QuestionBucketName, ""},
+				MsgRsp{cmd.QuestionBucketEnableEncryption, "y"},
+				MsgRsp{cmd.QuestionBucketSseKeyArn, ""},
+				// SNS Topic Questions
+				MsgRsp{cmd.QuestionsUseExistingSNSTopic, "n"},
+				MsgRsp{cmd.QuestionSnsTopicName, ""},
+				MsgRsp{cmd.QuestionSnsEnableEncryption, "y"},
+				MsgRsp{cmd.QuestionSnsEncryptionKeyArn, ""},
+				// SQS Questions
+				MsgRsp{cmd.QuestionSqsQueueName, ""},
+				MsgRsp{cmd.QuestionSqsEnableEncryption, "y"},
+				MsgRsp{cmd.QuestionSqsEncryptionKeyArn, ""},
+				MsgRsp{cmd.QuestionAwsAnotherAdvancedOpt, "y"},
+				MsgMenu{cmd.AwsAdvancedOptDone, 2},
+				MsgRsp{cmd.QuestionPrimaryAwsAccountProfile, "default"},
+				MsgRsp{cmd.QuestionSubAccountProfileName, "account1"},
+				MsgRsp{cmd.QuestionSubAccountRegion, "us-east-1"},
+				MsgRsp{cmd.QuestionSubAccountAddMore, "y"},
+				MsgRsp{cmd.QuestionSubAccountProfileName, "account2"},
+				MsgRsp{cmd.QuestionSubAccountRegion, "us-east-2"},
+				MsgRsp{cmd.QuestionSubAccountAddMore, "n"},
+				MsgRsp{cmd.QuestionAwsAnotherAdvancedOpt, "n"},
+				MsgRsp{cmd.QuestionRunTfPlan, "n"},
+			})
 			final, _ = c.ExpectEOF()
 		},
 		"generate",
@@ -467,34 +378,22 @@ func TestGenerationAwsAdvancedOptsConfigWithSubAccounts(t *testing.T) {
 	// Run CLI
 	tfResult := runGenerateTest(t,
 		func(c *expect.Console) {
-			expectString(t, c, cmd.QuestionAwsEnableConfig)
-			c.SendLine("y")
-			expectString(t, c, cmd.QuestionEnableCloudtrail)
-			c.SendLine("n")
-			expectString(t, c, cmd.QuestionAwsRegion)
-			c.SendLine(region)
-			expectString(t, c, cmd.QuestionAwsConfigAdvanced)
-			c.SendLine("y")
-			expectString(t, c, cmd.AwsAdvancedOptDone)
-			c.SendLine("\x1B[B")
-			expectString(t, c, cmd.QuestionPrimaryAwsAccountProfile)
-			c.SendLine("default")
-			expectString(t, c, cmd.QuestionSubAccountProfileName)
-			c.SendLine("account1")
-			expectString(t, c, cmd.QuestionSubAccountRegion)
-			c.SendLine("us-east-1")
-			expectString(t, c, cmd.QuestionSubAccountAddMore)
-			c.SendLine("y")
-			expectString(t, c, cmd.QuestionSubAccountProfileName)
-			c.SendLine("account2")
-			expectString(t, c, cmd.QuestionSubAccountRegion)
-			c.SendLine("us-east-2")
-			expectString(t, c, cmd.QuestionSubAccountAddMore)
-			c.SendLine("n")
-			expectString(t, c, cmd.QuestionAwsAnotherAdvancedOpt)
-			c.SendLine("n")
-			expectString(t, c, cmd.QuestionRunTfPlan)
-			c.SendLine("n")
+			expectsCliOutput(t, c, []MsgRspHandler{
+				MsgRsp{cmd.QuestionAwsEnableConfig, "y"},
+				MsgRsp{cmd.QuestionEnableCloudtrail, "n"},
+				MsgRsp{cmd.QuestionAwsRegion, region},
+				MsgRsp{cmd.QuestionAwsConfigAdvanced, "y"},
+				MsgMenu{cmd.AwsAdvancedOptDone, 1},
+				MsgRsp{cmd.QuestionPrimaryAwsAccountProfile, "default"},
+				MsgRsp{cmd.QuestionSubAccountProfileName, "account1"},
+				MsgRsp{cmd.QuestionSubAccountRegion, "us-east-1"},
+				MsgRsp{cmd.QuestionSubAccountAddMore, "y"},
+				MsgRsp{cmd.QuestionSubAccountProfileName, "account2"},
+				MsgRsp{cmd.QuestionSubAccountRegion, "us-east-2"},
+				MsgRsp{cmd.QuestionSubAccountAddMore, "n"},
+				MsgRsp{cmd.QuestionAwsAnotherAdvancedOpt, "n"},
+				MsgRsp{cmd.QuestionRunTfPlan, "n"},
+			})
 			final, _ = c.ExpectEOF()
 		},
 		"generate",
@@ -523,37 +422,23 @@ func TestGenerationAwsAdvancedOptsConsolidatedWithSubAccountsPassedByFlag(t *tes
 	// Run CLI
 	tfResult := runGenerateTest(t,
 		func(c *expect.Console) {
-			expectString(t, c, cmd.QuestionAwsEnableConfig)
-			c.SendLine("y")
-			expectString(t, c, cmd.QuestionEnableCloudtrail)
-			c.SendLine("y")
-			expectString(t, c, cmd.QuestionAwsRegion)
-			c.SendLine(region)
-			expectString(t, c, cmd.QuestionAwsConfigAdvanced)
-			c.SendLine("y")
-			expectString(t, c, cmd.AwsAdvancedOptDone)
-			c.Send("\x1B[B")
-			c.SendLine("\x1B[B") // Down arrow twice and enter on the submenu to add subaccounts
-			expectString(t, c, cmd.QuestionPrimaryAwsAccountProfile)
-			c.SendLine("default")
-			expectString(t, c, fmt.Sprintf(cmd.QuestionSubAccountReplace, "testaccount:us-east-1, testaccount1:us-east-2"))
-			c.SendLine("y")
-			expectString(t, c, cmd.QuestionSubAccountProfileName)
-			c.SendLine("account1")
-			expectString(t, c, cmd.QuestionSubAccountRegion)
-			c.SendLine("us-east-1")
-			expectString(t, c, cmd.QuestionSubAccountAddMore)
-			c.SendLine("y")
-			expectString(t, c, cmd.QuestionSubAccountProfileName)
-			c.SendLine("account2")
-			expectString(t, c, cmd.QuestionSubAccountRegion)
-			c.SendLine("us-east-2")
-			expectString(t, c, cmd.QuestionSubAccountAddMore)
-			c.SendLine("n")
-			expectString(t, c, cmd.QuestionAwsAnotherAdvancedOpt)
-			c.SendLine("n")
-			expectString(t, c, cmd.QuestionRunTfPlan)
-			c.SendLine("n")
+			expectsCliOutput(t, c, []MsgRspHandler{
+				MsgRsp{cmd.QuestionAwsEnableConfig, "y"},
+				MsgRsp{cmd.QuestionEnableCloudtrail, "y"},
+				MsgRsp{cmd.QuestionAwsRegion, region},
+				MsgRsp{cmd.QuestionAwsConfigAdvanced, "y"},
+				MsgMenu{cmd.AwsAdvancedOptDone, 2},
+				MsgRsp{cmd.QuestionPrimaryAwsAccountProfile, "default"},
+				MsgRsp{fmt.Sprintf(cmd.QuestionSubAccountReplace, "testaccount:us-east-1, testaccount1:us-east-2"), "y"},
+				MsgRsp{cmd.QuestionSubAccountProfileName, "account1"},
+				MsgRsp{cmd.QuestionSubAccountRegion, "us-east-1"},
+				MsgRsp{cmd.QuestionSubAccountAddMore, "y"},
+				MsgRsp{cmd.QuestionSubAccountProfileName, "account2"},
+				MsgRsp{cmd.QuestionSubAccountRegion, "us-east-2"},
+				MsgRsp{cmd.QuestionSubAccountAddMore, "n"},
+				MsgRsp{cmd.QuestionAwsAnotherAdvancedOpt, "n"},
+				MsgRsp{cmd.QuestionRunTfPlan, "n"},
+			})
 			final, _ = c.ExpectEOF()
 		},
 		"generate",
@@ -594,28 +479,18 @@ func TestGenerationAwsAdvancedOptsUseExistingIAM(t *testing.T) {
 	// Run CLI
 	tfResult := runGenerateTest(t,
 		func(c *expect.Console) {
-			expectString(t, c, cmd.QuestionAwsEnableConfig)
-			c.SendLine("y")
-			expectString(t, c, cmd.QuestionEnableCloudtrail)
-			c.SendLine("y")
-			expectString(t, c, cmd.QuestionAwsRegion)
-			c.SendLine(region)
-			expectString(t, c, cmd.QuestionAwsConfigAdvanced)
-			c.SendLine("y")
-			expectString(t, c, cmd.AwsAdvancedOptDone)
-			c.Send("\x1B[B")
-			c.Send("\x1B[B")
-			c.SendLine("\x1B[B") // Down arrow once and return
-			expectString(t, c, cmd.QuestionExistingIamRoleName)
-			c.SendLine(roleName)
-			expectString(t, c, cmd.QuestionExistingIamRoleArn)
-			c.SendLine(roleArn)
-			expectString(t, c, cmd.QuestionExistingIamRoleExtID)
-			c.SendLine(roleExtId)
-			expectString(t, c, cmd.QuestionAwsAnotherAdvancedOpt)
-			c.SendLine("n")
-			expectString(t, c, cmd.QuestionRunTfPlan)
-			c.SendLine("n")
+			expectsCliOutput(t, c, []MsgRspHandler{
+				MsgRsp{cmd.QuestionAwsEnableConfig, "y"},
+				MsgRsp{cmd.QuestionEnableCloudtrail, "y"},
+				MsgRsp{cmd.QuestionAwsRegion, region},
+				MsgRsp{cmd.QuestionAwsConfigAdvanced, "y"},
+				MsgMenu{cmd.AwsAdvancedOptDone, 3},
+				MsgRsp{cmd.QuestionExistingIamRoleName, roleName},
+				MsgRsp{cmd.QuestionExistingIamRoleArn, roleArn},
+				MsgRsp{cmd.QuestionExistingIamRoleExtID, roleExtId},
+				MsgRsp{cmd.QuestionAwsAnotherAdvancedOpt, "n"},
+				MsgRsp{cmd.QuestionRunTfPlan, "n"},
+			})
 			final, _ = c.ExpectEOF()
 		},
 		"generate",
@@ -649,36 +524,23 @@ func TestGenerationAwsAdvancedOptsUseExistingElements(t *testing.T) {
 	// Run CLI
 	tfResult := runGenerateTest(t,
 		func(c *expect.Console) {
-			expectString(t, c, cmd.QuestionAwsEnableConfig)
-			c.SendLine("y")
-			expectString(t, c, cmd.QuestionEnableCloudtrail)
-			c.SendLine("y")
-			expectString(t, c, cmd.QuestionAwsRegion)
-			c.SendLine(region)
-			expectString(t, c, cmd.QuestionAwsConfigAdvanced)
-			c.SendLine("y")
-			expectString(t, c, cmd.AwsAdvancedOptDone)
-			c.SendLine("\x1B[B") // Down arrow once and return
-			expectString(t, c, cmd.QuestionConsolidatedCloudtrail)
-			c.SendLine("n")
-			expectString(t, c, cmd.QuestionUseExistingCloudtrail)
-			c.SendLine("y")
-			expectString(t, c, cmd.QuestionCloudtrailExistingBucketArn)
-			c.SendLine(bucketArn)
-			expectString(t, c, cmd.QuestionsUseExistingSNSTopic)
-			c.SendLine("y")
-			expectString(t, c, cmd.QuestionSnsTopicArn)
-			c.SendLine(topicArn)
-			expectString(t, c, cmd.QuestionSqsQueueName)
-			c.SendLine(queueName)
-			expectString(t, c, cmd.QuestionSqsEnableEncryption)
-			c.SendLine("y")
-			expectString(t, c, cmd.QuestionSqsEncryptionKeyArn)
-			c.SendLine("")
-			expectString(t, c, cmd.QuestionAwsAnotherAdvancedOpt)
-			c.SendLine("n")
-			expectString(t, c, cmd.QuestionRunTfPlan)
-			c.SendLine("n")
+			expectsCliOutput(t, c, []MsgRspHandler{
+				MsgRsp{cmd.QuestionAwsEnableConfig, "y"},
+				MsgRsp{cmd.QuestionEnableCloudtrail, "y"},
+				MsgRsp{cmd.QuestionAwsRegion, region},
+				MsgRsp{cmd.QuestionAwsConfigAdvanced, "y"},
+				MsgMenu{cmd.AwsAdvancedOptDone, 1},
+				MsgRsp{cmd.QuestionConsolidatedCloudtrail, "n"},
+				MsgRsp{cmd.QuestionUseExistingCloudtrail, "y"},
+				MsgRsp{cmd.QuestionCloudtrailExistingBucketArn, bucketArn},
+				MsgRsp{cmd.QuestionsUseExistingSNSTopic, "y"},
+				MsgRsp{cmd.QuestionSnsTopicArn, topicArn},
+				MsgRsp{cmd.QuestionSqsQueueName, queueName},
+				MsgRsp{cmd.QuestionSqsEnableEncryption, "y"},
+				MsgRsp{cmd.QuestionSqsEncryptionKeyArn, ""},
+				MsgRsp{cmd.QuestionAwsAnotherAdvancedOpt, "n"},
+				MsgRsp{cmd.QuestionRunTfPlan, "n"},
+			})
 			final, _ = c.ExpectEOF()
 		},
 		"generate",
@@ -714,52 +576,32 @@ func TestGenerationAwsAdvancedOptsCreateNewElements(t *testing.T) {
 	// Run CLI
 	tfResult := runGenerateTest(t,
 		func(c *expect.Console) {
-			expectString(t, c, cmd.QuestionAwsEnableConfig)
-			c.SendLine("y")
-			expectString(t, c, cmd.QuestionEnableCloudtrail)
-			c.SendLine("y")
-			expectString(t, c, cmd.QuestionAwsRegion)
-			c.SendLine(region)
-			expectString(t, c, cmd.QuestionAwsConfigAdvanced)
-			c.SendLine("y")
-			expectString(t, c, cmd.AwsAdvancedOptDone)
-			c.SendLine("\x1B[B") // Down arrow once and return
-			expectString(t, c, cmd.QuestionConsolidatedCloudtrail)
-			c.SendLine("n")
-			expectString(t, c, cmd.QuestionUseExistingCloudtrail)
-			c.SendLine("n")
-			expectString(t, c, cmd.QuestionCloudtrailName)
-			c.SendLine(trailName)
-			// S3 Questions
-			expectString(t, c, cmd.QuestionForceDestroyS3Bucket)
-			c.SendLine("y")
-			expectString(t, c, cmd.QuestionBucketName)
-			c.SendLine(bucketName)
-			expectString(t, c, cmd.QuestionBucketEnableEncryption)
-			c.SendLine("y")
-			expectString(t, c, cmd.QuestionBucketSseKeyArn)
-			c.SendLine(kmsArn)
-			// SNS Topic Questions
-			expectString(t, c, cmd.QuestionsUseExistingSNSTopic)
-			c.SendLine("n")
-			expectString(t, c, cmd.QuestionSnsTopicName)
-			c.SendLine(topicName)
-			expectString(t, c, cmd.QuestionSnsEnableEncryption)
-			c.SendLine("y")
-			expectString(t, c, cmd.QuestionSnsEncryptionKeyArn)
-			c.SendLine(kmsArn)
-			// SQS Questions
-			expectString(t, c, cmd.QuestionSqsQueueName)
-			c.SendLine(queueName)
-			expectString(t, c, cmd.QuestionSqsEnableEncryption)
-			c.SendLine("y")
-			expectString(t, c, cmd.QuestionSqsEncryptionKeyArn)
-			c.SendLine(kmsArn)
-			//
-			expectString(t, c, cmd.QuestionAwsAnotherAdvancedOpt)
-			c.SendLine("n")
-			expectString(t, c, cmd.QuestionRunTfPlan)
-			c.SendLine("n")
+			expectsCliOutput(t, c, []MsgRspHandler{
+				MsgRsp{cmd.QuestionAwsEnableConfig, "y"},
+				MsgRsp{cmd.QuestionEnableCloudtrail, "y"},
+				MsgRsp{cmd.QuestionAwsRegion, region},
+				MsgRsp{cmd.QuestionAwsConfigAdvanced, "y"},
+				MsgMenu{cmd.AwsAdvancedOptDone, 1},
+				MsgRsp{cmd.QuestionConsolidatedCloudtrail, "n"},
+				MsgRsp{cmd.QuestionUseExistingCloudtrail, "n"},
+				MsgRsp{cmd.QuestionCloudtrailName, trailName},
+				// S3 Questions
+				MsgRsp{cmd.QuestionForceDestroyS3Bucket, "y"},
+				MsgRsp{cmd.QuestionBucketName, bucketName},
+				MsgRsp{cmd.QuestionBucketEnableEncryption, "y"},
+				MsgRsp{cmd.QuestionBucketSseKeyArn, kmsArn},
+				// SNS Topic Questions
+				MsgRsp{cmd.QuestionsUseExistingSNSTopic, "n"},
+				MsgRsp{cmd.QuestionSnsTopicName, topicName},
+				MsgRsp{cmd.QuestionSnsEnableEncryption, "y"},
+				MsgRsp{cmd.QuestionSnsEncryptionKeyArn, kmsArn},
+				// SQS Questions
+				MsgRsp{cmd.QuestionSqsQueueName, queueName},
+				MsgRsp{cmd.QuestionSqsEnableEncryption, "y"},
+				MsgRsp{cmd.QuestionSqsEncryptionKeyArn, kmsArn},
+				MsgRsp{cmd.QuestionAwsAnotherAdvancedOpt, "n"},
+				MsgRsp{cmd.QuestionRunTfPlan, "n"},
+			})
 			final, _ = c.ExpectEOF()
 		},
 		"generate",
@@ -808,25 +650,16 @@ func TestGenerationAwsWithExistingTerraform(t *testing.T) {
 	// Run CLI
 	runGenerateTest(t,
 		func(c *expect.Console) {
-			expectString(t, c, cmd.QuestionAwsEnableConfig)
-			c.SendLine("y")
-			expectString(t, c, cmd.QuestionEnableCloudtrail)
-			c.SendLine("y")
-			expectString(t, c, cmd.QuestionAwsRegion)
-			c.SendLine(region)
-			expectString(t, c, cmd.QuestionAwsConfigAdvanced)
-			c.SendLine("y")
-			expectString(t, c, cmd.AwsAdvancedOptDone)
-			c.Send("\x1B[B")
-			c.Send("\x1B[B")
-			c.Send("\x1B[B")
-			c.SendLine("\x1B[B")
-			expectString(t, c, cmd.QuestionAwsCustomizeOutputLocation)
-			c.SendLine(dir)
-			expectString(t, c, cmd.QuestionAwsAnotherAdvancedOpt)
-			c.SendLine("n")
-			expectString(t, c, fmt.Sprintf("%s/main.tf already exists, overwrite?", dir))
-			c.SendLine("n")
+			expectsCliOutput(t, c, []MsgRspHandler{
+				MsgRsp{cmd.QuestionAwsEnableConfig, "y"},
+				MsgRsp{cmd.QuestionEnableCloudtrail, "y"},
+				MsgRsp{cmd.QuestionAwsRegion, region},
+				MsgRsp{cmd.QuestionAwsConfigAdvanced, "y"},
+				MsgMenu{cmd.AwsAdvancedOptDone, 4},
+				MsgRsp{cmd.QuestionAwsCustomizeOutputLocation, dir},
+				MsgRsp{cmd.QuestionAwsAnotherAdvancedOpt, "n"},
+				MsgRsp{fmt.Sprintf("%s/main.tf already exists, overwrite?", dir), "n"},
+			})
 		},
 		"generate",
 		"cloud-account",
@@ -856,16 +689,13 @@ func TestGenerationAwsOverwrite(t *testing.T) {
 
 	runFakeTerminalTestFromDir(t, dir,
 		func(c *expect.Console) {
-			expectString(t, c, cmd.QuestionAwsEnableConfig)
-			c.SendLine("y")
-			expectString(t, c, cmd.QuestionEnableCloudtrail)
-			c.SendLine("y")
-			expectString(t, c, cmd.QuestionAwsRegion)
-			c.SendLine(region)
-			expectString(t, c, cmd.QuestionAwsConfigAdvanced)
-			c.SendLine("n")
-			expectString(t, c, cmd.QuestionRunTfPlan)
-			c.SendLine("n")
+			expectsCliOutput(t, c, []MsgRspHandler{
+				MsgRsp{cmd.QuestionAwsEnableConfig, "y"},
+				MsgRsp{cmd.QuestionEnableCloudtrail, "y"},
+				MsgRsp{cmd.QuestionAwsRegion, region},
+				MsgRsp{cmd.QuestionAwsConfigAdvanced, "n"},
+				MsgRsp{cmd.QuestionRunTfPlan, "n"},
+			})
 			final, _ = c.ExpectEOF()
 		},
 		"generate",
@@ -877,18 +707,14 @@ func TestGenerationAwsOverwrite(t *testing.T) {
 
 	runFakeTerminalTestFromDir(t, dir,
 		func(c *expect.Console) {
-			expectString(t, c, cmd.QuestionAwsEnableConfig)
-			c.SendLine("y")
-			expectString(t, c, cmd.QuestionEnableCloudtrail)
-			c.SendLine("y")
-			expectString(t, c, cmd.QuestionAwsRegion)
-			c.SendLine(region)
-			expectString(t, c, cmd.QuestionAwsConfigAdvanced)
-			c.SendLine("n")
-			expectString(t, c, "already exists, overwrite?")
-			c.SendLine("n")
-			expectString(t, c, cmd.QuestionRunTfPlan)
-			c.SendLine("n")
+			expectsCliOutput(t, c, []MsgRspHandler{
+				MsgRsp{cmd.QuestionAwsEnableConfig, "y"},
+				MsgRsp{cmd.QuestionEnableCloudtrail, "y"},
+				MsgRsp{cmd.QuestionAwsRegion, region},
+				MsgRsp{cmd.QuestionAwsConfigAdvanced, "n"},
+				MsgRsp{"already exists, overwrite?", "n"},
+				MsgRsp{cmd.QuestionRunTfPlan, "n"},
+			})
 			final, _ = c.ExpectEOF()
 		},
 		"generate",
@@ -917,16 +743,13 @@ func TestGenerationAwsOverwriteOutput(t *testing.T) {
 
 	runFakeTerminalTestFromDir(t, dir,
 		func(c *expect.Console) {
-			expectString(t, c, cmd.QuestionAwsEnableConfig)
-			c.SendLine("y")
-			expectString(t, c, cmd.QuestionEnableCloudtrail)
-			c.SendLine("y")
-			expectString(t, c, cmd.QuestionAwsRegion)
-			c.SendLine(region)
-			expectString(t, c, cmd.QuestionAwsConfigAdvanced)
-			c.SendLine("n")
-			expectString(t, c, cmd.QuestionRunTfPlan)
-			c.SendLine("n")
+			expectsCliOutput(t, c, []MsgRspHandler{
+				MsgRsp{cmd.QuestionAwsEnableConfig, "y"},
+				MsgRsp{cmd.QuestionEnableCloudtrail, "y"},
+				MsgRsp{cmd.QuestionAwsRegion, region},
+				MsgRsp{cmd.QuestionAwsConfigAdvanced, "n"},
+				MsgRsp{cmd.QuestionRunTfPlan, "n"},
+			})
 			final, _ = c.ExpectEOF()
 		},
 		"generate",
@@ -940,18 +763,14 @@ func TestGenerationAwsOverwriteOutput(t *testing.T) {
 
 	runFakeTerminalTestFromDir(t, dir,
 		func(c *expect.Console) {
-			expectString(t, c, cmd.QuestionAwsEnableConfig)
-			c.SendLine("y")
-			expectString(t, c, cmd.QuestionEnableCloudtrail)
-			c.SendLine("y")
-			expectString(t, c, cmd.QuestionAwsRegion)
-			c.SendLine(region)
-			expectString(t, c, cmd.QuestionAwsConfigAdvanced)
-			c.SendLine("n")
-			expectString(t, c, "already exists, overwrite?")
-			c.SendLine("n")
-			expectString(t, c, cmd.QuestionRunTfPlan)
-			c.SendLine("n")
+			expectsCliOutput(t, c, []MsgRspHandler{
+				MsgRsp{cmd.QuestionAwsEnableConfig, "y"},
+				MsgRsp{cmd.QuestionEnableCloudtrail, "y"},
+				MsgRsp{cmd.QuestionAwsRegion, region},
+				MsgRsp{cmd.QuestionAwsConfigAdvanced, "n"},
+				MsgRsp{"already exists, overwrite?", "n"},
+				MsgRsp{cmd.QuestionRunTfPlan, "n"},
+			})
 			final, _ = c.ExpectEOF()
 		},
 		"generate",
@@ -974,16 +793,14 @@ func TestGenerationAwsLaceworkProfile(t *testing.T) {
 
 	tfResult := runGenerateTest(t,
 		func(c *expect.Console) {
-			expectString(t, c, cmd.QuestionAwsEnableConfig)
-			c.SendLine("y")
-			expectString(t, c, cmd.QuestionEnableCloudtrail)
-			c.SendLine("y")
-			expectString(t, c, cmd.QuestionAwsRegion)
-			c.SendLine(region)
-			expectString(t, c, cmd.QuestionAwsConfigAdvanced)
-			c.SendLine("n")
-			expectString(t, c, cmd.QuestionRunTfPlan)
-			c.SendLine("n")
+			expectsCliOutput(t, c, []MsgRspHandler{
+				MsgRsp{cmd.QuestionAwsEnableConfig, "y"},
+				MsgRsp{cmd.QuestionEnableCloudtrail, "y"},
+				MsgRsp{cmd.QuestionAwsRegion, region},
+				MsgRsp{cmd.QuestionAwsConfigAdvanced, "n"},
+				MsgRsp{cmd.QuestionRunTfPlan, "n"},
+			})
+
 			final, _ = c.ExpectEOF()
 		},
 		"generate",

--- a/integration/azure_generation_test.go
+++ b/integration/azure_generation_test.go
@@ -34,13 +34,12 @@ func TestGenerationAzureErrorOnNoSelection(t *testing.T) {
 	// Run CLI
 	runGenerateAzureTest(t,
 		func(c *expect.Console) {
-			expectAzureString(c, cmd.QuestionAzureEnableConfig, &runError)
-			c.SendLine("n")
-			expectAzureString(c, cmd.QuestionEnableActivityLog, &runError)
-			c.SendLine("n")
-			expectAzureString(c, cmd.QuestionEnableAdIntegration, &runError)
-			c.SendLine("n")
-			expectAzureString(c, "ERROR collecting/confirming parameters: must enable activity log or config", &runError)
+			expectsCliOutput(t, c, []MsgRspHandler{
+				MsgRsp{cmd.QuestionAzureEnableConfig, "n"},
+				MsgRsp{cmd.QuestionEnableActivityLog, "n"},
+				MsgRsp{cmd.QuestionEnableAdIntegration, "n"},
+				MsgOnly{"ERROR collecting/confirming parameters: must enable activity log or config"},
+			})
 		},
 		"generate",
 		"cloud-account",
@@ -61,16 +60,13 @@ func TestGenerationAzureSimple(t *testing.T) {
 	// Run CLI
 	tfResult := runGenerateAzureTest(t,
 		func(c *expect.Console) {
-			expectAzureString(c, cmd.QuestionAzureEnableConfig, &runError)
-			c.SendLine("y")
-			expectAzureString(c, cmd.QuestionEnableActivityLog, &runError)
-			c.SendLine("y")
-			expectAzureString(c, cmd.QuestionEnableAdIntegration, &runError)
-			c.SendLine("y")
-			expectAzureString(c, cmd.QuestionAzureConfigAdvanced, &runError)
-			c.SendLine("n")
-			expectAzureString(c, cmd.QuestionRunTfPlan, &runError)
-			c.SendLine("n")
+			expectsCliOutput(t, c, []MsgRspHandler{
+				MsgRsp{cmd.QuestionAzureEnableConfig, "y"},
+				MsgRsp{cmd.QuestionEnableActivityLog, "y"},
+				MsgRsp{cmd.QuestionEnableAdIntegration, "y"},
+				MsgRsp{cmd.QuestionAzureConfigAdvanced, "n"},
+				MsgRsp{cmd.QuestionRunTfPlan, "n"},
+			})
 			final, _ = c.ExpectEOF()
 		},
 		"generate",
@@ -104,24 +100,15 @@ func TestGenerationAzureCustomizedOutputLocation(t *testing.T) {
 	// Run CLI
 	runGenerateAzureTest(t,
 		func(c *expect.Console) {
-			expectAzureString(c, cmd.QuestionAzureEnableConfig, &runError)
-			c.SendLine("y")
-			expectAzureString(c, cmd.QuestionEnableActivityLog, &runError)
-			c.SendLine("y")
-			expectAzureString(c, cmd.QuestionEnableAdIntegration, &runError)
-			c.SendLine("y")
-			expectAzureString(c, cmd.QuestionAzureConfigAdvanced, &runError)
-			c.SendLine("y")
-			expectAzureString(c, cmd.AzureAdvancedOptDone, &runError)
-			c.Send("\x1B[B")
-			c.Send("\x1B[B")
-			c.Send("\x1B[B")
-			c.Send("\x1B[B")
-			c.SendLine("\x1B[B")
-			expectAzureString(c, cmd.QuestionAzureCustomizeOutputLocation, &runError)
-			c.SendLine(dir)
-			expectAzureString(c, cmd.QuestionRunTfPlan, &runError)
-			c.SendLine("n")
+			expectsCliOutput(t, c, []MsgRspHandler{
+				MsgRsp{cmd.QuestionAzureEnableConfig, "y"},
+				MsgRsp{cmd.QuestionEnableActivityLog, "y"},
+				MsgRsp{cmd.QuestionEnableAdIntegration, "y"},
+				MsgRsp{cmd.QuestionAzureConfigAdvanced, "y"},
+				MsgMenu{cmd.AzureAdvancedOptDone, 5},
+				MsgRsp{cmd.QuestionAzureCustomizeOutputLocation, dir},
+				MsgRsp{cmd.QuestionRunTfPlan, "n"},
+			})
 			final, _ = c.ExpectEOF()
 		},
 		"generate",
@@ -151,16 +138,13 @@ func TestGenerationAzureConfigOnly(t *testing.T) {
 	// Run CLI
 	tfResult := runGenerateAzureTest(t,
 		func(c *expect.Console) {
-			expectAzureString(c, cmd.QuestionAzureEnableConfig, &runError)
-			c.SendLine("y")
-			expectAzureString(c, cmd.QuestionEnableActivityLog, &runError)
-			c.SendLine("n")
-			expectAzureString(c, cmd.QuestionEnableAdIntegration, &runError)
-			c.SendLine("y")
-			expectAzureString(c, cmd.QuestionAzureConfigAdvanced, &runError)
-			c.SendLine("n")
-			expectAzureString(c, cmd.QuestionRunTfPlan, &runError)
-			c.SendLine("n")
+			expectsCliOutput(t, c, []MsgRspHandler{
+				MsgRsp{cmd.QuestionAzureEnableConfig, "y"},
+				MsgRsp{cmd.QuestionEnableActivityLog, "n"},
+				MsgRsp{cmd.QuestionEnableAdIntegration, "y"},
+				MsgRsp{cmd.QuestionAzureConfigAdvanced, "n"},
+				MsgRsp{cmd.QuestionRunTfPlan, "n"},
+			})
 			final, _ = c.ExpectEOF()
 		},
 		"generate",
@@ -187,16 +171,13 @@ func TestGenerationAzureActivityLogOnly(t *testing.T) {
 	// Run CLI
 	tfResult := runGenerateAzureTest(t,
 		func(c *expect.Console) {
-			expectAzureString(c, cmd.QuestionAzureEnableConfig, &runError)
-			c.SendLine("n")
-			expectAzureString(c, cmd.QuestionEnableActivityLog, &runError)
-			c.SendLine("y")
-			expectAzureString(c, cmd.QuestionEnableAdIntegration, &runError)
-			c.SendLine("y")
-			expectAzureString(c, cmd.QuestionAzureConfigAdvanced, &runError)
-			c.SendLine("n")
-			expectAzureString(c, cmd.QuestionRunTfPlan, &runError)
-			c.SendLine("n")
+			expectsCliOutput(t, c, []MsgRspHandler{
+				MsgRsp{cmd.QuestionAzureEnableConfig, "n"},
+				MsgRsp{cmd.QuestionEnableActivityLog, "y"},
+				MsgRsp{cmd.QuestionEnableAdIntegration, "y"},
+				MsgRsp{cmd.QuestionAzureConfigAdvanced, "n"},
+				MsgRsp{cmd.QuestionRunTfPlan, "n"},
+			})
 			final, _ = c.ExpectEOF()
 		},
 		"generate",
@@ -226,30 +207,18 @@ func TestGenerationAzureNoADEnabled(t *testing.T) {
 	// Run CLI
 	tfResult := runGenerateAzureTest(t,
 		func(c *expect.Console) {
-			expectAzureString(c, cmd.QuestionAzureEnableConfig, &runError)
-			c.SendLine("y")
-			expectAzureString(c, cmd.QuestionEnableActivityLog, &runError)
-			c.SendLine("y")
-			expectAzureString(c, cmd.QuestionEnableAdIntegration, &runError)
-			c.SendLine("n")
-			expectAzureString(c, cmd.QuestionAzureConfigAdvanced, &runError)
-			c.SendLine("y")
-
-			expectAzureString(c, cmd.AzureAdvancedOptLocation, &runError)
-			c.Send("\x1B[B")
-			c.SendLine("\x1B[B")
-
-			expectAzureString(c, cmd.QuestionADApplicationPass, &runError)
-			c.SendLine(pass)
-			expectAzureString(c, cmd.QuestionADApplicationId, &runError)
-			c.SendLine(applicationId)
-			expectAzureString(c, cmd.QuestionADServicePrincpleId, &runError)
-			c.SendLine(principalId)
-
-			expectAzureString(c, cmd.QuestionAzureAnotherAdvancedOpt, &runError)
-			c.SendLine("n")
-			expectAzureString(c, cmd.QuestionRunTfPlan, &runError)
-			c.SendLine("n")
+			expectsCliOutput(t, c, []MsgRspHandler{
+				MsgRsp{cmd.QuestionAzureEnableConfig, "y"},
+				MsgRsp{cmd.QuestionEnableActivityLog, "y"},
+				MsgRsp{cmd.QuestionEnableAdIntegration, "n"},
+				MsgRsp{cmd.QuestionAzureConfigAdvanced, "y"},
+				MsgMenu{cmd.AzureAdvancedOptLocation, 2},
+				MsgRsp{cmd.QuestionADApplicationPass, pass},
+				MsgRsp{cmd.QuestionADApplicationId, applicationId},
+				MsgRsp{cmd.QuestionADServicePrincpleId, principalId},
+				MsgRsp{cmd.QuestionAzureAnotherAdvancedOpt, "n"},
+				MsgRsp{cmd.QuestionRunTfPlan, "n"},
+			})
 			final, _ = c.ExpectEOF()
 		},
 		"generate",
@@ -281,25 +250,19 @@ func TestGenerationAzureNamedConfig(t *testing.T) {
 	// Run CLI
 	tfResult := runGenerateAzureTest(t,
 		func(c *expect.Console) {
-			expectAzureString(c, cmd.QuestionAzureEnableConfig, &runError)
-			c.SendLine("y")
-			expectAzureString(c, cmd.QuestionEnableActivityLog, &runError)
-			c.SendLine("n")
-			expectAzureString(c, cmd.QuestionEnableAdIntegration, &runError)
-			c.SendLine("y")
-			expectAzureString(c, cmd.QuestionAzureConfigAdvanced, &runError)
-			c.SendLine("y")
+			expectsCliOutput(t, c, []MsgRspHandler{
+				MsgRsp{cmd.QuestionAzureEnableConfig, "y"},
+				MsgRsp{cmd.QuestionEnableActivityLog, "n"},
+				MsgRsp{cmd.QuestionEnableAdIntegration, "y"},
+				MsgRsp{cmd.QuestionAzureConfigAdvanced, "y"},
 
-			expectAzureString(c, cmd.AzureAdvancedOptDone, &runError)
-			c.SendLine("")
+				MsgMenu{cmd.AzureAdvancedOptDone, 0},
 
-			expectAzureString(c, cmd.QuestionAzureConfigName, &runError)
-			c.SendLine(configName)
+				MsgRsp{cmd.QuestionAzureConfigName, configName},
 
-			expectAzureString(c, cmd.QuestionAzureAnotherAdvancedOpt, &runError)
-			c.SendLine("n")
-			expectAzureString(c, cmd.QuestionRunTfPlan, &runError)
-			c.SendLine("n")
+				MsgRsp{cmd.QuestionAzureAnotherAdvancedOpt, "n"},
+				MsgRsp{cmd.QuestionRunTfPlan, "n"},
+			})
 			final, _ = c.ExpectEOF()
 		},
 		"generate",
@@ -329,25 +292,19 @@ func TestGenerationAzureNamedActivityLog(t *testing.T) {
 	// Run CLI
 	tfResult := runGenerateAzureTest(t,
 		func(c *expect.Console) {
-			expectAzureString(c, cmd.QuestionAzureEnableConfig, &runError)
-			c.SendLine("n")
-			expectAzureString(c, cmd.QuestionEnableActivityLog, &runError)
-			c.SendLine("y")
-			expectAzureString(c, cmd.QuestionEnableAdIntegration, &runError)
-			c.SendLine("y")
-			expectAzureString(c, cmd.QuestionAzureConfigAdvanced, &runError)
-			c.SendLine("y")
+			expectsCliOutput(t, c, []MsgRspHandler{
+				MsgRsp{cmd.QuestionAzureEnableConfig, "n"},
+				MsgRsp{cmd.QuestionEnableActivityLog, "y"},
+				MsgRsp{cmd.QuestionEnableAdIntegration, "y"},
+				MsgRsp{cmd.QuestionAzureConfigAdvanced, "y"},
 
-			expectAzureString(c, cmd.AzureAdvancedOptDone, &runError)
-			c.SendLine("")
+				MsgMenu{cmd.AzureAdvancedOptDone, 0},
 
-			expectAzureString(c, cmd.QuestionActivityLogName, &runError)
-			c.SendLine(activityName)
+				MsgRsp{cmd.QuestionActivityLogName, activityName},
 
-			expectAzureString(c, cmd.QuestionAzureAnotherAdvancedOpt, &runError)
-			c.SendLine("n")
-			expectAzureString(c, cmd.QuestionRunTfPlan, &runError)
-			c.SendLine("n")
+				MsgRsp{cmd.QuestionAzureAnotherAdvancedOpt, "n"},
+				MsgRsp{cmd.QuestionRunTfPlan, "n"},
+			})
 			final, _ = c.ExpectEOF()
 		},
 		"generate",
@@ -375,24 +332,15 @@ func TestGenerationAzureAdvancedOptsDone(t *testing.T) {
 	// Run CLI
 	tfResult := runGenerateAzureTest(t,
 		func(c *expect.Console) {
-			expectAzureString(c, cmd.QuestionAzureEnableConfig, &runError)
-			c.SendLine("y")
-			expectAzureString(c, cmd.QuestionEnableActivityLog, &runError)
-			c.SendLine("y")
-			expectAzureString(c, cmd.QuestionEnableAdIntegration, &runError)
-			c.SendLine("y")
-			expectAzureString(c, cmd.QuestionAzureConfigAdvanced, &runError)
-			c.SendLine("y")
+			expectsCliOutput(t, c, []MsgRspHandler{
+				MsgRsp{cmd.QuestionAzureEnableConfig, "y"},
+				MsgRsp{cmd.QuestionEnableActivityLog, "y"},
+				MsgRsp{cmd.QuestionEnableAdIntegration, "y"},
+				MsgRsp{cmd.QuestionAzureConfigAdvanced, "y"},
 
-			expectAzureString(c, cmd.AzureAdvancedOptDone, &runError)
-			c.Send("\x1B[B")
-			c.Send("\x1B[B")
-			c.Send("\x1B[B")
-			c.Send("\x1B[B")
-			c.Send("\x1B[B")
-			c.SendLine("\x1B[B")
-			expectAzureString(c, cmd.QuestionRunTfPlan, &runError)
-			c.SendLine("n")
+				MsgMenu{cmd.AzureAdvancedOptDone, 6},
+				MsgRsp{cmd.QuestionRunTfPlan, "n"},
+			})
 			final, _ = c.ExpectEOF()
 		},
 		"generate",
@@ -431,27 +379,17 @@ func TestGenerationAzureWithExistingTerraform(t *testing.T) {
 	// Run CLI
 	runGenerateAzureTest(t,
 		func(c *expect.Console) {
-			expectAzureString(c, cmd.QuestionAzureEnableConfig, &runError)
-			c.SendLine("y")
-			expectAzureString(c, cmd.QuestionEnableActivityLog, &runError)
-			c.SendLine("y")
-			expectAzureString(c, cmd.QuestionEnableAdIntegration, &runError)
-			c.SendLine("y")
-			expectAzureString(c, cmd.QuestionAzureConfigAdvanced, &runError)
-			c.SendLine("y")
-			expectAzureString(c, cmd.AzureAdvancedOptDone, &runError)
-			c.Send("\x1B[B")
-			c.Send("\x1B[B")
-			c.Send("\x1B[B")
-			c.Send("\x1B[B")
-			c.SendLine("\x1B[B")
-			expectAzureString(c, cmd.QuestionAzureCustomizeOutputLocation, &runError)
-			c.SendLine(dir)
-			expectAzureString(c, fmt.Sprintf("%s/main.tf already exists, overwrite?", dir), &runError)
-			c.SendLine("n")
+			expectsCliOutput(t, c, []MsgRspHandler{
+				MsgRsp{cmd.QuestionAzureEnableConfig, "y"},
+				MsgRsp{cmd.QuestionEnableActivityLog, "y"},
+				MsgRsp{cmd.QuestionEnableAdIntegration, "y"},
+				MsgRsp{cmd.QuestionAzureConfigAdvanced, "y"},
+				MsgMenu{cmd.AzureAdvancedOptDone, 5},
+				MsgRsp{cmd.QuestionAzureCustomizeOutputLocation, dir},
+				MsgRsp{fmt.Sprintf("%s/main.tf already exists, overwrite?", dir), "n"},
 
-			expectAzureString(c, cmd.QuestionRunTfPlan, &runError)
-			c.SendLine("n")
+				MsgRsp{cmd.QuestionRunTfPlan, "n"},
+			})
 			_, _ = c.ExpectEOF()
 		},
 		"generate",
@@ -479,25 +417,17 @@ func TestGenerationAzureConfigAllSubs(t *testing.T) {
 	// Run CLI
 	tfResult := runGenerateAzureTest(t,
 		func(c *expect.Console) {
-			expectAzureString(c, cmd.QuestionAzureEnableConfig, &runError)
-			c.SendLine("y")
-			expectAzureString(c, cmd.QuestionEnableActivityLog, &runError)
-			c.SendLine("n")
-			expectAzureString(c, cmd.QuestionEnableAdIntegration, &runError)
-			c.SendLine("y")
-			expectAzureString(c, cmd.QuestionAzureConfigAdvanced, &runError)
-			c.SendLine("y")
+			expectsCliOutput(t, c, []MsgRspHandler{
+				MsgRsp{cmd.QuestionAzureEnableConfig, "y"},
+				MsgRsp{cmd.QuestionEnableActivityLog, "n"},
+				MsgRsp{cmd.QuestionEnableAdIntegration, "y"},
+				MsgRsp{cmd.QuestionAzureConfigAdvanced, "y"},
+				MsgMenu{cmd.AzureAdvancedOptDone, 1},
+				MsgRsp{cmd.QuestionEnableAllSubscriptions, "y"},
 
-			expectAzureString(c, cmd.AzureAdvancedOptDone, &runError)
-			c.SendLine("\x1B[B")
-
-			expectAzureString(c, cmd.QuestionEnableAllSubscriptions, &runError)
-			c.SendLine("y")
-
-			expectAzureString(c, cmd.QuestionAzureAnotherAdvancedOpt, &runError)
-			c.SendLine("n")
-			expectAzureString(c, cmd.QuestionRunTfPlan, &runError)
-			c.SendLine("n")
+				MsgRsp{cmd.QuestionAzureAnotherAdvancedOpt, "n"},
+				MsgRsp{cmd.QuestionRunTfPlan, "n"},
+			})
 			final, _ = c.ExpectEOF()
 		},
 		"generate",
@@ -527,28 +457,19 @@ func TestGenerationAzureConfigMgmntGroup(t *testing.T) {
 	// Run CLI
 	tfResult := runGenerateAzureTest(t,
 		func(c *expect.Console) {
-			expectAzureString(c, cmd.QuestionAzureEnableConfig, &runError)
-			c.SendLine("y")
-			expectAzureString(c, cmd.QuestionEnableActivityLog, &runError)
-			c.SendLine("n")
-			expectAzureString(c, cmd.QuestionEnableAdIntegration, &runError)
-			c.SendLine("y")
-			expectAzureString(c, cmd.QuestionAzureConfigAdvanced, &runError)
-			c.SendLine("y")
+			expectsCliOutput(t, c, []MsgRspHandler{
+				MsgRsp{cmd.QuestionAzureEnableConfig, "y"},
+				MsgRsp{cmd.QuestionEnableActivityLog, "n"},
+				MsgRsp{cmd.QuestionEnableAdIntegration, "y"},
+				MsgRsp{cmd.QuestionAzureConfigAdvanced, "y"},
 
-			expectAzureString(c, cmd.AzureAdvancedOptDone, &runError)
-			c.Send("\x1B[B")
-			c.SendLine("\x1B[B")
+				MsgMenu{cmd.AzureAdvancedOptDone, 2},
+				MsgRsp{cmd.QuestionEnableManagementGroup, "y"},
+				MsgRsp{cmd.QuestionManagementGroupId, mgmtGrpId},
 
-			expectAzureString(c, cmd.QuestionEnableManagementGroup, &runError)
-			c.SendLine("y")
-			expectAzureString(c, cmd.QuestionManagementGroupId, &runError)
-			c.SendLine(mgmtGrpId)
-
-			expectAzureString(c, cmd.QuestionAzureAnotherAdvancedOpt, &runError)
-			c.SendLine("n")
-			expectAzureString(c, cmd.QuestionRunTfPlan, &runError)
-			c.SendLine("n")
+				MsgRsp{cmd.QuestionAzureAnotherAdvancedOpt, "n"},
+				MsgRsp{cmd.QuestionRunTfPlan, "n"},
+			})
 			final, _ = c.ExpectEOF()
 		},
 		"generate",
@@ -579,28 +500,20 @@ func TestGenerationAzureConfigSubs(t *testing.T) {
 	// Run CLI
 	tfResult := runGenerateAzureTest(t,
 		func(c *expect.Console) {
-			expectAzureString(c, cmd.QuestionAzureEnableConfig, &runError)
-			c.SendLine("y")
-			expectAzureString(c, cmd.QuestionEnableActivityLog, &runError)
-			c.SendLine("n")
-			expectAzureString(c, cmd.QuestionEnableAdIntegration, &runError)
-			c.SendLine("y")
-			expectAzureString(c, cmd.QuestionAzureConfigAdvanced, &runError)
-			c.SendLine("y")
+			expectsCliOutput(t, c, []MsgRspHandler{
+				MsgRsp{cmd.QuestionAzureEnableConfig, "y"},
+				MsgRsp{cmd.QuestionEnableActivityLog, "n"},
+				MsgRsp{cmd.QuestionEnableAdIntegration, "y"},
+				MsgRsp{cmd.QuestionAzureConfigAdvanced, "y"},
 
-			expectAzureString(c, cmd.AzureAdvancedOptDone, &runError)
-			c.SendLine("\x1B[B")
+				MsgMenu{cmd.AzureAdvancedOptDone, 1},
 
-			expectAzureString(c, cmd.QuestionEnableAllSubscriptions, &runError)
-			c.SendLine("n")
+				MsgRsp{cmd.QuestionEnableAllSubscriptions, "n"},
 
-			expectAzureString(c, cmd.QuestionSubscriptionIds, &runError)
-			c.SendLine(strings.Join(testIds[:], ","))
-
-			expectAzureString(c, cmd.QuestionAzureAnotherAdvancedOpt, &runError)
-			c.SendLine("n")
-			expectAzureString(c, cmd.QuestionRunTfPlan, &runError)
-			c.SendLine("n")
+				MsgRsp{cmd.QuestionSubscriptionIds, strings.Join(testIds[:], ",")},
+				MsgRsp{cmd.QuestionAzureAnotherAdvancedOpt, "n"},
+				MsgRsp{cmd.QuestionRunTfPlan, "n"},
+			})
 			final, _ = c.ExpectEOF()
 		},
 		"generate",
@@ -630,28 +543,20 @@ func TestGenerationAzureActivityLogSubs(t *testing.T) {
 	// Run CLI
 	tfResult := runGenerateAzureTest(t,
 		func(c *expect.Console) {
-			expectAzureString(c, cmd.QuestionAzureEnableConfig, &runError)
-			c.SendLine("n")
-			expectAzureString(c, cmd.QuestionEnableActivityLog, &runError)
-			c.SendLine("y")
-			expectAzureString(c, cmd.QuestionEnableAdIntegration, &runError)
-			c.SendLine("y")
-			expectAzureString(c, cmd.QuestionAzureConfigAdvanced, &runError)
-			c.SendLine("y")
+			expectsCliOutput(t, c, []MsgRspHandler{
+				MsgRsp{cmd.QuestionAzureEnableConfig, "n"},
+				MsgRsp{cmd.QuestionEnableActivityLog, "y"},
+				MsgRsp{cmd.QuestionEnableAdIntegration, "y"},
+				MsgRsp{cmd.QuestionAzureConfigAdvanced, "y"},
 
-			expectAzureString(c, cmd.AzureAdvancedOptDone, &runError)
-			c.SendLine("\x1B[B")
+				MsgMenu{cmd.AzureAdvancedOptDone, 1},
+				MsgRsp{cmd.QuestionEnableAllSubscriptions, "n"},
 
-			expectAzureString(c, cmd.QuestionEnableAllSubscriptions, &runError)
-			c.SendLine("n")
+				MsgRsp{cmd.QuestionSubscriptionIds, strings.Join(testIds[:], ",")},
 
-			expectAzureString(c, cmd.QuestionSubscriptionIds, &runError)
-			c.SendLine(strings.Join(testIds[:], ","))
-
-			expectAzureString(c, cmd.QuestionAzureAnotherAdvancedOpt, &runError)
-			c.SendLine("n")
-			expectAzureString(c, cmd.QuestionRunTfPlan, &runError)
-			c.SendLine("n")
+				MsgRsp{cmd.QuestionAzureAnotherAdvancedOpt, "n"},
+				MsgRsp{cmd.QuestionRunTfPlan, "n"},
+			})
 			final, _ = c.ExpectEOF()
 		},
 		"generate",
@@ -682,32 +587,22 @@ func TestGenerationAzureActivityLogStorageAccount(t *testing.T) {
 	// Run CLI
 	tfResult := runGenerateAzureTest(t,
 		func(c *expect.Console) {
-			expectAzureString(c, cmd.QuestionAzureEnableConfig, &runError)
-			c.SendLine("n")
-			expectAzureString(c, cmd.QuestionEnableActivityLog, &runError)
-			c.SendLine("y")
-			expectAzureString(c, cmd.QuestionEnableAdIntegration, &runError)
-			c.SendLine("y")
-			expectAzureString(c, cmd.QuestionAzureConfigAdvanced, &runError)
-			c.SendLine("y")
+			expectsCliOutput(t, c, []MsgRspHandler{
+				MsgRsp{cmd.QuestionAzureEnableConfig, "n"},
+				MsgRsp{cmd.QuestionEnableActivityLog, "y"},
+				MsgRsp{cmd.QuestionEnableAdIntegration, "y"},
+				MsgRsp{cmd.QuestionAzureConfigAdvanced, "y"},
 
-			expectAzureString(c, cmd.AzureAdvancedOptDone, &runError)
-			c.Send("\x1B[B")
-			c.Send("\x1B[B")
-			c.SendLine("\x1B[B")
+				MsgMenu{cmd.AzureAdvancedOptDone, 3},
 
-			expectAzureString(c, cmd.QuestionUseExistingStorageAccount, &runError)
-			c.SendLine("y")
+				MsgRsp{cmd.QuestionUseExistingStorageAccount, "y"},
 
-			expectAzureString(c, cmd.QuestionStorageAccountName, &runError)
-			c.SendLine(storageAccountName)
-			expectAzureString(c, cmd.QuestionStorageAccountResourceGroup, &runError)
-			c.SendLine(storageResourceGrp)
+				MsgRsp{cmd.QuestionStorageAccountName, storageAccountName},
+				MsgRsp{cmd.QuestionStorageAccountResourceGroup, storageResourceGrp},
 
-			expectAzureString(c, cmd.QuestionAzureAnotherAdvancedOpt, &runError)
-			c.SendLine("n")
-			expectAzureString(c, cmd.QuestionRunTfPlan, &runError)
-			c.SendLine("n")
+				MsgRsp{cmd.QuestionAzureAnotherAdvancedOpt, "n"},
+				MsgRsp{cmd.QuestionRunTfPlan, "n"},
+			})
 			final, _ = c.ExpectEOF()
 		},
 		"generate",
@@ -738,25 +633,19 @@ func TestGenerationAzureActivityLogAllSubs(t *testing.T) {
 	// Run CLI
 	tfResult := runGenerateAzureTest(t,
 		func(c *expect.Console) {
-			expectAzureString(c, cmd.QuestionAzureEnableConfig, &runError)
-			c.SendLine("n")
-			expectAzureString(c, cmd.QuestionEnableActivityLog, &runError)
-			c.SendLine("y")
-			expectAzureString(c, cmd.QuestionEnableAdIntegration, &runError)
-			c.SendLine("y")
-			expectAzureString(c, cmd.QuestionAzureConfigAdvanced, &runError)
-			c.SendLine("y")
+			expectsCliOutput(t, c, []MsgRspHandler{
+				MsgRsp{cmd.QuestionAzureEnableConfig, "n"},
+				MsgRsp{cmd.QuestionEnableActivityLog, "y"},
+				MsgRsp{cmd.QuestionEnableAdIntegration, "y"},
+				MsgRsp{cmd.QuestionAzureConfigAdvanced, "y"},
 
-			expectAzureString(c, cmd.AzureAdvancedOptDone, &runError)
-			c.SendLine("\x1B[B")
+				MsgMenu{cmd.AzureAdvancedOptDone, 1},
 
-			expectAzureString(c, cmd.QuestionEnableAllSubscriptions, &runError)
-			c.SendLine("y")
+				MsgRsp{cmd.QuestionEnableAllSubscriptions, "y"},
 
-			expectAzureString(c, cmd.QuestionAzureAnotherAdvancedOpt, &runError)
-			c.SendLine("n")
-			expectAzureString(c, cmd.QuestionRunTfPlan, &runError)
-			c.SendLine("n")
+				MsgRsp{cmd.QuestionAzureAnotherAdvancedOpt, "n"},
+				MsgRsp{cmd.QuestionRunTfPlan, "n"},
+			})
 			final, _ = c.ExpectEOF()
 		},
 		"generate",
@@ -786,26 +675,19 @@ func TestGenerationAzureActivityLogLocation(t *testing.T) {
 	// Run CLI
 	tfResult := runGenerateAzureTest(t,
 		func(c *expect.Console) {
-			expectAzureString(c, cmd.QuestionAzureEnableConfig, &runError)
-			c.SendLine("n")
-			expectAzureString(c, cmd.QuestionEnableActivityLog, &runError)
-			c.SendLine("y")
-			expectAzureString(c, cmd.QuestionEnableAdIntegration, &runError)
-			c.SendLine("y")
-			expectAzureString(c, cmd.QuestionAzureConfigAdvanced, &runError)
-			c.SendLine("y")
+			expectsCliOutput(t, c, []MsgRspHandler{
+				MsgRsp{cmd.QuestionAzureEnableConfig, "n"},
+				MsgRsp{cmd.QuestionEnableActivityLog, "y"},
+				MsgRsp{cmd.QuestionEnableAdIntegration, "y"},
+				MsgRsp{cmd.QuestionAzureConfigAdvanced, "y"},
 
-			expectAzureString(c, cmd.AzureAdvancedOptDone, &runError)
-			c.Send("\x1B[B")
-			c.SendLine("\x1B[B")
+				MsgMenu{cmd.AzureAdvancedOptDone, 2},
 
-			expectAzureString(c, cmd.QuestionStorageLocation, &runError)
-			c.SendLine(region)
+				MsgRsp{cmd.QuestionStorageLocation, region},
 
-			expectAzureString(c, cmd.QuestionAzureAnotherAdvancedOpt, &runError)
-			c.SendLine("n")
-			expectAzureString(c, cmd.QuestionRunTfPlan, &runError)
-			c.SendLine("n")
+				MsgRsp{cmd.QuestionAzureAnotherAdvancedOpt, "n"},
+				MsgRsp{cmd.QuestionRunTfPlan, "n"},
+			})
 			final, _ = c.ExpectEOF()
 		},
 		"generate",
@@ -828,7 +710,6 @@ func TestGenerationAzureOverwrite(t *testing.T) {
 	os.Setenv("LW_NOCACHE", "true")
 	defer os.Setenv("LW_NOCACHE", "")
 	var final string
-	var runError error
 
 	dir := createDummyTOMLConfig()
 	defer os.RemoveAll(dir)
@@ -839,16 +720,13 @@ func TestGenerationAzureOverwrite(t *testing.T) {
 
 	runFakeTerminalTestFromDir(t, dir,
 		func(c *expect.Console) {
-			expectAzureString(c, cmd.QuestionAzureEnableConfig, &runError)
-			c.SendLine("y")
-			expectAzureString(c, cmd.QuestionEnableActivityLog, &runError)
-			c.SendLine("y")
-			expectAzureString(c, cmd.QuestionEnableAdIntegration, &runError)
-			c.SendLine("y")
-			expectAzureString(c, cmd.QuestionAzureConfigAdvanced, &runError)
-			c.SendLine("n")
-			expectAzureString(c, cmd.QuestionRunTfPlan, &runError)
-			c.SendLine("n")
+			expectsCliOutput(t, c, []MsgRspHandler{
+				MsgRsp{cmd.QuestionAzureEnableConfig, "y"},
+				MsgRsp{cmd.QuestionEnableActivityLog, "y"},
+				MsgRsp{cmd.QuestionEnableAdIntegration, "y"},
+				MsgRsp{cmd.QuestionAzureConfigAdvanced, "n"},
+				MsgRsp{cmd.QuestionRunTfPlan, "n"},
+			})
 			final, _ = c.ExpectEOF()
 		},
 		"generate",
@@ -860,18 +738,14 @@ func TestGenerationAzureOverwrite(t *testing.T) {
 
 	runFakeTerminalTestFromDir(t, dir,
 		func(c *expect.Console) {
-			expectAzureString(c, cmd.QuestionAzureEnableConfig, &runError)
-			c.SendLine("y")
-			expectAzureString(c, cmd.QuestionEnableActivityLog, &runError)
-			c.SendLine("y")
-			expectAzureString(c, cmd.QuestionEnableAdIntegration, &runError)
-			c.SendLine("y")
-			expectAzureString(c, cmd.QuestionAzureConfigAdvanced, &runError)
-			c.SendLine("n")
-			expectString(t, c, "already exists, overwrite?")
-			c.SendLine("n")
-			expectAzureString(c, cmd.QuestionRunTfPlan, &runError)
-			c.SendLine("n")
+			expectsCliOutput(t, c, []MsgRspHandler{
+				MsgRsp{cmd.QuestionAzureEnableConfig, "y"},
+				MsgRsp{cmd.QuestionEnableActivityLog, "y"},
+				MsgRsp{cmd.QuestionEnableAdIntegration, "y"},
+				MsgRsp{cmd.QuestionAzureConfigAdvanced, "n"},
+				MsgRsp{"already exists, overwrite?", "n"},
+				MsgRsp{cmd.QuestionRunTfPlan, "n"},
+			})
 			final, _ = c.ExpectEOF()
 		},
 		"generate",
@@ -886,7 +760,6 @@ func TestGenerationAzureOverwriteOutput(t *testing.T) {
 	os.Setenv("LW_NOCACHE", "true")
 	defer os.Setenv("LW_NOCACHE", "")
 	var final string
-	var runError error
 
 	dir := createDummyTOMLConfig()
 	defer os.RemoveAll(dir)
@@ -900,16 +773,13 @@ func TestGenerationAzureOverwriteOutput(t *testing.T) {
 
 	runFakeTerminalTestFromDir(t, dir,
 		func(c *expect.Console) {
-			expectAzureString(c, cmd.QuestionAzureEnableConfig, &runError)
-			c.SendLine("y")
-			expectAzureString(c, cmd.QuestionEnableActivityLog, &runError)
-			c.SendLine("y")
-			expectAzureString(c, cmd.QuestionEnableAdIntegration, &runError)
-			c.SendLine("y")
-			expectAzureString(c, cmd.QuestionAzureConfigAdvanced, &runError)
-			c.SendLine("n")
-			expectAzureString(c, cmd.QuestionRunTfPlan, &runError)
-			c.SendLine("n")
+			expectsCliOutput(t, c, []MsgRspHandler{
+				MsgRsp{cmd.QuestionAzureEnableConfig, "y"},
+				MsgRsp{cmd.QuestionEnableActivityLog, "y"},
+				MsgRsp{cmd.QuestionEnableAdIntegration, "y"},
+				MsgRsp{cmd.QuestionAzureConfigAdvanced, "n"},
+				MsgRsp{cmd.QuestionRunTfPlan, "n"},
+			})
 			final, _ = c.ExpectEOF()
 		},
 		"generate",
@@ -923,18 +793,14 @@ func TestGenerationAzureOverwriteOutput(t *testing.T) {
 
 	runFakeTerminalTestFromDir(t, dir,
 		func(c *expect.Console) {
-			expectAzureString(c, cmd.QuestionAzureEnableConfig, &runError)
-			c.SendLine("y")
-			expectAzureString(c, cmd.QuestionEnableActivityLog, &runError)
-			c.SendLine("y")
-			expectAzureString(c, cmd.QuestionEnableAdIntegration, &runError)
-			c.SendLine("y")
-			expectAzureString(c, cmd.QuestionAzureConfigAdvanced, &runError)
-			c.SendLine("n")
-			expectString(t, c, "already exists, overwrite?")
-			c.SendLine("n")
-			expectAzureString(c, cmd.QuestionRunTfPlan, &runError)
-			c.SendLine("n")
+			expectsCliOutput(t, c, []MsgRspHandler{
+				MsgRsp{cmd.QuestionAzureEnableConfig, "y"},
+				MsgRsp{cmd.QuestionEnableActivityLog, "y"},
+				MsgRsp{cmd.QuestionEnableAdIntegration, "y"},
+				MsgRsp{cmd.QuestionAzureConfigAdvanced, "n"},
+				MsgRsp{"already exists, overwrite?", "n"},
+				MsgRsp{cmd.QuestionRunTfPlan, "n"},
+			})
 			final, _ = c.ExpectEOF()
 		},
 		"generate",
@@ -956,16 +822,13 @@ func TestGenerationAzureLaceworkProfile(t *testing.T) {
 
 	tfResult := runGenerateAzureTest(t,
 		func(c *expect.Console) {
-			expectAzureString(c, cmd.QuestionAzureEnableConfig, &runError)
-			c.SendLine("y")
-			expectAzureString(c, cmd.QuestionEnableActivityLog, &runError)
-			c.SendLine("y")
-			expectAzureString(c, cmd.QuestionEnableAdIntegration, &runError)
-			c.SendLine("y")
-			expectAzureString(c, cmd.QuestionAzureConfigAdvanced, &runError)
-			c.SendLine("n")
-			expectAzureString(c, cmd.QuestionRunTfPlan, &runError)
-			c.SendLine("n")
+			expectsCliOutput(t, c, []MsgRspHandler{
+				MsgRsp{cmd.QuestionAzureEnableConfig, "y"},
+				MsgRsp{cmd.QuestionEnableActivityLog, "y"},
+				MsgRsp{cmd.QuestionEnableAdIntegration, "y"},
+				MsgRsp{cmd.QuestionAzureConfigAdvanced, "n"},
+				MsgRsp{cmd.QuestionRunTfPlan, "n"},
+			})
 			final, _ = c.ExpectEOF()
 		},
 		"generate",

--- a/integration/framework_test.go
+++ b/integration/framework_test.go
@@ -20,6 +20,7 @@ package integration
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -32,6 +33,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/go-version"
+	"github.com/hashicorp/hc-install/product"
+	"github.com/hashicorp/hc-install/releases"
+	"github.com/hashicorp/terraform-exec/tfexec"
+	tfjson "github.com/hashicorp/terraform-json"
+
 	"github.com/Netflix/go-expect"
 	"github.com/hinshun/vt10x"
 	"github.com/lacework/go-sdk/api"
@@ -40,7 +47,15 @@ import (
 )
 
 // When emulating a terminal, the timeout to wait for output
-var expectStringTimeout = time.Second * 3
+const (
+	expectStringTimeout = time.Second * 3
+)
+
+var (
+	tfPath   string
+	tf       *tfexec.Terraform
+	execPath string
+)
 
 // Use this function to execute a real lacework CLI command, under the hood the function
 // will detect the correct binary depending on the running OS and architecture, if you
@@ -411,4 +426,52 @@ func expectsCliOutput(t *testing.T, c *expect.Console, m []MsgRspHandler) {
 	for _, elm := range m {
 		elm.handle(t, c)
 	}
+}
+
+func TestMain(m *testing.M) {
+	tfPath = createDummyTOMLConfig()
+
+	terraformInstall()
+
+	ret := m.Run()
+
+	err := os.RemoveAll(tfPath)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	os.Exit(ret)
+}
+
+func terraformInstall() {
+	installer := &releases.ExactVersion{
+		Product: product.Terraform,
+		Version: version.Must(version.NewVersion("1.3.4")),
+	}
+
+	_execPath, err := installer.Install(context.Background())
+	if err != nil {
+		log.Fatalf("error installing Terraform: %s", err)
+	}
+	execPath = _execPath
+}
+
+func terraformValidate(dir string) *tfjson.ValidateOutput {
+	_tf, err := tfexec.NewTerraform(dir, execPath)
+	if err != nil {
+		log.Fatalf("error running NewTerraform: %s", err)
+	}
+	tf = _tf
+
+	err = tf.Init(context.Background())
+	if err != nil {
+		log.Fatalf("error running Init: %s", err)
+	}
+
+	validateOutput, err := tf.Validate(context.Background())
+	if err != nil {
+		log.Fatalf("error running Show: %s", err)
+	}
+
+	return validateOutput
 }

--- a/integration/framework_test.go
+++ b/integration/framework_test.go
@@ -470,7 +470,7 @@ func terraformValidate(dir string) *tfjson.ValidateOutput {
 
 	validateOutput, err := tf.Validate(context.Background())
 	if err != nil {
-		log.Fatalf("error running Show: %s", err)
+		log.Fatalf("error running Validate: %s", err)
 	}
 
 	return validateOutput


### PR DESCRIPTION
## Summary

Tidying Azure and AWS integration tests.  Making use of the `MsgRspHandler` interface.

`TestMain` for integration tests that installs Terraform in tmpfs.  Each TF generation integration test will now install and validate the terraform.

## Motivation

Avoid a repeat of [ALLY-1275](https://lacework.atlassian.net/browse/ALLY-1275) by catching Terraform version incompatibility in our integration testing.

Catch Terraform module input errors.

## How did you test this change?

- unit
- integration

## Issue

[ALLY-1189](https://lacework.atlassian.net/browse/ALLY-1189)
