### PR TITLE
feat(cli): add filter for fixable alerts

### DIFF
--- a/cli/cmd/alert.go
+++ b/cli/cmd/alert.go
@@ -29,19 +29,31 @@ import (
 	"github.com/spf13/cobra"
 )
 
+type alertCmdStateType struct {
+	Comment  string
+	End      string
+	Fixable  bool
+	Range    string
+	Reason   int
+	Scope    string
+	Severity string
+	Status   string
+	Start    string
+	Type     string
+}
+
+// hasFilters returns true if certain filters are present
+// in the command state.  excludes time filters (start, end, range).
+func (s alertCmdStateType) hasFilters() bool {
+	// severity / status / type filters
+	if s.Severity != "" || s.Status != "" || s.Type != "" {
+		return true
+	}
+	return s.Fixable
+}
+
 var (
-	alertCmdState = struct {
-		Comment  string
-		End      string
-		Fixable  bool
-		Range    string
-		Reason   int
-		Scope    string
-		Severity string
-		Status   string
-		Start    string
-		Type     string
-	}{}
+	alertCmdState = alertCmdStateType{}
 
 	// alertCmd represents the alert parent command
 	alertCmd = &cobra.Command{

--- a/cli/cmd/alert.go
+++ b/cli/cmd/alert.go
@@ -33,6 +33,7 @@ var (
 	alertCmdState = struct {
 		Comment  string
 		End      string
+		Fixable  bool
 		Range    string
 		Reason   int
 		Scope    string

--- a/cli/cmd/alert_list_fixable.go
+++ b/cli/cmd/alert_list_fixable.go
@@ -1,0 +1,116 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/lacework/go-sdk/api"
+	"github.com/pkg/errors"
+)
+
+const remediateComponentName string = "remediate"
+
+// isRemediateInstalled returns true if the remediate component is installed
+func (c *cliState) isRemediateInstalled() bool {
+	return c.IsComponentInstalled(remediateComponentName)
+}
+
+// getTemplateIdentifiers runs the remediate component to retrieve a list
+// of remediation template identifiers
+func getRemediationTemplateIDs() ([]string, error) {
+	remediate, found := cli.LwComponents.GetComponent(remediateComponentName)
+	if !found {
+		return []string{}, errors.New("remediate component not found")
+	}
+
+	// set up environment variables
+	envs := []string{
+		fmt.Sprintf("LW_COMPONENT_NAME=%s", remediateComponentName),
+		"LW_JSON=true",
+		"LW_NONINTERACTIVE=true",
+	}
+	for _, e := range cli.envs() {
+		// don't let LW_JSON / LW_NONINTERACTIVE through here
+		if strings.HasPrefix(e, "LW_JSON=") || strings.HasPrefix(e, "LW_NONINTERACTIVE=") {
+			continue
+		}
+		envs = append(envs, e)
+	}
+	stdout, stderr, err := remediate.RunAndReturn([]string{"ls", "templates"}, nil, envs...)
+	if err != nil {
+		cli.Log.Debugw("remediate error details", "stderr", stderr)
+		return []string{}, err
+	}
+
+	var templates []map[string]interface{}
+	err = json.Unmarshal([]byte(stdout), &templates)
+	if err != nil {
+		return []string{}, err
+	}
+
+	templateIDs := []string{}
+	for _, template := range templates {
+		v, ok := template["id"]
+		if !ok {
+			continue
+		}
+		s, ok := v.(string)
+		if !ok {
+			continue
+		}
+		templateIDs = append(templateIDs, s)
+	}
+	return templateIDs, nil
+}
+
+// filterFixableAlerts identifies which alerts have corresponding remediation template IDs
+// and returns those which don't
+func filterFixableAlerts(
+	alerts api.Alerts,
+	getIDsFunc func() ([]string, error),
+) (api.Alerts, error) {
+	templateIDs, err := getIDsFunc()
+	if err != nil {
+		return alerts, err
+	}
+
+	fixableAlerts := api.Alerts{}
+	for _, alert := range alerts {
+		if alert.PolicyID == "" {
+			continue
+		}
+		found := false
+		// Historically alerts did not consistently populate policyID and
+		// templates were named arbitrarily.
+		// If and when policies explicitly reference templates we will no longer need
+		// any inference logic.
+		for _, id := range templateIDs {
+			if id == alert.PolicyID {
+				fixableAlerts = append(fixableAlerts, alert)
+				found = true
+				break
+			}
+		}
+		if found {
+			continue
+		}
+		// Another interesting problem that we have is that policyIDs are dynamic
+		// For instance, on dev7 policy lwcustom-11 is dev7-lwcustom-11
+		// On some other environment it might be someother-lwcustom-11
+		dynamicIDRE := regexp.MustCompile(`^\w+-\d+$`)
+		// Iterate through the templates looking for those with dynamic policy IDs
+		for _, id := range templateIDs {
+			if dynamicIDRE.MatchString(id) {
+				// if the policyID of the alert ends with -<id>
+				// i.e. if dev7-lwcustom-11 endswith -lwcustom-11
+				if strings.HasSuffix(alert.PolicyID, fmt.Sprintf("-%s", id)) {
+					fixableAlerts = append(fixableAlerts, alert)
+					break
+				}
+			}
+		}
+	}
+	return fixableAlerts, nil
+}

--- a/cli/cmd/alert_list_fixable.go
+++ b/cli/cmd/alert_list_fixable.go
@@ -67,15 +67,7 @@ func getRemediationTemplateIDs() ([]string, error) {
 
 // filterFixableAlerts identifies which alerts have corresponding remediation template IDs
 // and returns those which don't
-func filterFixableAlerts(
-	alerts api.Alerts,
-	getIDsFunc func() ([]string, error),
-) (api.Alerts, error) {
-	templateIDs, err := getIDsFunc()
-	if err != nil {
-		return alerts, err
-	}
-
+func filterFixableAlerts(alerts api.Alerts, templateIDs []string) api.Alerts {
 	fixableAlerts := api.Alerts{}
 	for _, alert := range alerts {
 		if alert.PolicyID == "" {
@@ -112,5 +104,5 @@ func filterFixableAlerts(
 			}
 		}
 	}
-	return fixableAlerts, nil
+	return fixableAlerts
 }

--- a/cli/cmd/alert_list_fixable_internal_test.go
+++ b/cli/cmd/alert_list_fixable_internal_test.go
@@ -4,17 +4,8 @@ import (
 	"testing"
 
 	"github.com/lacework/go-sdk/api"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 )
-
-func testGetRemediationTemplateIDsOK() ([]string, error) {
-	return []string{"LW_foo", "lacework-global-40", "lwcustom-11"}, nil
-}
-
-func testGetRemediationTemplateIDsFail() ([]string, error) {
-	return []string{}, errors.New("ah-ah-ah you didn't say the magic workd")
-}
 
 func TestFilterFixableAlerts(t *testing.T) {
 	alertsIn := api.Alerts{
@@ -36,11 +27,10 @@ func TestFilterFixableAlerts(t *testing.T) {
 			PolicyID: "dev7-lwcustom-11",
 		},
 	}
-	alertsActual, err := filterFixableAlerts(alertsIn, testGetRemediationTemplateIDsOK)
-	assert.Nil(t, err)
+	alertsActual := filterFixableAlerts(
+		alertsIn, []string{"LW_foo", "lacework-global-40", "lwcustom-11"})
 	assert.Equal(t, alertsExpected, alertsActual)
 
-	alertsActual, err = filterFixableAlerts(alertsIn, testGetRemediationTemplateIDsFail)
-	assert.NotNil(t, err)
-	assert.Equal(t, alertsIn, alertsActual)
+	alertsActual = filterFixableAlerts(alertsIn, []string{})
+	assert.Equal(t, api.Alerts{}, alertsActual)
 }

--- a/cli/cmd/alert_list_fixable_internal_test.go
+++ b/cli/cmd/alert_list_fixable_internal_test.go
@@ -1,0 +1,46 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/lacework/go-sdk/api"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+)
+
+func testGetRemediationTemplateIDsOK() ([]string, error) {
+	return []string{"LW_foo", "lacework-global-40", "lwcustom-11"}, nil
+}
+
+func testGetRemediationTemplateIDsFail() ([]string, error) {
+	return []string{}, errors.New("ah-ah-ah you didn't say the magic workd")
+}
+
+func TestFilterFixableAlerts(t *testing.T) {
+	alertsIn := api.Alerts{
+		{
+			PolicyID: "not-fixable",
+		},
+		{
+			PolicyID: "lacework-global-40",
+		},
+		{
+			PolicyID: "dev7-lwcustom-11",
+		},
+	}
+	alertsExpected := api.Alerts{
+		{
+			PolicyID: "lacework-global-40",
+		},
+		{
+			PolicyID: "dev7-lwcustom-11",
+		},
+	}
+	alertsActual, err := filterFixableAlerts(alertsIn, testGetRemediationTemplateIDsOK)
+	assert.Nil(t, err)
+	assert.Equal(t, alertsExpected, alertsActual)
+
+	alertsActual, err = filterFixableAlerts(alertsIn, testGetRemediationTemplateIDsFail)
+	assert.NotNil(t, err)
+	assert.Equal(t, alertsIn, alertsActual)
+}

--- a/cli/cmd/component.go
+++ b/cli/cmd/component.go
@@ -144,6 +144,22 @@ func isComponent(annotations map[string]string) bool {
 	return false
 }
 
+// isComponentInstalled returns true if component is
+// valid and installed
+func (c *cliState) IsComponentInstalled(name string) bool {
+	var err error
+	c.LwComponents, err = lwcomponent.LocalState()
+	if err != nil || c.LwComponents == nil {
+		return false
+	}
+
+	component, found := c.LwComponents.GetComponent(name)
+	if found && component.IsInstalled() {
+		return true
+	}
+	return false
+}
+
 // LoadComponents reads the local components state and loads all installed components
 // of type `CLI_COMMAND` dynamically into the root command of the CLI (`rootCmd`)
 func (c *cliState) LoadComponents() {

--- a/cli/cmd/component.go
+++ b/cli/cmd/component.go
@@ -144,7 +144,7 @@ func isComponent(annotations map[string]string) bool {
 	return false
 }
 
-// isComponentInstalled returns true if component is
+// IsComponentInstalled returns true if component is
 // valid and installed
 func (c *cliState) IsComponentInstalled(name string) bool {
 	var err error

--- a/cli/cmd/content_library.go
+++ b/cli/cmd/content_library.go
@@ -74,18 +74,8 @@ type LaceworkContentLibrary struct {
 	PolicyTags map[string][]string  `json:"policy_tags"`
 }
 
-func (c *cliState) IsLCLInstalled() bool {
-	var err error
-	c.LwComponents, err = lwcomponent.LocalState()
-	if err != nil || c.LwComponents == nil {
-		return false
-	}
-
-	component, found := c.LwComponents.GetComponent(lclComponentName)
-	if found && component.IsInstalled() {
-		return true
-	}
-	return false
+func (c *cliState) isLCLInstalled() bool {
+	return c.IsComponentInstalled(lclComponentName)
 }
 
 func (c *cliState) LoadLCL() (*LaceworkContentLibrary, error) {

--- a/cli/cmd/content_library_internal_test.go
+++ b/cli/cmd/content_library_internal_test.go
@@ -306,7 +306,7 @@ func TestLoadLCLNotFound(t *testing.T) {
 	cli := cliState{LwComponents: new(lwcomponent.State)}
 
 	// IsLCLInstalled
-	assert.Equal(t, false, cli.IsLCLInstalled())
+	assert.Equal(t, false, cli.isLCLInstalled())
 
 	_, err := cli.LoadLCL()
 	assert.Equal(
@@ -368,7 +368,7 @@ func _TestLoadLCLOK(t *testing.T) {
 	}
 
 	// IsLCLInstalled
-	assert.Equal(t, true, cli.IsLCLInstalled())
+	assert.Equal(t, true, cli.isLCLInstalled())
 
 	lcl, err := cli.LoadLCL()
 	assert.Nil(t, err)

--- a/cli/cmd/lql.go
+++ b/cli/cmd/lql.go
@@ -143,7 +143,7 @@ func init() {
 	// add sub-commands to the lql command
 	queryCmd.AddCommand(queryRunCmd)
 
-	if cli.IsLCLInstalled() {
+	if cli.isLCLInstalled() {
 		queryRunCmd.Flags().StringVarP(
 			&queryCmdState.CURVFromLibrary,
 			"library", "l", "",

--- a/cli/cmd/lql_create.go
+++ b/cli/cmd/lql_create.go
@@ -114,7 +114,7 @@ func init() {
 
 	setQuerySourceFlags(queryCreateCmd)
 
-	if cli.IsLCLInstalled() {
+	if cli.isLCLInstalled() {
 		queryCreateCmd.Flags().StringVarP(
 			&queryCmdState.CURVFromLibrary,
 			"library", "l", "",

--- a/cli/cmd/lql_library.go
+++ b/cli/cmd/lql_library.go
@@ -44,7 +44,7 @@ var (
 )
 
 func init() {
-	if cli.IsLCLInstalled() {
+	if cli.isLCLInstalled() {
 		queryCmd.AddCommand(queryListLibraryCmd)
 		queryCmd.AddCommand(queryShowLibraryCmd)
 	}

--- a/cli/cmd/lql_update.go
+++ b/cli/cmd/lql_update.go
@@ -62,7 +62,7 @@ func init() {
 
 	setQuerySourceFlags(queryUpdateCmd)
 
-	if cli.IsLCLInstalled() {
+	if cli.isLCLInstalled() {
 		queryUpdateCmd.Flags().StringVarP(
 			&queryCmdState.CURVFromLibrary,
 			"library", "l", "",

--- a/cli/cmd/lql_validate.go
+++ b/cli/cmd/lql_validate.go
@@ -61,7 +61,7 @@ func init() {
 
 	setQuerySourceFlags(queryValidateCmd)
 
-	if cli.IsLCLInstalled() {
+	if cli.isLCLInstalled() {
 		queryValidateCmd.Flags().StringVarP(
 			&queryCmdState.CURVFromLibrary,
 			"library", "l", "",

--- a/cli/cmd/policy.go
+++ b/cli/cmd/policy.go
@@ -212,7 +212,7 @@ func init() {
 	policyCmd.AddCommand(policyEnableTagCmd)
 
 	// Lacework Content Library
-	if cli.IsLCLInstalled() {
+	if cli.isLCLInstalled() {
 		policyCreateCmd.Flags().StringVarP(
 			&policyCmdState.CUFromLibrary,
 			"library", "l", "",

--- a/cli/cmd/policy_library.go
+++ b/cli/cmd/policy_library.go
@@ -72,7 +72,7 @@ To view all policies in the library and their associated tags.
 )
 
 func init() {
-	if !cli.IsLCLInstalled() {
+	if !cli.isLCLInstalled() {
 		return
 	}
 

--- a/integration/alert_list_test.go
+++ b/integration/alert_list_test.go
@@ -131,7 +131,7 @@ func TestAlertListStatusOpen(t *testing.T) {
 
 func TestAlertListTypeBad(t *testing.T) {
 	out, err, exitcode := LaceworkCLIWithTOMLConfig("alert", "list", "--type", "foo")
-	assert.Contains(t, out.String(), "There are no alerts in the specified time range.")
+	assert.Contains(t, out.String(), "No alerts match the specified filters within the given time range. Try removing filters or expanding the time range.")
 	assert.Empty(t, err.String(), "STDERR should be empty")
 	assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
 }

--- a/integration/alert_list_test.go
+++ b/integration/alert_list_test.go
@@ -91,7 +91,7 @@ func TestAlertListJSON(t *testing.T) {
 
 func TestAlertListNone(t *testing.T) {
 	out, err, exitcode := LaceworkCLIWithTOMLConfig("alert", "list", "--start", "-1s", "--end", "now")
-	assert.Contains(t, out.String(), "There are no alerts in your account in the specified time range.")
+	assert.Contains(t, out.String(), "There are no alerts in the specified time range.")
 	assert.Empty(t, err.String(), "STDERR should be empty")
 	assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
 }
@@ -131,7 +131,7 @@ func TestAlertListStatusOpen(t *testing.T) {
 
 func TestAlertListTypeBad(t *testing.T) {
 	out, err, exitcode := LaceworkCLIWithTOMLConfig("alert", "list", "--type", "foo")
-	assert.Contains(t, out.String(), "There are no alerts in your account in the specified time range.")
+	assert.Contains(t, out.String(), "There are no alerts in the specified time range.")
 	assert.Empty(t, err.String(), "STDERR should be empty")
 	assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
 }


### PR DESCRIPTION
## Summary
For CLI consumers which have the `remediate` CDK component installed they will get a new feature (flag) in the `lacework alert ls` command.  When using the `--fixable` flag you will also get an additional breadcrumb.

```
❯ lacework-dev component list
     STATUS            NAME         VERSION                      DESCRIPTION                      
----------------+-----------------+---------+-----------------------------------------------------
...
  Installed       remediate         0.0.1     A tool to isolate and remediate resources           
...

Components version: 0.2.0
```

```
❯ lacework-dev alert list -h
List all alerts.
...
Flags:
      --end string        end time for alerts (default "now")
      --fixable           filter alerts by fixability
...
```

```
❯ lacework-dev alert list --fixable
  ALERT ID |       TYPE        |        NAME        | SEVERITY |        START TIME        |         END TIME         | STATUS  
-----------+-------------------+--------------------+----------+--------------------------+--------------------------+---------
    209024 | ComplianceChanged | Compliance changed | Medium   | 2022-12-16T08:00:00.000Z | 2022-12-16T09:00:00.000Z | Open    
    208800 | ComplianceChanged | Compliance changed | Medium   | 2022-12-16T04:00:00.000Z | 2022-12-16T05:00:00.000Z | Open    

Use 'lacework alert show <alert_id>' to see details for a specific alert.
Use 'lacework remediate alert <alert_id>' to fix a specific alert.
```

## How did you test this change?

1. Existing integration tests
2. Added unit tests
3. Manually

## Issue
https://lacework.atlassian.net/browse/ANEP-1395
