### PR TITLE
fix(cli): ec2ssm use runner region, not cfg region

### DIFF
--- a/lwrunner/awsrunner.go
+++ b/lwrunner/awsrunner.go
@@ -134,7 +134,7 @@ func (run AWSRunner) SendPublicKey(pubBytes []byte) error {
 func (run AWSRunner) AssociateInstanceProfileWithRunner(cfg aws.Config, instanceProfile types.InstanceProfile) error {
 	c := ec2.New(ec2.Options{
 		Credentials: cfg.Credentials,
-		Region:      cfg.Region,
+		Region:      run.Region,
 	})
 
 	// Check to see if there are any instance profiles already associated with the runner

--- a/lwrunner/awsrunner.go
+++ b/lwrunner/awsrunner.go
@@ -254,7 +254,7 @@ const SSMInstancePolicy string = "arn:aws:iam::aws:policy/AmazonSSMManagedInstan
 func (run AWSRunner) RunSSMCommandOnRemoteHost(cfg aws.Config, operation string) (ssm.GetCommandInvocationOutput, error) {
 	c := ssm.New(ssm.Options{
 		Credentials: cfg.Credentials,
-		Region:      cfg.Region,
+		Region:      run.Region,
 	})
 
 	sendCommandOutput, err := c.SendCommand(


### PR DESCRIPTION
Calls to the EC2 API currently fail when the region of the runner is
different from the region of the credentials used to authenticate the
request.

This commit modifies the EC2 client that we create during `ec2ssm`
execution to use `run.Region` instead of `cfg.Region`.

Fixes RAIN-47298

Signed-off-by: nschmeller <nick.schmeller@lacework.net>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/lacework/go-sdk) and create your branch from `main`
  2. Run `make prepare` in the repository root
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`make test`)
  5. Format your code (`make fmt`)
  6. Make sure your code lints (`make lint`)
  7. If you are updating the Lacework CLI, make sure it compiles (`make build-cli-cross-platform`)
  8. Follow the commit message standard (`type(scope): subject`) documented in [DEVELOPER_GUIDELINES.md](https://github.com/lacework/go-sdk/blob/main/DEVELOPER_GUIDELINES.md#commit-message-standard)
  9. If you haven't already, configure signed commits by [telling git about your signing key](https://docs.github.com/en/github/authenticating-to-github/managing-commit-signature-verification/telling-git-about-your-signing-key) and [signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)

  Learn more about contributing: https://github.com/lacework/go-sdk/blob/main/CONTRIBUTING.md
-->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->
Found a bug during a customer deployment around this. There was a workaround to use credentials with the same region as the runners, but we should be region agnostic.

## How did you test this change?

<!--
  How exactly did you verify that your PR solves the issue you wanted to solve?
  Include any other relevant information such as how to use the new functionality, screenshots, etc.
-->
Adding an instance in a different region to the `ec2ssm` integration test sandbox infra, PR to come

## Issue

<!--
  Include the link to a Jira/Github issue
-->
https://lacework.atlassian.net/browse/RAIN-47298
