### PR TITLE
fix: avoid injecting empty alertProfile

### DIFF
--- a/api/policy.go
+++ b/api/policy.go
@@ -57,7 +57,7 @@ type NewPolicy struct {
 	Limit         int      `json:"limit,omitempty" yaml:"limit,omitempty"`
 	EvalFrequency string   `json:"evalFrequency,omitempty" yaml:"evalFrequency,omitempty"`
 	AlertEnabled  bool     `json:"alertEnabled" yaml:"alertEnabled"`
-	AlertProfile  string   `json:"alertProfile,omitempty" yaml:"alertProfile"`
+	AlertProfile  string   `json:"alertProfile,omitempty" yaml:"alertProfile,omitempty"`
 	Tags          []string `json:"tags,omitempty" yaml:"tags,omitempty"`
 }
 

--- a/api/policy.go
+++ b/api/policy.go
@@ -57,7 +57,7 @@ type NewPolicy struct {
 	Limit         int      `json:"limit,omitempty" yaml:"limit,omitempty"`
 	EvalFrequency string   `json:"evalFrequency,omitempty" yaml:"evalFrequency,omitempty"`
 	AlertEnabled  bool     `json:"alertEnabled" yaml:"alertEnabled"`
-	AlertProfile  string   `json:"alertProfile" yaml:"alertProfile"`
+	AlertProfile  string   `json:"alertProfile,omitempty" yaml:"alertProfile"`
 	Tags          []string `json:"tags,omitempty" yaml:"tags,omitempty"`
 }
 


### PR DESCRIPTION
## Summary

The lacework cli injects an empty string for the alertProfile when creating a policy.
```
lacework policies create -f p

fails when p contains the json:

{
  "policyType": "Compliance",
  "severity": "high",
  "title": "Trouble ahead",
  "description": "Trouble indeed, my friend",
  "remediation": "oh boy, it will not be easy",
  "enabled": true,
  "alertEnabled": true,
  "queryId": "SomeQuery"
}
```
The debug output contains:
```
{"level":"debug","ts":"2022-12-14T15:16:58-05:00","caller":"api/http.go:91","msg":"request","id":"60eb86346e026cc0","account":"dev8.dev8.corp","method":"POST","url":"https://dev8.dev8.corp.lacework.net","endpoint":"/api/v2/Policies","headers":{"Accept":["application/json"],"Authorization":["..."],"Content-Type":["application/json"],"Method":["POST"],"User-Agent":["Command-Line/0.46.0"]},"body":"{\"policyType\":\"Compliance\",\"queryId\":\"SomeQuery\",\"title\":\"Trouble ahead\",\"enabled\":true,\"description\":\"Trouble indeed, my friend\",\"remediation\":\"oh boy, it will not be easy\",\"severity\":\"high\",\"alertEnabled\":true,\"alertProfile\":\"\"}\n"}
- Creating policy... {"level":"info","ts":"2022-12-14T15:16:58-05:00","caller":"api/http.go:169","msg":"response","id":"60eb86346e026cc0","account":"dev8.dev8.corp","from_req_url":"https://dev8.dev8.corp.lacework.net/api/v2/Policies","code":400,"proto":"HTTP/2.0","headers":{"Access-Control-Allow-Headers":["DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,x-lw-uaks,Authorization"],"Access-Control-Allow-Methods":["GET, POST, PUT, DELETE, PATCH, OPTIONS"],"Access-Control-Allow-Origin":["*"],"Access-Control-Expose-Headers":["Content-Length,Content-Range"],"Content-Length":["46"],"Content-Type":["application/json"],"Date":["Wed, 14 Dec 2022 20:16:58 GMT"],"Ratelimit-Limit":["0"],"Ratelimit-Remaining":["0"],"Ratelimit-Reset":["0"],"Server":["nginx"]},"body":"{\"message\":\"key alertProfile is unrecognized\"}"}
```
Notice the part `\"alertProfile\":\"\"` that shows the the CLI injected `"alertProfile": ""` into the request body. The cli should not inject this field as it will cause a failure when creating custom compliance policies.

## How did you test this change?

Will write tests but I want to start the review/conversation since I see some issues with https://github.com/lacework/go-sdk/pull/1065

## Issue

https://lacework.atlassian.net/browse/RAIN-45238

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>

