### PR TITLE
feat(cdk): make help command work for components

### DIFF
--- a/integration/test_resources/help/no-command-provided
+++ b/integration/test_resources/help/no-command-provided
@@ -25,6 +25,7 @@ Available Commands:
   configure               Configure the Lacework CLI
   container-registry      Manage container registries
   generate                Generate code to onboard your account
+  help                    Help about any command
   policy                  Manage policies
   policy-exception        Manage policy exceptions
   query                   Run and manage queries


### PR DESCRIPTION
## Summary

The help command should show help for a component instead of help for the CLI.

## How did you test this change?

Run `go run cli/main.go iac help org list` and note that it now displays help for `... iac org list` instead of help for the CLI itself.

## Issue

https://lacework.atlassian.net/browse/RAIN-42930