### PR TITLE
fix(cdk): component arg/flag parsing

### DIFF
--- a/cli/cmd/component_args.go
+++ b/cli/cmd/component_args.go
@@ -45,6 +45,7 @@ func (p *componentArgParser) parseArgs(globalFlags *pflag.FlagSet, args []string
 			p.componentArgs = append(p.componentArgs, s)
 			continue
 		}
+
 		if len(s) == 0 || s[0] != '-' || len(s) == 1 {
 			// not a flag, passthrough
 			p.componentArgs = append(p.componentArgs, s)
@@ -145,7 +146,7 @@ func (p *componentArgParser) parseShortArg(flags *pflag.FlagSet, s string, args 
 			p.cliArgs = append(p.cliArgs, s)
 		} else if len(shorthands) > 1 {
 			// '-farg'
-			p.cliArgs = append(p.cliArgs, s)
+			p.componentArgs = append(p.componentArgs, s)
 			return args
 		} else if len(args) > 0 {
 			// '-f arg'

--- a/cli/cmd/component_args_test.go
+++ b/cli/cmd/component_args_test.go
@@ -47,10 +47,13 @@ func TestComponentArgs(t *testing.T) {
 			[]string{"-a", "qan", "--profile", "foo"},
 		},
 		{
-			[]string{
-				"iac", "org", "--help",
-			},
 			[]string{"iac", "org", "--help"},
+			[]string{"iac", "org", "--help"},
+			[]string{},
+		},
+		{
+			[]string{"component", "-source", "iam"},
+			[]string{"component", "-source", "iam"},
 			[]string{},
 		},
 		{


### PR DESCRIPTION
## Summary

The new component arg/flag parsing is not letting flags like `-foo` or `-bar` pass to the component.

## How did you test this change?

Added tests that shows the issue.

## Issue

N/A
