### PR TITLE
fix(cli): use request id to fetch scan results

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,9 +77,8 @@ integration-only: install-tools ## Run integration tests
 		generation \
 		compliance \
 		team_member \
+		vulnerability \
 		component" -run=$(regex)
-		# Disable vulnerability tests until https://lacework.atlassian.net/browse/RAIN-37563 is resolved
-		#vulnerability"
 
 .PHONY: integration-lql
 integration-lql: build-cli-cross-platform integration-lql-only ## Build and run lql integration tests

--- a/cli/cmd/vuln_container_show_assessments.go
+++ b/cli/cmd/vuln_container_show_assessments.go
@@ -77,14 +77,14 @@ func showContainerAssessmentsWithSha256(sha string, filter api.SearchFilter) err
 	)
 
 	if len(filter.Filters) > 0 {
-		cli.Log.Debugw("retrieve assessment with filters ", filter.Filters)
+		cli.Log.Debugw("retrieve assessment", "filters", filter.Filters)
 
 		cli.StartProgress("Fetching assessment...")
 		assessment, err = cli.LwApi.V2.Vulnerabilities.Containers.Search(filter)
 		cli.StopProgress()
 
 		if len(assessment.Data) == 0 {
-			cli.OutputHuman("No active containers found.\n")
+			cli.OutputHuman(fmt.Sprintf("There are no vulnerabilities found! Time for %s\n", randomEmoji()))
 			return nil
 		}
 	}

--- a/integration/container_vulnerability_test.go
+++ b/integration/container_vulnerability_test.go
@@ -1,7 +1,7 @@
 //go:build vulnerability
 
 // Author:: Salim Afiune Maya (<afiune@lacework.net>)
-// Copyright:: Copyright 2020, Lacework Inc.
+// Copyright:: Copyright 2020-2023, Lacework Inc.
 // License:: Apache License, Version 2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -48,8 +48,7 @@ func TestContainerVulnerabilityCommandAliases(t *testing.T) {
 	assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
 }
 
-// Disabled until https://lacework.atlassian.net/browse/RAIN-37563 is resolved
-func _TestContainerVulnerabilityCommandListRegistries(t *testing.T) {
+func TestContainerVulnerabilityCommandListRegistries(t *testing.T) {
 	out, err, exitcode := LaceworkCLIWithTOMLConfig("vulnerability", "container", "list-registries")
 	assert.Contains(t, out.String(), "CONTAINER REGISTRIES",
 		"STDOUT table headers changed, please check")
@@ -70,7 +69,6 @@ func TestContainerVulnerabilityCommandListAssessments(t *testing.T) {
 		"REPOSITORY",
 		"LAST SCAN",
 		"STATUS",
-		"CONTAINERS",
 		"VULNERABILITIES",
 		"IMAGE DIGEST",
 	}
@@ -104,28 +102,17 @@ func TestContainerVulnerabilityCommandListAssessments(t *testing.T) {
 func TestContainerVulnerabilityCommandListAssessmentsJson(t *testing.T) {
 	out, err, exitcode := LaceworkCLIWithTOMLConfig("vulnerability", "container", "list-assessments", "--json")
 	expectedJsonKeys := []string{
-		"eval_guid",
-		"eval_status",
-		"eval_type",
-		"image_created_time",
-		"image_digest",
+		"digest",
 		"image_id",
-		"image_namespace",
-		"image_registry",
-		"image_repo",
-		"image_scan_error_msg",
-		"image_scan_status",
-		"image_scan_time",
-		"image_size",
-		"image_tags",
-		"ndv_containers",
-		"num_fixes",
-		"num_vulnerabilities_severity_1",
-		"num_vulnerabilities_severity_2",
-		"num_vulnerabilities_severity_3",
-		"num_vulnerabilities_severity_4",
-		"num_vulnerabilities_severity_5",
-		"start_time",
+		"registry",
+		"repository",
+		"scan_status",
+		"scan_time",
+		"cves",
+		"fixable",
+		"package_name",
+		"severity",
+		"vuln_id",
 	}
 	t.Run("verify json keys", func(t *testing.T) {
 		for _, header := range expectedJsonKeys {

--- a/integration/host_vulnerability_test.go
+++ b/integration/host_vulnerability_test.go
@@ -1,4 +1,4 @@
-//go:build vulnerability
+//go:build host_vulnerability
 
 // Author:: Salim Afiune Maya (<afiune@lacework.net>)
 // Copyright:: Copyright 2020, Lacework Inc.
@@ -36,7 +36,6 @@ import (
 )
 
 // persistent host "ip-10-0-1-170.us-west-2.compute.internal"
-// NOTE: host will need to be updated "circle-ci-test-node" when RAIN-13990 is resolved
 // managed by TF: github.com/lacework-dev/tech-ally-ci-environment
 var (
 	machineID = "30"


### PR DESCRIPTION
## Summary
Once a scan is complete, we fetch results using the Search API but and filtering by repository, image and tag/sha. Now we are adding two more filters to return accurate data. The request id and `is_reeval`.

This fixes:
* https://lacework.atlassian.net/browse/GROW-1350
* https://lacework.atlassian.net/browse/LINK-1245

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>

## How did you test this change?

I have re enabled all container vulnerability tests.

<img src="https://media1.giphy.com/media/StoeNoDkYuum8cj8MV/giphy.gif"/>

## Issue
* https://lacework.atlassian.net/browse/GROW-1350
* https://lacework.atlassian.net/browse/LINK-1245

