### PR TITLE
fix: generate success message

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -75,7 +75,7 @@ Then, when you run a command, you can specify a `--profile prod` and use the
 credentials and settings stored under that name.
 
 ```bash
-lacework integration list --profile prod
+lacework cloud-account list --profile prod
 ```
 
 If there is no `--profile` option, the CLI will default to the `default` profile.

--- a/cli/cmd/generate_execute.go
+++ b/cli/cmd/generate_execute.go
@@ -344,9 +344,9 @@ func provideGuidanceAfterSuccess(workingDir string, laceworkProfile string) stri
 	fmt.Fprintf(out, "Lacework integration was successful! Terraform code saved in %s\n\n", workingDir)
 	fmt.Fprintln(out, "To view integration status:")
 
-	laceworkCmd := "    lacework integration list\n\n"
+	laceworkCmd := "    lacework cloud-account list\n\n"
 	if laceworkProfile != "" {
-		laceworkCmd = fmt.Sprintf("    lacework -p %s integration list\n\n", laceworkProfile)
+		laceworkCmd = fmt.Sprintf("    lacework -p %s cloud-account list\n\n", laceworkProfile)
 	}
 	fmt.Fprint(out, laceworkCmd)
 

--- a/cli/cmd/generate_terraform_test.go
+++ b/cli/cmd/generate_terraform_test.go
@@ -207,7 +207,7 @@ func TestGenerationTfExecutionSuccess(t *testing.T) {
 		assert.Equal(t, `Lacework integration was successful! Terraform code saved in /tmp
 
 To view integration status:
-    lacework integration list
+    lacework cloud-account list
 
 `, out)
 	})
@@ -216,7 +216,7 @@ To view integration status:
 		assert.Equal(t, `Lacework integration was successful! Terraform code saved in /tmp
 
 To view integration status:
-    lacework -p notdefault integration list
+    lacework -p notdefault cloud-account list
 
 `, out)
 	})


### PR DESCRIPTION
## Summary

No longer referring to deprecated command.

## How did you test this change?

- unit test

## Issue

[ALLY-1297](https://lacework.atlassian.net/browse/ALLY-1297)
