### PR TITLE
fix: vuln ctr scan to use tag/digest argument to filter

### DIFF
--- a/cli/cmd/vuln_container_scan.go
+++ b/cli/cmd/vuln_container_scan.go
@@ -251,19 +251,19 @@ func pollScanStatus(requestID string, args []string) error {
 					Expression: "eq",
 					Field:      getTagOrDigestField(args[2]),
 					Value:      args[2],
-				},				
+				},
 			},
 		})
 		return err
 	}
 }
 
-func getTagOrDigestField(arg string) (string){
+func getTagOrDigestField(arg string) string {
 	// Check if we need to search for a digest or a tag id
-	if strings.HasPrefix(arg, "sha256:"){
+	if strings.HasPrefix(arg, "sha256:") {
 		return "evalCtx.image_info.digest"
-	}	
-    return "evalCtx.image_info.tags[0]"
+	}
+	return "evalCtx.image_info.tags[0]"
 }
 
 func checkScanStatus(requestID string) (error, bool) {

--- a/cli/cmd/vuln_container_scan.go
+++ b/cli/cmd/vuln_container_scan.go
@@ -247,10 +247,23 @@ func pollScanStatus(requestID string, args []string) error {
 					Field:      "evalCtx.image_info.repo",
 					Value:      args[1],
 				},
+				{
+					Expression: "eq",
+					Field:      getTagOrDigestField(args[2]),
+					Value:      args[2],
+				},				
 			},
 		})
 		return err
 	}
+}
+
+func getTagOrDigestField(arg string) (string){
+	// Check if we need to search for a digest or a tag id
+	if strings.HasPrefix(arg, "sha256:"){
+		return "evalCtx.image_info.digest"
+	}	
+    return "evalCtx.image_info.tags[0]"
 }
 
 func checkScanStatus(requestID string) (error, bool) {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/lacework/go-sdk) and create your branch from `main`
  2. Run `make prepare` in the repository root
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`make test`)
  5. Format your code (`make fmt`)
  6. Make sure your code lints (`make lint`)
  7. If you are updating the Lacework CLI, make sure it compiles (`make build-cli-cross-platform`)
  8. Follow the commit message standard (`type(scope): subject`) documented in [DEVELOPER_GUIDELINES.md](https://github.com/lacework/go-sdk/blob/main/DEVELOPER_GUIDELINES.md#commit-message-standard)
  9. If you haven't already, configure signed commits by [telling git about your signing key](https://docs.github.com/en/github/authenticating-to-github/managing-commit-signature-verification/telling-git-about-your-signing-key) and [signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)

  Learn more about contributing: https://github.com/lacework/go-sdk/blob/main/CONTRIBUTING.md
-->

## Summary
Currently when the` <tag|digest>` argument is set for the Container Vulnerability Scan command in the CLI, it is not used in any filtering to return the required results
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->
This was raised by a customer and the fix is required as it is a blocker for the customer's very time sensitive promotion
## How did you test this change?
This was tested by using the cli command `lacework vuln ctr scan index.docker.io lacework/lacework-cli <tag|digest> --poll ` with alternative `tag` and `digest` values and then examining the results returned and checking that the filter has actually been applied

```
lacework vuln ctr scan index.docker.io lacework/lacework-cli  ubuntu-1804 --poll

    ID          sha256:ba6399b27f9bb063f95b12588e49125a69e528f6692cd0b7077a2464d91bf7e5       SEVERITY   COUNT   FIXABLE
    Digest      sha256:98dfc575b33dbf4f07b55f0d87a3cb825f8d1f5452cabc88c2c8d21c7e47f953     -----------+-------+----------
    Registry    index.docker.io                                                               Critical       0         0
    Repository  lacework/lacework-cli                                                         High           3         0
    Size        78.7 MB                                                                       Medium        12         1
    Created At  2022-12-07T19:52:10Z                                                          Low            0         0
    Tags        ubuntu-1804                                                                   Info           8         0

lacework vuln ctr scan index.docker.io lacework/lacework-cli latest --poll

    ID          sha256:b16a80153ec5e73da79fed309894b0a61da2b60cf9e170ccf4daeab9d472cb1b       SEVERITY   COUNT   FIXABLE
    Digest      sha256:4ebf893b89bf7b6e3f130152eb3dd9ac7a13b2c5bb29bfe7582a8edb178d9c49     -----------+-------+----------
    Registry    index.docker.io                                                               Critical       0         0
    Repository  lacework/lacework-cli                                                         High          11        10
    Size        311.8 MB                                                                      Medium        61        61
    Created At  2022-03-18T22:07:47Z                                                          Low            0         0
    Tags        latest                                                                        Info           0         0


lacework vuln ctr scan index.docker.io lacework/lacework-cli sha256:0b0abc32a211f52e0f9c93031c752f8042636a26efddbe844037e8bdfccd88b9 --poll

    ID          sha256:4174eb1821118356641ce9d1d5738f258dddb2ffeeb8cbc96add01f92f3d1b58       SEVERITY   COUNT   FIXABLE
    Digest      sha256:0b0abc32a211f52e0f9c93031c752f8042636a26efddbe844037e8bdfccd88b9     -----------+-------+----------
    Registry    index.docker.io                                                               Critical       1         0
    Repository  lacework/lacework-cli                                                         High          13         0
    Size        86.1 MB                                                                       Medium         5         0
    Created At  2022-12-07T19:52:07Z                                                          Low            0         0
    Tags        debian-10                                                                     Info          49         0


```

<!--
  How exactly did you verify that your PR solves the issue you wanted to solve?
  Include any other relevant information such as how to use the new functionality, screenshots, etc.
-->

## Issue
This fixes the issue that is detailed in https://lacework.atlassian.net/browse/LINK-1154
<!--
  Include the link to a Jira/Github issue
-->
