### PR TITLE
fix: revert compliance csv report_type field format

### DIFF
--- a/cli/cmd/compliance_aws.go
+++ b/cli/cmd/compliance_aws.go
@@ -188,7 +188,7 @@ To show recommendation details and affected resources for a recommendation id:
 					&complianceCSVReportDetails{
 						AccountName:     report.AccountID,
 						AccountID:       report.AccountID,
-						ReportType:      report.ReportType,
+						ReportType:      reportType.String(),
 						ReportTime:      report.ReportTime,
 						Recommendations: report.Recommendations,
 					},

--- a/cli/cmd/compliance_azure.go
+++ b/cli/cmd/compliance_azure.go
@@ -244,7 +244,7 @@ To show recommendation details and affected resources for a recommendation id:
 						AccountID:       report.SubscriptionID,
 						TenantName:      report.TenantName,
 						TenantID:        report.TenantID,
-						ReportType:      report.ReportType,
+						ReportType:      reportType.String(),
 						ReportTime:      report.ReportTime,
 						Recommendations: report.Recommendations,
 					},

--- a/cli/cmd/compliance_gcp.go
+++ b/cli/cmd/compliance_gcp.go
@@ -254,7 +254,7 @@ To show recommendation details and affected resources for a recommendation id:
 						TenantID:        report.OrganizationID,
 						AccountName:     report.ProjectName,
 						AccountID:       report.ProjectID,
-						ReportType:      report.ReportType,
+						ReportType:      reportType.String(),
 						ReportTime:      report.ReportTime,
 						Recommendations: report.Recommendations,
 					},


### PR DESCRIPTION
Signed-off-by: Darren Murray <darren.murray@lacework.net>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/lacework/go-sdk) and create your branch from `main`
  2. Run `make prepare` in the repository root
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`make test`)
  5. Format your code (`make fmt`)
  6. Make sure your code lints (`make lint`)
  7. If you are updating the Lacework CLI, make sure it compiles (`make build-cli-cross-platform`)
  8. Follow the commit message standard (`type(scope): subject`) documented in [DEVELOPER_GUIDELINES.md](https://github.com/lacework/go-sdk/blob/main/DEVELOPER_GUIDELINES.md#commit-message-standard)
  9. If you haven't already, configure signed commits by [telling git about your signing key](https://docs.github.com/en/github/authenticating-to-github/managing-commit-signature-verification/telling-git-about-your-signing-key) and [signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)

  Learn more about contributing: https://github.com/lacework/go-sdk/blob/main/CONTRIBUTING.md
-->

## Summary

Api v2 returns the report type in a different format. Revert the format change in cvs output 

The v1 api csv reports had the report_type field format as `AWS_CIS_S3`
The v2 api report_type field format was`CIS Amazon Web Services Foundations Benchmark v1.4.0`

This change reverts back to `AWS_CIS_S3`

## How did you test this change?

Run the compliance get-report cmd with csv flag

## Issue

https://lacework.atlassian.net/browse/ALLY-1306
