### PR TITLE
ci: fix release script; sort versions in find_latest_version

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -342,7 +342,7 @@ find_latest_version() {
   local _pattern="v[0-9]\+.[0-9]\+.[0-9]\+"
   local _versions
   _versions=$(git ls-remote --tags --quiet | grep $_pattern | tr '/' ' ' | awk '{print $NF}')
-  echo "$_versions" | tr '.' ' ' | sort -nr -k 1 -k 2 -k 3 | tr ' ' '.' | head -1
+  echo "$_versions" | tr '.' ' ' | sort -r -V | tr ' ' '.' | head -1
 }
 
 add_tag_version() {


### PR DESCRIPTION
find_latest_version() in  release script does not sort semver correctly. When trying to return the latest version v1.0.0 is returned at below v0.46.0 in the list.