### PR TITLE
chore(lwupdater): Make test that makes an API call more robust

### DIFF
--- a/integration/lwupdater_test.go
+++ b/integration/lwupdater_test.go
@@ -16,7 +16,7 @@
 // limitations under the License.
 //
 
-package lwupdater_test
+package integration_test
 
 import (
 	"io/ioutil"

--- a/lwupdater/updater.go
+++ b/lwupdater/updater.go
@@ -107,6 +107,8 @@ func LoadCache(path string) (*Version, error) {
 // getGitRelease uses the git API to fetch the release information of a project.
 // This function could hit request rate limits wich are roughly 60 every 30m, to
 // check your current rate limits run: curl https://api.github.com/rate_limit
+// If the GITHUB_TOKEN environment variable is set, then this function will use
+// it to authenticate the API request, which grants higher rate limits.
 func getGitRelease(project, version string) (*gitReleaseResponse, error) {
 	if project == "" {
 		return nil, errors.New("specify a valid project")
@@ -139,6 +141,11 @@ func getGitRelease(project, version string) (*gitReleaseResponse, error) {
 	// Set the user agent since it is required
 	// https://developer.github.com/v3/#user-agent-required
 	req.Header.Set("User-Agent", "lacework-updater")
+
+	token := os.Getenv("GITHUB_TOKEN")
+	if len(token) > 0 {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
 
 	resp, err := c.Do(req)
 	if err != nil {


### PR DESCRIPTION
## Summary

This does two things to make the test less likely to fail:

- Moves it to integration tests so it isn't run locally where users might hit rate limits by running it repeatedly.

- Uses the `GITHUB_TOKEN` environment variable if present (which it is in CI) to authenticate the request and get higher rate limits.

## How did you test this change?

The test being changed will be exercised by the CI on this PR.

## Issue

https://lacework.atlassian.net/browse/GROW-1320

[GROW-1320]: https://lacework.atlassian.net/browse/GROW-1320?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ