### PR TITLE
build(cli): Support aarch64 architecture

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -197,6 +197,8 @@ ifeq (x86_64, $(shell uname -m))
 	mv bin/$(PACKAGENAME)-$(shell uname -s | tr '[:upper:]' '[:lower:]')-amd64 /usr/local/bin/$(CLINAME)
 else ifeq (arm64, $(shell uname -m))
 	mv bin/$(PACKAGENAME)-$(shell uname -s | tr '[:upper:]' '[:lower:]')-arm64 /usr/local/bin/$(CLINAME)
+else ifeq (aarch64, $(shell uname -m))
+	mv bin/$(PACKAGENAME)-$(shell uname -s | tr '[:upper:]' '[:lower:]')-arm64 /usr/local/bin/$(CLINAME)
 else
 	mv bin/$(PACKAGENAME)-$(shell uname -s | tr '[:upper:]' '[:lower:]')-386 /usr/local/bin/$(CLINAME)
 endif


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/lacework/go-sdk) and create your branch from `main`
  2. Run `make prepare` in the repository root
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`make test`)
  5. Format your code (`make fmt`)
  6. Make sure your code lints (`make lint`)
  7. If you are updating the Lacework CLI, make sure it compiles (`make build-cli-cross-platform`)
  8. Follow the commit message standard (`type(scope): subject`) documented in [DEVELOPER_GUIDELINES.md](https://github.com/lacework/go-sdk/blob/main/DEVELOPER_GUIDELINES.md#commit-message-standard)
  9. If you haven't already, configure signed commits by [telling git about your signing key](https://docs.github.com/en/github/authenticating-to-github/managing-commit-signature-verification/telling-git-about-your-signing-key) and [signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)

  Learn more about contributing: https://github.com/lacework/go-sdk/blob/main/CONTRIBUTING.md
-->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

On some arm64 platforms, the `uname -m` command will return 'aarch64' and not 'arm64'. This results in the incorrect lacework cli executable to be installed, namely a 386 version of it. This commit ensures that aarch64 is treated identically to arm64.



## How did you test this change?

<!--
  How exactly did you verify that your PR solves the issue you wanted to solve?
  Include any other relevant information such as how to use the new functionality, screenshots, etc.
-->

Test plan:
1. On an M1 mac, I open a Docker container:
```
docker run -it --rm --entrypoint /bin/bash -v `pwd`:/go-sdk golang:1.18
```
2. Verify that `uname -m` outputs aarch64.
3. I install the cli:
```
cd /go-sdk
make prepare
make install-cli
```
4. Verify that the installed version works:
```
lacework version
```

The fact that the Lacework version worked means that we're no longer invoking a 386 binary (which of course immediately crashed)/


## Issue

<!--
  Include the link to a Jira/Github issue
-->
