### PR TITLE
fix(lwlogger): do not override explicit level argument

### DIFF
--- a/lwlogger/logger.go
+++ b/lwlogger/logger.go
@@ -51,9 +51,8 @@ var (
 
 // New initialize a new logger with the provided level and options
 func New(level string, options ...zap.Option) *zap.Logger {
-	// give priority to the environment variable
-	if envLevel := LogLevelFromEnvironment(); envLevel != "" {
-		level = envLevel
+	if level == "" {
+		level = LogLevelFromEnvironment()
 	}
 
 	zapConfig := zap.Config{
@@ -81,9 +80,8 @@ func New(level string, options ...zap.Option) *zap.Logger {
 // NewWithWriter initialize a new logger with the provided level and options
 // but redirecting the logs to the provider io.Writer
 func NewWithWriter(level string, out io.Writer, options ...zap.Option) *zap.Logger {
-	// give priority to the environment variable
-	if envLevel := LogLevelFromEnvironment(); envLevel != "" {
-		level = envLevel
+	if level == "" {
+		level = LogLevelFromEnvironment()
 	}
 
 	var (


### PR DESCRIPTION
Signed-off-by: Kolbeinn Karlsson <kolbeinn.karlsson@lacework.net>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/lacework/go-sdk) and create your branch from `main`
  2. Run `make prepare` in the repository root
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`make test`)
  5. Format your code (`make fmt`)
  6. Make sure your code lints (`make lint`)
  7. If you are updating the Lacework CLI, make sure it compiles (`make build-cli-cross-platform`)
  8. Follow the commit message standard (`type(scope): subject`) documented in [DEVELOPER_GUIDELINES.md](https://github.com/lacework/go-sdk/blob/main/DEVELOPER_GUIDELINES.md#commit-message-standard)
  9. If you haven't already, configure signed commits by [telling git about your signing key](https://docs.github.com/en/github/authenticating-to-github/managing-commit-signature-verification/telling-git-about-your-signing-key) and [signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)

  Learn more about contributing: https://github.com/lacework/go-sdk/blob/main/CONTRIBUTING.md
-->

## Summary

lwlogger silently overrides any level passed to it with the value of the LW_LOG environment variable. This may not cause issues in the main CLI, but for CLI components, LW_LOG is always set, and thus there is no way to create any lwloggers without their level being overridden.

This PR changes it so that the lwlogger level is overridden with LW_LOG only if `level=""`. This is provides maximum flexibility for the logger. You can call `lwlogger.New("")` to have the level be determined by LW_LOG, or you can call `lwlogger.New(myDesiredLevel)` to explicitly set the level.

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## How did you test this change?

In the Lacework remediate component, I create a simple function foo with the following logic:
```
func foo(cmd *cobra.Command, args []string) {
	loggerOne := lwlogger.New("INFO")
	loggerTwo := lwlogger.New("")

	loggerOne.Info("Logger one INFO call. xyz123")
	loggerTwo.Info("Logger two INFO call. xyz123")
	loggerOne.Debug("Logger one DEBUG call. xyz123")
	loggerTwo.Debug("Logger two DEBUG call. xyz123")
}
```
Then call the function twice. Once with LW_LOG explicitly set and once without:
```shell
$ lacework-dev remediate foo 2>&1 | grep xyz123
{"level":"info","ts":"2022-12-27T11:25:33Z","caller":"cmd/foo.go:40","msg":"Logger one INFO call. xyz123"}
$ LW_LOG=DEBUG lacework-dev remediate foo 2>&1 | grep xyz123
{"level":"info","ts":"2022-12-27T11:25:37Z","caller":"cmd/foo.go:40","msg":"Logger one INFO call. xyz123"}
{"level":"info","ts":"2022-12-27T11:25:37Z","caller":"cmd/foo.go:41","msg":"Logger two INFO call. xyz123"}
{"level":"debug","ts":"2022-12-27T11:25:37Z","caller":"cmd/foo.go:43","msg":"Logger two DEBUG call. xyz123"}
```
This shows me that `loggerOne` has the INFO level regardless of LW_LOG, while `loggerTwo` follows LW_LOG.
<!--
  How exactly did you verify that your PR solves the issue you wanted to solve?
  Include any other relevant information such as how to use the new functionality, screenshots, etc.
-->

## Issue

<!--
  Include the link to a Jira/Github issue
-->
