### PR TITLE
test(lwupdater): fix windows test

### DIFF
--- a/integration/lwupdater_test.go
+++ b/integration/lwupdater_test.go
@@ -22,6 +22,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
+	"runtime"
 	"testing"
 	"time"
 
@@ -79,7 +80,11 @@ func TestVersionLoadCacheError(t *testing.T) {
 	v, err := lwupdater.LoadCache(cacheFile)
 	assert.Empty(t, v)
 	if assert.NotNil(t, err) {
-		assert.Contains(t, err.Error(), "no such file or directory")
+		if runtime.GOOS == "windows" {
+			assert.Contains(t, err.Error(), "The system cannot find the file specified")
+		} else {
+			assert.Contains(t, err.Error(), "no such file or directory")
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
CI is complaining with:
```
=== FAIL: integration TestVersionLoadCacheError (0.00s)
    lwupdater_test.go:82:
                Error Trace:    C:\codefresh\volume\go-sdk\integration\lwupdater_test.go:82
                Error:          "open C:\\Users\\ContainerAdministrator\\AppData\\Local\\Temp\\version_cache3254653061/version_cache: The system cannot find the file specified." does not contain "no such file or directory"
                Test:           TestVersionLoadCacheError
```

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>


## How did you test this change?

CI should pass

## Issue

N/A