### PR TITLE
fix: generate EKS non-interactive

### DIFF
--- a/cli/cmd/generate_aws_eks_audit.go
+++ b/cli/cmd/generate_aws_eks_audit.go
@@ -679,7 +679,10 @@ func promptAwsEksAuditAdditionalClusterRegionQuestions(
 	extraState *AwsEksAuditGenerateCommandExtraState,
 ) error {
 	// For each region, collect which clusters to integrate with
-	askAgain := true
+	askAgain := false
+	if cli.InteractiveMode() {
+		askAgain = true
+	}
 
 	if config.ParsedRegionClusterMap == nil {
 		config.ParsedRegionClusterMap = make(map[string][]string)

--- a/integration/aws_eks_audit_generation_test.go
+++ b/integration/aws_eks_audit_generation_test.go
@@ -620,3 +620,29 @@ func TestGenerationEksMultiRegionCliFlag(t *testing.T) {
 	buildTf, _ := aws_eks_audit.NewTerraform(aws_eks_audit.WithParsedRegionClusterMap(regionClusterMap)).Generate()
 	assert.Equal(t, buildTf, tfResult)
 }
+
+func TestGenerationEksNonInteractive(t *testing.T) {
+	os.Setenv("LW_NOCACHE", "true")
+	defer os.Setenv("LW_NOCACHE", "")
+	var final string
+
+	tfResult := runEksAuditGenerateTest(t,
+		func(c *expect.Console) {
+			final, _ = c.ExpectEOF()
+		},
+		"generate",
+		"k8s",
+		"eks",
+		"--region_clusters",
+		"us-west-1=cluster1,cluster2",
+		"--noninteractive",
+	)
+
+	assertEksAuditTerraformSaved(t, final)
+
+	regionClusterMap := make(map[string][]string)
+	regionClusterMap["us-west-1"] = []string{"cluster1", "cluster2"}
+
+	buildTf, _ := aws_eks_audit.NewTerraform(aws_eks_audit.WithParsedRegionClusterMap(regionClusterMap)).Generate()
+	assert.Equal(t, buildTf, tfResult)
+}


### PR DESCRIPTION
## Summary

Skipping prompt  with `--noninteractive` leads to creation of a blank region.

## How did you test this change?

- integration test
- manual testing

## Issue

[ALLY-1299](https://lacework.atlassian.net/browse/ALLY-1299)
