### PR TITLE
feat(cli): add hidden suppressions migrate gcp command

### DIFF
--- a/cli/cmd/suppressions.go
+++ b/cli/cmd/suppressions.go
@@ -172,6 +172,8 @@ func convertResourceNamesSupConditions(supConditions []string) []any {
 	var conditions []any
 	for _, condition := range supConditions {
 		ok := arn.IsARN(condition)
+		// If the legacy suppression resourceNames field contains an ARN, we should parse and pull
+		// out the resource name. ARNs are not supported in policy exceptions
 		if ok {
 			parsedEntry, _ := arn.Parse(condition)
 			condition = parsedEntry.Resource

--- a/cli/cmd/suppressions.go
+++ b/cli/cmd/suppressions.go
@@ -138,10 +138,16 @@ func convertSupCondition(supCondition []string, fieldKey string,
 		policyIdExceptionsTemplate, fieldKey) {
 
 		var condition []any
-		// verify if "ALL_ACCOUNTS" OR "ALL_REGIONS" is in the suppression condition slice
+		// verify for aws:
+		// if "ALL_ACCOUNTS" OR "ALL_REGIONS" is in the suppression condition slice
+		// verify for gcp:
+		// if "ALL_ORGANIZATIONS" OR "ALL_PROJECTS" is in the suppression condition slice
 		// if so we should ignore the supplied conditions and replace with a wildcard *
 		if (slices.Contains(supCondition, "ALL_ACCOUNTS") && fieldKey == "accountIds") ||
 			(slices.Contains(supCondition, "ALL_REGIONS") && fieldKey == "regionNames") {
+			condition = append(condition, "*")
+		} else if (slices.Contains(supCondition, "ALL_ORGANIZATIONS") && fieldKey == "organizations") ||
+			(slices.Contains(supCondition, "ALL_PROJECTS") && fieldKey == "projects") {
 			condition = append(condition, "*")
 		} else {
 			condition = convertToAnySlice(supCondition)

--- a/cli/cmd/suppressions.go
+++ b/cli/cmd/suppressions.go
@@ -72,14 +72,14 @@ func init() {
 }
 
 func autoConvertSuppressions(convertedPolicyExceptions []map[string]api.PolicyException) {
-	cli.StartProgress("Creating policy exceptions ...")
+	cli.StartProgress("Creating policy exceptions...")
 	for _, exceptionMap := range convertedPolicyExceptions {
 		for policyId, exception := range exceptionMap {
 			response, err := cli.LwApi.V2.Policy.Exceptions.Create(policyId, exception)
 			if err != nil {
 				cli.Log.Debug(err, "unable to create exception")
 				cli.OutputHuman(color.RedString(
-					"Error creating policy exception to create exception. %e"),
+					"Error creating policy exception to create exception. %s"),
 					err)
 				continue
 			}

--- a/cli/cmd/suppressions.go
+++ b/cli/cmd/suppressions.go
@@ -248,3 +248,12 @@ func convertToAnySlice(slice []string) []any {
 	}
 	return s
 }
+
+func updateDiscardedSupConditionsComments(suppressionInfo api.SuppressionV2, comment string) api.SuppressionV2 {
+	var updatedSupInfo api.SuppressionV2
+	for _, suppression := range suppressionInfo.SuppressionConditions {
+		suppression.Comment = comment
+		updatedSupInfo.SuppressionConditions = append(updatedSupInfo.SuppressionConditions, suppression)
+	}
+	return updatedSupInfo
+}

--- a/cli/cmd/suppressions_aws.go
+++ b/cli/cmd/suppressions_aws.go
@@ -29,7 +29,6 @@ import (
 	"github.com/lacework/go-sdk/api"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"golang.org/x/exp/slices"
 )
 
 var (
@@ -297,7 +296,7 @@ func suppressionsAwsMigrate(_ *cobra.Command, _ []string) error {
 			return err
 		}
 		if confirm {
-			autoConvertAwsSuppressions(convertedPolicyExceptions)
+			autoConvertSuppressions(convertedPolicyExceptions)
 			printDiscardedSuppressions(discardedSuppressions)
 			cli.OutputHuman(color.GreenString("To view the newly created Exceptions, " +
 				"try running `lacework policy-exceptions list <policyId>"))
@@ -307,26 +306,6 @@ func suppressionsAwsMigrate(_ *cobra.Command, _ []string) error {
 	}
 
 	return nil
-}
-
-func autoConvertAwsSuppressions(convertedPolicyExceptions []map[string]api.PolicyException) {
-	cli.StartProgress("Creating policy exceptions ...")
-	for _, exceptionMap := range convertedPolicyExceptions {
-		for policyId, exception := range exceptionMap {
-			response, err := cli.LwApi.V2.Policy.Exceptions.Create(policyId, exception)
-			if err != nil {
-				cli.Log.Debug(err, "unable to create exception")
-				cli.OutputHuman(color.RedString(
-					"Error creating policy exception to create exception. %e"),
-					err)
-				continue
-			}
-			cli.OutputHuman("Exception created for PolicyId: %s - ExceptionId: %s\n\n",
-				color.GreenString(policyId), color.BlueString(response.Data.ExceptionID))
-		}
-	}
-
-	cli.StopProgress()
 }
 
 func convertAwsSuppressions(
@@ -439,116 +418,4 @@ func convertAwsSuppressions(
 	}
 
 	return convertedPolicyExceptions, payloadsText, discardedSuppressions
-}
-
-func printPayloadsText(payloadsText []string) {
-	if len(payloadsText) >= 1 {
-		cli.OutputHuman(color.YellowString("#### Legacy Suppressions --> Exceptions payloads\n\n"))
-		for _, payload := range payloadsText {
-			cli.OutputHuman(color.GreenString("%s \n\n", payload))
-		}
-	} else {
-		cli.OutputHuman("No legacy suppressions found that could be migrated\n")
-	}
-}
-
-func printConvertedSuppressions(convertedSuppressions []map[string]api.PolicyException) {
-	if len(convertedSuppressions) >= 1 {
-		cli.OutputHuman(color.YellowString("#### Converted legacy suppressions in Policy Exception" +
-			" format" +
-			"\n"))
-		for _, exception := range convertedSuppressions {
-			err := cli.OutputJSON(exception)
-			if err != nil {
-				return
-			}
-		}
-		colorizeR := color.New(color.FgRed, color.Bold)
-		cli.OutputHuman(colorizeR.Sprintf("WARNING: Before continuing, " +
-			"please thoroughly inspect the above exceptions to ensure they are valid and" +
-			" required. By continuing, you accept liability for any compliance violations" +
-			" missed as a result of the above exceptions!\n\n"))
-
-	}
-}
-
-func printDiscardedSuppressions(discardedSuppressions []map[string]api.SuppressionV2) {
-	if len(discardedSuppressions) >= 1 {
-		cli.OutputHuman(color.YellowString("#### Discarded legacy suppressions\n"))
-		for _, suppression := range discardedSuppressions {
-			err := cli.OutputJSON(suppression)
-			if err != nil {
-				return
-			}
-		}
-	}
-}
-
-func convertSupCondition(supCondition []string, fieldKey string,
-	policyIdExceptionsTemplate []string) api.PolicyExceptionConstraint {
-	if len(supCondition) >= 1 && slices.Contains(
-		policyIdExceptionsTemplate, fieldKey) {
-
-		var condition []any
-		// verify if "ALL_ACCOUNTS" OR "ALL_REGIONS" is in the suppression condition slice
-		// if so we should ignore the supplied conditions and replace with a wildcard *
-		if (slices.Contains(supCondition, "ALL_ACCOUNTS") && fieldKey == "accountIds") ||
-			(slices.Contains(supCondition, "ALL_REGIONS") && fieldKey == "regionNames") {
-			condition = append(condition, "*")
-		} else {
-			condition = convertToAnySlice(supCondition)
-		}
-
-		return api.PolicyExceptionConstraint{
-			FieldKey:    fieldKey,
-			FieldValues: condition,
-		}
-	}
-	return api.PolicyExceptionConstraint{}
-}
-
-func convertSupConditionTags(supCondition []map[string]string, fieldKey string,
-	policyIdExceptionsTemplate []string) api.PolicyExceptionConstraint {
-	if len(supCondition) >= 1 && slices.Contains(
-		policyIdExceptionsTemplate, fieldKey) {
-
-		// api.PolicyExceptionConstraint expects []any for the FieldValues
-		// Therefore we need to take the supCondition []map[string]string and append each map to
-		// the new convertedTags []any var
-		var convertedTags []any
-		for _, tagMap := range supCondition {
-			convertedTags = append(convertedTags, tagMap)
-		}
-
-		return api.PolicyExceptionConstraint{
-			FieldKey:    fieldKey,
-			FieldValues: convertedTags,
-		}
-	}
-	return api.PolicyExceptionConstraint{}
-}
-
-func getPoliciesExceptionConstraintsMap() map[string][]string {
-	// get a list of all policies and parse the valid exception constraints and return a map of
-	// {"<policyId>": [<validPolicyConstraints>]}
-	policies, err := cli.LwApi.V2.Policy.List()
-	if err != nil {
-		return nil
-	}
-
-	policiesSupportedConstraints := make(map[string][]string)
-	for _, policy := range policies.Data {
-		exceptionConstraints := getPolicyExceptionConstraintsSlice(policy.ExceptionConfiguration)
-		policiesSupportedConstraints[policy.PolicyID] = exceptionConstraints
-	}
-
-	return policiesSupportedConstraints
-}
-
-func convertToAnySlice(slice []string) []any {
-	s := make([]interface{}, len(slice))
-	for i, v := range slice {
-		s[i] = v
-	}
-	return s
 }

--- a/cli/cmd/suppressions_gcp.go
+++ b/cli/cmd/suppressions_gcp.go
@@ -232,7 +232,7 @@ func suppressionsGcpMigrate(_ *cobra.Command, _ []string) error {
 			cli.OutputHuman(color.GreenString("To view the newly created Exceptions, " +
 				"try running `lacework policy-exceptions list <policyId>"))
 		} else {
-			cli.OutputHuman("Cancelled Legacy Suppression to Exception migration!")
+			cli.OutputHuman("Cancelled Legacy Suppression to Exception migration!\n")
 		}
 	}
 

--- a/cli/cmd/suppressions_gcp.go
+++ b/cli/cmd/suppressions_gcp.go
@@ -117,7 +117,7 @@ var (
 		"GCP_CIS12_7_3":    "lacework-global-314",
 	}
 
-	// suppressionsMigrateGcpCmd represents the azure sub-command inside the suppressions migrate command
+	// suppressionsMigrateGcpCmd represents the gcp sub-command inside the suppressions migrate command
 	suppressionsMigrateGcpCmd = &cobra.Command{
 		Use:     "migrate",
 		Aliases: []string{"mig"},
@@ -365,13 +365,4 @@ func convertGcpSuppressions(
 	}
 
 	return convertedPolicyExceptions, payloadsText, discardedSuppressions
-}
-
-func updateDiscardedSupConditionsComments(suppressionInfo api.SuppressionV2, comment string) api.SuppressionV2 {
-	var updatedSupInfo api.SuppressionV2
-	for _, suppression := range suppressionInfo.SuppressionConditions {
-		suppression.Comment = comment
-		updatedSupInfo.SuppressionConditions = append(updatedSupInfo.SuppressionConditions, suppression)
-	}
-	return updatedSupInfo
 }

--- a/cli/cmd/suppressions_gcp.go
+++ b/cli/cmd/suppressions_gcp.go
@@ -166,18 +166,18 @@ func suppressionsGcpMigrate(_ *cobra.Command, _ []string) error {
 		payloadsText              []string
 		discardedSuppressions     []map[string]api.SuppressionV2
 	)
-	suppressionsMap, err = cli.LwApi.V2.Suppressions.Aws.List()
+	suppressionsMap, err = cli.LwApi.V2.Suppressions.Gcp.List()
 	if err != nil {
-		if strings.Contains(err.Error(), "No active AWS accounts") {
-			cli.OutputHuman("No active AWS accounts found. " +
-				"Unable to get legacy aws suppressions")
+		if strings.Contains(err.Error(), "No active GCP accounts") {
+			cli.OutputHuman("No active GCP accounts found. " +
+				"Unable to get legacy gcp suppressions")
 			return nil
 		}
-		return errors.Wrap(err, "Unable to get legacy aws suppressions")
+		return errors.Wrap(err, "Unable to get legacy gcp suppressions")
 	}
 
 	if len(suppressionsMap) == 0 {
-		cli.OutputHuman("No legacy AWS suppressions found.\n")
+		cli.OutputHuman("No legacy GCP suppressions found.\n")
 		return nil
 	}
 
@@ -254,7 +254,7 @@ func convertGcpSuppressions(
 		// verify there is a mapped policy for this recommendation
 		// if the recommendation is not a key in the map we can assume this is not mapped and
 		// continue
-		mappedPolicyId, ok := awsEquivalencesMap[id]
+		mappedPolicyId, ok := gcpEquivalencesMap[id]
 		if !ok {
 			// when we don't have a mapped policy, add the legacy suppression info
 			if suppressionInfo.SuppressionConditions != nil {
@@ -280,21 +280,21 @@ func convertGcpSuppressions(
 				var convertedConstraints []api.PolicyExceptionConstraint
 
 				organizationIdsConstraint := convertSupCondition(suppression.OrganizationIds,
-					"organizationIds",
+					"organizations",
 					policyIdExceptionsTemplate)
 				if organizationIdsConstraint.FieldKey != "" {
 					convertedConstraints = append(convertedConstraints, organizationIdsConstraint)
 				}
 
 				projectIdsConstraint := convertSupCondition(suppression.ProjectIds,
-					"projectIds",
+					"projects",
 					policyIdExceptionsTemplate)
 				if projectIdsConstraint.FieldKey != "" {
 					convertedConstraints = append(convertedConstraints, projectIdsConstraint)
 				}
 
 				resourceNamesConstraint := convertSupCondition(suppression.ResourceNames,
-					"resourceNames",
+					"resourceName",
 					policyIdExceptionsTemplate)
 				if resourceNamesConstraint.FieldKey != "" {
 					convertedConstraints = append(convertedConstraints, resourceNamesConstraint)

--- a/cli/cmd/suppressions_gcp.go
+++ b/cli/cmd/suppressions_gcp.go
@@ -258,6 +258,8 @@ func convertGcpSuppressions(
 		if !ok {
 			// when we don't have a mapped policy, add the legacy suppression info
 			if suppressionInfo.SuppressionConditions != nil {
+				suppressionInfo = updateDiscardedSupConditionsComments(suppressionInfo,
+					"Legacy suppression discarded as there is no equivalent policy")
 				discardedSuppressions = append(
 					discardedSuppressions,
 					map[string]api.SuppressionV2{id: suppressionInfo},
@@ -272,6 +274,20 @@ func convertGcpSuppressions(
 		// We then parse this into a list of constraints
 		policyIdExceptionsTemplate := policyExceptionsConstraintsMap[mappedPolicyId]
 		if policyIdExceptionsTemplate == nil {
+			// Updating the suppression conditions comments to make it clear why these were
+			// discarded
+			if len(suppressionInfo.SuppressionConditions) >= 1 {
+				suppressionInfo = updateDiscardedSupConditionsComments(suppressionInfo,
+					fmt.Sprintf("Legacy suppression discarded as the new policy: %s does not"+
+						" support exception conditions", mappedPolicyId))
+			}
+
+			// if the list of supported constraints is empty for a policy,
+			// we should let the customers know that we have discarded this suppression
+			discardedSuppressions = append(
+				discardedSuppressions,
+				map[string]api.SuppressionV2{id: suppressionInfo},
+			)
 			continue
 		}
 		if len(suppressionInfo.SuppressionConditions) >= 1 {
@@ -349,4 +365,13 @@ func convertGcpSuppressions(
 	}
 
 	return convertedPolicyExceptions, payloadsText, discardedSuppressions
+}
+
+func updateDiscardedSupConditionsComments(suppressionInfo api.SuppressionV2, comment string) api.SuppressionV2 {
+	var updatedSupInfo api.SuppressionV2
+	for _, suppression := range suppressionInfo.SuppressionConditions {
+		suppression.Comment = comment
+		updatedSupInfo.SuppressionConditions = append(updatedSupInfo.SuppressionConditions, suppression)
+	}
+	return updatedSupInfo
 }

--- a/cli/cmd/suppressions_gcp.go
+++ b/cli/cmd/suppressions_gcp.go
@@ -19,14 +19,112 @@
 package cmd
 
 import (
+	"encoding/json"
+	"fmt"
 	"strings"
 
+	"github.com/fatih/color"
+
+	"github.com/AlecAivazis/survey/v2"
 	"github.com/lacework/go-sdk/api"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
 var (
+	gcpEquivalencesMap = map[string]string{
+		"GCP_CIS12_1_2":   "lacework-global-233",
+		"GCP_CIS12_1_3":   "lacework-global-293",
+		"GCP_CIS12_1_4":   "lacework-global-234",
+		"GCP_CIS12_1_5":   "lacework-global-235",
+		"GCP_CIS12_1_6":   "lacework-global-236",
+		"GCP_CIS12_1_7":   "lacework-global-237",
+		"GCP_CIS12_1_8":   "lacework-global-294",
+		"GCP_CIS12_1_9":   "lacework-global-238",
+		"GCP_CIS12_1_10":  "lacework-global-239",
+		"GCP_CIS12_1_11":  "lacework-global-295",
+		"GCP_CIS12_1_12":  "lacework-global-296",
+		"GCP_CIS12_1_13":  "lacework-global-240",
+		"GCP_CIS12_1_14":  "lacework-global-241",
+		"GCP_CIS12_1_15":  "lacework-global-242",
+		"GCP_CIS12_2_1":   "lacework-global-245",
+		"GCP_CIS12_2_2":   "lacework-global-246",
+		"GCP_CIS12_2_3":   "lacework-global-298",
+		"GCP_CIS12_2_4":   "lacework-global-247",
+		"GCP_CIS12_2_5":   "lacework-global-248",
+		"GCP_CIS12_2_6":   "lacework-global-249",
+		"GCP_CIS12_2_7":   "lacework-global-250",
+		"GCP_CIS12_2_8":   "lacework-global-251",
+		"GCP_CIS12_2_9":   "lacework-global-252",
+		"GCP_CIS12_2_10":  "lacework-global-253",
+		"GCP_CIS12_2_11":  "lacework-global-254",
+		"GCP_CIS12_2_12":  "lacework-global-255",
+		"GCP_CIS12_3_1":   "lacework-global-300",
+		"GCP_CIS12_3_2":   "lacework-global-258",
+		"GCP_CIS12_3_3":   "lacework-global-259",
+		"GCP_CIS12_3_4":   "lacework-global-260",
+		"GCP_CIS12_3_5":   "lacework-global-261",
+		"GCP_CIS12_3_6":   "lacework-global-301",
+		"GCP_CIS12_3_7":   "lacework-global-302",
+		"GCP_CIS12_3_8":   "lacework-global-262",
+		"GCP_CIS12_3_9":   "lacework-global-263",
+		"GCP_CIS12_3_10":  "lacework-global-303",
+		"GCP_CIS12_4_1":   "lacework-global-264",
+		"GCP_CIS12_4_2":   "lacework-global-265",
+		"GCP_CIS12_4_3":   "lacework-global-266",
+		"GCP_CIS12_4_4":   "lacework-global-267",
+		"GCP_CIS12_4_5":   "lacework-global-268",
+		"GCP_CIS12_4_6":   "lacework-global-269",
+		"GCP_CIS12_4_7":   "lacework-global-304",
+		"GCP_CIS12_4_8":   "lacework-global-305",
+		"GCP_CIS12_4_9":   "lacework-global-306",
+		"GCP_CIS12_4_10":  "lacework-global-307",
+		"GCP_CIS12_4_11":  "lacework-global-308",
+		"GCP_CIS12_5_1":   "lacework-global-270",
+		"GCP_CIS12_5_2":   "lacework-global-310",
+		"GCP_CIS12_6_1_1": "lacework-global-274",
+		"GCP_CIS12_6_1_2": "lacework-global-275",
+		"GCP_CIS12_6_1_3": "lacework-global-276",
+		//"GCP_CIS12_6_2_1": "N/A",
+		"GCP_CIS12_6_2_2": "lacework-global-312",
+		"GCP_CIS12_6_2_3": "lacework-global-277",
+		"GCP_CIS12_6_2_4": "lacework-global-278",
+		//"GCP_CIS12_6_2_5": "N/A",
+		//"GCP_CIS12_6_2_6": "N/A",
+		"GCP_CIS12_6_2_7": "lacework-global-279",
+		"GCP_CIS12_6_2_8": "lacework-global-280",
+		//"GCP_CIS12_6_2_9": "N/A",
+		//"GCP_CIS12_6_2_10": "N/A",
+		//"GCP_CIS12_6_2_11": "N/A",
+		//"GCP_CIS12_6_2_12": "N/A",
+		"GCP_CIS12_6_2_13": "lacework-global-281",
+		"GCP_CIS12_6_2_14": "lacework-global-282",
+		//"GCP_CIS12_6_2_15": "N/A",
+		"GCP_CIS12_6_2_16": "lacework-global-283",
+		"GCP_CIS12_6_3_1":  "lacework-global-285",
+		"GCP_CIS12_6_3_2":  "lacework-global-286",
+		"GCP_CIS12_6_3_3":  "lacework-global-287",
+		"GCP_CIS12_6_3_4":  "lacework-global-288",
+		"GCP_CIS12_6_3_5":  "lacework-global-289",
+		"GCP_CIS12_6_3_6":  "lacework-global-290",
+		"GCP_CIS12_6_3_7":  "lacework-global-291",
+		"GCP_CIS12_6_4":    "lacework-global-271",
+		"GCP_CIS12_6_5":    "lacework-global-272",
+		"GCP_CIS12_6_6":    "lacework-global-311",
+		"GCP_CIS12_6_7":    "lacework-global-273",
+		"GCP_CIS12_7_1":    "lacework-global-292",
+		"GCP_CIS12_7_2":    "lacework-global-313",
+		"GCP_CIS12_7_3":    "lacework-global-314",
+	}
+
+	// suppressionsMigrateGcpCmd represents the azure sub-command inside the suppressions migrate command
+	suppressionsMigrateGcpCmd = &cobra.Command{
+		Use:     "migrate",
+		Aliases: []string{"mig"},
+		Short:   "Migrate legacy suppressions for Gcp to mapped policy exceptions",
+		RunE:    suppressionsGcpMigrate,
+	}
+
 	// suppressionsListGcpCmd represents the gcp sub-command inside the suppressions list command
 	suppressionsListGcpCmd = &cobra.Command{
 		Use:     "list",
@@ -57,4 +155,198 @@ func suppressionsGcpList(_ *cobra.Command, _ []string) error {
 		return nil
 	}
 	return cli.OutputJSON(suppressions)
+}
+
+func suppressionsGcpMigrate(_ *cobra.Command, _ []string) error {
+	var (
+		suppressionsMap map[string]api.SuppressionV2
+		err             error
+
+		convertedPolicyExceptions []map[string]api.PolicyException
+		payloadsText              []string
+		discardedSuppressions     []map[string]api.SuppressionV2
+	)
+	suppressionsMap, err = cli.LwApi.V2.Suppressions.Aws.List()
+	if err != nil {
+		if strings.Contains(err.Error(), "No active AWS accounts") {
+			cli.OutputHuman("No active AWS accounts found. " +
+				"Unable to get legacy aws suppressions")
+			return nil
+		}
+		return errors.Wrap(err, "Unable to get legacy aws suppressions")
+	}
+
+	if len(suppressionsMap) == 0 {
+		cli.OutputHuman("No legacy AWS suppressions found.\n")
+		return nil
+	}
+
+	answer := ""
+	manualMigration := "Output translated legacy suppressions as policy exception commands to be" +
+		" run manually (Recommended)"
+	autoMigration := "Auto migrate legacy suppressions.\nDISCLAIMER: " +
+		"By selecting this option, you accept liability for the migration and " +
+		"any compliance violations missed as a result of the added exceptions"
+	if err := SurveyQuestionInteractiveOnly(SurveyQuestionWithValidationArgs{
+		Prompt: &survey.Select{
+			Message: "Select your legacy suppression migration approach?",
+			Options: []string{
+				manualMigration,
+				autoMigration,
+			},
+		},
+		Response: &answer,
+	}); err != nil {
+		return err
+	}
+
+	// get a list of all policies and parse the valid exception constraints and create a map of
+	// {"<policyId>": [<validPolicyConstraints>]}
+	policyExceptionsConstraintsMap := getPoliciesExceptionConstraintsMap()
+
+	switch answer {
+	case manualMigration:
+		_, payloadsText, discardedSuppressions = convertGcpSuppressions(
+			suppressionsMap,
+			policyExceptionsConstraintsMap,
+		)
+		printPayloadsText(payloadsText)
+		printDiscardedSuppressions(discardedSuppressions)
+	case autoMigration:
+		convertedPolicyExceptions, _, discardedSuppressions = convertGcpSuppressions(
+			suppressionsMap,
+			policyExceptionsConstraintsMap,
+		)
+		printConvertedSuppressions(convertedPolicyExceptions)
+		confirm := false
+		err := survey.AskOne(&survey.Confirm{
+			Message: "Confirm the above exceptions have been reviewed and you wish to continue" +
+				" with the auto migration.",
+		}, &confirm)
+		if err != nil {
+			return err
+		}
+		if confirm {
+			autoConvertSuppressions(convertedPolicyExceptions)
+			printDiscardedSuppressions(discardedSuppressions)
+			cli.OutputHuman(color.GreenString("To view the newly created Exceptions, " +
+				"try running `lacework policy-exceptions list <policyId>"))
+		} else {
+			cli.OutputHuman("Cancelled Legacy Suppression to Exception migration!")
+		}
+	}
+
+	return nil
+}
+
+func convertGcpSuppressions(
+	suppressionsMap map[string]api.SuppressionV2,
+	policyExceptionsConstraintsMap map[string][]string,
+) ([]map[string]api.PolicyException,
+	[]string, []map[string]api.SuppressionV2) {
+	var (
+		convertedPolicyExceptions []map[string]api.PolicyException
+		payloadsText              []string
+		discardedSuppressions     []map[string]api.SuppressionV2
+	)
+
+	for id, suppressionInfo := range suppressionsMap {
+		// verify there is a mapped policy for this recommendation
+		// if the recommendation is not a key in the map we can assume this is not mapped and
+		// continue
+		mappedPolicyId, ok := awsEquivalencesMap[id]
+		if !ok {
+			// when we don't have a mapped policy, add the legacy suppression info
+			if suppressionInfo.SuppressionConditions != nil {
+				discardedSuppressions = append(
+					discardedSuppressions,
+					map[string]api.SuppressionV2{id: suppressionInfo},
+				)
+			}
+			continue
+		}
+
+		// get the supported policy exception fields for the mapped policy
+		// in order to ensure we have an up-to-date list of exception constraints we need to
+		// get the policy from the /api/v2/Policies/<policyId> api.
+		// We then parse this into a list of constraints
+		policyIdExceptionsTemplate := policyExceptionsConstraintsMap[mappedPolicyId]
+		if policyIdExceptionsTemplate == nil {
+			continue
+		}
+		if len(suppressionInfo.SuppressionConditions) >= 1 {
+			for _, suppression := range suppressionInfo.SuppressionConditions {
+				// used to store the converted legacy suppressions
+				var convertedConstraints []api.PolicyExceptionConstraint
+
+				organizationIdsConstraint := convertSupCondition(suppression.OrganizationIds,
+					"organizationIds",
+					policyIdExceptionsTemplate)
+				if organizationIdsConstraint.FieldKey != "" {
+					convertedConstraints = append(convertedConstraints, organizationIdsConstraint)
+				}
+
+				projectIdsConstraint := convertSupCondition(suppression.ProjectIds,
+					"projectIds",
+					policyIdExceptionsTemplate)
+				if projectIdsConstraint.FieldKey != "" {
+					convertedConstraints = append(convertedConstraints, projectIdsConstraint)
+				}
+
+				resourceNamesConstraint := convertSupCondition(suppression.ResourceNames,
+					"resourceNames",
+					policyIdExceptionsTemplate)
+				if resourceNamesConstraint.FieldKey != "" {
+					convertedConstraints = append(convertedConstraints, resourceNamesConstraint)
+				}
+
+				resourceTagsConstraint := convertSupConditionTags(suppression.ResourceTags,
+					"resourceTags",
+					policyIdExceptionsTemplate)
+				if resourceTagsConstraint.FieldKey != "" {
+					convertedConstraints = append(convertedConstraints, resourceTagsConstraint)
+				}
+
+				description := fmt.Sprintf(
+					"Migrated exception from legacy compliance policy %s. ", id,
+				)
+				if suppression.Comment != "" {
+					description = description + fmt.Sprintf(
+						"Legacy Policy comment: %s", suppression.Comment,
+					)
+				}
+				if len(convertedConstraints) >= 1 {
+					convertedPolicyExceptions = append(
+						convertedPolicyExceptions,
+						map[string]api.PolicyException{
+							mappedPolicyId: {
+								Description: description,
+								Constraints: convertedConstraints,
+							},
+						},
+					)
+
+					exception := api.PolicyException{
+						Description: description,
+						Constraints: convertedConstraints,
+					}
+					jsonException, err := json.Marshal(exception)
+					if err != nil {
+						cli.Log.Error(err)
+					}
+
+					payloadsText = append(
+						payloadsText,
+						fmt.Sprintf(
+							"lacework api post '/Exceptions?policyId=%s' -d '%s'",
+							mappedPolicyId,
+							jsonException,
+						),
+					)
+				}
+			}
+		}
+	}
+
+	return convertedPolicyExceptions, payloadsText, discardedSuppressions
 }

--- a/cli/cmd/suppressions_gcp.go
+++ b/cli/cmd/suppressions_gcp.go
@@ -280,14 +280,14 @@ func convertGcpSuppressions(
 				suppressionInfo = updateDiscardedSupConditionsComments(suppressionInfo,
 					fmt.Sprintf("Legacy suppression discarded as the new policy: %s does not"+
 						" support exception conditions", mappedPolicyId))
-			}
 
-			// if the list of supported constraints is empty for a policy,
-			// we should let the customers know that we have discarded this suppression
-			discardedSuppressions = append(
-				discardedSuppressions,
-				map[string]api.SuppressionV2{id: suppressionInfo},
-			)
+				// if the list of supported constraints is empty for a policy,
+				// we should let the customers know that we have discarded this suppression
+				discardedSuppressions = append(
+					discardedSuppressions,
+					map[string]api.SuppressionV2{id: suppressionInfo},
+				)
+			}
 			continue
 		}
 		if len(suppressionInfo.SuppressionConditions) >= 1 {

--- a/cli/cmd/suppressions_gcp_test.go
+++ b/cli/cmd/suppressions_gcp_test.go
@@ -1,0 +1,1384 @@
+//
+// Author:: Ross Moles (<ross.moles@lacework.net>)
+// Copyright:: Copyright 2022, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cmd
+
+import (
+	"fmt"
+	"net/http"
+	"sort"
+	"testing"
+
+	"github.com/lacework/go-sdk/api"
+	"github.com/lacework/go-sdk/internal/lacework"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConvertGcpSuppressions(t *testing.T) {
+	var (
+		fakeServer = lacework.MockServer()
+	)
+
+	fakeServer.UseApiV2()
+	fakeServer.MockToken("TOKEN")
+	fakeServer.MockAPI("suppressions/gcp/allExceptions",
+		func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "GET", r.Method, "GcpList() should be a GET method")
+			Suppressions := rawGcpSuppressions()
+			fmt.Fprintf(w, Suppressions)
+		},
+	)
+	defer fakeServer.Close()
+
+	c, err := api.NewClient("test",
+		api.WithApiV2(),
+		api.WithToken("TOKEN"),
+		api.WithURL(fakeServer.URL()),
+	)
+	assert.Nil(t, err)
+
+	response, err := c.V2.Suppressions.Gcp.List()
+	assert.Nil(t, err)
+	assert.NotNil(t, response)
+	var recsWithSuppressions []string
+	suppCondCount := 0
+	for key, sup := range response {
+		if len(sup.SuppressionConditions) >= 1 {
+			recsWithSuppressions = append(recsWithSuppressions, key)
+			suppCondCount += len(sup.SuppressionConditions)
+		}
+	}
+	assert.Equal(t, 5, len(recsWithSuppressions))
+	expectedRecsWithSup := []string{"GCP_CIS12_1_8", "GCP_CIS12_4_5", "GCP_CIS12_6_2_5",
+		"GCP_CIS12_6_3_3", "GCP_CIS12_6_3_6"}
+	sort.Strings(expectedRecsWithSup)
+	sort.Strings(recsWithSuppressions)
+	assert.Equal(t, expectedRecsWithSup, recsWithSuppressions)
+
+	convertedPolicyExceptions, payloadsText, discardedSuppressions := convertGcpSuppressions(
+		response, genGcpPoliciesExceptionConstraintsMap())
+	assert.Equal(t, 1, len(discardedSuppressions))
+	assert.Equal(t, suppCondCount, len(payloadsText))
+	var actualConvertedPolicyIds []string
+	expectedConvertedPolicyIds := []string{"lacework-global-290", "lacework-global-268",
+		"lacework-global-287"}
+
+	for _, entry := range convertedPolicyExceptions {
+		for key, _ := range entry {
+			actualConvertedPolicyIds = append(actualConvertedPolicyIds, key)
+		}
+	}
+	sort.Strings(actualConvertedPolicyIds)
+	sort.Strings(expectedConvertedPolicyIds)
+	assert.Equal(t, expectedConvertedPolicyIds, actualConvertedPolicyIds)
+}
+
+func TestConvertGcpSupCondition(t *testing.T) {
+	gcpPoliciesExceptionConstraintsMap := genGcpPoliciesExceptionConstraintsMap()
+	resourceNamesConstraint1 := convertSupCondition([]string{"foobar",
+		"buzz"},
+		"resourceName",
+		gcpPoliciesExceptionConstraintsMap["lacework-global-234"])
+	expectedResourceNamesConstraint1 := api.PolicyExceptionConstraint{
+		FieldKey:    "resourceName",
+		FieldValues: []any{"*/foobar", "*/buzz"},
+	}
+
+	resourceNamesConstraint2 := convertSupCondition([]string{"*"},
+		"resourceName",
+		gcpPoliciesExceptionConstraintsMap["lacework-global-234"])
+	expectedResourceNamesConstraint2 := api.PolicyExceptionConstraint{
+		FieldKey:    "resourceName",
+		FieldValues: []any{"*"},
+	}
+
+	projectConstraint1 := convertSupCondition([]string{"ALL_PROJECTS"},
+		"projects",
+		gcpPoliciesExceptionConstraintsMap["lacework-global-234"])
+	expectedProjectsConstraint1 := api.PolicyExceptionConstraint{
+		FieldKey:    "projects",
+		FieldValues: []any{"*"},
+	}
+
+	projectConstraint2 := convertSupCondition([]string{"foobar"},
+		"projects",
+		gcpPoliciesExceptionConstraintsMap["lacework-global-234"])
+	expectedProjectsConstraint2 := api.PolicyExceptionConstraint{
+		FieldKey:    "projects",
+		FieldValues: []any{"foobar"},
+	}
+
+	organizationConstraint1 := convertSupCondition([]string{"ALL_ORGANIZATIONS"},
+		"organizations",
+		gcpPoliciesExceptionConstraintsMap["lacework-global-234"])
+	expectedOrganizationConstraint1 := api.PolicyExceptionConstraint{
+		FieldKey:    "organizations",
+		FieldValues: []any{"*"},
+	}
+
+	organizationConstraint2 := convertSupCondition([]string{"foobar"},
+		"organizations",
+		gcpPoliciesExceptionConstraintsMap["lacework-global-234"])
+	expectedOrganizationConstraint2 := api.PolicyExceptionConstraint{
+		FieldKey:    "organizations",
+		FieldValues: []any{"foobar"},
+	}
+
+	assert.Equal(t, expectedResourceNamesConstraint1, resourceNamesConstraint1)
+	assert.Equal(t, expectedResourceNamesConstraint2, resourceNamesConstraint2)
+	assert.Equal(t, expectedProjectsConstraint1, projectConstraint1)
+	assert.Equal(t, expectedProjectsConstraint2, projectConstraint2)
+	assert.Equal(t, expectedOrganizationConstraint1, organizationConstraint1)
+	assert.Equal(t, expectedOrganizationConstraint2, organizationConstraint2)
+}
+
+func rawGcpSuppressions() string {
+	return `{
+	"data": [{
+		"recommendationExceptions": {
+			"GCP_CIS12_1_1": {
+				"enabled": true,
+				"suppressionConditions": null
+			},
+			"GCP_CIS12_1_10": {
+				"enabled": true,
+				"suppressionConditions": null
+			},
+			"GCP_CIS12_1_11": {
+				"enabled": true,
+				"suppressionConditions": null
+			},
+			"GCP_CIS12_1_12": {
+				"enabled": true,
+				"suppressionConditions": null
+			},
+			"GCP_CIS12_1_13": {
+				"enabled": true,
+				"suppressionConditions": null
+			},
+			"GCP_CIS12_1_14": {
+				"enabled": true,
+				"suppressionConditions": null
+			},
+			"GCP_CIS12_1_15": {
+				"enabled": true,
+				"suppressionConditions": null
+			},
+			"GCP_CIS12_1_2": {
+				"enabled": true,
+				"suppressionConditions": null
+			},
+			"GCP_CIS12_1_3": {
+				"enabled": true,
+				"suppressionConditions": null
+			},
+			"GCP_CIS12_1_4": {
+				"enabled": true,
+				"suppressionConditions": null
+			},
+			"GCP_CIS12_1_5": {
+				"enabled": true,
+				"suppressionConditions": null
+			},
+			"GCP_CIS12_1_6": {
+				"enabled": true,
+				"suppressionConditions": null
+			},
+			"GCP_CIS12_1_7": {
+				"enabled": true,
+				"suppressionConditions": null
+			},
+			"GCP_CIS12_1_8": {
+				"enabled": true,
+				"suppressionConditions": [{
+					"organizationIds": [
+						"ALL_ORGANIZATIONS"
+					],
+					"projectIds": [
+						"ALL_PROJECTS"
+					],
+					"resourceNames": [
+						"test"
+					]
+				}]
+			},
+			"GCP_CIS12_1_9": {
+				"enabled": true,
+				"suppressionConditions": null
+			},
+			"GCP_CIS12_2_1": {
+				"enabled": true,
+				"suppressionConditions": null
+			},
+			"GCP_CIS12_2_10": {
+				"enabled": true,
+				"suppressionConditions": null
+			},
+			"GCP_CIS12_2_11": {
+				"enabled": true,
+				"suppressionConditions": null
+			},
+			"GCP_CIS12_2_12": {
+				"enabled": true,
+				"suppressionConditions": null
+			},
+			"GCP_CIS12_2_2": {
+				"enabled": true,
+				"suppressionConditions": null
+			},
+			"GCP_CIS12_2_3": {
+				"enabled": true,
+				"suppressionConditions": null
+			},
+			"GCP_CIS12_2_4": {
+				"enabled": true,
+				"suppressionConditions": null
+			},
+			"GCP_CIS12_2_5": {
+				"enabled": true,
+				"suppressionConditions": null
+			},
+			"GCP_CIS12_2_6": {
+				"enabled": true,
+				"suppressionConditions": null
+			},
+			"GCP_CIS12_2_7": {
+				"enabled": true,
+				"suppressionConditions": null
+			},
+			"GCP_CIS12_2_8": {
+				"enabled": true,
+				"suppressionConditions": null
+			},
+			"GCP_CIS12_2_9": {
+				"enabled": true,
+				"suppressionConditions": null
+			},
+			"GCP_CIS12_3_1": {
+				"enabled": true,
+				"suppressionConditions": null
+			},
+			"GCP_CIS12_3_10": {
+				"enabled": false,
+				"suppressionConditions": null
+			},
+			"GCP_CIS12_3_3": {
+				"enabled": true,
+				"suppressionConditions": null
+			},
+			"GCP_CIS12_3_4": {
+				"enabled": true,
+				"suppressionConditions": null
+			},
+			"GCP_CIS12_3_5": {
+				"enabled": true,
+				"suppressionConditions": null
+			},
+			"GCP_CIS12_3_6": {
+				"enabled": true,
+				"suppressionConditions": null
+			},
+			"GCP_CIS12_3_7": {
+				"enabled": true,
+				"suppressionConditions": null
+			},
+			"GCP_CIS12_3_8": {
+				"enabled": true,
+				"suppressionConditions": []
+			},
+			"GCP_CIS12_3_9": {
+				"enabled": true,
+				"suppressionConditions": null
+			},
+			"GCP_CIS12_4_1": {
+				"enabled": true,
+				"suppressionConditions": null
+			},
+			"GCP_CIS12_4_10": {
+				"enabled": true,
+				"suppressionConditions": null
+			},
+			"GCP_CIS12_4_11": {
+				"enabled": true,
+				"suppressionConditions": null
+			},
+			"GCP_CIS12_4_2": {
+				"enabled": true,
+				"suppressionConditions": null
+			},
+			"GCP_CIS12_4_3": {
+				"enabled": true,
+				"suppressionConditions": null
+			},
+			"GCP_CIS12_4_4": {
+				"enabled": true,
+				"suppressionConditions": null
+			},
+			"GCP_CIS12_4_5": {
+				"enabled": true,
+				"suppressionConditions": [{
+					"organizationIds": [
+						"ALL_ORGANIZATIONS"
+					],
+					"projectIds": [
+						"ALL_PROJECTS"
+					],
+					"resourceNames": [
+						"*"
+					]
+				}]
+			},
+			"GCP_CIS12_4_6": {
+				"enabled": true,
+				"suppressionConditions": null
+			},
+			"GCP_CIS12_4_7": {
+				"enabled": true,
+				"suppressionConditions": null
+			},
+			"GCP_CIS12_4_8": {
+				"enabled": true,
+				"suppressionConditions": null
+			},
+			"GCP_CIS12_4_9": {
+				"enabled": true,
+				"suppressionConditions": null
+			},
+			"GCP_CIS12_5_1": {
+				"enabled": true,
+				"suppressionConditions": null
+			},
+			"GCP_CIS12_5_2": {
+				"enabled": true,
+				"suppressionConditions": null
+			},
+			"GCP_CIS12_6_1_1": {
+				"enabled": true,
+				"suppressionConditions": null
+			},
+			"GCP_CIS12_6_1_2": {
+				"enabled": true,
+				"suppressionConditions": null
+			},
+			"GCP_CIS12_6_1_3": {
+				"enabled": true,
+				"suppressionConditions": null
+			},
+			"GCP_CIS12_6_2_1": {
+				"enabled": true,
+				"suppressionConditions": null
+			},
+			"GCP_CIS12_6_2_10": {
+				"enabled": true,
+				"suppressionConditions": null
+			},
+			"GCP_CIS12_6_2_11": {
+				"enabled": true,
+				"suppressionConditions": null
+			},
+			"GCP_CIS12_6_2_12": {
+				"enabled": true,
+				"suppressionConditions": null
+			},
+			"GCP_CIS12_6_2_13": {
+				"enabled": true,
+				"suppressionConditions": null
+			},
+			"GCP_CIS12_6_2_14": {
+				"enabled": true,
+				"suppressionConditions": null
+			},
+			"GCP_CIS12_6_2_15": {
+				"enabled": true,
+				"suppressionConditions": null
+			},
+			"GCP_CIS12_6_2_16": {
+				"enabled": true,
+				"suppressionConditions": null
+			},
+			"GCP_CIS12_6_2_2": {
+				"enabled": true,
+				"suppressionConditions": null
+			},
+			"GCP_CIS12_6_2_3": {
+				"enabled": true,
+				"suppressionConditions": null
+			},
+			"GCP_CIS12_6_2_4": {
+				"enabled": true,
+				"suppressionConditions": null
+			},
+			"GCP_CIS12_6_2_5": {
+				"enabled": true,
+				"suppressionConditions": [{
+					"organizationIds": [
+						"ALL_ORGANIZATIONS"
+					],
+					"projectIds": [
+						"ALL_PROJECTS"
+					],
+					"resourceNames": [
+						"*"
+					]
+				}]
+			},
+			"GCP_CIS12_6_2_6": {
+				"enabled": true,
+				"suppressionConditions": null
+			},
+			"GCP_CIS12_6_2_7": {
+				"enabled": true,
+				"suppressionConditions": null
+			},
+			"GCP_CIS12_6_2_8": {
+				"enabled": true,
+				"suppressionConditions": null
+			},
+			"GCP_CIS12_6_2_9": {
+				"enabled": true,
+				"suppressionConditions": null
+			},
+			"GCP_CIS12_6_3_1": {
+				"enabled": true,
+				"suppressionConditions": null
+			},
+			"GCP_CIS12_6_3_2": {
+				"enabled": true,
+				"suppressionConditions": null
+			},
+			"GCP_CIS12_6_3_3": {
+				"enabled": true,
+				"suppressionConditions": [{
+					"organizationIds": [
+						"ALL_ORGANIZATIONS"
+					],
+					"projectIds": [
+						"ALL_PROJECTS"
+					],
+					"resourceNames": [
+						"*"
+					]
+				}]
+			},
+			"GCP_CIS12_6_3_4": {
+				"enabled": false,
+				"suppressionConditions": null
+			},
+			"GCP_CIS12_6_3_5": {
+				"enabled": true,
+				"suppressionConditions": null
+			},
+			"GCP_CIS12_6_3_6": {
+				"enabled": true,
+				"suppressionConditions": [{
+					"organizationIds": [
+						"ALL_ORGANIZATIONS"
+					],
+					"projectIds": [
+						"ALL_PROJECTS"
+					],
+					"resourceLabels": [{
+						"key": "key",
+						"value": "value"
+					}],
+					"resourceNames": [
+						"*"
+					]
+				}]
+			},
+			"GCP_CIS12_6_3_7": {
+				"enabled": true,
+				"suppressionConditions": null
+			},
+			"GCP_CIS12_6_4": {
+				"enabled": true,
+				"suppressionConditions": null
+			},
+			"GCP_CIS12_6_5": {
+				"enabled": true,
+				"suppressionConditions": null
+			},
+			"GCP_CIS12_6_6": {
+				"enabled": true,
+				"suppressionConditions": null
+			},
+			"GCP_CIS12_6_7": {
+				"enabled": true,
+				"suppressionConditions": null
+			},
+			"GCP_CIS12_7_1": {
+				"enabled": true,
+				"suppressionConditions": null
+			},
+			"GCP_CIS12_7_2": {
+				"enabled": true,
+				"suppressionConditions": null
+			},
+			"GCP_CIS12_7_3": {
+				"enabled": true,
+				"suppressionConditions": null
+			},
+			"GCP_K8S_1_1": {
+				"enabled": true,
+				"suppressionConditions": null
+			},
+			"GCP_K8S_1_10": {
+				"enabled": true,
+				"suppressionConditions": null
+			},
+			"GCP_K8S_1_11": {
+				"enabled": true,
+				"suppressionConditions": null
+			},
+			"GCP_K8S_1_12": {
+				"enabled": true,
+				"suppressionConditions": null
+			},
+			"GCP_K8S_1_13": {
+				"enabled": true,
+				"suppressionConditions": null
+			},
+			"GCP_K8S_1_14": {
+				"enabled": true,
+				"suppressionConditions": null
+			},
+			"GCP_K8S_1_15": {
+				"enabled": true,
+				"suppressionConditions": null
+			},
+			"GCP_K8S_1_16": {
+				"enabled": true,
+				"suppressionConditions": null
+			},
+			"GCP_K8S_1_17": {
+				"enabled": true,
+				"suppressionConditions": null
+			},
+			"GCP_K8S_1_18": {
+				"enabled": true,
+				"suppressionConditions": null
+			},
+			"GCP_K8S_1_2": {
+				"enabled": true,
+				"suppressionConditions": null
+			},
+			"GCP_K8S_1_3": {
+				"enabled": true,
+				"suppressionConditions": null
+			},
+			"GCP_K8S_1_4": {
+				"enabled": true,
+				"suppressionConditions": null
+			},
+			"GCP_K8S_1_5": {
+				"enabled": true,
+				"suppressionConditions": null
+			},
+			"GCP_K8S_1_6": {
+				"enabled": true,
+				"suppressionConditions": null
+			},
+			"GCP_K8S_1_7": {
+				"enabled": true,
+				"suppressionConditions": null
+			},
+			"GCP_K8S_1_8": {
+				"enabled": true,
+				"suppressionConditions": null
+			},
+			"GCP_K8S_1_9": {
+				"enabled": true,
+				"suppressionConditions": null
+			}
+		}
+	}],
+	"message": "SUCCESS",
+	"ok": true
+}`
+}
+
+func genGcpPoliciesExceptionConstraintsMap() map[string][]string {
+	return map[string][]string{
+		"lacework-global-234": {
+			"organizations",
+			"projects",
+			"resourceName",
+		},
+		"lacework-global-235": {
+			"organizations",
+			"projects",
+			"resourceName",
+		},
+		"lacework-global-236": nil,
+		"lacework-global-237": {
+			"organizations",
+			"projects",
+			"resourceName",
+		},
+		"lacework-global-238": {
+			"organizations",
+			"projects",
+			"resourceName",
+		},
+		"lacework-global-239": {
+			"organizations",
+			"projects",
+			"resourceName",
+		},
+		"lacework-global-24": nil,
+		"lacework-global-240": {
+			"organizations",
+			"projects",
+			"resourceName",
+		},
+		"lacework-global-241": {
+			"organizations",
+			"projects",
+			"resourceName",
+		},
+		"lacework-global-242": {
+			"organizations",
+			"projects",
+			"resourceName",
+		},
+		"lacework-global-243": nil,
+		"lacework-global-244": nil,
+		"lacework-global-245": {
+			"organizations",
+			"projects",
+			"resourceLabel",
+			"resourceName",
+		},
+		"lacework-global-246": {
+			"organizations",
+			"projects",
+			"resourceLabel",
+			"resourceName",
+		},
+		"lacework-global-247": {
+			"organizations",
+			"projects",
+			"resourceLabel",
+			"resourceName",
+		},
+		"lacework-global-248": {
+			"organizations",
+			"projects",
+			"resourceLabel",
+			"resourceName",
+		},
+		"lacework-global-249": {
+			"organizations",
+			"projects",
+			"resourceLabel",
+			"resourceName",
+		},
+		"lacework-global-25": nil,
+		"lacework-global-250": {
+			"organizations",
+			"projects",
+			"resourceLabel",
+			"resourceName",
+		},
+		"lacework-global-251": {
+			"organizations",
+			"projects",
+			"resourceLabel",
+			"resourceName",
+		},
+		"lacework-global-252": {
+			"organizations",
+			"projects",
+			"resourceLabel",
+			"resourceName",
+		},
+		"lacework-global-253": {
+			"organizations",
+			"projects",
+			"resourceLabel",
+			"resourceName",
+		},
+		"lacework-global-254": {
+			"organizations",
+			"projects",
+			"resourceLabel",
+			"resourceName",
+		},
+		"lacework-global-255": {
+			"organizations",
+			"projects",
+			"resourceName",
+		},
+		"lacework-global-256": {
+			"organizations",
+			"projects",
+			"resourceLabel",
+			"resourceName",
+		},
+		"lacework-global-257": nil,
+		"lacework-global-258": {
+			"organizations",
+			"projects",
+			"resourceLabel",
+			"resourceName",
+		},
+		"lacework-global-259": {
+			"organizations",
+			"projects",
+			"resourceName",
+		},
+		"lacework-global-26": nil,
+		"lacework-global-260": {
+			"organizations",
+			"projects",
+			"resourceName",
+		},
+		"lacework-global-261": {
+			"organizations",
+			"projects",
+			"resourceName",
+		},
+		"lacework-global-262": {
+			"organizations",
+			"projects",
+			"resourceName",
+		},
+		"lacework-global-263": {
+			"organizations",
+			"projects",
+			"resourceName",
+		},
+		"lacework-global-264": {
+			"organizations",
+			"projects",
+			"resourceLabel",
+			"resourceName",
+		},
+		"lacework-global-265": {
+			"organizations",
+			"projects",
+			"resourceLabel",
+			"resourceName",
+		},
+		"lacework-global-266": {
+			"organizations",
+			"projects",
+			"resourceLabel",
+			"resourceName",
+		},
+		"lacework-global-267": {
+			"organizations",
+			"projects",
+			"resourceLabel",
+			"resourceName",
+		},
+		"lacework-global-268": {
+			"organizations",
+			"projects",
+			"resourceLabel",
+			"resourceName",
+		},
+		"lacework-global-269": {
+			"organizations",
+			"projects",
+			"resourceLabel",
+			"resourceName",
+		},
+		"lacework-global-27": nil,
+		"lacework-global-270": {
+			"organizations",
+			"projects",
+			"resourceLabel",
+			"resourceName",
+		},
+		"lacework-global-271": {
+			"organizations",
+			"projects",
+			"resourceLabel",
+			"resourceName",
+		},
+		"lacework-global-272": {
+			"organizations",
+			"projects",
+			"resourceLabel",
+			"resourceName",
+		},
+		"lacework-global-273": {
+			"organizations",
+			"projects",
+			"resourceLabel",
+			"resourceName",
+		},
+		"lacework-global-274": nil,
+		"lacework-global-275": {
+			"organizations",
+			"projects",
+			"resourceLabel",
+			"resourceName",
+		},
+		"lacework-global-276": {
+			"organizations",
+			"projects",
+			"resourceLabel",
+			"resourceName",
+		},
+		"lacework-global-277": {
+			"organizations",
+			"projects",
+			"resourceLabel",
+			"resourceName",
+		},
+		"lacework-global-278": {
+			"organizations",
+			"projects",
+			"resourceLabel",
+			"resourceName",
+		},
+		"lacework-global-279": {
+			"organizations",
+			"projects",
+			"resourceLabel",
+			"resourceName",
+		},
+		"lacework-global-28": nil,
+		"lacework-global-280": {
+			"organizations",
+			"projects",
+			"resourceLabel",
+			"resourceName",
+		},
+		"lacework-global-281": {
+			"organizations",
+			"projects",
+			"resourceLabel",
+			"resourceName",
+		},
+		"lacework-global-282": {
+			"organizations",
+			"projects",
+			"resourceLabel",
+			"resourceName",
+		},
+		"lacework-global-283": {
+			"organizations",
+			"projects",
+			"resourceLabel",
+			"resourceName",
+		},
+		"lacework-global-284": {
+			"organizations",
+			"projects",
+			"resourceLabel",
+			"resourceName",
+		},
+		"lacework-global-285": {
+			"organizations",
+			"projects",
+			"resourceLabel",
+			"resourceName",
+		},
+		"lacework-global-286": {
+			"organizations",
+			"projects",
+			"resourceLabel",
+			"resourceName",
+		},
+		"lacework-global-287": {
+			"organizations",
+			"projects",
+			"resourceLabel",
+			"resourceName",
+		},
+		"lacework-global-288": {
+			"organizations",
+			"projects",
+			"resourceLabel",
+			"resourceName",
+		},
+		"lacework-global-289": {
+			"organizations",
+			"projects",
+			"resourceLabel",
+			"resourceName",
+		},
+		"lacework-global-29": nil,
+		"lacework-global-290": {
+			"organizations",
+			"projects",
+			"resourceLabel",
+			"resourceName",
+		},
+		"lacework-global-291": {
+			"organizations",
+			"projects",
+			"resourceLabel",
+			"resourceName",
+		},
+		"lacework-global-292": {
+			"organizations",
+			"projects",
+			"resourceName",
+		},
+		"lacework-global-293": nil,
+		"lacework-global-294": nil,
+		"lacework-global-295": nil,
+		"lacework-global-296": {
+			"organizations",
+			"projects",
+			"resourceName",
+		},
+		"lacework-global-297": {
+			"organizations",
+			"projects",
+			"resourceName",
+		},
+		"lacework-global-298": {
+			"organizations",
+			"projects",
+			"resourceLabel",
+			"resourceName",
+		},
+		"lacework-global-299": nil,
+		"lacework-global-3":   nil,
+		"lacework-global-30":  nil,
+		"lacework-global-300": {
+			"organizations",
+			"projects",
+			"resourceLabel",
+			"resourceName",
+		},
+		"lacework-global-301": {
+			"organizations",
+			"projects",
+			"resourceName",
+		},
+		"lacework-global-302": {
+			"organizations",
+			"projects",
+			"resourceName",
+		},
+		"lacework-global-303": nil,
+		"lacework-global-304": {
+			"organizations",
+			"projects",
+			"resourceLabel",
+			"resourceName",
+		},
+		"lacework-global-305": {
+			"organizations",
+			"projects",
+			"resourceLabel",
+			"resourceName",
+		},
+		"lacework-global-306": {
+			"organizations",
+			"projects",
+			"resourceLabel",
+			"resourceName",
+		},
+		"lacework-global-307": nil,
+		"lacework-global-308": {
+			"organizations",
+			"projects",
+			"resourceLabel",
+			"resourceName",
+		},
+		"lacework-global-309": nil,
+		"lacework-global-31":  nil,
+		"lacework-global-310": {
+			"organizations",
+			"projects",
+			"resourceLabel",
+			"resourceName",
+		},
+		"lacework-global-311": {
+			"organizations",
+			"projects",
+			"resourceLabel",
+			"resourceName",
+		},
+		"lacework-global-312": {
+			"organizations",
+			"projects",
+			"resourceLabel",
+			"resourceName",
+		},
+		"lacework-global-313": {
+			"organizations",
+			"projects",
+			"resourceName",
+		},
+		"lacework-global-314": {
+			"organizations",
+			"projects",
+			"resourceName",
+		},
+		"lacework-global-32": nil,
+		"lacework-global-33": nil,
+		"lacework-global-34": {
+			"accountIds",
+		},
+		"lacework-global-35": {
+			"accountIds",
+		},
+		"lacework-global-36": {
+			"accountIds",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-37": {
+			"accountIds",
+		},
+		"lacework-global-38": {
+			"accountIds",
+		},
+		"lacework-global-39": {
+			"accountIds",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-4": nil,
+		"lacework-global-40": {
+			"accountIds",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-41": {
+			"accountIds",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-42": {
+			"accountIds",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-43": {
+			"accountIds",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-44": {
+			"accountIds",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-45": {
+			"accountIds",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-46": {
+			"accountIds",
+		},
+		"lacework-global-47": {
+			"accountIds",
+		},
+		"lacework-global-48": {
+			"accountIds",
+			"regionNames",
+		},
+		"lacework-global-482": {
+			"accountIds",
+			"regionNames",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-483": {
+			"accountIds",
+			"regionNames",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-484": nil,
+		"lacework-global-485": {
+			"accountIds",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-486": {
+			"accountIds",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-487": {
+			"organizations",
+			"projects",
+			"resourceLabel",
+			"resourceName",
+		},
+		"lacework-global-488": {
+			"organizations",
+			"projects",
+			"resourceLabel",
+			"resourceName",
+		},
+		"lacework-global-489": {
+			"organizations",
+			"projects",
+			"resourceLabel",
+			"resourceName",
+		},
+		"lacework-global-49": {
+			"accountIds",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-490": {
+			"organizations",
+			"projects",
+			"resourceName",
+		},
+		"lacework-global-491": nil,
+		"lacework-global-492": nil,
+		"lacework-global-493": nil,
+		"lacework-global-494": nil,
+		"lacework-global-495": nil,
+		"lacework-global-496": nil,
+		"lacework-global-497": {
+			"accountIds",
+		},
+		"lacework-global-498": {
+			"organizations",
+			"projects",
+			"resourceLabel",
+			"resourceName",
+		},
+		"lacework-global-5": nil,
+		"lacework-global-50": {
+			"accountIds",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-51": {
+			"accountIds",
+			"regionNames",
+			"resourceTags",
+		},
+		"lacework-global-52": {
+			"accountIds",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-53": {
+			"accountIds",
+		},
+		"lacework-global-54": {
+			"accountIds",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-55": {
+			"accountIds",
+			"regionNames",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-56": {
+			"accountIds",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-57": {
+			"accountIds",
+		},
+		"lacework-global-58": {
+			"accountIds",
+		},
+		"lacework-global-59": {
+			"accountIds",
+		},
+		"lacework-global-6": nil,
+		"lacework-global-60": {
+			"accountIds",
+		},
+		"lacework-global-61": {
+			"accountIds",
+		},
+		"lacework-global-62": {
+			"accountIds",
+		},
+		"lacework-global-63": {
+			"accountIds",
+		},
+		"lacework-global-64": {
+			"accountIds",
+		},
+		"lacework-global-646": nil,
+		"lacework-global-647": nil,
+		"lacework-global-65": {
+			"accountIds",
+		},
+		"lacework-global-656": nil,
+		"lacework-global-657": nil,
+		"lacework-global-658": nil,
+		"lacework-global-659": nil,
+		"lacework-global-66": {
+			"accountIds",
+		},
+		"lacework-global-660": nil,
+		"lacework-global-67": {
+			"accountIds",
+			"regionNames",
+			"resourceNames",
+		},
+		"lacework-global-68": {
+			"accountIds",
+			"regionNames",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-69": {
+			"accountIds",
+		},
+		"lacework-global-7":  nil,
+		"lacework-global-70": nil,
+		"lacework-global-71": nil,
+		"lacework-global-72": {
+			"accountIds",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-73": {
+			"accountIds",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-74": nil,
+		"lacework-global-75": {
+			"accountIds",
+			"regionNames",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-76": {
+			"accountIds",
+			"regionNames",
+		},
+		"lacework-global-77": {
+			"accountIds",
+			"regionNames",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-78": {
+			"accountIds",
+			"regionNames",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-79": {
+			"accountIds",
+			"regionNames",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-8": nil,
+		"lacework-global-80": {
+			"accountIds",
+			"regionNames",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-81": {
+			"accountIds",
+			"regionNames",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-82": {
+			"accountIds",
+		},
+		"lacework-global-83": {
+			"accountIds",
+		},
+		"lacework-global-84": {
+			"accountIds",
+		},
+		"lacework-global-85": {
+			"accountIds",
+		},
+		"lacework-global-86": {
+			"accountIds",
+		},
+		"lacework-global-87": {
+			"accountIds",
+			"regionNames",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-88": nil,
+		"lacework-global-89": {
+			"accountIds",
+			"regionNames",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-9": nil,
+		"lacework-global-90": {
+			"accountIds",
+			"regionNames",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-91": {
+			"accountIds",
+			"regionNames",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-92": {
+			"accountIds",
+		},
+		"lacework-global-93": {
+			"accountIds",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-94": {
+			"accountIds",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-95": {
+			"accountIds",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-96": {
+			"accountIds",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-97": {
+			"accountIds",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-98": {
+			"accountIds",
+			"resourceNames",
+			"resourceTags",
+		},
+		"lacework-global-99": {
+			"accountIds",
+			"resourceNames",
+			"resourceTags",
+		},
+	}
+}

--- a/cli/cmd/suppressions_gcp_test.go
+++ b/cli/cmd/suppressions_gcp_test.go
@@ -56,11 +56,9 @@ func TestConvertGcpSuppressions(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, response)
 	var recsWithSuppressions []string
-	suppCondCount := 0
 	for key, sup := range response {
 		if len(sup.SuppressionConditions) >= 1 {
 			recsWithSuppressions = append(recsWithSuppressions, key)
-			suppCondCount += len(sup.SuppressionConditions)
 		}
 	}
 	assert.Equal(t, 5, len(recsWithSuppressions))
@@ -72,8 +70,8 @@ func TestConvertGcpSuppressions(t *testing.T) {
 
 	convertedPolicyExceptions, payloadsText, discardedSuppressions := convertGcpSuppressions(
 		response, genGcpPoliciesExceptionConstraintsMap())
-	assert.Equal(t, 1, len(discardedSuppressions))
-	assert.Equal(t, suppCondCount, len(payloadsText))
+	assert.Equal(t, 2, len(discardedSuppressions))
+	assert.Equal(t, 3, len(payloadsText))
 	var actualConvertedPolicyIds []string
 	expectedConvertedPolicyIds := []string{"lacework-global-290", "lacework-global-268",
 		"lacework-global-287"}

--- a/vendor/github.com/aws/aws-sdk-go-v2/aws/arn/arn.go
+++ b/vendor/github.com/aws/aws-sdk-go-v2/aws/arn/arn.go
@@ -1,0 +1,92 @@
+// Package arn provides a parser for interacting with Amazon Resource Names.
+package arn
+
+import (
+	"errors"
+	"strings"
+)
+
+const (
+	arnDelimiter = ":"
+	arnSections  = 6
+	arnPrefix    = "arn:"
+
+	// zero-indexed
+	sectionPartition = 1
+	sectionService   = 2
+	sectionRegion    = 3
+	sectionAccountID = 4
+	sectionResource  = 5
+
+	// errors
+	invalidPrefix   = "arn: invalid prefix"
+	invalidSections = "arn: not enough sections"
+)
+
+// ARN captures the individual fields of an Amazon Resource Name.
+// See http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html for more information.
+type ARN struct {
+	// The partition that the resource is in. For standard AWS regions, the partition is "aws". If you have resources in
+	// other partitions, the partition is "aws-partitionname". For example, the partition for resources in the China
+	// (Beijing) region is "aws-cn".
+	Partition string
+
+	// The service namespace that identifies the AWS product (for example, Amazon S3, IAM, or Amazon RDS). For a list of
+	// namespaces, see
+	// http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#genref-aws-service-namespaces.
+	Service string
+
+	// The region the resource resides in. Note that the ARNs for some resources do not require a region, so this
+	// component might be omitted.
+	Region string
+
+	// The ID of the AWS account that owns the resource, without the hyphens. For example, 123456789012. Note that the
+	// ARNs for some resources don't require an account number, so this component might be omitted.
+	AccountID string
+
+	// The content of this part of the ARN varies by service. It often includes an indicator of the type of resource —
+	// for example, an IAM user or Amazon RDS database - followed by a slash (/) or a colon (:), followed by the
+	// resource name itself. Some services allows paths for resource names, as described in
+	// http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#arns-paths.
+	Resource string
+}
+
+// Parse parses an ARN into its constituent parts.
+//
+// Some example ARNs:
+// arn:aws:elasticbeanstalk:us-east-1:123456789012:environment/My App/MyEnvironment
+// arn:aws:iam::123456789012:user/David
+// arn:aws:rds:eu-west-1:123456789012:db:mysql-db
+// arn:aws:s3:::my_corporate_bucket/exampleobject.png
+func Parse(arn string) (ARN, error) {
+	if !strings.HasPrefix(arn, arnPrefix) {
+		return ARN{}, errors.New(invalidPrefix)
+	}
+	sections := strings.SplitN(arn, arnDelimiter, arnSections)
+	if len(sections) != arnSections {
+		return ARN{}, errors.New(invalidSections)
+	}
+	return ARN{
+		Partition: sections[sectionPartition],
+		Service:   sections[sectionService],
+		Region:    sections[sectionRegion],
+		AccountID: sections[sectionAccountID],
+		Resource:  sections[sectionResource],
+	}, nil
+}
+
+// IsARN returns whether the given string is an arn
+// by looking for whether the string starts with arn:
+func IsARN(arn string) bool {
+	return strings.HasPrefix(arn, arnPrefix) && strings.Count(arn, ":") >= arnSections-1
+}
+
+// String returns the canonical representation of the ARN
+func (arn ARN) String() string {
+	return arnPrefix +
+		arn.Partition + arnDelimiter +
+		arn.Service + arnDelimiter +
+		arn.Region + arnDelimiter +
+		arn.AccountID + arnDelimiter +
+		arn.Resource
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -54,6 +54,7 @@ github.com/apparentlymart/go-textseg/v13/textseg
 ## explicit; go 1.15
 github.com/aws/aws-sdk-go-v2
 github.com/aws/aws-sdk-go-v2/aws
+github.com/aws/aws-sdk-go-v2/aws/arn
 github.com/aws/aws-sdk-go-v2/aws/defaults
 github.com/aws/aws-sdk-go-v2/aws/middleware
 github.com/aws/aws-sdk-go-v2/aws/protocol/ec2query


### PR DESCRIPTION
Signed-off-by: Ross <ross.moles@lacework.net>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/lacework/go-sdk) and create your branch from `main`
  2. Run `make prepare` in the repository root
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`make test`)
  5. Format your code (`make fmt`)
  6. Make sure your code lints (`make lint`)
  7. If you are updating the Lacework CLI, make sure it compiles (`make build-cli-cross-platform`)
  8. Follow the commit message standard (`type(scope): subject`) documented in [DEVELOPER_GUIDELINES.md](https://github.com/lacework/go-sdk/blob/main/DEVELOPER_GUIDELINES.md#commit-message-standard)
  9. If you haven't already, configure signed commits by [telling git about your signing key](https://docs.github.com/en/github/authenticating-to-github/managing-commit-signature-verification/telling-git-about-your-signing-key) and [signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)

  Learn more about contributing: https://github.com/lacework/go-sdk/blob/main/CONTRIBUTING.md
-->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

As part of the legacy compliance deprecation effort, the legacy cfg-analyzers will be decommissioned some time in January 2023. As a result customers will be moved across to the new LPP policies and CIS benchmarks. This is likely to cause a lot of noise for customers as they will have suppressions in place for resources which they expect to be in a non compliant state.
At present there is no easy path for customers to migrate their old suppressions to the new exceptions policies.

We do have a scripted approach created by Marc Garcia: https://github.com/lacework-dev/scripts/tree/main/lw-suppressions-migration

This PR adds the following hidden commands:

```
lacework suppressions migrate gcp
```
suppressions has the following alias' `suppression, sup, sups`
migrate has the following alias `mig`

`lacework suppressions migrate gcp`
Will enable users to migrate their legacy suppressions to new LPP policy Exceptions.
This supports the migration in 2 modes:
 - Manual (recommended): This outputs the converted suppressions as commands that the user can review and run as they wish
 - Automatic: This gives the user the option to allow Lacework to handle the suppressions migration. It will output the converted legacy suppressions in the Exception format and ask the user to confirm they are happy with the Exceptions and accepting liability for any Compliance violations that may be missed as a result of this.

Additionally this PR includes a fix for the `lacework suppressions migrate aws` command. This checks legacy suppressions for ARNs in the resourceNames field and parses out the resource name from the ARN, as ARNs are not supported for policy exceptions.

## How did you test this change?
Tested locally ✅ 

## Issue
https://lacework.atlassian.net/browse/RAIN-46613
https://lacework.atlassian.net/browse/RAIN-47184