### PR TITLE
feat: add --active flag back to vuln ctr list-assessments

### DIFF
--- a/api/entities.go
+++ b/api/entities.go
@@ -35,6 +35,7 @@ const (
 	MachineDetailsEntityType
 	UsersEntityType
 	ImagesEntityType
+	ContainersEntityType
 )
 
 // EntityTypes is the list of available entity types
@@ -43,6 +44,7 @@ var EntityTypes = map[EntityType]string{
 	MachineDetailsEntityType: "MachineDetails",
 	UsersEntityType:          "Users",
 	ImagesEntityType:         "Images",
+	ContainersEntityType:     "Containers",
 }
 
 // Search expects the response and the search filters
@@ -74,6 +76,9 @@ func (svc *EntitiesService) Search(response interface{}, filters SearchFilter) e
 
 	case *ImagesEntityResponse:
 		apiPath = fmt.Sprintf(apiV2EntitiesSearch, EntityTypes[ImagesEntityType])
+
+	case *ContainersEntityResponse:
+		apiPath = fmt.Sprintf(apiV2EntitiesSearch, EntityTypes[ContainersEntityType])
 
 	default:
 		return errors.New("missing implementation for the provided entity response")

--- a/api/entities_containers.go
+++ b/api/entities_containers.go
@@ -111,6 +111,17 @@ func (r *ContainersEntityResponse) ResetPaging() {
 	r.Paging = V2Pagination{}
 }
 
+// Total returns the total number of active containers
+func (r *ContainersEntityResponse) Total() int {
+	uniqMIDs := []int{}
+	for _, container := range r.Data {
+		if !array.ContainsInt(uniqMIDs, container.Mid) {
+			uniqMIDs = append(uniqMIDs, container.Mid)
+		}
+	}
+	return len(uniqMIDs)
+}
+
 // Count returns the number of active containers with the provided image ID
 func (r *ContainersEntityResponse) Count(imageID string) int {
 	uniqMIDs := []int{}

--- a/api/entities_containers.go
+++ b/api/entities_containers.go
@@ -1,0 +1,149 @@
+//
+// Author:: Salim Afiune Maya (<afiune@lacework.net>)
+// Copyright:: Copyright 2023, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package api
+
+import (
+	"time"
+
+	"github.com/lacework/go-sdk/internal/array"
+)
+
+// ListContainers returns a list of Active Containers from the last 7 days
+func (svc *EntitiesService) ListContainers() (response ContainersEntityResponse, err error) {
+	now := time.Now().UTC()
+	before := now.AddDate(0, 0, -7) // 7 days from ago
+	err = svc.Search(&response,
+		SearchFilter{
+			TimeFilter: &TimeFilter{
+				StartTime: &before,
+				EndTime:   &now,
+			},
+		},
+	)
+	return
+}
+
+// ListContainersWithFilters returns a list of Active Containers based on a user defined filter
+func (svc *EntitiesService) ListContainersWithFilters(filters SearchFilter) (response ContainersEntityResponse, err error) {
+	err = svc.Search(&response, filters)
+	return
+}
+
+// ListAllContainers iterates over all pages to return all active container information at once
+func (svc *EntitiesService) ListAllContainers() (response ContainersEntityResponse, err error) {
+	response, err = svc.ListContainers()
+	if err != nil {
+		return
+	}
+
+	var (
+		all    []ContainerEntity
+		pageOk bool
+	)
+	for {
+		all = append(all, response.Data...)
+
+		pageOk, err = svc.client.NextPage(&response)
+		if err == nil && pageOk {
+			continue
+		}
+		break
+	}
+
+	response.Data = all
+	response.ResetPaging()
+	return
+}
+
+// ListAllContainersWithFilters iterates over all pages to return all active container information at once based on a user defined filter
+func (svc *EntitiesService) ListAllContainersWithFilters(filters SearchFilter) (response ContainersEntityResponse, err error) {
+	response, err = svc.ListContainersWithFilters(filters)
+	if err != nil {
+		return
+	}
+
+	var (
+		all    []ContainerEntity
+		pageOk bool
+	)
+
+	for {
+		all = append(all, response.Data...)
+
+		pageOk, err = svc.client.NextPage(&response)
+		if err == nil && pageOk {
+			continue
+		}
+		break
+	}
+
+	response.Data = all
+	response.ResetPaging()
+	return
+}
+
+type ContainersEntityResponse struct {
+	Data   []ContainerEntity `json:"data"`
+	Paging V2Pagination      `json:"paging"`
+}
+
+// Fulfill Pageable interface (look at api/v2.go)
+func (r ContainersEntityResponse) PageInfo() *V2Pagination {
+	return &r.Paging
+}
+func (r *ContainersEntityResponse) ResetPaging() {
+	r.Paging = V2Pagination{}
+}
+
+// Count returns the number of active containers with the provided image ID
+func (r *ContainersEntityResponse) Count(imageID string) int {
+	uniqMIDs := []int{}
+	for _, container := range r.Data {
+		if container.ImageID == imageID &&
+			!array.ContainsInt(uniqMIDs, container.Mid) {
+			uniqMIDs = append(uniqMIDs, container.Mid)
+		}
+	}
+	return len(uniqMIDs)
+}
+
+type ContainerEntity struct {
+	ContainerName  string                 `json:"containerName"`
+	ImageID        string                 `json:"imageId"`
+	Mid            int                    `json:"mid"`
+	StartTime      time.Time              `json:"startTime"`
+	EndTime        time.Time              `json:"endTime"`
+	PodName        string                 `json:"podName"`
+	PropsContainer map[string]interface{} `json:"propsContainer"`
+	Tags           map[string]interface{} `json:"tags"`
+}
+
+type ContainerEntityProps struct {
+	Name             string    `json:"NAME"`
+	ContainerType    string    `json:"CONTAINER_TYPE"`
+	ImageAuthor      string    `json:"IMAGE_AUTHOR"`
+	ImageCreatedTime time.Time `json:"IMAGE_CREATED_TIME"`
+	ImageID          string    `json:"IMAGE_ID"`
+	ImageParentID    string    `json:"IMAGE_PARENT_ID"`
+	ImageRepo        string    `json:"IMAGE_REPO"`
+	ImageSize        int64     `json:"IMAGE_SIZE"`
+	ImageTag         string    `json:"IMAGE_TAG"`
+	ImageVersion     string    `json:"IMAGE_VERSION"`
+	Ipv4             string    `json:"IPV4"`
+}

--- a/cli/cmd/flags.go
+++ b/cli/cmd/flags.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
-	"time"
 
 	"github.com/pkg/errors"
 )
@@ -118,29 +117,4 @@ func stringSliceToMarkdownList(filters []string) string {
 		return ""
 	}
 	return fmt.Sprintf("    * %s", strings.Join(filters, "\n    * "))
-}
-
-// parse the start and end time provided by the user
-func parseStartAndEndTime(s, e string) (start time.Time, end time.Time, err error) {
-	if s == "" {
-		err = errors.New("when providing an end time, start time should be provided (--start)")
-		return
-	}
-	start, err = time.Parse(time.RFC3339, s)
-	if err != nil {
-		err = errors.Wrap(err, "unable to parse start time")
-		return
-	}
-
-	if e == "" {
-		end = time.Now()
-		return
-	}
-	end, err = time.Parse(time.RFC3339, e)
-	if err != nil {
-		err = errors.Wrap(err, "unable to parse end time")
-		return
-	}
-
-	return
 }

--- a/cli/cmd/vuln_container.go
+++ b/cli/cmd/vuln_container.go
@@ -78,6 +78,10 @@ func init() {
 		vulContainerShowAssessmentCmd.Flags(),
 	)
 
+	setActiveFlag(
+		vulContainerListAssessmentsCmd.Flags(),
+	)
+
 	setFixableFlag(
 		vulContainerScanCmd.Flags(),
 		vulContainerShowAssessmentCmd.Flags(),

--- a/cli/cmd/vuln_container.go
+++ b/cli/cmd/vuln_container.go
@@ -33,11 +33,15 @@ func init() {
 
 	// add start flag to list-assessments command
 	vulContainerListAssessmentsCmd.Flags().StringVar(&vulCmdState.Start,
-		"start", "", "start of the time range in UTC (format: yyyy-MM-ddTHH:mm:ssZ)",
+		"start", "-24h", "start of the time range",
 	)
 	// add end flag to list-assessments command
 	vulContainerListAssessmentsCmd.Flags().StringVar(&vulCmdState.End,
-		"end", "", "end of the time range in UTC (format: yyyy-MM-ddTHH:mm:ssZ)",
+		"end", "now", "end of the time range",
+	)
+	// range time flag
+	vulContainerListAssessmentsCmd.Flags().StringVar(&vulCmdState.Range,
+		"range", "", "natural time range for query",
 	)
 	// add repository flag to list-assessments command
 	vulContainerListAssessmentsCmd.Flags().StringSliceVarP(&vulCmdState.Repositories,

--- a/cli/cmd/vuln_container_test.go
+++ b/cli/cmd/vuln_container_test.go
@@ -58,8 +58,23 @@ func TestBuildCSVVulnCtrReportVulnerabilitiesListing(t *testing.T) {
 		panic(err)
 	}
 
-	headers := []string{"Registry", "Repository", "Last Scan", "Status", "Vulnerabilities", "Image Digest"}
-	assessments := buildVulnCtrAssessmentSummary(data.Data)
+	headers := []string{"Registry", "Repository", "Last Scan", "Status", "Containers", "Vulnerabilities", "Image Digest"}
+	assessments := buildVulnCtrAssessmentSummary(data.Data, api.ContainersEntityResponse{
+		Data: []api.ContainerEntity{
+			api.ContainerEntity{
+				ImageID: "sha256:7652596622b05043763f962cff30edf01f6ea1ba29374f1703dda759dc9ff3a1",
+				Mid:     1,
+			},
+			api.ContainerEntity{
+				ImageID: "sha256:7652596622b05043763f962cff30edf01f6ea1ba29374f1703dda759dc9ff3a1",
+				Mid:     2,
+			},
+			api.ContainerEntity{
+				ImageID: "sha256:1252596622b05043763f962gff30adf01f6ea1ba29374f1703dda759dc9ab3a1",
+				Mid:     3,
+			},
+		},
+	})
 	filteredAssessments := applyVulnCtrFilters(assessments)
 	assessmentOutput := assessmentSummaryToOutputFormat(filteredAssessments)
 	rows := vulAssessmentsToTable(assessmentOutput)
@@ -69,10 +84,10 @@ func TestBuildCSVVulnCtrReportVulnerabilitiesListing(t *testing.T) {
 	}
 
 	expected := `
-Registry,Repository,Last Scan,Status,Vulnerabilities,Image Digest
-index.docker.io,techally-test/test-cli,2022-11-21T18:33:28Z,Success,1 Medium 1 Fixable,sha256:77b2d2246518044ef95e3dbd029e51dd477788e5bf8e278e418685aabc3fe28a
-gcr.io,techally-test-4/exservice,2022-11-21T19:21:57Z,Success,1 High 1 Fixable,sha256:15b072fd2ce1732e4c2f0f601c2c12ea2ea657c9572d9ba477b1174d9159e123
-gcr.io,techally-test-2/exservice,2022-11-21T19:21:57Z,Success,1 Critical,sha256:12b072fd2ce1732e4c2f0f601c2c12ea2ea657c9572d9ba477b1174d9159e123
+Registry,Repository,Last Scan,Status,Containers,Vulnerabilities,Image Digest
+gcr.io,techally-test-2/exservice,2022-11-21T19:21:57Z,Success,2,1 Critical,sha256:12b072fd2ce1732e4c2f0f601c2c12ea2ea657c9572d9ba477b1174d9159e123
+gcr.io,techally-test-4/exservice,2022-11-21T19:21:57Z,Success,1,1 High 1 Fixable,sha256:15b072fd2ce1732e4c2f0f601c2c12ea2ea657c9572d9ba477b1174d9159e123
+index.docker.io,techally-test/test-cli,2022-11-21T18:33:28Z,Success,0,1 Medium 1 Fixable,sha256:77b2d2246518044ef95e3dbd029e51dd477788e5bf8e278e418685aabc3fe28a
 `
 
 	assert.Equal(t, strings.TrimPrefix(expected, "\n"), csv)

--- a/cli/cmd/vulnerability.go
+++ b/cli/cmd/vulnerability.go
@@ -67,6 +67,9 @@ var (
 		// end time for listing assessments
 		End string
 
+		// natural time range for listing assessments
+		Range string
+
 		// active flag to filter container vulnerability assessments and
 		// show only assessments of containers actively running
 		Active bool

--- a/integration/container_vulnerability_test.go
+++ b/integration/container_vulnerability_test.go
@@ -68,6 +68,7 @@ func TestContainerVulnerabilityCommandListAssessments(t *testing.T) {
 		"REGISTRY",
 		"REPOSITORY",
 		"LAST SCAN",
+		"CONTAINERS",
 		"STATUS",
 		"VULNERABILITIES",
 		"IMAGE DIGEST",

--- a/integration/test_resources/help/vulnerability_container
+++ b/integration/test_resources/help/vulnerability_container
@@ -22,7 +22,7 @@ Aliases:
   container, ctr
 
 Available Commands:
-  list-assessments List container vulnerability assessments (default last 7 days)
+  list-assessments List container vulnerability assessments (default last 24 hours)
   list-registries  List all container registries configured
   scan             Request an on-demand container vulnerability assessment
   show-assessment  Show results of a container vulnerability assessment

--- a/integration/test_resources/help/vulnerability_container_list-assessments
+++ b/integration/test_resources/help/vulnerability_container_list-assessments
@@ -9,6 +9,7 @@ Aliases:
   list-assessments, list, ls
 
 Flags:
+      --active               only show vulnerabilities of packages actively running in your environment
       --csv                  output vulnerability assessment in CSV format
       --end string           end of the time range in UTC (format: yyyy-MM-ddTHH:mm:ssZ)
       --fixable              only show fixable vulnerabilities

--- a/integration/test_resources/help/vulnerability_container_list-assessments
+++ b/integration/test_resources/help/vulnerability_container_list-assessments
@@ -1,6 +1,23 @@
-List all container vulnerability assessments for the last 7 days by default, or
-pass --start and --end to specify a custom time range. You can pass --fixable to
-filter on containers with vulnerabilities that have fixes available.
+List all container vulnerability assessments for the last 24 hours by default.
+
+To customize the time range use use '--start', '--end', or '--range'.
+
+The start and end times can be specified in one of the following formats:
+
+    A. A relative time specifier
+    B. RFC3339 date and time
+    C. Epoch time in milliseconds
+
+Or use a natural time range like.
+
+    lacework vuln container list --range yesterday
+
+The natural time range of 'yesterday' would represent a relative start time of '-1d@d'
+and a relative end time of '@d'.
+
+You can also pass '--fixable' to filter on containers with vulnerabilities that have
+fixes available, or '--active' to filter on container images actively running in your
+environment.
 
 Usage:
   lacework vulnerability container list-assessments [flags]
@@ -11,12 +28,13 @@ Aliases:
 Flags:
       --active               only show vulnerabilities of packages actively running in your environment
       --csv                  output vulnerability assessment in CSV format
-      --end string           end of the time range in UTC (format: yyyy-MM-ddTHH:mm:ssZ)
+      --end string           end of the time range (default "now")
       --fixable              only show fixable vulnerabilities
   -h, --help                 help for list-assessments
+      --range string         natural time range for query
       --registry strings     filter assessments for specific registries
   -r, --repository strings   filter assessments for specific repositories
-      --start string         start of the time range in UTC (format: yyyy-MM-ddTHH:mm:ssZ)
+      --start string         start of the time range (default "-24h")
 
 Global Flags:
   -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)

--- a/scripts/codefresh.ps1
+++ b/scripts/codefresh.ps1
@@ -19,6 +19,4 @@ gox -output="bin/lacework-cli-{{.OS}}-{{.Arch}}" -os="windows" -arch="amd64 386"
 
 Write-Host "Running integrations tests."
 $env:Path += ";$pwd\bin"
-
-# Disable vulnerability tests until https://lacework.atlassian.net/browse/RAIN-37563 is resolved
-gotestsum -- -v github.com/lacework/go-sdk/integration -timeout 30m -tags="account agent_token alert_rules compliance configure event help integration migration policy query version generation"
+gotestsum -- -v github.com/lacework/go-sdk/integration -timeout 30m -tags="account vulnerability agent_token alert_rules compliance configure event help integration migration policy query version generation"


### PR DESCRIPTION
## User Story
As a Lacework CLI user that upgraded to version 1.0.0 or above,
I want to have the flag `--active` back,
Since I have running workflows that depend on it to give me actionable insights of vulnerabilities actively running on my environment

## Summary

We removed this flag as part of the v1.0.0 release but we are adding it back!

<img src="https://media3.giphy.com/media/StoeNoDkYuum8cj8MV/giphy.gif"/>

## How did you test this change?

Locally and integration tests should now display active containers.

## Issue

https://lacework.atlassian.net/browse/GROW-1361
