### PR TITLE
docs: fix documentation autogeneration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 .DS_Store
 .idea
-
+*.iml
 # vim
 *.swp
 

--- a/cli/cmd/agent_gcp-install-osl.go
+++ b/cli/cmd/agent_gcp-install-osl.go
@@ -35,7 +35,7 @@ var (
 		RunE:  installGCPOSL,
 		Long: `This command installs the agent on all GCE instances in a GCP organization using OSLogin.
 
-The username of the GCP user or service account, in the form 'users/<username>', is a
+The username of the GCP user or service account, in the form ` + "`users/<username>`" + `, is a
 required argument.
 
 This command will attempt to query the GCE metadata server for the current project. If this

--- a/cli/cmd/compliance_azure.go
+++ b/cli/cmd/compliance_azure.go
@@ -42,7 +42,7 @@ var (
 	complianceAzureListSubsCmd = &cobra.Command{
 		Use:     "list-subscriptions",
 		Aliases: []string{"list-subs"},
-		Short:   "List subscriptions <tenant-id>",
+		Short:   "List subscriptions `<tenant-id>`",
 		Long: `List all Azure subscriptions for Tenant.
 
 Use the following command to list all Azure Tenants configured in your account:

--- a/integration/test_resources/help/agent_gcp-install_osl
+++ b/integration/test_resources/help/agent_gcp-install_osl
@@ -1,6 +1,6 @@
 This command installs the agent on all GCE instances in a GCP organization using OSLogin.
 
-The username of the GCP user or service account, in the form 'users/<username>', is a
+The username of the GCP user or service account, in the form `users/<username>`, is a
 required argument.
 
 This command will attempt to query the GCE metadata server for the current project. If this

--- a/integration/test_resources/help/compliance_azure
+++ b/integration/test_resources/help/compliance_azure
@@ -27,7 +27,7 @@ Aliases:
 Available Commands:
   get-report         Get the latest Azure compliance report
   list               List Azure tenants and subscriptions
-  list-subscriptions List subscriptions <tenant-id>
+  list-subscriptions List subscriptions `<tenant-id>`
 
 Flags:
   -h, --help   help for azure


### PR DESCRIPTION
Signed-off-by: Darren Murray <darren.murray@lacework.net>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/lacework/go-sdk) and create your branch from `main`
  2. Run `make prepare` in the repository root
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`make test`)
  5. Format your code (`make fmt`)
  6. Make sure your code lints (`make lint`)
  7. If you are updating the Lacework CLI, make sure it compiles (`make build-cli-cross-platform`)
  8. Follow the commit message standard (`type(scope): subject`) documented in [DEVELOPER_GUIDELINES.md](https://github.com/lacework/go-sdk/blob/main/DEVELOPER_GUIDELINES.md#commit-message-standard)
  9. If you haven't already, configure signed commits by [telling git about your signing key](https://docs.github.com/en/github/authenticating-to-github/managing-commit-signature-verification/telling-git-about-your-signing-key) and [signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)

  Learn more about contributing: https://github.com/lacework/go-sdk/blob/main/CONTRIBUTING.md
-->

## Summary

Documentation Autogeneration was broken due to usage of <>. Per request from the docs team.
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## How did you test this change?

<!--
  How exactly did you verify that your PR solves the issue you wanted to solve?
  Include any other relevant information such as how to use the new functionality, screenshots, etc.
-->

## Issue

<!--
  Include the link to a Jira/Github issue
-->
https://lacework.atlassian.net/browse/ALLY-1302
