### PR TITLE
style(cdk): rename lifecycle event cdk-cleanup

### DIFF
--- a/cli/cmd/component.go
+++ b/cli/cmd/component.go
@@ -492,8 +492,8 @@ func runComponentsDelete(_ *cobra.Command, args []string) (err error) {
 	}
 
 	cli.StartProgress("Cleaning component data...")
-	// component life cycle: remove
-	stdout, stderr, errCmd := component.RunAndReturn([]string{"cdk-remove"}, nil, cli.envs()...)
+	// component life cycle: cleanup
+	stdout, stderr, errCmd := component.RunAndReturn([]string{"cdk-cleanup"}, nil, cli.envs()...)
 	if errCmd != nil {
 		cli.Log.Warnw("component life cycle",
 			"error", errCmd.Error(), "stdout", stdout, "stderr", stderr)


### PR DESCRIPTION
## User Story
As a Lacework CDK developer,
I need a way to run a cleanup event for when my component is being uninstalled,
So that I can remove any file, cache, libraries, etc. before the component is removed.

## Summary

When installing new CDK components, users use the command `lacework component install <component>` which runs the lifecycle event `cdk-init`, this event helps components to deploy any necessary file, cache, config, libraries, etc. during installation. When users want to uninstall the component, we should have a cleanup event to remove anything deployed.


## Impact

There are no components that implement this lifecycle so there should not be any impact.

## Issue

Jira: https://lacework.atlassian.net/browse/GROW-1081
Documentation: https://lacework.atlassian.net/l/cp/u18EHxx1

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>



[GROW-1081]: https://lacework.atlassian.net/browse/GROW-1081?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ