### PR TITLE
fix: fix vuln ctr fail_on_severity

### DIFF
--- a/api/v2_vulnerabilities.go
+++ b/api/v2_vulnerabilities.go
@@ -177,9 +177,8 @@ type VulnerabilitiesContainersResponse struct {
 }
 
 func (r VulnerabilitiesContainersResponse) HighestSeverity() string {
-	var (
-		sevs []lwseverity.Severity
-	)
+	var sevs []lwseverity.Severity
+
 	for _, vuln := range r.Data {
 		sevs = append(sevs, lwseverity.NewSeverity(vuln.Severity))
 	}

--- a/api/v2_vulnerabilities.go
+++ b/api/v2_vulnerabilities.go
@@ -23,6 +23,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/lacework/go-sdk/lwseverity"
 )
 
 // v2VulnerabilitiesService is a service that interacts with the Vulnerabilities
@@ -176,19 +178,18 @@ type VulnerabilitiesContainersResponse struct {
 
 func (r VulnerabilitiesContainersResponse) HighestSeverity() string {
 	var (
-		sevs []int
-		max  int
+		sevs []lwseverity.Severity
 	)
 	for _, vuln := range r.Data {
-		sevs = append(sevs, SeverityOrder(vuln.Severity))
-		if len(sevs) == 1 {
-			max = SeverityOrder(vuln.Severity)
-		} else if SeverityOrder(vuln.Severity) > max {
-			max = SeverityOrder(vuln.Severity)
-		}
+		sevs = append(sevs, lwseverity.NewSeverity(vuln.Severity))
 	}
 
-	return SeverityInt(max)
+	if len(sevs) == 0 {
+		return lwseverity.Unknown.String()
+	}
+
+	lwseverity.SortSlice(sevs)
+	return sevs[0].GetSeverity()
 }
 
 func (r VulnerabilitiesContainersResponse) HighestFixableSeverity() string {


### PR DESCRIPTION
Signed-off-by: Darren Murray <darren.murray@lacework.net>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/lacework/go-sdk) and create your branch from `main`
  2. Run `make prepare` in the repository root
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`make test`)
  5. Format your code (`make fmt`)
  6. Make sure your code lints (`make lint`)
  7. If you are updating the Lacework CLI, make sure it compiles (`make build-cli-cross-platform`)
  8. Follow the commit message standard (`type(scope): subject`) documented in [DEVELOPER_GUIDELINES.md](https://github.com/lacework/go-sdk/blob/main/DEVELOPER_GUIDELINES.md#commit-message-standard)
  9. If you haven't already, configure signed commits by [telling git about your signing key](https://docs.github.com/en/github/authenticating-to-github/managing-commit-signature-verification/telling-git-about-your-signing-key) and [signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)

  Learn more about contributing: https://github.com/lacework/go-sdk/blob/main/CONTRIBUTING.md
-->

## Summary

Fix highest found severity sorting

## How did you test this change?

<!--
  How exactly did you verify that your PR solves the issue you wanted to solve?
  Include any other relevant information such as how to use the new functionality, screenshots, etc.
-->

Run `lacework vuln ctr --fail_on_severity` with different thresholds, and confirm exit code is correct

## Issue

<!--
  Include the link to a Jira/Github issue
-->

https://lacework.atlassian.net/browse/ALLY-1301