### PR TITLE
feat(cdk): pass LW_CLI_VERSION env variable

### DIFF
--- a/cli/cmd/cdk.go
+++ b/cli/cmd/cdk.go
@@ -48,6 +48,7 @@ func (c *cliState) envs() []string {
 		fmt.Sprintf("LW_JSON=%v", c.jsonOutput),
 		fmt.Sprintf("LW_CDK_TARGET=%s", c.GrpcTarget()),
 		fmt.Sprintf("LW_API_SERVER_URL=%s", c.LwApi.URL()),
+		fmt.Sprintf("LW_CLI_VERSION=%s", Version),
 	}
 }
 


### PR DESCRIPTION

## Summary

Maybe, components will need to know the version of the Lacework CLI they are running on.

## How did you test this change?

Verified that the new variable was there.

## Issue
https://lacework.atlassian.net/browse/GROW-1264
