### PR TITLE
feat(lwlogger): add merge logger function

### DIFF
--- a/lwlogger/logger.go
+++ b/lwlogger/logger.go
@@ -103,6 +103,16 @@ func NewWithWriter(level string, out io.Writer, options ...zap.Option) *zap.Logg
 	return zap.New(core, options...).WithOptions(localOpts...)
 }
 
+// Merges multiple loggers into one. A call to the merged logger will be
+// forwarded to all the loggers
+func Merge(loggers ...*zap.Logger) *zap.Logger {
+	cores := make([]zapcore.Core, len(loggers))
+	for i, log := range loggers {
+		cores[i] = log.Core()
+	}
+	return zap.New(zapcore.NewTee(cores...))
+}
+
 func ValidLevel(level string) bool {
 	for _, l := range SupportedLogLevels {
 		if l == level {

--- a/lwlogger/logger_test.go
+++ b/lwlogger/logger_test.go
@@ -19,6 +19,7 @@
 package lwlogger_test
 
 import (
+	"bytes"
 	"io/ioutil"
 	"os"
 	"syscall"
@@ -217,6 +218,24 @@ func TestLoggerNewWithOptions(t *testing.T) {
 	assert.Contains(t, logOutput, "we are debugging")
 	assert.Contains(t, logOutput, "\"my_field\"")
 	assert.Contains(t, logOutput, "\"awesome\"")
+}
+
+func TestLoggerMerge(t *testing.T) {
+	var bufOne bytes.Buffer
+	var bufTwo bytes.Buffer
+
+	logOne := lwlogger.NewWithWriter("INFO", &bufOne)
+	logTwo := lwlogger.NewWithWriter("DEBUG", &bufTwo)
+
+	mergedLog := lwlogger.Merge(logOne, logTwo)
+	mergedLog.Info("ABCD")
+	mergedLog.Debug("XYZ")
+	_ = mergedLog.Sync()
+
+	assert.Contains(t, bufOne.String(), "ABCD")
+	assert.NotContains(t, bufOne.String(), "XYZ")
+	assert.Contains(t, bufTwo.String(), "ABCD")
+	assert.Contains(t, bufTwo.String(), "XYZ")
 }
 
 func TestValidLevel(t *testing.T) {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/lacework/go-sdk) and create your branch from `main`
  2. Run `make prepare` in the repository root
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`make test`)
  5. Format your code (`make fmt`)
  6. Make sure your code lints (`make lint`)
  7. If you are updating the Lacework CLI, make sure it compiles (`make build-cli-cross-platform`)
  8. Follow the commit message standard (`type(scope): subject`) documented in [DEVELOPER_GUIDELINES.md](https://github.com/lacework/go-sdk/blob/main/DEVELOPER_GUIDELINES.md#commit-message-standard)
  9. If you haven't already, configure signed commits by [telling git about your signing key](https://docs.github.com/en/github/authenticating-to-github/managing-commit-signature-verification/telling-git-about-your-signing-key) and [signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)

  Learn more about contributing: https://github.com/lacework/go-sdk/blob/main/CONTRIBUTING.md
-->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

Merging multiple loggers into one creates a ton of power and flexibility for lwlogger. This enables you to easily create a logger that writes to multiple outputs (e.g. standard output and a file), potentially at varying levels (e.g. only write ERROR level messages to stdout but include INFO messages in the file). This is something we needed to do in the 'remediate' component. I figure other people might want to do the same so I propose we add this function to lwlogger itself. 

## How did you test this change?

<!--
  How exactly did you verify that your PR solves the issue you wanted to solve?
  Include any other relevant information such as how to use the new functionality, screenshots, etc.
-->

I added a unit test, TestLoggerMerge. Run it by running `go test ./lwlogger/...`.

## Issue

<!--
  Include the link to a Jira/Github issue
-->
