### PR TITLE
refactor: Use alpine as our base Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,7 @@
-FROM alpine:3.6 as alpine
-RUN apk add -U --no-cache ca-certificates
-
-FROM  scratch
+FROM alpine:latest
 LABEL maintainer="tech-ally@lacework.net" \
       description="The Lacework CLI helps you manage the Lacework cloud security platform"
-
+RUN apk add -U --no-cache ca-certificates
 COPY LICENSE /
-COPY --from=alpine /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 ADD bin/lacework-cli-linux-amd64 /usr/local/bin/lacework
 ENTRYPOINT ["/usr/local/bin/lacework"]


### PR DESCRIPTION
## Summary

Our CircleCI orb is complaining with the following error message:
```
Build image is not supported. Please check that it contains a shell and /bin directory.
```

This is caused by the fact that the `scratch` base image has pretty much nothing inside,
not even a Shell. We made this decision so that our image is less than 20 MB. This is not
working for us anymore and we are refactoring our image to use `alpine` as our base image.

This change will only add a few MBs more to our image.

## How did you test this change?

Running a CircleCI jobs to validate: https://github.com/lacework/circleci-orb-lacework/pull/40

Uploaded the image to a [temporal Docker repository](https://hub.docker.com/layers/techallylw/lacework-cli/alpine/images/sha256-539b1a823bbd654b39b05d6ff388433f8841e007083a8c7136bc3de82f938671?context=explore
https://hub.docker.com/layers/techallylw/lacework-cli/alpine).

![Screen Shot 2023-01-05 at 10 42 37 AM](https://user-images.githubusercontent.com/5712253/210856546-efd68fec-631c-4f0c-8ccb-5cdbd3d6d654.png)

## Issue

N/A
