### PR TITLE
feat: Add support from hidden suppressions migration command

### DIFF
--- a/.go-version
+++ b/.go-version
@@ -1,2 +1,1 @@
-// go version to be used by goenv
 1.18.0

--- a/api/v2_suppressions_aws.go
+++ b/api/v2_suppressions_aws.go
@@ -1,5 +1,5 @@
 //
-// Author:: Darren Murray (<darren.murray@lacework.net>)
+// Author:: Ross Moles (<ross.moles@lacework.net>)
 // Copyright:: Copyright 2022, Lacework Inc.
 // License:: Apache License, Version 2.0
 //

--- a/api/v2_suppressions_test.go
+++ b/api/v2_suppressions_test.go
@@ -1,5 +1,5 @@
 //
-// Author:: Darren Murray (<darren.murray@lacework.net>)
+// Author:: Ross Moles (<ross.moles@lacework.net>)
 // Copyright:: Copyright 2022, Lacework Inc.
 // License:: Apache License, Version 2.0
 //

--- a/cli/cmd/suppressions.go
+++ b/cli/cmd/suppressions.go
@@ -29,9 +29,6 @@ var (
 )
 
 func init() {
-	// add the suppressions command
-	rootCmd.AddCommand(suppressionsCommand)
-
 	suppressionsCommand.AddCommand(suppressionsListCmd)
 	suppressionsListCmd.AddCommand(suppressionsListAwsCmd)
 

--- a/cli/cmd/suppressions.go
+++ b/cli/cmd/suppressions.go
@@ -1,0 +1,40 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var (
+	// top-level cloud-account command
+	suppressionsCommand = &cobra.Command{
+		Use:     "suppressions",
+		Aliases: []string{"suppression", "sup", "sups"},
+		Short:   "Manage legacy suppressions",
+		Long:    "Manage legacy suppressions",
+	}
+
+	// suppressionsListCmd represents the list sub-command inside the suppressions command
+	suppressionsListCmd = &cobra.Command{
+		Use:     "list",
+		Aliases: []string{"ls"},
+		Short:   "List all legacy suppressions per CSP",
+	}
+
+	// suppressionsMigrateCmd represents the migrate sub-command inside the suppressions command
+	suppressionsMigrateCmd = &cobra.Command{
+		Use:     "migrate",
+		Aliases: []string{"mig"},
+		Short:   "Migrate legacy suppressions for selected CSP, to policy exceptions",
+	}
+)
+
+func init() {
+	// add the suppressions command
+	rootCmd.AddCommand(suppressionsCommand)
+
+	suppressionsCommand.AddCommand(suppressionsListCmd)
+	suppressionsListCmd.AddCommand(suppressionsListAwsCmd)
+
+	suppressionsCommand.AddCommand(suppressionsMigrateCmd)
+	suppressionsMigrateCmd.AddCommand(suppressionsMigrateAwsCmd)
+}

--- a/cli/cmd/suppressions.go
+++ b/cli/cmd/suppressions.go
@@ -23,7 +23,7 @@ import (
 )
 
 var (
-	// top-level cloud-account command
+	// top-level suppressions command
 	suppressionsCommand = &cobra.Command{
 		Use:     "suppressions",
 		Hidden:  true,
@@ -32,26 +32,16 @@ var (
 		Long:    "Manage legacy suppressions",
 	}
 
-	// suppressionsListCmd represents the list sub-command inside the suppressions command
-	suppressionsListCmd = &cobra.Command{
-		Use:     "list",
-		Aliases: []string{"ls"},
-		Short:   "List all legacy suppressions per CSP",
-	}
-
-	// suppressionsMigrateCmd represents the migrate sub-command inside the suppressions command
-	suppressionsMigrateCmd = &cobra.Command{
-		Use:     "migrate",
-		Aliases: []string{"mig"},
-		Short:   "Migrate legacy suppressions for selected CSP, to policy exceptions",
+	// suppressionsAwsCmd represents the aws sub-command inside the suppressions command
+	suppressionsAwsCmd = &cobra.Command{
+		Use:   "aws",
+		Short: "Manage legacy suppressions for aws",
 	}
 )
 
 func init() {
 	rootCmd.AddCommand(suppressionsCommand)
-	suppressionsCommand.AddCommand(suppressionsListCmd)
-	suppressionsListCmd.AddCommand(suppressionsListAwsCmd)
-
-	suppressionsCommand.AddCommand(suppressionsMigrateCmd)
-	suppressionsMigrateCmd.AddCommand(suppressionsMigrateAwsCmd)
+	suppressionsCommand.AddCommand(suppressionsAwsCmd)
+	suppressionsAwsCmd.AddCommand(suppressionsListAwsCmd)
+	suppressionsAwsCmd.AddCommand(suppressionsMigrateAwsCmd)
 }

--- a/cli/cmd/suppressions.go
+++ b/cli/cmd/suppressions.go
@@ -1,3 +1,21 @@
+//
+// Author:: Ross Moles (<ross.moles@lacework.net>)
+// Copyright:: Copyright 2022, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
 package cmd
 
 import (

--- a/cli/cmd/suppressions.go
+++ b/cli/cmd/suppressions.go
@@ -8,6 +8,7 @@ var (
 	// top-level cloud-account command
 	suppressionsCommand = &cobra.Command{
 		Use:     "suppressions",
+		Hidden:  true,
 		Aliases: []string{"suppression", "sup", "sups"},
 		Short:   "Manage legacy suppressions",
 		Long:    "Manage legacy suppressions",
@@ -29,6 +30,7 @@ var (
 )
 
 func init() {
+	rootCmd.AddCommand(suppressionsCommand)
 	suppressionsCommand.AddCommand(suppressionsListCmd)
 	suppressionsListCmd.AddCommand(suppressionsListAwsCmd)
 

--- a/cli/cmd/suppressions_aws.go
+++ b/cli/cmd/suppressions_aws.go
@@ -1,0 +1,629 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/AlecAivazis/survey/v2"
+	"github.com/lacework/go-sdk/api"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"golang.org/x/exp/slices"
+)
+
+var (
+	// constraint types
+	// ResourceNames, in the old CIS1.1, works for EC2 instance ID,
+	// VPC ID, Group ID, ARN, ELB ID, Lambda name, IAM policy, etc)
+	allAwsConditions           = []string{"accountIds", "regionNames", "resourceNames", "resourceTags"}
+	noRegionNames              = []string{"accountIds", "resourceNames", "resourceTags"}
+	accountIdsOnly             = []string{"accountIds"}
+	accountIdsAndResourceNames = []string{"accountIds", "resourceNames"}
+	noResourceTags             = []string{"accountIds", "regionNames", "resourceNames"}
+
+	// https://docs.lacework.com/console/aws-compliance-policy-exceptions-criteria#lacework-custom-policies-for-aws-iam
+	// https://docs.lacework.com/console/cis-aws-140-benchmark-report#identity-and-access-management
+	// old ID to new ID mapping, using the old Constraints with the hope they match the new Constraints
+	awsEquivalencesMap = map[string]string{
+		"AWS_CIS_1_2":   "lacework-global-39",
+		"AWS_CIS_1_3":   "lacework-global-41",
+		"AWS_CIS_1_4":   "lacework-global-43",
+		"AWS_CIS_1_9":   "lacework-global-37",
+		"AWS_CIS_1_10":  "lacework-global-38",
+		"AWS_CIS_1_12":  "lacework-global-34",
+		"AWS_CIS_1_13":  "lacework-global-35",
+		"AWS_CIS_1_14":  "lacework-global-69",
+		"AWS_CIS_1_15":  "lacework-global-33",
+		"AWS_CIS_1_16":  "lacework-global-44", // no iam policies to users
+		"AWS_CIS_1_19":  "lacework-global-31", // manual?
+		"AWS_CIS_1_20":  "lacework-global-32", // manual?
+		"AWS_CIS_1_21":  "lacework-global-70", // manual?
+		"AWS_CIS_1_22":  "lacework-global-46",
+		"AWS_CIS_1_23":  "lacework-global-40",
+		"AWS_CIS_1_24":  "lacework-global-45",
+		"AWS_CIS_2_1":   "lacework-global-53",
+		"AWS_CIS_2_2":   "lacework-global-75",
+		"AWS_CIS_2_3":   "lacework-global-54", // s3 bucket cloudtrail log
+		"AWS_CIS_2_4":   "lacework-global-55",
+		"AWS_CIS_2_5":   "lacework-global-76",
+		"AWS_CIS_2_6":   "lacework-global-56", // s3 bucket cloudtrail log
+		"AWS_CIS_2_7":   "lacework-global-77",
+		"AWS_CIS_2_8":   "lacework-global-78",
+		"AWS_CIS_2_9":   "lacework-global-79",
+		"AWS_CIS_3_1":   "lacework-global-57",
+		"AWS_CIS_3_2":   "lacework-global-58",
+		"AWS_CIS_3_3":   "lacework-global-59",
+		"AWS_CIS_3_4":   "lacework-global-60",
+		"AWS_CIS_3_5":   "lacework-global-61",
+		"AWS_CIS_3_6":   "lacework-global-82",
+		"AWS_CIS_3_7":   "lacework-global-83",
+		"AWS_CIS_3_8":   "lacework-global-62",
+		"AWS_CIS_3_9":   "lacework-global-84",
+		"AWS_CIS_3_10":  "lacework-global-85",
+		"AWS_CIS_3_11":  "lacework-global-86",
+		"AWS_CIS_3_12":  "lacework-global-63",
+		"AWS_CIS_3_13":  "lacework-global-64",
+		"AWS_CIS_3_14":  "lacework-global-65",
+		"AWS_CIS_4_1":   "lacework-global-68",
+		"AWS_CIS_4_2":   "lacework-global-68",
+		"AWS_CIS_4_3":   "lacework-global-79",
+		"AWS_CIS_4_4":   "lacework-global-87",
+		"LW_S3_1":       "lacework-global-130",
+		"LW_S3_2":       "lacework-global-131",
+		"LW_S3_3":       "lacework-global-132",
+		"LW_S3_4":       "lacework-global-133",
+		"LW_S3_5":       "lacework-global-134",
+		"LW_S3_6":       "lacework-global-135",
+		"LW_S3_7":       "lacework-global-136",
+		"LW_S3_8":       "lacework-global-137",
+		"LW_S3_9":       "lacework-global-138",
+		"LW_S3_10":      "lacework-global-139",
+		"LW_S3_11":      "lacework-global-140",
+		"LW_S3_12":      "lacework-global-94",
+		"LW_S3_13":      "lacework-global-95",
+		"LW_S3_14":      "lacework-global-217",
+		"LW_S3_15":      "lacework-global-96",
+		"LW_S3_16":      "lacework-global-97",
+		"LW_S3_18":      "lacework-global-98",
+		"LW_S3_19":      "lacework-global-99",
+		"LW_S3_20":      "lacework-global-100",
+		"LW_S3_21":      "lacework-global-101",
+		"LW_AWS_IAM_1":  "lacework-global-115",
+		"LW_AWS_IAM_2":  "lacework-global-116",
+		"LW_AWS_IAM_3":  "lacework-global-117",
+		"LW_AWS_IAM_4":  "lacework-global-118",
+		"LW_AWS_IAM_5":  "lacework-global-119",
+		"LW_AWS_IAM_6":  "lacework-global-120",
+		"LW_AWS_IAM_7":  "lacework-global-121",
+		"LW_AWS_IAM_11": "lacework-global-181", // non-root user
+		"LW_AWS_IAM_12": "lacework-global-142",
+		"LW_AWS_IAM_13": "lacework-global-141",
+		"LW_AWS_IAM_14": "lacework-global-105",
+		// "AWS_CIS_4_5" : "88 (Manual)",
+		"LW_AWS_NETWORKING_1":       "lacework-global-227", // sec-group
+		"LW_AWS_NETWORKING_2":       "lacework-global-145", // network acl
+		"LW_AWS_NETWORKING_3":       "lacework-global-146", // network acl
+		"LW_AWS_NETWORKING_4":       "lacework-global-147",
+		"LW_AWS_NETWORKING_5":       "lacework-global-148",
+		"LW_AWS_NETWORKING_6":       "lacework-global-149",
+		"LW_AWS_NETWORKING_7":       "lacework-global-228",
+		"LW_AWS_NETWORKING_8":       "lacework-global-229",
+		"LW_AWS_NETWORKING_9":       "lacework-global-230",
+		"LW_AWS_NETWORKING_10":      "lacework-global-231",
+		"LW_AWS_NETWORKING_11":      "lacework-global-199",
+		"LW_AWS_NETWORKING_12":      "lacework-global-150",
+		"LW_AWS_NETWORKING_13":      "lacework-global-151",
+		"LW_AWS_NETWORKING_14":      "lacework-global-152",
+		"LW_AWS_NETWORKING_15":      "lacework-global-153",
+		"LW_AWS_NETWORKING_16":      "lacework-global-225",
+		"LW_AWS_NETWORKING_17":      "lacework-global-226",
+		"LW_AWS_NETWORKING_18":      "lacework-global-154",
+		"LW_AWS_NETWORKING_19":      "lacework-global-155",
+		"LW_AWS_NETWORKING_20":      "lacework-global-156",
+		"LW_AWS_NETWORKING_21":      "lacework-global-104",
+		"LW_AWS_NETWORKING_22":      "lacework-global-106",
+		"LW_AWS_NETWORKING_23":      "lacework-global-107",
+		"LW_AWS_NETWORKING_24":      "lacework-global-108",
+		"LW_AWS_NETWORKING_25":      "lacework-global-109",
+		"LW_AWS_NETWORKING_26":      "lacework-global-110",
+		"LW_AWS_NETWORKING_27":      "lacework-global-111",
+		"LW_AWS_NETWORKING_28":      "lacework-global-112",
+		"LW_AWS_NETWORKING_29":      "lacework-global-113",
+		"LW_AWS_NETWORKING_30":      "lacework-global-114",
+		"LW_AWS_NETWORKING_31":      "lacework-global-218",
+		"LW_AWS_NETWORKING_32":      "lacework-global-219",
+		"LW_AWS_NETWORKING_33":      "lacework-global-220",
+		"LW_AWS_NETWORKING_34":      "lacework-global-221",
+		"LW_AWS_NETWORKING_35":      "lacework-global-222",
+		"LW_AWS_NETWORKING_36":      "lacework-global-148",
+		"LW_AWS_NETWORKING_37":      "lacework-global-102",
+		"LW_AWS_NETWORKING_38":      "lacework-global-223",
+		"LW_AWS_NETWORKING_39":      "lacework-global-184",
+		"LW_AWS_NETWORKING_40":      "lacework-global-103",
+		"LW_AWS_NETWORKING_41":      "lacework-global-125", // cloudfront
+		"LW_AWS_NETWORKING_42":      "lacework-global-126", // cloudfront
+		"LW_AWS_NETWORKING_43":      "lacework-global-127",
+		"LW_AWS_NETWORKING_44":      "lacework-global-231",
+		"LW_AWS_NETWORKING_45":      "lacework-global-482",
+		"LW_AWS_NETWORKING_46":      "lacework-global-157",
+		"LW_AWS_NETWORKING_47":      "lacework-global-128",
+		"LW_AWS_NETWORKING_49":      "lacework-global-159",
+		"LW_AWS_NETWORKING_50":      "lacework-global-129", // cloudfront
+		"LW_AWS_NETWORKING_51":      "lacework-global-483",
+		"LW_AWS_MONGODB_1":          "lacework-global-196", // not documented
+		"LW_AWS_MONGODB_2":          "lacework-global-196",
+		"LW_AWS_MONGODB_3":          "lacework-global-197",
+		"LW_AWS_MONGODB_4":          "lacework-global-197",
+		"LW_AWS_MONGODB_5":          "lacework-global-198",
+		"LW_AWS_MONGODB_6":          "lacework-global-198",
+		"LW_AWS_GENERAL_SECURITY_1": "lacework-global-89", // ec2 tags
+		"LW_AWS_GENERAL_SECURITY_2": "lacework-global-90",
+		"LW_AWS_GENERAL_SECURITY_3": "lacework-global-160",
+		"LW_AWS_GENERAL_SECURITY_4": "lacework-global-171",
+		"LW_AWS_GENERAL_SECURITY_5": "lacework-global-91",
+		"LW_AWS_GENERAL_SECURITY_6": "lacework-global-92",
+		"LW_AWS_GENERAL_SECURITY_7": "lacework-global-182",
+		"LW_AWS_GENERAL_SECURITY_8": "lacework-global-183",
+		"LW_AWS_SERVERLESS_1":       "lacework-global-179",
+		"LW_AWS_SERVERLESS_2":       "lacework-global-180",
+		"LW_AWS_SERVERLESS_4":       "lacework-global-143",
+		"LW_AWS_SERVERLESS_5":       "lacework-global-144",
+		"LW_AWS_RDS_1":              "lacework-global-93",
+		"LW_AWS_ELASTICSEARCH_1":    "lacework-global-122",
+		"LW_AWS_ELASTICSEARCH_2":    "lacework-global-123",
+		"LW_AWS_ELASTICSEARCH_3":    "lacework-global-124",
+		"LW_AWS_ELASTICSEARCH_4":    "lacework-global-161",
+	}
+
+	policyExceptionTemplatesMap = map[string][]string{
+		"lacework-global-39":  accountIdsAndResourceNames,
+		"lacework-global-41":  allAwsConditions,
+		"lacework-global-43":  accountIdsAndResourceNames,
+		"lacework-global-37":  accountIdsOnly,
+		"lacework-global-38":  accountIdsOnly,
+		"lacework-global-34":  accountIdsOnly,
+		"lacework-global-35":  accountIdsOnly,
+		"lacework-global-69":  accountIdsOnly,
+		"lacework-global-33":  accountIdsOnly,
+		"lacework-global-44":  accountIdsAndResourceNames, // no iam policies to users
+		"lacework-global-31":  accountIdsOnly,             // manual?
+		"lacework-global-32":  accountIdsOnly,             // manual?
+		"lacework-global-70":  noRegionNames,              // manual?
+		"lacework-global-46":  accountIdsOnly,
+		"lacework-global-40":  accountIdsAndResourceNames,
+		"lacework-global-45":  accountIdsAndResourceNames,
+		"lacework-global-53":  accountIdsOnly,
+		"lacework-global-75":  noResourceTags,
+		"lacework-global-54":  noRegionNames, // s3 bucket cloudtrail log
+		"lacework-global-55":  noResourceTags,
+		"lacework-global-76":  noResourceTags,
+		"lacework-global-56":  noRegionNames, // s3 bucket cloudtrail log
+		"lacework-global-77":  allAwsConditions,
+		"lacework-global-78":  allAwsConditions,
+		"lacework-global-79":  allAwsConditions,
+		"lacework-global-57":  accountIdsOnly,
+		"lacework-global-58":  accountIdsOnly,
+		"lacework-global-59":  accountIdsOnly,
+		"lacework-global-60":  accountIdsOnly,
+		"lacework-global-61":  accountIdsOnly,
+		"lacework-global-82":  accountIdsOnly,
+		"lacework-global-83":  accountIdsOnly,
+		"lacework-global-62":  accountIdsOnly,
+		"lacework-global-84":  accountIdsOnly,
+		"lacework-global-85":  accountIdsOnly,
+		"lacework-global-86":  accountIdsOnly,
+		"lacework-global-63":  accountIdsOnly,
+		"lacework-global-64":  accountIdsOnly,
+		"lacework-global-65":  accountIdsOnly,
+		"lacework-global-68":  allAwsConditions,
+		"lacework-global-87":  allAwsConditions,
+		"lacework-global-130": allAwsConditions,
+		"lacework-global-131": allAwsConditions,
+		"lacework-global-132": allAwsConditions,
+		"lacework-global-133": allAwsConditions,
+		"lacework-global-134": allAwsConditions,
+		"lacework-global-135": allAwsConditions,
+		"lacework-global-136": allAwsConditions,
+		"lacework-global-137": allAwsConditions,
+		"lacework-global-138": allAwsConditions,
+		"lacework-global-139": allAwsConditions,
+		"lacework-global-140": allAwsConditions,
+		"lacework-global-94":  allAwsConditions,
+		"lacework-global-95":  allAwsConditions,
+		"lacework-global-217": allAwsConditions,
+		"lacework-global-96":  allAwsConditions,
+		"lacework-global-97":  allAwsConditions,
+		"lacework-global-98":  allAwsConditions,
+		"lacework-global-99":  allAwsConditions,
+		"lacework-global-100": allAwsConditions,
+		"lacework-global-101": allAwsConditions,
+		"lacework-global-115": accountIdsAndResourceNames,
+		"lacework-global-116": accountIdsAndResourceNames,
+		"lacework-global-117": accountIdsAndResourceNames,
+		"lacework-global-118": accountIdsAndResourceNames,
+		"lacework-global-119": accountIdsAndResourceNames,
+		"lacework-global-120": accountIdsAndResourceNames,
+		"lacework-global-121": accountIdsAndResourceNames,
+		"lacework-global-181": accountIdsOnly, // non-root user
+		"lacework-global-142": accountIdsAndResourceNames,
+		"lacework-global-141": accountIdsAndResourceNames,
+		"lacework-global-105": accountIdsAndResourceNames,
+		"lacework-global-227": noRegionNames, // sec-group
+		"lacework-global-145": noRegionNames, // network acl
+		"lacework-global-146": noRegionNames, // network acl
+		"lacework-global-147": accountIdsAndResourceNames,
+		"lacework-global-148": allAwsConditions,
+		"lacework-global-149": allAwsConditions,
+		"lacework-global-228": allAwsConditions,
+		"lacework-global-229": allAwsConditions,
+		"lacework-global-230": allAwsConditions,
+		"lacework-global-231": allAwsConditions,
+		"lacework-global-199": allAwsConditions,
+		"lacework-global-150": allAwsConditions,
+		"lacework-global-151": allAwsConditions,
+		"lacework-global-152": allAwsConditions,
+		"lacework-global-153": allAwsConditions,
+		"lacework-global-225": allAwsConditions,
+		"lacework-global-226": allAwsConditions,
+		"lacework-global-154": allAwsConditions,
+		"lacework-global-155": allAwsConditions,
+		"lacework-global-156": allAwsConditions,
+		"lacework-global-104": allAwsConditions,
+		"lacework-global-106": allAwsConditions,
+		"lacework-global-107": allAwsConditions,
+		"lacework-global-108": allAwsConditions,
+		"lacework-global-109": allAwsConditions,
+		"lacework-global-110": allAwsConditions,
+		"lacework-global-111": allAwsConditions,
+		"lacework-global-112": allAwsConditions,
+		"lacework-global-113": allAwsConditions,
+		"lacework-global-114": allAwsConditions,
+		"lacework-global-218": allAwsConditions,
+		"lacework-global-219": allAwsConditions,
+		"lacework-global-220": allAwsConditions,
+		"lacework-global-221": allAwsConditions,
+		"lacework-global-222": allAwsConditions,
+		"lacework-global-102": allAwsConditions,
+		"lacework-global-223": allAwsConditions,
+		"lacework-global-184": allAwsConditions,
+		"lacework-global-103": allAwsConditions,
+		"lacework-global-125": noRegionNames, // cloudfront
+		"lacework-global-126": noRegionNames, // cloudfront
+		"lacework-global-127": allAwsConditions,
+		"lacework-global-482": allAwsConditions,
+		"lacework-global-157": allAwsConditions,
+		"lacework-global-128": allAwsConditions,
+		"lacework-global-159": allAwsConditions,
+		"lacework-global-129": noRegionNames, // cloudfront
+		"lacework-global-483": allAwsConditions,
+		"lacework-global-196": allAwsConditions,
+		"lacework-global-197": allAwsConditions,
+		"lacework-global-198": allAwsConditions,
+		"lacework-global-89":  noRegionNames, // ec2 tags
+		"lacework-global-90":  allAwsConditions,
+		"lacework-global-160": noRegionNames,
+		"lacework-global-171": noRegionNames,
+		"lacework-global-91":  noRegionNames,
+		"lacework-global-92":  noResourceTags,
+		"lacework-global-182": noRegionNames,
+		"lacework-global-183": noRegionNames,
+		"lacework-global-179": allAwsConditions,
+		"lacework-global-180": allAwsConditions,
+		"lacework-global-143": allAwsConditions,
+		"lacework-global-144": allAwsConditions,
+		"lacework-global-93":  allAwsConditions,
+		"lacework-global-122": noResourceTags,
+		"lacework-global-123": noResourceTags,
+		"lacework-global-124": noResourceTags,
+		"lacework-global-161": noResourceTags,
+	}
+
+	// suppressionsMigrateAwsCmd represents the aws sub-command inside the suppressions migrate command
+	suppressionsMigrateAwsCmd = &cobra.Command{
+		Use:     "aws",
+		Aliases: []string{"aws"},
+		Short:   "Migrate legacy suppressions for AWS to mapped policy exceptions",
+		RunE:    suppressionsAwsMigrate,
+	}
+
+	// suppressionsListAwsCmd represents the aws sub-command inside the suppressions list command
+	suppressionsListAwsCmd = &cobra.Command{
+		Use:     "aws",
+		Aliases: []string{"aws"},
+		Short:   "List legacy suppressions for AWS",
+		RunE:    suppressionsAwsList,
+	}
+)
+
+func suppressionsAwsList(_ *cobra.Command, _ []string) error {
+	var (
+		suppressions map[string]api.SuppressionV2
+		err          error
+	)
+
+	suppressions, err = cli.LwApi.V2.Suppressions.Aws.List()
+	if err != nil {
+		return errors.Wrap(err, "unable to get legacy aws suppressions")
+	}
+
+	if len(suppressions) == 0 {
+		cli.OutputHuman("No legacy AWS suppressions found.\n")
+		return nil
+	}
+	return cli.OutputJSON(suppressions)
+}
+
+func suppressionsAwsMigrate(_ *cobra.Command, _ []string) error {
+	var (
+		suppressionsMap map[string]api.SuppressionV2
+		err             error
+
+		convertedPolicyExceptions []map[string]api.PolicyException
+		payloadsText              []string
+		discardedSuppressions     []map[string]api.SuppressionV2
+	)
+	answer := ""
+	manualMigration := "Output translated legacy suppressions as policy exception commands to be run manually"
+	autoMigration := "Auto migrate legacy suppressions. DISCLAIMER: " +
+		"By selecting this option, you accept responsibility for " +
+		"the migration and any compliance violations missed as a result of the added exceptions"
+	if err := SurveyQuestionInteractiveOnly(SurveyQuestionWithValidationArgs{
+		Prompt: &survey.Select{
+			Message: "Which migration approach would you like to take?",
+			Options: []string{
+				manualMigration,
+				autoMigration,
+			},
+		},
+		Response: &answer,
+	}); err != nil {
+		return err
+	}
+
+	suppressionsMap, err = cli.LwApi.V2.Suppressions.Aws.List()
+	if err != nil {
+		return errors.Wrap(err, "unable to get legacy aws suppressions")
+	}
+
+	switch answer {
+	case manualMigration:
+		_, payloadsText, discardedSuppressions = convertAwsSuppressions(suppressionsMap)
+		printPayloadsText(payloadsText)
+		printDiscardedSuppressions(discardedSuppressions)
+	case autoMigration:
+		convertedPolicyExceptions, _, discardedSuppressions = convertAwsSuppressions(
+			suppressionsMap)
+		printConvertedSuppressions(convertedPolicyExceptions)
+		confirm := false
+		err := survey.AskOne(&survey.Confirm{
+			Message: "Confirm that you have reviewed the above exceptions and wish to continue" +
+				" with the auto migration.",
+		}, &confirm)
+		if err != nil {
+			return err
+		}
+		if confirm {
+			autoConvertAwsSuppressions(convertedPolicyExceptions)
+			printDiscardedSuppressions(discardedSuppressions)
+			cli.OutputHuman("To view the newly created Exceptions, " +
+				"try running `lacework policy-exceptions list <policyId>")
+		} else {
+			cli.OutputHuman("Cancelled Legacy Suppression to Exception migration!")
+		}
+	}
+
+	return nil
+}
+
+func autoConvertAwsSuppressions(convertedPolicyExceptions []map[string]api.PolicyException) {
+	cli.StartProgress("Creating policy exceptions ...")
+	for _, exceptionMap := range convertedPolicyExceptions {
+		for policyId, exception := range exceptionMap {
+			response, err := cli.LwApi.V2.Policy.Exceptions.Create(policyId, exception)
+			if err != nil {
+				cli.Log.Debug(err, "unable to create exception")
+				continue
+			}
+			cli.OutputHuman("Exception created for PolicyId: %s - ExceptionId: %s\n\n",
+				policyId, response.Data.ExceptionID)
+		}
+	}
+
+	cli.StopProgress()
+}
+
+func convertAwsSuppressions(suppressionsMap map[string]api.SuppressionV2) ([]map[string]api.PolicyException,
+	[]string, []map[string]api.SuppressionV2) {
+	var (
+		convertedPolicyExceptions []map[string]api.PolicyException
+		payloadsText              []string
+		discardedSuppressions     []map[string]api.SuppressionV2
+	)
+
+	for id, suppressionInfo := range suppressionsMap {
+		// verify there is a mapped policy for this recommendation
+		// if the recommendation is not a key in the map we can assume this is not mapped and
+		// continue
+		mappedPolicyId, ok := awsEquivalencesMap[id]
+		if !ok {
+			// when we don't have a mapped policy, add the legacy suppression info
+			if suppressionInfo.SuppressionConditions != nil {
+				discardedSuppressions = append(
+					discardedSuppressions,
+					map[string]api.SuppressionV2{id: suppressionInfo},
+				)
+			}
+			continue
+		}
+
+		// get the policy exception template for the mapped policy
+		// the exception template defines the exception fields that are supported for the policy
+		policyIdExceptionsTemplate := policyExceptionTemplatesMap[mappedPolicyId]
+		if len(suppressionInfo.SuppressionConditions) >= 1 {
+			for _, suppression := range suppressionInfo.SuppressionConditions {
+				// used to store the converted legacy suppressions
+				var convertedConstraints []api.PolicyExceptionConstraint
+
+				accountIdsConstraint := convertSupCondition(suppression.AccountIds,
+					"accountIds",
+					policyIdExceptionsTemplate)
+				if accountIdsConstraint.FieldKey != "" {
+					convertedConstraints = append(convertedConstraints, accountIdsConstraint)
+				}
+
+				regionNamesConstraint := convertSupCondition(suppression.RegionNames,
+					"regionNames",
+					policyIdExceptionsTemplate)
+				if regionNamesConstraint.FieldKey != "" {
+					convertedConstraints = append(convertedConstraints, regionNamesConstraint)
+				}
+
+				resourceNamesConstraint := convertSupCondition(suppression.ResourceNames,
+					"resourceNames",
+					policyIdExceptionsTemplate)
+				if resourceNamesConstraint.FieldKey != "" {
+					convertedConstraints = append(convertedConstraints, resourceNamesConstraint)
+				}
+
+				resourceTagsConstraint := convertSupConditionTags(suppression.ResourceTags,
+					"resourceTags",
+					policyIdExceptionsTemplate)
+				if resourceTagsConstraint.FieldKey != "" {
+					convertedConstraints = append(convertedConstraints, resourceTagsConstraint)
+				}
+
+				description := fmt.Sprintf(
+					"Migrated exception from legacy compliance policy %s. ", id,
+				)
+				if suppression.Comment != "" {
+					description = description + fmt.Sprintf(
+						"Legacy Policy comment: %s", suppression.Comment,
+					)
+				}
+				if len(convertedConstraints) >= 1 {
+					convertedPolicyExceptions = append(
+						convertedPolicyExceptions,
+						map[string]api.PolicyException{
+							mappedPolicyId: {
+								Description: description,
+								Constraints: convertedConstraints,
+							},
+						},
+					)
+
+					exception := api.PolicyException{
+						Description: description,
+						Constraints: convertedConstraints,
+					}
+					jsonException, err := json.Marshal(exception)
+					if err != nil {
+						cli.Log.Error(err)
+					}
+
+					payloadsText = append(
+						payloadsText,
+						fmt.Sprintf(
+							"lacework api post '/Exceptions?policyId=%s' -d '%s'",
+							mappedPolicyId,
+							jsonException,
+						),
+					)
+				}
+			}
+		}
+	}
+
+	return convertedPolicyExceptions, payloadsText, discardedSuppressions
+}
+
+func printPayloadsText(payloadsText []string) {
+	if len(payloadsText) >= 1 {
+		cli.OutputHuman("#### Legacy Suppressions --> Exceptions payloads\n")
+		for _, payload := range payloadsText {
+			cli.OutputHuman("%s \n\n", payload)
+		}
+	} else {
+		cli.OutputHuman("No legacy suppressions found that could be migrated\n")
+	}
+}
+
+func printConvertedSuppressions(convertedSuppressions []map[string]api.PolicyException) {
+	if len(convertedSuppressions) >= 1 {
+		cli.OutputHuman("#### Converted legacy suppressions in Policy Exception format\n")
+		for _, exception := range convertedSuppressions {
+			b, err := json.Marshal(exception)
+			if err != nil {
+				return
+			}
+			cli.OutputHuman("%s \n\n", string(b))
+		}
+		cli.OutputHuman("WARNING: Before continuing, " +
+			"please thoroughly inspect the above exceptions to ensure they are valid and" +
+			" required. Lacework is not responsible for any compliance violations missed as a " +
+			"result of the above exceptions!\n\n")
+	}
+}
+
+func printDiscardedSuppressions(discardedSuppressions []map[string]api.SuppressionV2) {
+	if len(discardedSuppressions) >= 1 {
+		cli.OutputHuman("#### Discarded legacy suppressions\n")
+		for _, suppression := range discardedSuppressions {
+			b, err := json.Marshal(suppression)
+			if err != nil {
+				return
+			}
+			cli.OutputHuman("%s \n\n", string(b))
+		}
+	}
+}
+
+func convertSupCondition(supCondition []string, fieldKey string,
+	policyIdExceptionsTemplate []string) api.PolicyExceptionConstraint {
+	if len(supCondition) >= 1 && slices.Contains(
+		policyIdExceptionsTemplate, fieldKey) {
+
+		var condition []any
+		// verify if "ALL_ACCOUNTS" OR "ALL_REGIONS" is in the suppression condition slice
+		// if so we should ignore the supplied conditions and replace with a wildcard *
+		if (slices.Contains(supCondition, "ALL_ACCOUNTS") && fieldKey == "accountIds") ||
+			(slices.Contains(supCondition, "ALL_REGIONS") && fieldKey == "regionNames") {
+			condition = append(condition, "*")
+		} else {
+			condition = convertToAnySlice(supCondition)
+		}
+
+		return api.PolicyExceptionConstraint{
+			FieldKey:    fieldKey,
+			FieldValues: condition,
+		}
+	}
+	return api.PolicyExceptionConstraint{}
+}
+
+func convertSupConditionTags(supCondition []map[string]string, fieldKey string,
+	policyIdExceptionsTemplate []string) api.PolicyExceptionConstraint {
+	if len(supCondition) >= 1 && slices.Contains(
+		policyIdExceptionsTemplate, fieldKey) {
+
+		// api.PolicyExceptionConstraint expects []any for the FieldValues
+		// Therefore we need to take the supCondition []map[string]string and append each map to
+		// the new convertedTags []any var
+		var convertedTags []any
+		for _, tagMap := range supCondition {
+			convertedTags = append(convertedTags, tagMap)
+		}
+
+		return api.PolicyExceptionConstraint{
+			FieldKey:    fieldKey,
+			FieldValues: convertedTags,
+		}
+	}
+	return api.PolicyExceptionConstraint{}
+}
+
+func convertToAnySlice(slice []string) []any {
+	s := make([]interface{}, len(slice))
+	for i, v := range slice {
+		s[i] = v
+	}
+	return s
+}

--- a/cli/cmd/suppressions_aws.go
+++ b/cli/cmd/suppressions_aws.go
@@ -37,19 +37,19 @@ var (
 	// https://docs.lacework.com/console/cis-aws-140-benchmark-report#identity-and-access-management
 	// old ID to new ID mapping, using the old Constraints with the hope they match the new Constraints
 	awsEquivalencesMap = map[string]string{
-		"AWS_CIS_1_2":   "lacework-global-39",
-		"AWS_CIS_1_3":   "lacework-global-41",
-		"AWS_CIS_1_4":   "lacework-global-43",
-		"AWS_CIS_1_9":   "lacework-global-37",
-		"AWS_CIS_1_10":  "lacework-global-38",
-		"AWS_CIS_1_12":  "lacework-global-34",
-		"AWS_CIS_1_13":  "lacework-global-35",
-		"AWS_CIS_1_14":  "lacework-global-69",
-		"AWS_CIS_1_15":  "lacework-global-33",
-		"AWS_CIS_1_16":  "lacework-global-44", // no iam policies to users
-		"AWS_CIS_1_19":  "lacework-global-31", // manual?
-		"AWS_CIS_1_20":  "lacework-global-32", // manual?
-		"AWS_CIS_1_21":  "lacework-global-70", // manual?
+		"AWS_CIS_1_2":  "lacework-global-39",
+		"AWS_CIS_1_3":  "lacework-global-41",
+		"AWS_CIS_1_4":  "lacework-global-43",
+		"AWS_CIS_1_9":  "lacework-global-37",
+		"AWS_CIS_1_10": "lacework-global-38",
+		"AWS_CIS_1_12": "lacework-global-34",
+		"AWS_CIS_1_13": "lacework-global-35",
+		"AWS_CIS_1_14": "lacework-global-69",
+		"AWS_CIS_1_15": "lacework-global-33",
+		"AWS_CIS_1_16": "lacework-global-44", // no iam policies to users
+		//"AWS_CIS_1_19":  "lacework-global-31", manual
+		//"AWS_CIS_1_20":  "lacework-global-32", manual
+		//"AWS_CIS_1_21":  "lacework-global-70", manual
 		"AWS_CIS_1_22":  "lacework-global-46",
 		"AWS_CIS_1_23":  "lacework-global-40",
 		"AWS_CIS_1_24":  "lacework-global-45",

--- a/cli/cmd/suppressions_aws.go
+++ b/cli/cmd/suppressions_aws.go
@@ -12,15 +12,6 @@ import (
 )
 
 var (
-	// constraint types
-	// ResourceNames, in the old CIS1.1, works for EC2 instance ID,
-	// VPC ID, Group ID, ARN, ELB ID, Lambda name, IAM policy, etc)
-	allAwsConditions           = []string{"accountIds", "regionNames", "resourceNames", "resourceTags"}
-	noRegionNames              = []string{"accountIds", "resourceNames", "resourceTags"}
-	accountIdsOnly             = []string{"accountIds"}
-	accountIdsAndResourceNames = []string{"accountIds", "resourceNames"}
-	noResourceTags             = []string{"accountIds", "regionNames", "resourceNames"}
-
 	// https://docs.lacework.com/console/aws-compliance-policy-exceptions-criteria#lacework-custom-policies-for-aws-iam
 	// https://docs.lacework.com/console/cis-aws-140-benchmark-report#identity-and-access-management
 	// old ID to new ID mapping, using the old Constraints with the hope they match the new Constraints
@@ -175,149 +166,6 @@ var (
 		"LW_AWS_ELASTICSEARCH_4":    "lacework-global-161",
 	}
 
-	policyExceptionTemplatesMap = map[string][]string{
-		"lacework-global-39":  accountIdsAndResourceNames,
-		"lacework-global-41":  allAwsConditions,
-		"lacework-global-43":  accountIdsAndResourceNames,
-		"lacework-global-37":  accountIdsOnly,
-		"lacework-global-38":  accountIdsOnly,
-		"lacework-global-34":  accountIdsOnly,
-		"lacework-global-35":  accountIdsOnly,
-		"lacework-global-69":  accountIdsOnly,
-		"lacework-global-33":  accountIdsOnly,
-		"lacework-global-44":  accountIdsAndResourceNames, // no iam policies to users
-		"lacework-global-31":  accountIdsOnly,             // manual?
-		"lacework-global-32":  accountIdsOnly,             // manual?
-		"lacework-global-70":  noRegionNames,              // manual?
-		"lacework-global-46":  accountIdsOnly,
-		"lacework-global-40":  accountIdsAndResourceNames,
-		"lacework-global-45":  accountIdsAndResourceNames,
-		"lacework-global-53":  accountIdsOnly,
-		"lacework-global-75":  noResourceTags,
-		"lacework-global-54":  noRegionNames, // s3 bucket cloudtrail log
-		"lacework-global-55":  noResourceTags,
-		"lacework-global-76":  noResourceTags,
-		"lacework-global-56":  noRegionNames, // s3 bucket cloudtrail log
-		"lacework-global-77":  allAwsConditions,
-		"lacework-global-78":  allAwsConditions,
-		"lacework-global-79":  allAwsConditions,
-		"lacework-global-57":  accountIdsOnly,
-		"lacework-global-58":  accountIdsOnly,
-		"lacework-global-59":  accountIdsOnly,
-		"lacework-global-60":  accountIdsOnly,
-		"lacework-global-61":  accountIdsOnly,
-		"lacework-global-82":  accountIdsOnly,
-		"lacework-global-83":  accountIdsOnly,
-		"lacework-global-62":  accountIdsOnly,
-		"lacework-global-84":  accountIdsOnly,
-		"lacework-global-85":  accountIdsOnly,
-		"lacework-global-86":  accountIdsOnly,
-		"lacework-global-63":  accountIdsOnly,
-		"lacework-global-64":  accountIdsOnly,
-		"lacework-global-65":  accountIdsOnly,
-		"lacework-global-68":  allAwsConditions,
-		"lacework-global-87":  allAwsConditions,
-		"lacework-global-130": allAwsConditions,
-		"lacework-global-131": allAwsConditions,
-		"lacework-global-132": allAwsConditions,
-		"lacework-global-133": allAwsConditions,
-		"lacework-global-134": allAwsConditions,
-		"lacework-global-135": allAwsConditions,
-		"lacework-global-136": allAwsConditions,
-		"lacework-global-137": allAwsConditions,
-		"lacework-global-138": allAwsConditions,
-		"lacework-global-139": allAwsConditions,
-		"lacework-global-140": allAwsConditions,
-		"lacework-global-94":  allAwsConditions,
-		"lacework-global-95":  allAwsConditions,
-		"lacework-global-217": allAwsConditions,
-		"lacework-global-96":  allAwsConditions,
-		"lacework-global-97":  allAwsConditions,
-		"lacework-global-98":  allAwsConditions,
-		"lacework-global-99":  allAwsConditions,
-		"lacework-global-100": allAwsConditions,
-		"lacework-global-101": allAwsConditions,
-		"lacework-global-115": accountIdsAndResourceNames,
-		"lacework-global-116": accountIdsAndResourceNames,
-		"lacework-global-117": accountIdsAndResourceNames,
-		"lacework-global-118": accountIdsAndResourceNames,
-		"lacework-global-119": accountIdsAndResourceNames,
-		"lacework-global-120": accountIdsAndResourceNames,
-		"lacework-global-121": accountIdsAndResourceNames,
-		"lacework-global-181": accountIdsOnly, // non-root user
-		"lacework-global-142": accountIdsAndResourceNames,
-		"lacework-global-141": accountIdsAndResourceNames,
-		"lacework-global-105": accountIdsAndResourceNames,
-		"lacework-global-227": noRegionNames, // sec-group
-		"lacework-global-145": noRegionNames, // network acl
-		"lacework-global-146": noRegionNames, // network acl
-		"lacework-global-147": accountIdsAndResourceNames,
-		"lacework-global-148": allAwsConditions,
-		"lacework-global-149": allAwsConditions,
-		"lacework-global-228": allAwsConditions,
-		"lacework-global-229": allAwsConditions,
-		"lacework-global-230": allAwsConditions,
-		"lacework-global-231": allAwsConditions,
-		"lacework-global-199": allAwsConditions,
-		"lacework-global-150": allAwsConditions,
-		"lacework-global-151": allAwsConditions,
-		"lacework-global-152": allAwsConditions,
-		"lacework-global-153": allAwsConditions,
-		"lacework-global-225": allAwsConditions,
-		"lacework-global-226": allAwsConditions,
-		"lacework-global-154": allAwsConditions,
-		"lacework-global-155": allAwsConditions,
-		"lacework-global-156": allAwsConditions,
-		"lacework-global-104": allAwsConditions,
-		"lacework-global-106": allAwsConditions,
-		"lacework-global-107": allAwsConditions,
-		"lacework-global-108": allAwsConditions,
-		"lacework-global-109": allAwsConditions,
-		"lacework-global-110": allAwsConditions,
-		"lacework-global-111": allAwsConditions,
-		"lacework-global-112": allAwsConditions,
-		"lacework-global-113": allAwsConditions,
-		"lacework-global-114": allAwsConditions,
-		"lacework-global-218": allAwsConditions,
-		"lacework-global-219": allAwsConditions,
-		"lacework-global-220": allAwsConditions,
-		"lacework-global-221": allAwsConditions,
-		"lacework-global-222": allAwsConditions,
-		"lacework-global-102": allAwsConditions,
-		"lacework-global-223": allAwsConditions,
-		"lacework-global-184": allAwsConditions,
-		"lacework-global-103": allAwsConditions,
-		"lacework-global-125": noRegionNames, // cloudfront
-		"lacework-global-126": noRegionNames, // cloudfront
-		"lacework-global-127": allAwsConditions,
-		"lacework-global-482": allAwsConditions,
-		"lacework-global-157": allAwsConditions,
-		"lacework-global-128": allAwsConditions,
-		"lacework-global-159": allAwsConditions,
-		"lacework-global-129": noRegionNames, // cloudfront
-		"lacework-global-483": allAwsConditions,
-		"lacework-global-196": allAwsConditions,
-		"lacework-global-197": allAwsConditions,
-		"lacework-global-198": allAwsConditions,
-		"lacework-global-89":  noRegionNames, // ec2 tags
-		"lacework-global-90":  allAwsConditions,
-		"lacework-global-160": noRegionNames,
-		"lacework-global-171": noRegionNames,
-		"lacework-global-91":  noRegionNames,
-		"lacework-global-92":  noResourceTags,
-		"lacework-global-182": noRegionNames,
-		"lacework-global-183": noRegionNames,
-		"lacework-global-179": allAwsConditions,
-		"lacework-global-180": allAwsConditions,
-		"lacework-global-143": allAwsConditions,
-		"lacework-global-144": allAwsConditions,
-		"lacework-global-93":  allAwsConditions,
-		"lacework-global-122": noResourceTags,
-		"lacework-global-123": noResourceTags,
-		"lacework-global-124": noResourceTags,
-		"lacework-global-161": noResourceTags,
-	}
-
 	// suppressionsMigrateAwsCmd represents the aws sub-command inside the suppressions migrate command
 	suppressionsMigrateAwsCmd = &cobra.Command{
 		Use:     "aws",
@@ -439,6 +287,9 @@ func convertAwsSuppressions(suppressionsMap map[string]api.SuppressionV2) ([]map
 		payloadsText              []string
 		discardedSuppressions     []map[string]api.SuppressionV2
 	)
+	// get a list of all policies and parse the valid exception constraints and create a map of
+	// {"<policyId>": [<validPolicyConstraints>]}
+	policyExceptionsConstraintsMap := getPoliciesExceptionConstraintsMap()
 
 	for id, suppressionInfo := range suppressionsMap {
 		// verify there is a mapped policy for this recommendation
@@ -456,9 +307,14 @@ func convertAwsSuppressions(suppressionsMap map[string]api.SuppressionV2) ([]map
 			continue
 		}
 
-		// get the policy exception template for the mapped policy
-		// the exception template defines the exception fields that are supported for the policy
-		policyIdExceptionsTemplate := policyExceptionTemplatesMap[mappedPolicyId]
+		// get the supported policy exception fields for the mapped policy
+		// in order to ensure we have an up-to-date list of exception constraints we need to
+		// get the policy from the /api/v2/Policies/<policyId> api.
+		// We then parse this into a list of constraints
+		policyIdExceptionsTemplate := policyExceptionsConstraintsMap[mappedPolicyId]
+		if policyIdExceptionsTemplate == nil {
+			continue
+		}
 		if len(suppressionInfo.SuppressionConditions) >= 1 {
 			for _, suppression := range suppressionInfo.SuppressionConditions {
 				// used to store the converted legacy suppressions
@@ -619,6 +475,23 @@ func convertSupConditionTags(supCondition []map[string]string, fieldKey string,
 		}
 	}
 	return api.PolicyExceptionConstraint{}
+}
+
+func getPoliciesExceptionConstraintsMap() map[string][]string {
+	// get a list of all policies and parse the valid exception constraints and return a map of
+	// {"<policyId>": [<validPolicyConstraints>]}
+	policies, err := cli.LwApi.V2.Policy.List()
+	if err != nil {
+		return nil
+	}
+
+	policiesSupportedConstraints := make(map[string][]string)
+	for _, policy := range policies.Data {
+		exceptionConstraints := getPolicyExceptionConstraintsSlice(policy.ExceptionConfiguration)
+		policiesSupportedConstraints[policy.PolicyID] = exceptionConstraints
+	}
+
+	return policiesSupportedConstraints
 }
 
 func convertToAnySlice(slice []string) []any {

--- a/cli/cmd/suppressions_aws.go
+++ b/cli/cmd/suppressions_aws.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/lacework/go-sdk/api"
 	"github.com/pkg/errors"

--- a/cli/cmd/suppressions_aws_test.go
+++ b/cli/cmd/suppressions_aws_test.go
@@ -1,0 +1,1563 @@
+//
+// Author:: Ross Moles (<ross.moles@lacework.net>)
+// Copyright:: Copyright 2022, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cmd
+
+import (
+	"fmt"
+	"github.com/lacework/go-sdk/api"
+	"github.com/lacework/go-sdk/internal/lacework"
+	"github.com/stretchr/testify/assert"
+	"net/http"
+	"sort"
+	"testing"
+)
+
+func TestConvertAwsSuppressions(t *testing.T) {
+	var (
+		fakeServer = lacework.MockServer()
+	)
+
+	fakeServer.UseApiV2()
+	fakeServer.MockToken("TOKEN")
+	fakeServer.MockAPI("suppressions/aws/allExceptions",
+		func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "GET", r.Method, "AwsList() should be a GET method")
+			Suppressions := rawSuppressions()
+			fmt.Fprintf(w, Suppressions)
+		},
+	)
+	defer fakeServer.Close()
+
+	c, err := api.NewClient("test",
+		api.WithApiV2(),
+		api.WithToken("TOKEN"),
+		api.WithURL(fakeServer.URL()),
+	)
+	assert.Nil(t, err)
+
+	response, err := c.V2.Suppressions.Aws.List()
+	assert.Nil(t, err)
+	assert.NotNil(t, response)
+	var recsWithSuppressions []string
+	suppCondCount := 0
+	for key, sup := range response {
+		if len(sup.SuppressionConditions) >= 1 {
+			recsWithSuppressions = append(recsWithSuppressions, key)
+			suppCondCount += len(sup.SuppressionConditions)
+		}
+	}
+	assert.Equal(t, 5, len(recsWithSuppressions))
+	expectedRecsWithSup := []string{"AWS_CIS_1_14", "AWS_CIS_2_7", "AWS_CIS_4_4",
+		"LW_AWS_NETWORKING_50",
+		"LW_S3_1"}
+	sort.Strings(expectedRecsWithSup)
+	sort.Strings(recsWithSuppressions)
+	assert.Equal(t, expectedRecsWithSup, recsWithSuppressions)
+
+	convertedPolicyExceptions, payloadsText, discardedSuppressions := convertAwsSuppressions(
+		response, genPoliciesExceptionConstraintsMap())
+	assert.Equal(t, 1, len(discardedSuppressions))
+	assert.Equal(t, suppCondCount, len(payloadsText))
+	var actualConvertedPolicyIds []string
+	expectedConvertedPolicyIds := []string{"lacework-global-129", "lacework-global-87",
+		"lacework-global-69", "lacework-global-130", "lacework-global-130", "lacework-global-130",
+		"lacework-global-77"}
+
+	for _, entry := range convertedPolicyExceptions {
+		for key, _ := range entry {
+			actualConvertedPolicyIds = append(actualConvertedPolicyIds, key)
+		}
+	}
+	sort.Strings(actualConvertedPolicyIds)
+	sort.Strings(expectedConvertedPolicyIds)
+	assert.Equal(t, expectedConvertedPolicyIds, actualConvertedPolicyIds)
+}
+
+func rawSuppressions() string {
+	return `{
+  "data": [
+    {
+      "recommendationExceptions": {
+        "AWS_CIS_1_1": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "AWS_CIS_1_10": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "AWS_CIS_1_11": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "AWS_CIS_1_12": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "AWS_CIS_1_13": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "AWS_CIS_1_14": {
+          "enabled": true,
+          "suppressionConditions": [
+            {
+              "accountIds": [
+                "ALL_ACCOUNTS"
+              ],
+              "comments": "",
+              "regionNames": [
+                "ALL_REGIONS"
+              ],
+              "resourceNames": [],
+              "resourceTags": []
+            }
+          ]
+        },
+        "AWS_CIS_1_15": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "AWS_CIS_1_16": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "AWS_CIS_1_17": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "AWS_CIS_1_19": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "AWS_CIS_1_2": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "AWS_CIS_1_20": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "AWS_CIS_1_21": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "AWS_CIS_1_22": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "AWS_CIS_1_23": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "AWS_CIS_1_24": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "AWS_CIS_1_3": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "AWS_CIS_1_4": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "AWS_CIS_1_5": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "AWS_CIS_1_6": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "AWS_CIS_1_7": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "AWS_CIS_1_8": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "AWS_CIS_1_9": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "AWS_CIS_2_1": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "AWS_CIS_2_2": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "AWS_CIS_2_3": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "AWS_CIS_2_4": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "AWS_CIS_2_5": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "AWS_CIS_2_6": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "AWS_CIS_2_7": {
+          "enabled": true,
+          "suppressionConditions": [
+            {
+              "accountIds": [
+                "ALL_ACCOUNTS"
+              ],
+              "comments": "",
+              "regionNames": [
+                "eu-central-1",
+                "eu-north-1"
+              ],
+              "resourceNames": [
+                "*"
+              ],
+              "resourceTags": []
+            }
+          ]
+        },
+        "AWS_CIS_2_8": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "AWS_CIS_2_9": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "AWS_CIS_3_10": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "AWS_CIS_3_11": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "AWS_CIS_3_12": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "AWS_CIS_3_13": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "AWS_CIS_3_14": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "AWS_CIS_3_15": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "AWS_CIS_3_2": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "AWS_CIS_3_3": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "AWS_CIS_3_4": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "AWS_CIS_3_5": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "AWS_CIS_3_6": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "AWS_CIS_3_7": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "AWS_CIS_3_8": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "AWS_CIS_3_9": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "AWS_CIS_4_1": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "AWS_CIS_4_2": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "AWS_CIS_4_4": {
+          "enabled": true,
+          "suppressionConditions": [
+            {
+              "accountIds": [
+                "ALL_ACCOUNTS"
+              ],
+              "comments": "this is a dev exception",
+              "regionNames": [
+                "ALL_REGIONS"
+              ],
+              "resourceNames": [
+                "*"
+              ],
+              "resourceTags": [
+                {
+                  "key": "owner",
+                  "value": "dev"
+                },
+                {
+                  "key": "env",
+                  "value": "dev1"
+                }
+              ]
+            }
+          ]
+        },
+        "AWS_CIS_4_5": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "LW_AWS_ELASTICSEARCH_1": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "LW_AWS_ELASTICSEARCH_2": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "LW_AWS_ELASTICSEARCH_3": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "LW_AWS_ELASTICSEARCH_4": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "LW_AWS_GENERAL_SECURITY_1": {
+          "enabled": true,
+          "suppressionConditions": []
+        },
+        "LW_AWS_GENERAL_SECURITY_2": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "LW_AWS_GENERAL_SECURITY_3": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "LW_AWS_GENERAL_SECURITY_4": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "LW_AWS_GENERAL_SECURITY_5": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "LW_AWS_GENERAL_SECURITY_6": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "LW_AWS_GENERAL_SECURITY_7": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "LW_AWS_GENERAL_SECURITY_8": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "LW_AWS_IAM_1": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "LW_AWS_IAM_10": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "LW_AWS_IAM_11": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "LW_AWS_IAM_12": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "LW_AWS_IAM_13": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "LW_AWS_IAM_14": {
+          "enabled": true,
+          "suppressionConditions": []
+        },
+        "LW_AWS_IAM_2": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "LW_AWS_IAM_3": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "LW_AWS_IAM_4": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "LW_AWS_IAM_5": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "LW_AWS_IAM_6": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "LW_AWS_IAM_7": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "LW_AWS_IAM_8": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "LW_AWS_IAM_9": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "LW_AWS_MONGODB_1": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "LW_AWS_MONGODB_2": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "LW_AWS_MONGODB_3": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "LW_AWS_MONGODB_4": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "LW_AWS_MONGODB_5": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "LW_AWS_MONGODB_6": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "LW_AWS_NETWORKING_1": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "LW_AWS_NETWORKING_10": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "LW_AWS_NETWORKING_11": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "LW_AWS_NETWORKING_12": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "LW_AWS_NETWORKING_13": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "LW_AWS_NETWORKING_14": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "LW_AWS_NETWORKING_15": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "LW_AWS_NETWORKING_16": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "LW_AWS_NETWORKING_17": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "LW_AWS_NETWORKING_18": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "LW_AWS_NETWORKING_19": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "LW_AWS_NETWORKING_2": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "LW_AWS_NETWORKING_20": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "LW_AWS_NETWORKING_21": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "LW_AWS_NETWORKING_22": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "LW_AWS_NETWORKING_23": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "LW_AWS_NETWORKING_24": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "LW_AWS_NETWORKING_25": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "LW_AWS_NETWORKING_26": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "LW_AWS_NETWORKING_27": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "LW_AWS_NETWORKING_28": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "LW_AWS_NETWORKING_29": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "LW_AWS_NETWORKING_3": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "LW_AWS_NETWORKING_30": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "LW_AWS_NETWORKING_31": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "LW_AWS_NETWORKING_32": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "LW_AWS_NETWORKING_33": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "LW_AWS_NETWORKING_34": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "LW_AWS_NETWORKING_35": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "LW_AWS_NETWORKING_36": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "LW_AWS_NETWORKING_37": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "LW_AWS_NETWORKING_38": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "LW_AWS_NETWORKING_39": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "LW_AWS_NETWORKING_4": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "LW_AWS_NETWORKING_40": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "LW_AWS_NETWORKING_41": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "LW_AWS_NETWORKING_42": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "LW_AWS_NETWORKING_43": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "LW_AWS_NETWORKING_44": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "LW_AWS_NETWORKING_45": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "LW_AWS_NETWORKING_46": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "LW_AWS_NETWORKING_47": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "LW_AWS_NETWORKING_48": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "LW_AWS_NETWORKING_49": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "LW_AWS_NETWORKING_5": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "LW_AWS_NETWORKING_50": {
+          "enabled": true,
+          "suppressionConditions": [
+            {
+              "accountIds": [
+                "287105300711"
+              ],
+              "comments": "Test Suppressions for TA - LINK-819",
+              "regionNames": [
+                "ALL_REGIONS"
+              ],
+              "resourceNames": [],
+              "resourceTags": [
+                {
+                  "key": "http_https_redirect",
+                  "value": "true"
+                }
+              ]
+            }
+          ]
+        },
+        "LW_AWS_NETWORKING_51": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "LW_AWS_NETWORKING_6": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "LW_AWS_NETWORKING_7": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "LW_AWS_NETWORKING_8": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "LW_AWS_NETWORKING_9": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "LW_AWS_RDS_1": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "LW_AWS_SERVERLESS_1": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "LW_AWS_SERVERLESS_2": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "LW_AWS_SERVERLESS_3": {
+          "enabled": true,
+          "suppressionConditions": []
+        },
+        "LW_AWS_SERVERLESS_4": {
+          "enabled": true,
+          "suppressionConditions": []
+        },
+        "LW_AWS_SERVERLESS_5": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "LW_S3_1": {
+          "enabled": true,
+          "suppressionConditions": [
+            {
+              "accountIds": [
+                "287105300711"
+              ],
+              "comments": "",
+              "regionNames": [
+                "ALL_REGIONS"
+              ],
+              "resourceNames": [
+                "eco-eng-cw-delivery-channel-bucket"
+              ],
+              "resourceTags": []
+            },
+            {
+              "accountIds": [
+                "ALL_ACCOUNTS"
+              ],
+              "comments": "A suppression comment",
+              "regionNames": [
+                "ALL_REGIONS"
+              ],
+              "resourceNames": [
+                "Test"
+              ],
+              "resourceTags": []
+            },
+            {
+              "accountIds": [
+                "ALL_ACCOUNTS"
+              ],
+              "comments": "",
+              "regionNames": [
+                "ALL_REGIONS"
+              ],
+              "resourceNames": [
+                "*"
+              ],
+              "resourceTags": [
+                {
+                  "key": "FOO",
+                  "value": "BAR"
+                }
+              ]
+            }
+          ]
+        },
+        "LW_S3_10": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "LW_S3_11": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "LW_S3_12": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "LW_S3_13": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "LW_S3_14": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "LW_S3_15": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "LW_S3_16": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "LW_S3_17": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "LW_S3_18": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "LW_S3_19": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "LW_S3_2": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "LW_S3_20": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "LW_S3_21": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "LW_S3_3": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "LW_S3_4": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "LW_S3_5": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "LW_S3_6": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "LW_S3_7": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "LW_S3_8": {
+          "enabled": true,
+          "suppressionConditions": null
+        },
+        "LW_S3_9": {
+          "enabled": true,
+          "suppressionConditions": null
+        }
+      }
+    }
+  ],
+  "message": "SUCCESS",
+  "ok": true
+}`
+}
+
+func genPoliciesExceptionConstraintsMap() map[string][]string {
+	return map[string][]string{
+		"lacework-global-100": {
+			"accountIds",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-101": {
+			"accountIds",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-102": {
+			"accountIds",
+			"regionNames",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-103": {
+			"accountIds",
+			"regionNames",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-104": {
+			"accountIds",
+			"regionNames",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-105": {
+			"accountIds",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-106": {
+			"accountIds",
+			"regionNames",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-107": {
+			"accountIds",
+			"regionNames",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-108": {
+			"accountIds",
+			"regionNames",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-109": {
+			"accountIds",
+			"regionNames",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-110": {
+			"accountIds",
+			"regionNames",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-111": {
+			"accountIds",
+			"regionNames",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-112": {
+			"accountIds",
+			"regionNames",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-113": {
+			"accountIds",
+			"regionNames",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-114": {
+			"accountIds",
+			"regionNames",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-115": {
+			"accountIds",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-116": {
+			"accountIds",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-117": {
+			"accountIds",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-118": {
+			"accountIds",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-119": {
+			"accountIds",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-120": {
+			"accountIds",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-121": {
+			"accountIds",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-122": {
+			"accountIds",
+			"regionNames",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-123": {
+			"accountIds",
+			"regionNames",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-124": {
+			"accountIds",
+			"regionNames",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-125": {
+			"accountIds",
+			"regionNames",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-126": {
+			"accountIds",
+			"regionNames",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-127": {
+			"accountIds",
+			"regionNames",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-128": {
+			"accountIds",
+			"regionNames",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-129": {
+			"accountIds",
+			"regionNames",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-130": {
+			"accountIds",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-131": {
+			"accountIds",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-132": {
+			"accountIds",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-133": {
+			"accountIds",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-134": {
+			"accountIds",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-135": {
+			"accountIds",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-136": {
+			"accountIds",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-137": {
+			"accountIds",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-138": {
+			"accountIds",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-139": {
+			"accountIds",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-140": {
+			"accountIds",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-141": {
+			"accountIds",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-142": {
+			"accountIds",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-143": {
+			"accountIds",
+			"regionNames",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-144": {
+			"accountIds",
+			"regionNames",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-145": {
+			"accountIds",
+			"regionNames",
+			"resourceNames",
+		},
+		"lacework-global-146": {
+			"accountIds",
+			"regionNames",
+			"resourceNames",
+		},
+		"lacework-global-147": {
+			"accountIds",
+			"regionNames",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-148": {
+			"accountIds",
+			"regionNames",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-149": {
+			"accountIds",
+			"regionNames",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-150": {
+			"accountIds",
+			"regionNames",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-151": {
+			"accountIds",
+			"regionNames",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-152": {
+			"accountIds",
+			"regionNames",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-153": {
+			"accountIds",
+			"regionNames",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-154": {
+			"accountIds",
+			"regionNames",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-155": {
+			"accountIds",
+			"regionNames",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-156": {
+			"accountIds",
+			"regionNames",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-157": {
+			"accountIds",
+			"regionNames",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-159": {
+			"accountIds",
+			"regionNames",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-160": {
+			"accountIds",
+			"regionNames",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-161": {
+			"accountIds",
+			"regionNames",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-171": {
+			"accountIds",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-179": {
+			"accountIds",
+			"regionNames",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-180": {
+			"accountIds",
+			"regionNames",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-181": {
+			"accountIds",
+		},
+		"lacework-global-182": {
+			"accountIds",
+			"regionNames",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-183": {
+			"accountIds",
+			"regionNames",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-184": {
+			"accountIds",
+			"regionNames",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-196": {
+			"accountIds",
+			"regionNames",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-197": {
+			"accountIds",
+			"regionNames",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-198": {
+			"accountIds",
+			"regionNames",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-199": {
+			"accountIds",
+			"regionNames",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-217": {
+			"accountIds",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-218": {
+			"accountIds",
+			"regionNames",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-219": {
+			"accountIds",
+			"regionNames",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-220": {
+			"accountIds",
+			"regionNames",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-221": {
+			"accountIds",
+			"regionNames",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-222": {
+			"accountIds",
+			"regionNames",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-223": {
+			"accountIds",
+			"regionNames",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-225": {
+			"accountIds",
+			"regionNames",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-226": {
+			"accountIds",
+			"regionNames",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-227": {
+			"accountIds",
+			"regionNames",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-228": {
+			"accountIds",
+			"regionNames",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-229": {
+			"accountIds",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-230": {
+			"accountIds",
+			"regionNames",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-231": {
+			"accountIds",
+			"regionNames",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-31": nil,
+		"lacework-global-32": nil,
+		"lacework-global-33": nil,
+		"lacework-global-34": {
+			"accountIds",
+		},
+		"lacework-global-35": {
+			"accountIds",
+		},
+		"lacework-global-37": {
+			"accountIds",
+		},
+		"lacework-global-38": {
+			"accountIds",
+		},
+		"lacework-global-39": {
+			"accountIds",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-40": {
+			"accountIds",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-41": {
+			"accountIds",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-43": {
+			"accountIds",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-44": {
+			"accountIds",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-45": {
+			"accountIds",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-46": {
+			"accountIds",
+		},
+		"lacework-global-482": {
+			"accountIds",
+			"regionNames",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-483": {
+			"accountIds",
+			"regionNames",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-53": {
+			"accountIds",
+		},
+		"lacework-global-54": {
+			"accountIds",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-55": {
+			"accountIds",
+			"regionNames",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-56": {
+			"accountIds",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-58": {
+			"accountIds",
+		},
+		"lacework-global-59": {
+			"accountIds",
+		},
+		"lacework-global-60": {
+			"accountIds",
+		},
+		"lacework-global-61": {
+			"accountIds",
+		},
+		"lacework-global-62": {
+			"accountIds",
+		},
+		"lacework-global-63": {
+			"accountIds",
+		},
+		"lacework-global-64": {
+			"accountIds",
+		},
+		"lacework-global-65": {
+			"accountIds",
+		},
+		"lacework-global-68": {
+			"accountIds",
+			"regionNames",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-69": {
+			"accountIds",
+		},
+		"lacework-global-70": nil,
+		"lacework-global-75": {
+			"accountIds",
+			"regionNames",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-76": {
+			"accountIds",
+			"regionNames",
+		},
+		"lacework-global-77": {
+			"accountIds",
+			"regionNames",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-78": {
+			"accountIds",
+			"regionNames",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-79": {
+			"accountIds",
+			"regionNames",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-82": {
+			"accountIds",
+		},
+		"lacework-global-83": {
+			"accountIds",
+		},
+		"lacework-global-84": {
+			"accountIds",
+		},
+		"lacework-global-85": {
+			"accountIds",
+		},
+		"lacework-global-86": {
+			"accountIds",
+		},
+		"lacework-global-87": {
+			"accountIds",
+			"regionNames",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-89": {
+			"accountIds",
+			"regionNames",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-90": {
+			"accountIds",
+			"regionNames",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-91": {
+			"accountIds",
+			"regionNames",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-92": {
+			"accountIds",
+		},
+		"lacework-global-93": {
+			"accountIds",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-94": {
+			"accountIds",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-95": {
+			"accountIds",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-96": {
+			"accountIds",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-97": {
+			"accountIds",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-98": {
+			"accountIds",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-99": {
+			"accountIds",
+			"resourceNames",
+			"resourceTags",
+		},
+	}
+}

--- a/cli/cmd/suppressions_aws_test.go
+++ b/cli/cmd/suppressions_aws_test.go
@@ -20,12 +20,13 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/lacework/go-sdk/api"
-	"github.com/lacework/go-sdk/internal/lacework"
-	"github.com/stretchr/testify/assert"
 	"net/http"
 	"sort"
 	"testing"
+
+	"github.com/lacework/go-sdk/api"
+	"github.com/lacework/go-sdk/internal/lacework"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestConvertAwsSuppressions(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Ross <ross.moles@lacework.net>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/lacework/go-sdk) and create your branch from `main`
  2. Run `make prepare` in the repository root
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`make test`)
  5. Format your code (`make fmt`)
  6. Make sure your code lints (`make lint`)
  7. If you are updating the Lacework CLI, make sure it compiles (`make build-cli-cross-platform`)
  8. Follow the commit message standard (`type(scope): subject`) documented in [DEVELOPER_GUIDELINES.md](https://github.com/lacework/go-sdk/blob/main/DEVELOPER_GUIDELINES.md#commit-message-standard)
  9. If you haven't already, configure signed commits by [telling git about your signing key](https://docs.github.com/en/github/authenticating-to-github/managing-commit-signature-verification/telling-git-about-your-signing-key) and [signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)

  Learn more about contributing: https://github.com/lacework/go-sdk/blob/main/CONTRIBUTING.md
-->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

As part of the legacy compliance deprecation effort, the legacy cfg-analyzers will be decommissioned some time in January 2023. As a result customers will be moved across to the new LPP policies and CIS benchmarks. This is likely to cause a lot of noise for customers as they will have suppressions in place for resources which they expect to be in a non compliant state.
At present there is no easy path for customers to migrate their old suppressions to the new exceptions policies.

We do have a scripted approach created by Marc Garcia: https://github.com/lacework-dev/scripts/tree/main/lw-suppressions-migration

However it was decided that we should add this to the CLI as a more "official" approach.

This PR adds the following hidden commands:

```
lacework suppressions list aws
lacework suppressions migrate aws
```
suppressions has the following alias' `suppression, sup, sups`
list has the following alias `ls`
migrate has the following alias `mig`

`lacework suppressions list`
Will allow the users to get their legacy suppressions. Currently they aren't able to view these anywhere else...

`lacework suppressions migrate aws`
Will enable users to migrate their legacy suppressions to new LPP policy Exceptions.
This supports the migration in 2 modes:
 - Manual (recommended): This outputs the converted suppressions as commands that the user can review and run as they wish
 - Automatic: This gives the user the option to allow Lacework to handle the suppressions migration. It will output the converted legacy suppressions in the Exception format and ask the user to confirm they are happy with the Exceptions and accepting liability for any Compliance violations that may be missed as a result of this.

#1066 & #1068 should be merged before this

## How did you test this change?
Tested locally ✅ 

## Issue
https://lacework.atlassian.net/browse/45215
