### PR TITLE
feat(lwseverity): add valid severity use cases

### DIFF
--- a/cli/cmd/compliance_aws.go
+++ b/cli/cmd/compliance_aws.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/lacework/go-sdk/api"
 	"github.com/lacework/go-sdk/internal/array"
+	"github.com/lacework/go-sdk/lwseverity"
 )
 
 var (
@@ -139,9 +140,9 @@ To show recommendation details and affected resources for a recommendation id:
 			}
 
 			if compCmdState.Severity != "" {
-				if !array.ContainsStr(api.ValidEventSeverities, compCmdState.Severity) {
+				if !lwseverity.IsValid(compCmdState.Severity) {
 					return errors.Errorf("the severity %s is not valid, use one of %s",
-						compCmdState.Severity, strings.Join(api.ValidEventSeverities, ", "),
+						compCmdState.Severity, lwseverity.ValidSeverities.String(),
 					)
 				}
 			}
@@ -563,7 +564,7 @@ func init() {
 
 	complianceAwsGetReportCmd.Flags().StringVar(&compCmdState.Severity, "severity", "",
 		fmt.Sprintf("filter report details by severity threshold (%s)",
-			strings.Join(api.ValidEventSeverities, ", ")),
+			lwseverity.ValidSeverities.String()),
 	)
 
 	complianceAwsGetReportCmd.Flags().StringVar(&compCmdState.Status, "status", "",

--- a/cli/cmd/compliance_azure.go
+++ b/cli/cmd/compliance_azure.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/lacework/go-sdk/api"
 	"github.com/lacework/go-sdk/internal/array"
+	"github.com/lacework/go-sdk/lwseverity"
 )
 
 var (
@@ -180,9 +181,9 @@ To show recommendation details and affected resources for a recommendation id:
 			}
 
 			if compCmdState.Severity != "" {
-				if !array.ContainsStr(api.ValidEventSeverities, compCmdState.Severity) {
+				if !lwseverity.IsValid(compCmdState.Severity) {
 					return errors.Errorf("the severity %s is not valid, use one of %s",
-						compCmdState.Severity, strings.Join(api.ValidEventSeverities, ", "),
+						compCmdState.Severity, lwseverity.ValidSeverities.String(),
 					)
 				}
 			}
@@ -513,7 +514,7 @@ func init() {
 
 	complianceAzureGetReportCmd.Flags().StringVar(&compCmdState.Severity, "severity", "",
 		fmt.Sprintf("filter report details by severity threshold (%s)",
-			strings.Join(api.ValidEventSeverities, ", ")),
+			lwseverity.ValidSeverities.String()),
 	)
 
 	complianceAzureGetReportCmd.Flags().StringVar(&compCmdState.Status, "status", "",

--- a/cli/cmd/compliance_gcp.go
+++ b/cli/cmd/compliance_gcp.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/lacework/go-sdk/api"
 	"github.com/lacework/go-sdk/internal/array"
+	"github.com/lacework/go-sdk/lwseverity"
 )
 
 var (
@@ -185,9 +186,9 @@ To show recommendation details and affected resources for a recommendation id:
 			}
 
 			if compCmdState.Severity != "" {
-				if !array.ContainsStr(api.ValidEventSeverities, compCmdState.Severity) {
+				if !lwseverity.IsValid(compCmdState.Severity) {
 					return errors.Errorf("the severity %s is not valid, use one of %s",
-						compCmdState.Severity, strings.Join(api.ValidEventSeverities, ", "),
+						compCmdState.Severity, lwseverity.ValidSeverities.String(),
 					)
 				}
 			}
@@ -525,7 +526,7 @@ func init() {
 
 	complianceGcpGetReportCmd.Flags().StringVar(&compCmdState.Severity, "severity", "",
 		fmt.Sprintf("filter report details by severity threshold (%s)",
-			strings.Join(api.ValidEventSeverities, ", ")),
+			lwseverity.ValidSeverities.String()),
 	)
 
 	complianceGcpGetReportCmd.Flags().StringVar(&compCmdState.Status, "status", "",

--- a/cli/cmd/vulnerability.go
+++ b/cli/cmd/vulnerability.go
@@ -29,7 +29,7 @@ import (
 	flag "github.com/spf13/pflag"
 
 	"github.com/lacework/go-sdk/api"
-	"github.com/lacework/go-sdk/internal/array"
+	"github.com/lacework/go-sdk/lwseverity"
 )
 
 var (
@@ -201,7 +201,7 @@ func setFailOnSeverityFlag(cmds ...*flag.FlagSet) {
 		if cmd != nil {
 			cmd.StringVar(&vulCmdState.FailOnSeverity, "fail_on_severity", "",
 				fmt.Sprintf("specify a severity threshold to fail if vulnerabilities are found (%s)",
-					strings.Join(api.ValidEventSeverities, ", ")),
+					lwseverity.ValidSeverities.String()),
 			)
 		}
 	}
@@ -222,7 +222,7 @@ func setSeverityFlag(cmds ...*flag.FlagSet) {
 		if cmd != nil {
 			cmd.StringVar(&vulCmdState.Severity, "severity", "",
 				fmt.Sprintf("filter vulnerability assessment by severity threshold (%s)",
-					strings.Join(api.ValidEventSeverities, ", ")),
+					lwseverity.ValidSeverities.String()),
 			)
 		}
 	}
@@ -480,17 +480,17 @@ func stringToInt(s string) int {
 
 func validateSeverityFlags() error {
 	if vulCmdState.Severity != "" {
-		if !array.ContainsStr(api.ValidEventSeverities, vulCmdState.Severity) {
+		if !lwseverity.IsValid(vulCmdState.Severity) {
 			return errors.Errorf("the severity %s is not valid, use one of %s",
-				vulCmdState.Severity, strings.Join(api.ValidEventSeverities, ", "),
+				vulCmdState.Severity, lwseverity.ValidSeverities.String(),
 			)
 		}
 	}
 
 	if vulCmdState.FailOnSeverity != "" {
-		if !array.ContainsStr(api.ValidEventSeverities, vulCmdState.FailOnSeverity) {
+		if !lwseverity.IsValid(vulCmdState.FailOnSeverity) {
 			return errors.Errorf("the severity %s is not valid, use one of %s",
-				vulCmdState.FailOnSeverity, strings.Join(api.ValidEventSeverities, ", "),
+				vulCmdState.FailOnSeverity, lwseverity.ValidSeverities.String(),
 			)
 		}
 	}

--- a/cli/cmd/vulnerabilty_exceptions.go
+++ b/cli/cmd/vulnerabilty_exceptions.go
@@ -27,6 +27,7 @@ import (
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/AlecAivazis/survey/v2/core"
 	"github.com/lacework/go-sdk/api"
+	"github.com/lacework/go-sdk/lwseverity"
 	"github.com/olekukonko/tablewriter"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -368,14 +369,14 @@ func validateSeverities() survey.Validator {
 	return func(val interface{}) error {
 		if list, ok := val.([]core.OptionAnswer); ok {
 			for _, i := range list {
-				match := strings.Contains(strings.Join(api.ValidEventSeverities, ", "), strings.ToLower(i.Value))
+				match := strings.Contains(lwseverity.ValidSeverities.String(), strings.ToLower(i.Value))
 				if !match {
 					return fmt.Errorf("severity '%s' is invalid. Must be one of 'Critical', 'High', 'Medium', 'Low', 'Info'", i.Value)
 				}
 			}
 		} else {
 			value := val.(core.OptionAnswer).Value
-			match := strings.Contains(strings.Join(api.ValidEventSeverities, ", "), strings.ToLower(value))
+			match := strings.Contains(lwseverity.ValidSeverities.String(), strings.ToLower(value))
 			if !match {
 				return fmt.Errorf("severity '%s' is invalid. Must be one of 'Critical', 'High', 'Medium', 'Low', 'Info'", value)
 			}

--- a/lwseverity/severity.go
+++ b/lwseverity/severity.go
@@ -20,6 +20,7 @@
 package lwseverity
 
 import (
+	"fmt"
 	"sort"
 	"strings"
 )
@@ -55,6 +56,23 @@ func (s severity) String() string {
 	return severities[s]
 }
 
+type validSeverities []severity
+
+// A list of valid Lacework severities (critical, high, medium, low, info)
+var ValidSeverities = validSeverities{Critical, High, Medium, Low, Info}
+
+// Return a string representation of valid severities
+// "critical, high, medium, low, info"
+func (v validSeverities) String() string {
+	s := ""
+
+	for _, severity := range v {
+		s += fmt.Sprintf("%s, ", strings.ToLower(severities[severity]))
+	}
+
+	return strings.TrimRight(s, ", ")
+}
+
 // Initialize a severity from string
 func NewSeverity(s string) severity {
 	switch strings.ToLower(s) {
@@ -88,6 +106,12 @@ type Severity interface {
 func Normalize(s string) (int, string) {
 	severity := NewSeverity(s)
 	return int(severity), severity.String()
+}
+
+// Take a string representation of Lacework severity and
+// return whether it properly maps to a valid severity (not unknown)
+func IsValid(s string) bool {
+	return NewSeverity(s) != Unknown
 }
 
 // Returns true if the first severity not as critical as the second severity

--- a/lwseverity/severity_test.go
+++ b/lwseverity/severity_test.go
@@ -129,3 +129,12 @@ func TestSort(t *testing.T) {
 	lwseverity.SortSliceA(m)
 	assert.Equal(t, expected, m)
 }
+
+func TestIsValid(t *testing.T) {
+	assert.Equal(t, true, lwseverity.IsValid("Critical"))
+	assert.Equal(t, false, lwseverity.IsValid("JackBauer"))
+}
+
+func TestValidSeveritiesString(t *testing.T) {
+	assert.Equal(t, "critical, high, medium, low, info", lwseverity.ValidSeverities.String())
+}


### PR DESCRIPTION
## Summary
Support use cases where the CLI needs to validate a severity (i.e. via input).

Current Pattern:
```
if !array.ContainsStr(api.ValidEventSeverities, vulCmdState.Severity) {
    return errors.Errorf("the severity %s is not valid, use one of %s",
        vulCmdState.Severity, strings.Join(api.ValidEventSeverities, ", "),
    )
}
```

Updated Pattern:
```
if !lwseverity.IsValid(vulCmdState.Severity) {
    return errors.Errorf("the severity %s is not valid, use one of %s",
        vulCmdState.Severity, lwseverity.ValidSeverities.String(),
    )
}
```

## How did you test this change?
Unit Testing
Existing Integration Testing

## Issue
https://lacework.atlassian.net/browse/ALLY-1284
