### PR TITLE
feat: default to non-interactive if stdout is not a terminal

### DIFF
--- a/cli/cmd/cli_state.go
+++ b/cli/cmd/cli_state.go
@@ -32,6 +32,7 @@ import (
 	"github.com/briandowns/spinner"
 	"github.com/fatih/color"
 	prettyjson "github.com/hokaccha/go-prettyjson"
+	"github.com/mattn/go-isatty"
 	"github.com/peterbourgon/diskv/v3"
 	"github.com/pkg/errors"
 	"github.com/spf13/viper"
@@ -102,6 +103,7 @@ func NewDefaultState() *cliState {
 			Indent:      2,
 			Newline:     "\n",
 		},
+		nonInteractive: !isatty.IsTerminal(os.Stdout.Fd()),
 	}
 
 	// initialize honeycomb library and honeyvent

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -26,6 +26,7 @@ import (
 	"github.com/fatih/color"
 	homedir "github.com/mitchellh/go-homedir"
 	"github.com/pkg/errors"
+	"github.com/spf13/cast"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
@@ -287,8 +288,12 @@ func initConfig() {
 		os.Setenv("NO_COLOR", "true")
 	}
 
-	if viper.GetBool("noninteractive") {
-		cli.NonInteractive()
+	if b := viper.Get("noninteractive"); b != nil {
+		if cast.ToBool(b) {
+			cli.NonInteractive()
+		} else {
+			cli.Interactive()
+		}
 	}
 
 	if viper.GetBool("nocache") {

--- a/integration/framework_test.go
+++ b/integration/framework_test.go
@@ -147,6 +147,9 @@ func runLaceworkCLI(workingDir string, args ...string) (stdout bytes.Buffer, std
 	cmd := NewLaceworkCLI(workingDir, nil, args...)
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
+	// set interactive mode by default for tests, since that's
+	// what they expect
+	cmd.Env = append(cmd.Env, "LW_NONINTERACTIVE=false")
 
 	exitcode, err := runLaceworkCLIFromCmd(cmd)
 	if exitcode == 999 {


### PR DESCRIPTION
## Summary

Default to non-interactive output if stdout is not a terminal.

## How did you test this change?

I've happen to have 1.2.0 installed and at the moment the latest version is 1.3.1.

```
; rm ~/.config/lacework/version_check
; lacework configure show account > /tmp/account.txt
; cat /tmp/account.txt
qan.qan.corp

A newer version of the Lacework CLI is available! The latest version is v1.3.1,
to update execute the following command:

  brew upgrade lacework-cli
; rm ~/.config/lacework/version_check
; go run cli/main.go configure show account > /tmp/account.txt
; cat /tmp/account.txt
qan.qan.corp
```

After thinking about it a bit it's not the daily version check that's the problem, it's that we shouldn't assume we're interactive if stdout isn't a terminal.

## Issue

https://lacework.atlassian.net/browse/RAIN-45976
