### PR TITLE
feat(RAIN-45215): Add Hidden Azure & GCP suppressions list commands

### DIFF
--- a/api/v2.go
+++ b/api/v2.go
@@ -91,8 +91,8 @@ func NewV2Endpoints(c *Client) *V2Endpoints {
 		&AlertsService{c},
 		&SuppressionsServiceV2{c,
 			&AwsSuppressionsV2{c},
-			//&AzureSuppressionsV2{c},
-			//&GcpSuppressionsV2{c},
+			&AzureSuppressionsV2{c},
+			&GcpSuppressionsV2{c},
 		},
 	}
 

--- a/api/v2_suppressions.go
+++ b/api/v2_suppressions.go
@@ -29,8 +29,8 @@ import (
 type SuppressionsServiceV2 struct {
 	client *Client
 	Aws    suppressionServiceV2
-	//Azure  suppressionServiceV2
-	//Gcp    suppressionServiceV2
+	Azure  suppressionServiceV2
+	Gcp    suppressionServiceV2
 }
 
 type suppressionServiceV2 interface {
@@ -40,7 +40,9 @@ type suppressionServiceV2 interface {
 type SuppressionTypeV2 string
 
 const (
-	AwsSuppression SuppressionTypeV2 = "aws"
+	AwsSuppression   SuppressionTypeV2 = "aws"
+	AzureSuppression SuppressionTypeV2 = "azure"
+	GcpSuppression   SuppressionTypeV2 = "gcp"
 )
 
 func (svc *SuppressionsServiceV2) list(cloudType SuppressionTypeV2) (map[string]SuppressionV2,

--- a/api/v2_suppressions_azure.go
+++ b/api/v2_suppressions_azure.go
@@ -1,0 +1,29 @@
+//
+// Author:: Ross Moles (<ross.moles@lacework.net>)
+// Copyright:: Copyright 2022, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package api
+
+// AzureSuppressionsV2 is a service that interacts with the V2 Suppressions
+// endpoints from the Lacework Server
+type AzureSuppressionsV2 struct {
+	client *Client
+}
+
+func (svc *AzureSuppressionsV2) List() (map[string]SuppressionV2, error) {
+	return svc.client.V2.Suppressions.list(AzureSuppression)
+}

--- a/api/v2_suppressions_gcp.go
+++ b/api/v2_suppressions_gcp.go
@@ -1,0 +1,29 @@
+//
+// Author:: Ross Moles (<ross.moles@lacework.net>)
+// Copyright:: Copyright 2022, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package api
+
+// GcpSuppressionsV2 is a service that interacts with the V2 Suppressions
+// endpoints from the Lacework Server
+type GcpSuppressionsV2 struct {
+	client *Client
+}
+
+func (svc *GcpSuppressionsV2) List() (map[string]SuppressionV2, error) {
+	return svc.client.V2.Suppressions.list(GcpSuppression)
+}

--- a/cli/cmd/suppressions.go
+++ b/cli/cmd/suppressions.go
@@ -37,11 +37,30 @@ var (
 		Use:   "aws",
 		Short: "Manage legacy suppressions for aws",
 	}
+
+	// suppressionsAzureCmd represents the aws sub-command inside the suppressions command
+	suppressionsAzureCmd = &cobra.Command{
+		Use:   "azure",
+		Short: "Manage legacy suppressions for azure",
+	}
+
+	// suppressionsGcpCmd represents the aws sub-command inside the suppressions command
+	suppressionsGcpCmd = &cobra.Command{
+		Use:   "gcp",
+		Short: "Manage legacy suppressions for gcp",
+	}
 )
 
 func init() {
 	rootCmd.AddCommand(suppressionsCommand)
+	// aws
 	suppressionsCommand.AddCommand(suppressionsAwsCmd)
 	suppressionsAwsCmd.AddCommand(suppressionsListAwsCmd)
 	suppressionsAwsCmd.AddCommand(suppressionsMigrateAwsCmd)
+	// azure
+	suppressionsCommand.AddCommand(suppressionsAzureCmd)
+	suppressionsAzureCmd.AddCommand(suppressionsListAzureCmd)
+	// gcp
+	suppressionsCommand.AddCommand(suppressionsGcpCmd)
+	suppressionsGcpCmd.AddCommand(suppressionsListGcpCmd)
 }

--- a/cli/cmd/suppressions_aws.go
+++ b/cli/cmd/suppressions_aws.go
@@ -214,7 +214,7 @@ func suppressionsAwsList(_ *cobra.Command, _ []string) error {
 	if err != nil {
 		if strings.Contains(err.Error(), "No active AWS accounts") {
 			cli.OutputHuman("No active AWS accounts found. " +
-				"Unable to get legacy aws suppressions")
+				"Unable to get legacy aws suppressions\n")
 			return nil
 		}
 		return errors.Wrap(err, "Unable to get legacy aws suppressions")

--- a/cli/cmd/suppressions_azure.go
+++ b/cli/cmd/suppressions_azure.go
@@ -1,0 +1,61 @@
+//
+// Author:: Ross Moles (<ross.moles@lacework.net>)
+// Copyright:: Copyright 2022, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cmd
+
+import (
+	"strings"
+
+	"github.com/lacework/go-sdk/api"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+var (
+	// suppressionsListAzureCmd represents the azure sub-command inside the suppressions list
+	//command
+	suppressionsListAzureCmd = &cobra.Command{
+		Use:     "list",
+		Aliases: []string{"ls"},
+		Short:   "List legacy suppressions for Azure",
+		RunE:    suppressionsAzureList,
+	}
+)
+
+func suppressionsAzureList(_ *cobra.Command, _ []string) error {
+	var (
+		suppressions map[string]api.SuppressionV2
+		err          error
+	)
+
+	suppressions, err = cli.LwApi.V2.Suppressions.Azure.List()
+	if err != nil {
+		if strings.Contains(err.Error(), "No active Azure accounts") {
+			cli.OutputHuman("No active Azure accounts found. " +
+				"Unable to get legacy Azure suppressions")
+			return nil
+		}
+		return errors.Wrap(err, "Unable to get legacy Azure suppressions")
+	}
+
+	if len(suppressions) == 0 {
+		cli.OutputHuman("No legacy Azure suppressions found.\n")
+		return nil
+	}
+	return cli.OutputJSON(suppressions)
+}

--- a/cli/cmd/suppressions_azure.go
+++ b/cli/cmd/suppressions_azure.go
@@ -47,7 +47,7 @@ func suppressionsAzureList(_ *cobra.Command, _ []string) error {
 	if err != nil {
 		if strings.Contains(err.Error(), "No active Azure accounts") {
 			cli.OutputHuman("No active Azure accounts found. " +
-				"Unable to get legacy Azure suppressions")
+				"Unable to get legacy Azure suppressions\n")
 			return nil
 		}
 		return errors.Wrap(err, "Unable to get legacy Azure suppressions")

--- a/cli/cmd/suppressions_gcp.go
+++ b/cli/cmd/suppressions_gcp.go
@@ -1,0 +1,60 @@
+//
+// Author:: Ross Moles (<ross.moles@lacework.net>)
+// Copyright:: Copyright 2022, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cmd
+
+import (
+	"strings"
+
+	"github.com/lacework/go-sdk/api"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+var (
+	// suppressionsListGcpCmd represents the gcp sub-command inside the suppressions list command
+	suppressionsListGcpCmd = &cobra.Command{
+		Use:     "list",
+		Aliases: []string{"ls"},
+		Short:   "List legacy suppressions for GCP",
+		RunE:    suppressionsGcpList,
+	}
+)
+
+func suppressionsGcpList(_ *cobra.Command, _ []string) error {
+	var (
+		suppressions map[string]api.SuppressionV2
+		err          error
+	)
+
+	suppressions, err = cli.LwApi.V2.Suppressions.Gcp.List()
+	if err != nil {
+		if strings.Contains(err.Error(), "No active GCP accounts") {
+			cli.OutputHuman("No active GCP accounts found. " +
+				"Unable to get legacy GCP suppressions")
+			return nil
+		}
+		return errors.Wrap(err, "Unable to get legacy GCP suppressions")
+	}
+
+	if len(suppressions) == 0 {
+		cli.OutputHuman("No legacy GCP suppressions found.\n")
+		return nil
+	}
+	return cli.OutputJSON(suppressions)
+}

--- a/cli/cmd/suppressions_gcp.go
+++ b/cli/cmd/suppressions_gcp.go
@@ -46,7 +46,7 @@ func suppressionsGcpList(_ *cobra.Command, _ []string) error {
 	if err != nil {
 		if strings.Contains(err.Error(), "No active GCP accounts") {
 			cli.OutputHuman("No active GCP accounts found. " +
-				"Unable to get legacy GCP suppressions")
+				"Unable to get legacy GCP suppressions\n")
 			return nil
 		}
 		return errors.Wrap(err, "Unable to get legacy GCP suppressions")


### PR DESCRIPTION
Signed-off-by: Ross <ross.moles@lacework.net>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/lacework/go-sdk) and create your branch from `main`
  2. Run `make prepare` in the repository root
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`make test`)
  5. Format your code (`make fmt`)
  6. Make sure your code lints (`make lint`)
  7. If you are updating the Lacework CLI, make sure it compiles (`make build-cli-cross-platform`)
  8. Follow the commit message standard (`type(scope): subject`) documented in [DEVELOPER_GUIDELINES.md](https://github.com/lacework/go-sdk/blob/main/DEVELOPER_GUIDELINES.md#commit-message-standard)
  9. If you haven't already, configure signed commits by [telling git about your signing key](https://docs.github.com/en/github/authenticating-to-github/managing-commit-signature-verification/telling-git-about-your-signing-key) and [signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)

  Learn more about contributing: https://github.com/lacework/go-sdk/blob/main/CONTRIBUTING.md
-->

## Summary
Following on from https://github.com/lacework/go-sdk/pull/1069, there has been an ask to make the Azure & GCP suppressions objects available via the CLI to aide in any manual migration of the Azure & GCP suppressions

## How did you test this change?
Installed CLI locally and verified the suppression objects are returned as expected

## Issue
https://lacework.atlassian.net/browse/RAIN-45215