### PR TITLE
chore: Update lacework compliance <csp> help text

### DIFF
--- a/cli/cmd/compliance.go
+++ b/cli/cmd/compliance.go
@@ -110,10 +110,6 @@ To get the latest Azure compliance assessment report, use the command:
     lacework compliance azure get-report <tenant_id> <subscription_id>
 
 These reports run on a regular schedule, typically once a day.
-
-To run an ad-hoc compliance assessment use the command:
-
-    lacework compliance azure run-assessment <tenant_id>
 `,
 	}
 
@@ -137,10 +133,6 @@ To get the latest GCP compliance assessment report, use the command:
     lacework compliance gcp get-report <organization_id> <project_id>
 
 These reports run on a regular schedule, typically once a day.
-
-To run an ad-hoc compliance assessment use the command:
-
-    lacework compliance gcp run-assessment <org_or_project_id>
 `,
 	}
 
@@ -159,10 +151,6 @@ To get the latest AWS compliance assessment report:
     lacework compliance aws get-report <account_id>
 
 These reports run on a regular schedule, typically once a day.
-
-To run an ad-hoc compliance assessment:
-
-    lacework compliance aws run-assessment <account_id>
 `,
 	}
 )

--- a/integration/test_resources/help/compliance_aws
+++ b/integration/test_resources/help/compliance_aws
@@ -10,10 +10,6 @@ To get the latest AWS compliance assessment report:
 
 These reports run on a regular schedule, typically once a day.
 
-To run an ad-hoc compliance assessment:
-
-    lacework compliance aws run-assessment <account_id>
-
 Usage:
   lacework compliance aws [command]
 

--- a/integration/test_resources/help/compliance_azure
+++ b/integration/test_resources/help/compliance_azure
@@ -14,10 +14,6 @@ To get the latest Azure compliance assessment report, use the command:
 
 These reports run on a regular schedule, typically once a day.
 
-To run an ad-hoc compliance assessment use the command:
-
-    lacework compliance azure run-assessment <tenant_id>
-
 Usage:
   lacework compliance azure [command]
 

--- a/integration/test_resources/help/compliance_google
+++ b/integration/test_resources/help/compliance_google
@@ -14,10 +14,6 @@ To get the latest GCP compliance assessment report, use the command:
 
 These reports run on a regular schedule, typically once a day.
 
-To run an ad-hoc compliance assessment use the command:
-
-    lacework compliance gcp run-assessment <org_or_project_id>
-
 Usage:
   lacework compliance google [command]
 


### PR DESCRIPTION
Signed-off-by: Ross <ross.moles@lacework.net>


## Summary
It appears we may have left in some help test in relation to running legacy on demand scans, which is no longer supported in the CLI. We should remove this text.

## How did you test this change?
Verified locally that the on demand scan help text no longer appears

