### PR TITLE
style(lint): enable line length check

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,3 +2,11 @@ run:
   deadline: 5m
   tests: false
   modules-download-mode: vendor
+
+linters-settings:
+  lll:
+    line-length: 160
+
+linters:
+  enable:
+    - lll

--- a/api/errors.go
+++ b/api/errors.go
@@ -21,7 +21,7 @@ package api
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 )
 
@@ -78,7 +78,7 @@ func checkErrorInResponse(r *http.Response) error {
 
 	var (
 		errRes    = &errorResponse{Response: r}
-		data, err = ioutil.ReadAll(r.Body)
+		data, err = io.ReadAll(r.Body)
 	)
 	if err == nil && len(data) > 0 {
 		// try to unmarshal the api error response

--- a/api/http.go
+++ b/api/http.go
@@ -22,7 +22,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 
@@ -235,7 +234,7 @@ func (c *Client) httpResponseBodySniffer(r *http.Response) string {
 
 // a very simple body sniffer (use only for debugging purposes)
 func sniffBody(body io.ReadCloser) (io.ReadCloser, string) {
-	bodyBytes, err := ioutil.ReadAll(body)
+	bodyBytes, err := io.ReadAll(body)
 	if err != nil {
 		return nil, ""
 	}
@@ -244,5 +243,5 @@ func sniffBody(body io.ReadCloser) (io.ReadCloser, string) {
 		return nil, ""
 	}
 
-	return ioutil.NopCloser(bytes.NewBuffer(bodyBytes)), string(bodyBytes)
+	return io.NopCloser(bytes.NewBuffer(bodyBytes)), string(bodyBytes)
 }

--- a/api/http_test.go
+++ b/api/http_test.go
@@ -20,7 +20,7 @@ package api_test
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 
@@ -83,11 +83,11 @@ func TestNewRequestWithExpiredToken(t *testing.T) {
 // httpBodySniffer is like a request sniffer, it reads the body
 // from the provided request without closing it
 func httpBodySniffer(r *http.Request) string {
-	bodyBytes, err := ioutil.ReadAll(r.Body)
+	bodyBytes, err := io.ReadAll(r.Body)
 	if err != nil {
 		return ""
 	}
 
-	r.Body = ioutil.NopCloser(bytes.NewBuffer(bodyBytes))
+	r.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
 	return string(bodyBytes)
 }

--- a/api/logging_test.go
+++ b/api/logging_test.go
@@ -19,7 +19,6 @@
 package api_test
 
 import (
-	"io/ioutil"
 	"log"
 	"os"
 	"syscall"
@@ -76,7 +75,7 @@ func TestClientWithLogLevelAndWriter(t *testing.T) {
 	_, err = c.NewRequest("GET", "foo", nil)
 	assert.Nil(t, err)
 
-	logContentB, err := ioutil.ReadFile(tmpfile)
+	logContentB, err := os.ReadFile(tmpfile)
 	assert.Nil(t, err)
 	logContent := string(logContentB)
 
@@ -121,7 +120,7 @@ func TestClientWithLogLevelAndFile(t *testing.T) {
 	fakeServer := lacework.MockServer()
 	defer fakeServer.Close()
 
-	tmpfile, err := ioutil.TempFile("", "logger")
+	tmpfile, err := os.CreateTemp("", "logger")
 	assert.Nil(t, err)
 	defer os.Remove(tmpfile.Name())
 
@@ -133,7 +132,7 @@ func TestClientWithLogLevelAndFile(t *testing.T) {
 		assert.Equal(t, "v1", c.ApiVersion(), "API version should be v1")
 	}
 
-	logContentB, err := ioutil.ReadFile(tmpfile.Name())
+	logContentB, err := os.ReadFile(tmpfile.Name())
 	assert.Nil(t, err)
 	logContent := string(logContentB)
 
@@ -177,7 +176,7 @@ func testNewClientLogOutput(t *testing.T, out string) {
 }
 
 func configureNativeGoLoggerAsConsumers(t *testing.T) string {
-	tmpfile, err := ioutil.TempFile("", "logger")
+	tmpfile, err := os.CreateTemp("", "logger")
 	assert.Nil(t, err)
 	logOutput, err := os.OpenFile(tmpfile.Name(), syscall.O_CREAT|syscall.O_RDWR|syscall.O_APPEND, 0666)
 	assert.Nil(t, err)

--- a/api/reports_gcp.go
+++ b/api/reports_gcp.go
@@ -53,9 +53,13 @@ func NewGcpReportType(report string) (GcpReportType, error) {
 	return NONE_GCP_REPORT, errors.Errorf("no report type found for %s", report)
 }
 
-var gcpReportTypes = map[GcpReportType]string{GCP_HIPAA: "GCP_HIPAA", GCP_CIS: "GCP_CIS", GCP_SOC: "GCP_SOC", GCP_CIS12: "GCP_CIS12",
-	GCP_K8S: "GCP_K8S", GCP_PCI_Rev2: "GCP_PCI_Rev2", GCP_SOC_Rev2: "GCP_SOC_Rev2", GCP_HIPAA_Rev2: "GCP_HIPAA_Rev2", GCP_ISO_27001: "GCP_ISO_27001",
-	GCP_NIST_CSF: "GCP_NIST_CSF", GCP_NIST_800_53_REV4: "GCP_NIST_800_53_REV4", GCP_NIST_800_171_REV2: "GCP_NIST_800_171_REV2", GCP_PCI: "GCP_PCI", GCP_CIS13: "GCP_CIS13"}
+var gcpReportTypes = map[GcpReportType]string{
+	GCP_HIPAA: "GCP_HIPAA", GCP_CIS: "GCP_CIS", GCP_SOC: "GCP_SOC", GCP_CIS12: "GCP_CIS12",
+	GCP_K8S: "GCP_K8S", GCP_PCI_Rev2: "GCP_PCI_Rev2", GCP_SOC_Rev2: "GCP_SOC_Rev2",
+	GCP_HIPAA_Rev2: "GCP_HIPAA_Rev2", GCP_ISO_27001: "GCP_ISO_27001",
+	GCP_NIST_CSF: "GCP_NIST_CSF", GCP_NIST_800_53_REV4: "GCP_NIST_800_53_REV4",
+	GCP_NIST_800_171_REV2: "GCP_NIST_800_171_REV2", GCP_PCI: "GCP_PCI", GCP_CIS13: "GCP_CIS13",
+}
 
 const (
 	NONE_GCP_REPORT GcpReportType = iota
@@ -81,7 +85,8 @@ func (svc *gcpReportsService) Get(reportCfg GcpReportConfig) (response GcpReport
 		return GcpReportResponse{}, errors.New("project id and org id are required")
 	}
 
-	apiPath := fmt.Sprintf(apiV2ReportsSecondaryQuery, reportCfg.OrganizationID, reportCfg.ProjectID, "json", reportCfg.Type.String())
+	apiPath := fmt.Sprintf(apiV2ReportsSecondaryQuery,
+		reportCfg.OrganizationID, reportCfg.ProjectID, "json", reportCfg.Type.String())
 	err = svc.client.RequestDecoder("GET", apiPath, nil, &response)
 	return
 }

--- a/api/version_test.go
+++ b/api/version_test.go
@@ -19,7 +19,7 @@
 package api_test
 
 import (
-	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 
@@ -29,7 +29,7 @@ import (
 )
 
 func TestVersionMatchVERSIONfile(t *testing.T) {
-	expectedVersion, err := ioutil.ReadFile("../VERSION")
+	expectedVersion, err := os.ReadFile("../VERSION")
 	assert.Nil(t, err)
 	assert.Equalf(t, strings.TrimSuffix(string(expectedVersion), "\n"), subject.Version,
 		"api/version.go doesn't match with VERSION file; run scripts/version_updater.sh")

--- a/cli/cmd/cache_test.go
+++ b/cli/cmd/cache_test.go
@@ -19,7 +19,7 @@
 package cmd
 
 import (
-	"io/ioutil"
+	"os"
 	"path"
 	"testing"
 	"time"
@@ -29,10 +29,7 @@ import (
 
 func TestCacheGlobal(t *testing.T) {
 	// create a temporal directory for our global cache
-	dir, err := ioutil.TempDir("", "lacework-cli-cache")
-	if err != nil {
-		panic(err)
-	}
+	dir := os.TempDir()
 	cli.InitCache(dir)
 
 	defer func() {
@@ -42,7 +39,7 @@ func TestCacheGlobal(t *testing.T) {
 	key := "global/file"
 	expected := []byte("data")
 
-	err = cli.Cache.Write(key, expected)
+	err := cli.Cache.Write(key, expected)
 	assert.Nil(t, err)
 	cache, err := cli.Cache.Read(key)
 	assert.Nil(t, err)
@@ -54,10 +51,7 @@ func TestCacheGlobal(t *testing.T) {
 
 func TestCacheGlobalWithLongPath(t *testing.T) {
 	// create a temporal directory for our global cache
-	dir, err := ioutil.TempDir("", "lacework-cli-cache")
-	if err != nil {
-		panic(err)
-	}
+	dir := os.TempDir()
 	cli.InitCache(dir)
 
 	defer func() {
@@ -67,7 +61,7 @@ func TestCacheGlobalWithLongPath(t *testing.T) {
 	key := "global/path/to/file"
 	expected := []byte("data")
 
-	err = cli.Cache.Write(key, expected)
+	err := cli.Cache.Write(key, expected)
 	assert.Nil(t, err)
 	cache, err := cli.Cache.Read(key)
 	assert.Nil(t, err)
@@ -79,10 +73,7 @@ func TestCacheGlobalWithLongPath(t *testing.T) {
 
 func TestCacheScopedStandalone(t *testing.T) {
 	// create a temporal directory for our global cache
-	dir, err := ioutil.TempDir("", "lacework-cli-cache")
-	if err != nil {
-		panic(err)
-	}
+	dir := os.TempDir()
 	cli.InitCache(dir)
 
 	// setting up required Lacework CLI config
@@ -100,7 +91,7 @@ func TestCacheScopedStandalone(t *testing.T) {
 	key := "compliance_report"
 	expected := []byte("data")
 
-	err = cli.Cache.Write(key, expected)
+	err := cli.Cache.Write(key, expected)
 	assert.Nil(t, err)
 	cache, err := cli.Cache.Read(key)
 	assert.Nil(t, err)
@@ -112,10 +103,7 @@ func TestCacheScopedStandalone(t *testing.T) {
 
 func TestCacheScopedOrgAccounts(t *testing.T) {
 	// create a temporal directory for our global cache
-	dir, err := ioutil.TempDir("", "lacework-cli-cache")
-	if err != nil {
-		panic(err)
-	}
+	dir := os.TempDir()
 	cli.InitCache(dir)
 
 	// setting up required Lacework CLI config
@@ -131,7 +119,7 @@ func TestCacheScopedOrgAccounts(t *testing.T) {
 	key := "vuln_assessment"
 	expected := []byte("data")
 
-	err = cli.Cache.Write(key, expected)
+	err := cli.Cache.Write(key, expected)
 	assert.Nil(t, err)
 	cache, err := cli.Cache.Read(key)
 	assert.Nil(t, err)
@@ -143,10 +131,7 @@ func TestCacheScopedOrgAccounts(t *testing.T) {
 
 func TestCacheEndToEnd(t *testing.T) {
 	// create a temporal directory for our global cache
-	dir, err := ioutil.TempDir("", "lacework-cli-cache")
-	if err != nil {
-		panic(err)
-	}
+	dir := os.TempDir()
 	cli.InitCache(dir)
 
 	defer func() {
@@ -157,7 +142,7 @@ func TestCacheEndToEnd(t *testing.T) {
 	expected := []byte("data")
 
 	// Create
-	err = cli.Cache.Write(key, expected)
+	err := cli.Cache.Write(key, expected)
 	assert.Nil(t, err)
 
 	// Read
@@ -183,10 +168,7 @@ func TestCacheEndToEnd(t *testing.T) {
 
 func TestWriteReadAssetToCache(t *testing.T) {
 	// create a temporal directory for our global cache
-	dir, err := ioutil.TempDir("", "lacework-cli-cache")
-	if err != nil {
-		panic(err)
-	}
+	dir := os.TempDir()
 	cli.InitCache(dir)
 
 	t.Run("primitive type: string", func(t *testing.T) {

--- a/cli/cmd/compliance_aws.go
+++ b/cli/cmd/compliance_aws.go
@@ -418,7 +418,10 @@ The output from status with the --json flag can be used in the body of PATCH api
 					Csp:     api.AwsInventoryType,
 				}
 			)
-			err := api.WindowedSearchFirst(cli.LwApi.V2.Inventory.Search, api.V2ApiMaxSearchWindowDays, api.V2ApiMaxSearchHistoryDays, &awsInventorySearchResponse, &filter)
+			err := api.WindowedSearchFirst(
+				cli.LwApi.V2.Inventory.Search, api.V2ApiMaxSearchWindowDays,
+				api.V2ApiMaxSearchHistoryDays, &awsInventorySearchResponse, &filter,
+			)
 			cli.StopProgress()
 
 			if len(awsInventorySearchResponse.Data) == 0 {
@@ -450,7 +453,10 @@ The output from status with the --json flag can be used in the body of PATCH api
 				}
 			)
 
-			err = api.WindowedSearchFirst(cli.LwApi.V2.ComplianceEvaluations.Search, api.V2ApiMaxSearchWindowDays, api.V2ApiMaxSearchHistoryDays, &awsComplianceEvaluationSearchResponse, &complianceFilter)
+			err = api.WindowedSearchFirst(
+				cli.LwApi.V2.ComplianceEvaluations.Search, api.V2ApiMaxSearchWindowDays,
+				api.V2ApiMaxSearchHistoryDays, &awsComplianceEvaluationSearchResponse, &complianceFilter,
+			)
 			cli.StopProgress()
 			if err != nil {
 				return err

--- a/cli/cmd/configure.go
+++ b/cli/cmd/configure.go
@@ -21,7 +21,7 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"regexp"
 	"sort"
 	"strings"
@@ -367,7 +367,7 @@ type apiKeyDetails struct {
 
 func loadUIJsonFile(file string) error {
 	cli.Log.Debugw("loading API key JSON file", "path", file)
-	jsonData, err := ioutil.ReadFile(file)
+	jsonData, err := os.ReadFile(file)
 	if err != nil {
 		return err
 	}

--- a/cli/cmd/generate_aws.go
+++ b/cli/cmd/generate_aws.go
@@ -63,7 +63,7 @@ var (
 	AwsAdvancedOptLocation = "Customize output location"
 
 	// AwsArnRegex original source: https://regex101.com/r/pOfxYN/1
-	AwsArnRegex = `^arn:(?P<Partition>[^:\n]*):(?P<Service>[^:\n]*):(?P<Region>[^:\n]*):(?P<AccountID>[^:\n]*):(?P<Ignore>(?P<ResourceType>[^:\/\n]*)[:\/])?(?P<Resource>.*)$`
+	AwsArnRegex = `^arn:(?P<Partition>[^:\n]*):(?P<Service>[^:\n]*):(?P<Region>[^:\n]*):(?P<AccountID>[^:\n]*):(?P<Ignore>(?P<ResourceType>[^:\/\n]*)[:\/])?(?P<Resource>.*)$` //nolint
 	// AwsRegionRegex regex used for validating region input; note intentionally does not match gov cloud
 	AwsRegionRegex  = `(us|ap|ca|cn|eu|sa)-(central|(north|south)?(east|west)?)-\d`
 	AwsProfileRegex = `([A-Za-z_0-9-]+)`

--- a/cli/cmd/generate_aws_eks_audit.go
+++ b/cli/cmd/generate_aws_eks_audit.go
@@ -882,7 +882,12 @@ func writeAwsEksAuditGenerationArgsCache(a *aws_eks_audit.GenerateAwsEksAuditTfC
 }
 
 // entry point for launching a survey to build out the required generation parameters
-func promptAwsEksAuditGenerate(config *aws_eks_audit.GenerateAwsEksAuditTfConfigurationArgs, existingIam *aws_eks_audit.ExistingCrossAccountIamRoleDetails, extraState *AwsEksAuditGenerateCommandExtraState) error {
+func promptAwsEksAuditGenerate(
+	config *aws_eks_audit.GenerateAwsEksAuditTfConfigurationArgs,
+	existingIam *aws_eks_audit.ExistingCrossAccountIamRoleDetails,
+	extraState *AwsEksAuditGenerateCommandExtraState,
+) error {
+
 	// Cache for later use if generation is abandoned and in interactive mode
 	if cli.InteractiveMode() {
 		defer writeAwsEksAuditGenerationArgsCache(config)

--- a/cli/cmd/generate_azure.go
+++ b/cli/cmd/generate_azure.go
@@ -147,16 +147,19 @@ var (
 		Short:   "Generate and/or execute Terraform code for Azure integration",
 		Long: `Use this command to generate Terraform code for deploying Lacework into new Azure environment.
 
-By default, this command will function interactively, prompting for the required information to setup the new cloud account. In interactive mode, this command will:
+By default, this command will function interactively, prompting for the required information to setup
+the new cloud account. In interactive mode, this command will:
 		
 * Prompt for the required information to setup the integration
 * Generate new Terraform code using the inputs
 * Optionally, run the generated Terraform code:
   * If Terraform is already installed, the version will be confirmed suitable for use
-	* If Terraform is not installed, or the version installed is not suitable, a new version will be installed into a temporary location
-	* Once Terraform is detected or installed, Terraform plan will be executed
-	* The command will prompt with the outcome of the plan and allow to view more details or continue with Terraform apply
-	* If confirmed, Terraform apply will be run, completing the setup of the cloud account
+  * If Terraform is not installed, or the version installed is not suitable, a new version will be
+    installed into a temporary location
+  * Once Terraform is detected or installed, Terraform plan will be executed
+  * The command will prompt with the outcome of the plan and allow to view more details or continue
+    with Terraform apply
+  * If confirmed, Terraform apply will be run, completing the setup of the cloud account
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Generate TF Code

--- a/cli/cmd/generate_azure_test.go
+++ b/cli/cmd/generate_azure_test.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -61,10 +60,7 @@ func TestInvalidStorageLocations(t *testing.T) {
 
 func TestAzureGenerationCache(t *testing.T) {
 	t.Run("extra state shouldn't be written if empty", func(t *testing.T) {
-		dir, err := ioutil.TempDir("", "lacework-cli-cache")
-		if err != nil {
-			panic(err)
-		}
+		dir := os.TempDir()
 		defer os.RemoveAll(dir)
 		cli.InitCache(dir)
 
@@ -73,10 +69,7 @@ func TestAzureGenerationCache(t *testing.T) {
 		assert.NoFileExists(t, filepath.FromSlash(fmt.Sprintf("%s/cache/standalone/%s", dir, CachedAzureAssetExtraState)))
 	})
 	t.Run("extra state should be written if not empty", func(t *testing.T) {
-		dir, err := ioutil.TempDir("", "lacework-cli-cache")
-		if err != nil {
-			panic(err)
-		}
+		dir := os.TempDir()
 		defer os.RemoveAll(dir)
 		cli.InitCache(dir)
 
@@ -85,10 +78,7 @@ func TestAzureGenerationCache(t *testing.T) {
 		assert.FileExists(t, filepath.FromSlash(fmt.Sprintf("%s/cache/standalone/%s", dir, CachedAzureAssetExtraState)))
 	})
 	t.Run("iac params should not be cached when empty", func(t *testing.T) {
-		dir, err := ioutil.TempDir("", "lacework-cli-cache")
-		if err != nil {
-			panic(err)
-		}
+		dir := os.TempDir()
 		defer os.RemoveAll(dir)
 		cli.InitCache(dir)
 
@@ -97,10 +87,7 @@ func TestAzureGenerationCache(t *testing.T) {
 		assert.NoFileExists(t, filepath.FromSlash(fmt.Sprintf("%s/cache/standalone/%s", dir, CachedAzureAssetIacParams)))
 	})
 	t.Run("iac params should be cached when not empty", func(t *testing.T) {
-		dir, err := ioutil.TempDir("", "lacework-cli-cache")
-		if err != nil {
-			panic(err)
-		}
+		dir := os.TempDir()
 		defer os.RemoveAll(dir)
 		cli.InitCache(dir)
 

--- a/cli/cmd/generate_gcp.go
+++ b/cli/cmd/generate_gcp.go
@@ -58,7 +58,9 @@ var (
 	CachedGcpAssetIacParams                  = "iac-gcp-generate-params"
 	CachedAssetGcpExtraState                 = "iac-gcp-extra-state"
 
-	InvalidProjectIDMessage = "invalid GCP project ID.  It must be 6 to 30 lowercase ASCII letters, digits, or hyphens. It must start with a letter. Trailing hyphens are prohibited. Example: tokyo-rain-123"
+	InvalidProjectIDMessage = "invalid GCP project ID. " +
+		"It must be 6 to 30 lowercase ASCII letters, digits, or hyphens. " +
+		"It must start with a letter. Trailing hyphens are prohibited. Example: tokyo-rain-123"
 
 	// gcp command is used to generate TF code for gcp
 	generateGcpTfCommand = &cobra.Command{
@@ -73,10 +75,12 @@ In interactive mode, this command will:
 * Generate new Terraform code using the inputs
 * Optionally, run the generated Terraform code:
   * If Terraform is already installed, the version is verified as compatible for use
-	* If Terraform is not installed, or the version installed is not compatible, a new version will be installed into a temporary location
-	* Once Terraform is detected or installed, Terraform plan will be executed
-	* The command will prompt with the outcome of the plan and allow to view more details or continue with Terraform apply
-	* If confirmed, Terraform apply will be run, completing the setup of the cloud account
+  * If Terraform is not installed, or the version installed is not compatible, a new version will be
+    installed into a temporary location
+  * Once Terraform is detected or installed, Terraform plan will be executed
+  * The command will prompt with the outcome of the plan and allow to view more details or continue with
+    Terraform apply
+  * If confirmed, Terraform apply will be run, completing the setup of the cloud account
 
 This command can also be run in noninteractive mode.
 See help output for more details on the parameter value(s) required for Terraform code generation.
@@ -255,8 +259,11 @@ See help output for more details on the parameter value(s) required for Terrafor
 			}
 
 			// Collect and/or confirm parameters
-			err = promptGcpGenerate(GenerateGcpCommandState, GenerateGcpExistingServiceAccountDetails, GenerateGcpCommandExtraState)
-			if err != nil {
+			if err := promptGcpGenerate(
+				GenerateGcpCommandState,
+				GenerateGcpExistingServiceAccountDetails,
+				GenerateGcpCommandExtraState,
+			); err != nil {
 				return errors.Wrap(err, "collecting/confirming parameters")
 			}
 
@@ -461,7 +468,11 @@ func validateGcpRegion(val interface{}) error {
 	return nil
 }
 
-func promptGcpAuditLogQuestions(config *gcp.GenerateGcpTfConfigurationArgs, extraState *GcpGenerateCommandExtraState) error {
+func promptGcpAuditLogQuestions(
+	config *gcp.GenerateGcpTfConfigurationArgs,
+	extraState *GcpGenerateCommandExtraState,
+) error {
+
 	// Only ask these questions if configure audit log is true
 	err := SurveyMultipleQuestionWithValidation([]SurveyQuestionWithValidationArgs{
 		{
@@ -592,9 +603,9 @@ func askAdvancedOptions(config *gcp.GenerateGcpTfConfigurationArgs, extraState *
 
 	// Prompt for options
 	for answer != GcpAdvancedOptDone {
-		// Construction of this slice is a bit strange at first look, but the reason for that is because we have to do string
-		// validation to know which option was selected due to how survey works; and doing it by index (also supported) is
-		// difficult when the options are dynamic (which they are)
+		// Construction of this slice is a bit strange at first look, but the reason for that is because we have to do
+		// string validation to know which option was selected due to how survey works; and doing it by index (also
+		// supported) is difficult when the options are dynamic (which they are)
 		var options []string
 
 		// Only show Advanced AuditLog options if AuditLog integration is set to true
@@ -602,7 +613,12 @@ func askAdvancedOptions(config *gcp.GenerateGcpTfConfigurationArgs, extraState *
 			options = append(options, GcpAdvancedOptAuditLog)
 		}
 
-		options = append(options, GcpAdvancedOptExistingServiceAccount, GcpAdvancedOptIntegrationName, GcpAdvancedOptLocation, GcpAdvancedOptDone)
+		options = append(options,
+			GcpAdvancedOptExistingServiceAccount,
+			GcpAdvancedOptIntegrationName,
+			GcpAdvancedOptLocation,
+			GcpAdvancedOptDone,
+		)
 		if err := SurveyQuestionInteractiveOnly(SurveyQuestionWithValidationArgs{
 			Prompt: &survey.Select{
 				Message: "Which options would you like to configure?",

--- a/cli/cmd/generate_gcp_test.go
+++ b/cli/cmd/generate_gcp_test.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -53,10 +52,7 @@ func TestGcpBucketRegionRegex(t *testing.T) {
 
 func TestGcpGenerationCache(t *testing.T) {
 	t.Run("extra state shouldn't be written if empty", func(t *testing.T) {
-		dir, err := ioutil.TempDir("", "lacework-cli-cache")
-		if err != nil {
-			panic(err)
-		}
+		dir := os.TempDir()
 		defer os.RemoveAll(dir)
 		cli.InitCache(dir)
 
@@ -65,10 +61,7 @@ func TestGcpGenerationCache(t *testing.T) {
 		assert.NoFileExists(t, filepath.FromSlash(fmt.Sprintf("%s/cache/standalone/%s", dir, CachedAssetGcpExtraState)))
 	})
 	t.Run("extra state should be written if not empty", func(t *testing.T) {
-		dir, err := ioutil.TempDir("", "lacework-cli-cache")
-		if err != nil {
-			panic(err)
-		}
+		dir := os.TempDir()
 		defer os.RemoveAll(dir)
 		cli.InitCache(dir)
 
@@ -77,10 +70,7 @@ func TestGcpGenerationCache(t *testing.T) {
 		assert.FileExists(t, filepath.FromSlash(fmt.Sprintf("%s/cache/standalone/%s", dir, CachedAssetGcpExtraState)))
 	})
 	t.Run("iac params should not be cached when empty", func(t *testing.T) {
-		dir, err := ioutil.TempDir("", "lacework-cli-cache")
-		if err != nil {
-			panic(err)
-		}
+		dir := os.TempDir()
 		defer os.RemoveAll(dir)
 		cli.InitCache(dir)
 
@@ -89,10 +79,7 @@ func TestGcpGenerationCache(t *testing.T) {
 		assert.NoFileExists(t, filepath.FromSlash(fmt.Sprintf("%s/cache/standalone/%s", dir, CachedGcpAssetIacParams)))
 	})
 	t.Run("iac params should be cached when not empty", func(t *testing.T) {
-		dir, err := ioutil.TempDir("", "lacework-cli-cache")
-		if err != nil {
-			panic(err)
-		}
+		dir := os.TempDir()
 		defer os.RemoveAll(dir)
 		cli.InitCache(dir)
 

--- a/cli/cmd/generate_gke_test.go
+++ b/cli/cmd/generate_gke_test.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -28,10 +27,7 @@ func TestGenerateMostBasicGkeArgs(t *testing.T) {
 
 func TestGkeGenerationCache(t *testing.T) {
 	t.Run("extra state shouldn't be written if empty", func(t *testing.T) {
-		dir, err := ioutil.TempDir("", "lacework-cli-cache")
-		if err != nil {
-			panic(err)
-		}
+		dir := os.TempDir()
 		defer os.RemoveAll(dir)
 		cli.InitCache(dir)
 
@@ -40,10 +36,7 @@ func TestGkeGenerationCache(t *testing.T) {
 		assert.NoFileExists(t, filepath.FromSlash(fmt.Sprintf("%s/cache/standalone/%s", dir, CachedGkeAssetExtraState)))
 	})
 	t.Run("extra state should be written if not empty", func(t *testing.T) {
-		dir, err := ioutil.TempDir("", "lacework-cli-cache")
-		if err != nil {
-			panic(err)
-		}
+		dir := os.TempDir()
 		defer os.RemoveAll(dir)
 		cli.InitCache(dir)
 
@@ -52,10 +45,7 @@ func TestGkeGenerationCache(t *testing.T) {
 		assert.FileExists(t, filepath.FromSlash(fmt.Sprintf("%s/cache/standalone/%s", dir, CachedGkeAssetExtraState)))
 	})
 	t.Run("iac params should not be cached when empty", func(t *testing.T) {
-		dir, err := ioutil.TempDir("", "lacework-cli-cache")
-		if err != nil {
-			panic(err)
-		}
+		dir := os.TempDir()
 		defer os.RemoveAll(dir)
 		cli.InitCache(dir)
 
@@ -64,10 +54,7 @@ func TestGkeGenerationCache(t *testing.T) {
 		assert.NoFileExists(t, filepath.FromSlash(fmt.Sprintf("%s/cache/standalone/%s", dir, CachedGkeAssetIacParams)))
 	})
 	t.Run("iac params should be cached when not empty", func(t *testing.T) {
-		dir, err := ioutil.TempDir("", "lacework-cli-cache")
-		if err != nil {
-			panic(err)
-		}
+		dir := os.TempDir()
 		defer os.RemoveAll(dir)
 		cli.InitCache(dir)
 

--- a/cli/cmd/generate_terraform_test.go
+++ b/cli/cmd/generate_terraform_test.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -29,10 +28,7 @@ func TestGenerationTfInstallation(t *testing.T) {
 	t.Run("forced installation should installed expected version", func(t *testing.T) {
 		toggleNonInteractive()
 		defer toggleNonInteractive()
-		dir, err := ioutil.TempDir("", "tf-install-test")
-		if err != nil {
-			panic(err)
-		}
+		dir := os.TempDir()
 		defer os.RemoveAll(dir)
 
 		// Force install
@@ -48,10 +44,7 @@ func TestGenerationTfInstallation(t *testing.T) {
 	t.Run("existing terraform version should be located and used, if version is new enough", func(t *testing.T) {
 		toggleNonInteractive()
 		defer toggleNonInteractive()
-		dir, err := ioutil.TempDir("", "tf-install-test")
-		if err != nil {
-			panic(err)
-		}
+		dir := os.TempDir()
 		defer os.RemoveAll(dir)
 
 		// Install some version that should be detected
@@ -82,10 +75,7 @@ func TestGenerationTfInstallation(t *testing.T) {
 	t.Run("installed version of terraform that is too old gets ephemeral installation", func(t *testing.T) {
 		toggleNonInteractive()
 		defer toggleNonInteractive()
-		dir, err := ioutil.TempDir("", "tf-install-test")
-		if err != nil {
-			panic(err)
-		}
+		dir := os.TempDir()
 		defer os.RemoveAll(dir)
 
 		// Install some version that should be detected
@@ -121,10 +111,7 @@ func TestGenerationTfInstallation(t *testing.T) {
 	t.Run("installed version of terraform that is too old to support version checking gets ephemeral installation", func(t *testing.T) {
 		toggleNonInteractive()
 		defer toggleNonInteractive()
-		dir, err := ioutil.TempDir("", "tf-install-test")
-		if err != nil {
-			panic(err)
-		}
+		dir := os.TempDir()
 		defer os.RemoveAll(dir)
 
 		// Install some version that should be detected

--- a/cli/cmd/lql.go
+++ b/cli/cmd/lql.go
@@ -20,7 +20,7 @@ package cmd
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"strconv"
@@ -233,7 +233,7 @@ func inputQuery(cmd *cobra.Command) (string, error) {
 	if err != nil {
 		cli.Log.Debugw("error retrieving stdin mode", "error", err.Error())
 	} else if (stat.Mode() & os.ModeCharDevice) == 0 {
-		bytes, err := ioutil.ReadAll(os.Stdin)
+		bytes, err := io.ReadAll(os.Stdin)
 		return string(bytes), err
 	}
 	// if running via editor
@@ -256,7 +256,7 @@ func inputQueryFromLibrary(id string) (string, error) {
 }
 
 func inputQueryFromFile(filePath string) (string, error) {
-	fileData, err := ioutil.ReadFile(filePath)
+	fileData, err := os.ReadFile(filePath)
 
 	if err != nil {
 		return "", errors.Wrap(err, "unable to read file")
@@ -280,7 +280,7 @@ func inputQueryFromURL(url string) (query string, err error) {
 		return
 	}
 
-	body, err := ioutil.ReadAll(response.Body)
+	body, err := io.ReadAll(response.Body)
 	if err != nil {
 		err = errors.Wrap(err, msg)
 		return

--- a/cli/cmd/package_manifest.go
+++ b/cli/cmd/package_manifest.go
@@ -22,7 +22,6 @@ import (
 	"bufio"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"regexp"
@@ -275,7 +274,7 @@ func (c *cliState) IsEsmEnabled() bool {
 
 	if file.FileExists(procUAStatusFile) {
 		c.Log.Debugw("detecting ubuntu ESM support", "file", procUAStatusFile)
-		uaStatusBytes, err := ioutil.ReadFile(procUAStatusFile)
+		uaStatusBytes, err := os.ReadFile(procUAStatusFile)
 		if err != nil {
 			c.Log.Warnw("unable to read UA status file", "error", err)
 			return false

--- a/cli/cmd/package_manifest_test.go
+++ b/cli/cmd/package_manifest_test.go
@@ -20,7 +20,6 @@ package cmd
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -199,7 +198,7 @@ func TestIsEsmEnabledWhenIsNotEnabled(t *testing.T) {
 }
 
 func TestIsEsmEnabledWhenIsActuallyEnabled(t *testing.T) {
-	file, err := ioutil.TempFile("", "ubuntu-advantage-status-json")
+	file, err := os.CreateTemp("", "ubuntu-advantage-status-json")
 	assert.Nil(t, err)
 	_, err = file.WriteString(mockUbuntuUAStatusFile)
 	assert.Nil(t, err)
@@ -216,7 +215,7 @@ func TestIsEsmEnabledWhenIsActuallyEnabled(t *testing.T) {
 }
 
 func TestParseOsRelease(t *testing.T) {
-	file, err := ioutil.TempFile("", "os-release")
+	file, err := os.CreateTemp("", "os-release")
 	assert.Nil(t, err)
 	_, err = file.WriteString(mockUbuntuOSReleaseFile)
 	assert.Nil(t, err)
@@ -230,7 +229,7 @@ func TestParseOsRelease(t *testing.T) {
 }
 
 func TestParseSysRelease(t *testing.T) {
-	file, err := ioutil.TempFile("", "system-release")
+	file, err := os.CreateTemp("", "system-release")
 	assert.Nil(t, err)
 	_, err = file.WriteString(mockCentosSystemFile)
 	assert.Nil(t, err)

--- a/cli/cmd/policy.go
+++ b/cli/cmd/policy.go
@@ -20,7 +20,7 @@ package cmd
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"regexp"
@@ -306,7 +306,7 @@ func inputPolicy(cmd *cobra.Command, args ...string) (string, error) {
 	if err != nil {
 		cli.Log.Debugw("error retrieving stdin mode", "error", err.Error())
 	} else if (stat.Mode() & os.ModeCharDevice) == 0 {
-		bytes, err := ioutil.ReadAll(os.Stdin)
+		bytes, err := io.ReadAll(os.Stdin)
 		return string(bytes), err
 	}
 	// if running via editor
@@ -362,7 +362,7 @@ func inputPolicyFromLibrary(id string) (string, error) {
 }
 
 func inputPolicyFromFile(filePath string) (string, error) {
-	fileData, err := ioutil.ReadFile(filePath)
+	fileData, err := os.ReadFile(filePath)
 
 	if err != nil {
 		return "", errors.Wrap(err, "unable to read file")
@@ -386,7 +386,7 @@ func inputPolicyFromURL(url string) (policy string, err error) {
 		return
 	}
 
-	body, err := ioutil.ReadAll(response.Body)
+	body, err := io.ReadAll(response.Body)
 	if err != nil {
 		err = errors.Wrap(err, msg)
 		return
@@ -726,7 +726,12 @@ func setPolicyStateByTag(tag string, policyState bool) error {
 	}
 
 	for i, p := range matchingPolicies {
-		cli.StartProgress(fmt.Sprintf(" %sing policies %d/%d (%s)...", strings.TrimSuffix(msg, "e"), i+1, len(matchingPolicies), p.PolicyID))
+		cli.StartProgress(
+			fmt.Sprintf(
+				" %sing policies %d/%d (%s)...",
+				strings.TrimSuffix(msg, "e"), i+1, len(matchingPolicies), p.PolicyID,
+			),
+		)
 		policy := api.UpdatePolicy{PolicyID: p.PolicyID, Enabled: &policyState}
 		resp, err := cli.LwApi.V2.Policy.Update(policy)
 		if err != nil {

--- a/cli/cmd/team_members.go
+++ b/cli/cmd/team_members.go
@@ -394,7 +394,9 @@ func sliceToUpper(list []string) (upper []string) {
 
 func validateEmail() survey.Validator {
 	return func(val interface{}) error {
-		emailRegex, _ := regexp.Compile("[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?")
+		emailRegex, _ := regexp.Compile(
+			"[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?", //nolint
+		)
 		if !emailRegex.MatchString(val.(string)) {
 			return fmt.Errorf("not a valid email %s", val.(string))
 		}

--- a/cli/cmd/vuln_host_scan_package_manifest.go
+++ b/cli/cmd/vuln_host_scan_package_manifest.go
@@ -21,7 +21,7 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"sort"
 	"strconv"
 	"strings"
@@ -80,7 +80,7 @@ To generate a package-manifest from the local host and scan it automatically:
 				pkgManifestBytes = []byte(args[0])
 				cli.Log.Debugw("package manifest loaded from arguments", "raw", args[0])
 			} else if pkgManifestFile != "" {
-				pkgManifestBytes, err = ioutil.ReadFile(pkgManifestFile)
+				pkgManifestBytes, err = os.ReadFile(pkgManifestFile)
 				if err != nil {
 					return errors.Wrap(err, "unable to read file")
 				}

--- a/cli/cmd/vuln_html.go
+++ b/cli/cmd/vuln_html.go
@@ -22,7 +22,6 @@ import (
 	"bytes"
 	"fmt"
 	"html/template"
-	"io/ioutil"
 	"os"
 	"regexp"
 	"sort"
@@ -316,7 +315,7 @@ func generateVulnAssessmentHTML(response api.VulnerabilitiesContainersResponse) 
 		return errors.Wrap(err, "unable to execute template")
 	}
 
-	if err := ioutil.WriteFile(outputHTML, buff.Bytes(), os.ModePerm); err != nil {
+	if err := os.WriteFile(outputHTML, buff.Bytes(), os.ModePerm); err != nil {
 		return errors.Wrap(err, "unable to write html file")
 	}
 

--- a/integration/alert_profile_test.go
+++ b/integration/alert_profile_test.go
@@ -20,7 +20,6 @@
 package integration
 
 import (
-	"io/ioutil"
 	"log"
 	"os"
 	"testing"
@@ -40,10 +39,7 @@ func TestAlertProfileUpdateEditor(t *testing.T) {
 
 // CUSTOM_CUSTOMER_DEMO_GCP
 func TestAlertProfileUpdate(t *testing.T) {
-	dir, err := ioutil.TempDir("", "lacework-cli")
-	if err != nil {
-		panic(err)
-	}
+	dir := os.TempDir()
 	defer os.RemoveAll(dir)
 
 	runAlertProfileTest(t,

--- a/integration/aws_eks_audit_generation_test.go
+++ b/integration/aws_eks_audit_generation_test.go
@@ -4,7 +4,6 @@ package integration
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -30,7 +29,7 @@ func runEksAuditGenerateTest(t *testing.T, conditions func(*expect.Console), arg
 	hcl_path := filepath.Join(tfPath, eksPath, "main.tf")
 
 	runFakeTerminalTestFromDir(t, tfPath, conditions, args...)
-	out, err := ioutil.ReadFile(hcl_path)
+	out, err := os.ReadFile(hcl_path)
 	if err != nil {
 		return fmt.Sprintf("main.tf not found: %s", err)
 	}
@@ -377,10 +376,7 @@ func TestGenerationEksSingleRegionAdvancedCustomOutputLocation(t *testing.T) {
 	defer os.Setenv("LW_NOCACHE", "")
 	var final string
 
-	dir, err := ioutil.TempDir("", "lacework-cli")
-	if err != nil {
-		panic(err)
-	}
+	dir := os.TempDir()
 	defer os.RemoveAll(dir)
 
 	runEksAuditGenerateTest(t,
@@ -405,7 +401,7 @@ func TestGenerationEksSingleRegionAdvancedCustomOutputLocation(t *testing.T) {
 
 	assertEksAuditTerraformSaved(t, final)
 
-	result, _ := ioutil.ReadFile(filepath.FromSlash(fmt.Sprintf("%s/main.tf", dir)))
+	result, _ := os.ReadFile(filepath.FromSlash(fmt.Sprintf("%s/main.tf", dir)))
 
 	regionClusterMap := make(map[string][]string)
 	regionClusterMap["us-west-1"] = []string{"cluster1", "cluster2"}
@@ -419,10 +415,7 @@ func TestGenerationEksSingleRegionExistingTerraform(t *testing.T) {
 	os.Setenv("LW_NOCACHE", "true")
 	defer os.Setenv("LW_NOCACHE", "")
 
-	dir, err := ioutil.TempDir("", "lacework-cli")
-	if err != nil {
-		panic(err)
-	}
+	dir := os.TempDir()
 	defer os.RemoveAll(dir)
 
 	if err := os.WriteFile(filepath.FromSlash(fmt.Sprintf("%s/main.tf", dir)), []byte{}, 0644); err != nil {

--- a/integration/aws_generation_test.go
+++ b/integration/aws_generation_test.go
@@ -4,7 +4,6 @@ package integration
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -83,10 +82,7 @@ func TestGenerationAwsCustomizedOutputLocation(t *testing.T) {
 	region := "us-east-2"
 
 	// Tempdir for test
-	dir, err := ioutil.TempDir("", "lacework-cli")
-	if err != nil {
-		panic(err)
-	}
+	dir := os.TempDir()
 	defer os.RemoveAll(dir)
 
 	// Run CLI
@@ -113,7 +109,7 @@ func TestGenerationAwsCustomizedOutputLocation(t *testing.T) {
 	assert.Contains(t, final, "Terraform code saved in")
 
 	// Get result
-	result, _ := ioutil.ReadFile(filepath.FromSlash(fmt.Sprintf("%s/main.tf", dir)))
+	result, _ := os.ReadFile(filepath.FromSlash(fmt.Sprintf("%s/main.tf", dir)))
 
 	// Create the TF directly with lwgenerate and validate same result via CLI
 	buildTf, _ := aws.NewTerraform(region, true, true,
@@ -640,10 +636,7 @@ func TestGenerationAwsWithExistingTerraform(t *testing.T) {
 	region := "us-east-2"
 
 	// Tempdir for test
-	dir, err := ioutil.TempDir("", "lacework-cli")
-	if err != nil {
-		panic(err)
-	}
+	dir := os.TempDir()
 	defer os.RemoveAll(dir)
 
 	// Create fake main.tf
@@ -829,7 +822,7 @@ func runGenerateTest(t *testing.T, conditions func(*expect.Console), args ...str
 	hcl_path := filepath.Join(tfPath, awsPath, "main.tf")
 
 	runFakeTerminalTestFromDir(t, tfPath, conditions, args...)
-	out, err := ioutil.ReadFile(hcl_path)
+	out, err := os.ReadFile(hcl_path)
 	if err != nil {
 		return fmt.Sprintf("main.tf not found: %s", err)
 	}

--- a/integration/azure_generation_test.go
+++ b/integration/azure_generation_test.go
@@ -4,7 +4,6 @@ package integration
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -95,10 +94,7 @@ func TestGenerationAzureCustomizedOutputLocation(t *testing.T) {
 	var runError error
 
 	// Tempdir for test
-	dir, err := ioutil.TempDir("", "lacework-cli")
-	if err != nil {
-		panic(err)
-	}
+	dir := os.TempDir()
 	defer os.RemoveAll(dir)
 
 	// Run CLI
@@ -125,7 +121,7 @@ func TestGenerationAzureCustomizedOutputLocation(t *testing.T) {
 	assert.Contains(t, final, "Terraform code saved in")
 
 	// Get result
-	result, _ := ioutil.ReadFile(filepath.FromSlash(fmt.Sprintf("%s/main.tf", dir)))
+	result, _ := os.ReadFile(filepath.FromSlash(fmt.Sprintf("%s/main.tf", dir)))
 
 	// Create the TF directly with lwgenerate and validate same result via CLI
 	buildTf, _ := azure.NewTerraform(true, true, true).Generate()
@@ -369,11 +365,8 @@ func TestGenerationAzureWithExistingTerraform(t *testing.T) {
 	var runError error
 
 	// Tempdir for test
-	dir, err := ioutil.TempDir("", "lacework-cli")
-	if err != nil {
-		panic(err)
-	}
-	//defer os.RemoveAll(dir)
+	dir := os.TempDir()
+	defer os.RemoveAll(dir)
 
 	// Create fake main.tf
 	if err := os.WriteFile(filepath.FromSlash(fmt.Sprintf("%s/main.tf", dir)), []byte{}, 0644); err != nil {
@@ -857,7 +850,7 @@ func runGenerateAzureTest(t *testing.T, conditions func(*expect.Console), args .
 	hcl_path := filepath.Join(tfPath, azurePath, "main.tf")
 
 	runFakeTerminalTestFromDir(t, tfPath, conditions, args...)
-	out, err := ioutil.ReadFile(hcl_path)
+	out, err := os.ReadFile(hcl_path)
 	if err != nil {
 		return fmt.Sprintf("main.tf not found: %s", err)
 	}

--- a/integration/configure_test.go
+++ b/integration/configure_test.go
@@ -20,7 +20,6 @@
 package integration
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -49,11 +48,7 @@ func TestConfigureListHelp(t *testing.T) {
 func TestConfigureCommandNonInteractive(t *testing.T) {
 	// create a temporal directory where we will check that the
 	// configuration file is deployed (.lacework.toml)
-	home, err := ioutil.TempDir("", "lacework-cli")
-	if err != nil {
-		panic(err)
-	}
-
+	home := os.TempDir()
 	defer os.RemoveAll(home)
 	out, errB, exitcode := LaceworkCLIWithHome(home, "configure",
 		"--noninteractive",
@@ -70,7 +65,7 @@ func TestConfigureCommandNonInteractive(t *testing.T) {
 
 	configPath := path.Join(home, ".lacework.toml")
 	assert.FileExists(t, configPath, "the configuration file is missing")
-	laceworkTOML, err := ioutil.ReadFile(configPath)
+	laceworkTOML, err := os.ReadFile(configPath)
 	if err != nil {
 		panic(err)
 	}
@@ -85,11 +80,7 @@ func TestConfigureCommandNonInteractive(t *testing.T) {
 }
 
 func TestConfigureCommandNonInteractiveFailures(t *testing.T) {
-	home, err := ioutil.TempDir("", "lacework-cli")
-	if err != nil {
-		panic(err)
-	}
-
+	home := os.TempDir()
 	defer os.RemoveAll(home)
 
 	tests := []struct {
@@ -128,7 +119,7 @@ func TestConfigureCommandNonInteractiveFailures(t *testing.T) {
 
 func createJSONFileLikeWebUI(content string) string {
 	contentBytes := []byte(content)
-	tmpfile, err := ioutil.TempFile("", "json_file")
+	tmpfile, err := os.CreateTemp("", "json_file")
 	if err != nil {
 		panic(err)
 	}
@@ -140,11 +131,7 @@ func createJSONFileLikeWebUI(content string) string {
 }
 
 func createTOMLConfig() string {
-	dir, err := ioutil.TempDir("", "lacework-toml")
-	if err != nil {
-		panic(err)
-	}
-
+	home := os.TempDir()
 	configFile := filepath.Join(dir, ".lacework.toml")
 	c := []byte(`[default]
 account = 'test.account'
@@ -175,7 +162,7 @@ api_key = 'V2CONFIG_KEY'
 api_secret = '_secret'
 subaccount = 'sub-account'
 `)
-	err = ioutil.WriteFile(configFile, c, 0644)
+	err = os.WriteFile(configFile, c, 0644)
 	if err != nil {
 		panic(err)
 	}

--- a/integration/configure_unix_test.go
+++ b/integration/configure_unix_test.go
@@ -21,7 +21,6 @@ package integration
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"testing"
@@ -359,7 +358,7 @@ func TestConfigureCommandWithExistingConfigAndMultiProfile(t *testing.T) {
 
 	// assert.Contains(t, state, "You are all set!", "you are not all set, check configure cmd")
 	assert.FileExists(t, configPath, "the configuration file is missing")
-	laceworkTOML, err := ioutil.ReadFile(configPath)
+	laceworkTOML, err := os.ReadFile(configPath)
 	assert.Nil(t, err)
 
 	assert.Equal(t, `[default]
@@ -414,7 +413,7 @@ func TestConfigureCommandWithExistingConfigAndMultiProfile(t *testing.T) {
 
 		// assert.Contains(t, state, "You are all set!", "you are not all set, check configure cmd")
 		assert.FileExists(t, configPath, "the configuration file is missing")
-		laceworkTOML, err := ioutil.ReadFile(configPath)
+		laceworkTOML, err := os.ReadFile(configPath)
 		assert.Nil(t, err)
 
 		assert.Equal(t, `[default]
@@ -517,11 +516,7 @@ func TestConfigureSwitchProfileHelp(t *testing.T) {
 func runConfigureTest(t *testing.T, conditions func(*expect.Console), args ...string) (string, string) {
 	// create a temporal directory where we will check that the
 	// configuration file is deployed (.lacework.toml)
-	dir, err := ioutil.TempDir("", "lacework-cli")
-	if err != nil {
-		fmt.Println(err)
-		t.FailNow()
-	}
+	dir := os.TempDir()
 	defer os.RemoveAll(dir)
 
 	state := runFakeTerminalTestFromDir(t, dir, conditions, args...)
@@ -529,7 +524,7 @@ func runConfigureTest(t *testing.T, conditions func(*expect.Console), args ...st
 	configPath := path.Join(dir, ".lacework.toml")
 	assert.Contains(t, state, "You are all set!", "you are not all set, check configure cmd")
 	assert.FileExists(t, configPath, "the configuration file is missing")
-	laceworkTOML, err := ioutil.ReadFile(configPath)
+	laceworkTOML, err := os.ReadFile(configPath)
 	assert.Nil(t, err)
 	return state, string(laceworkTOML)
 }

--- a/integration/framework_test.go
+++ b/integration/framework_test.go
@@ -23,7 +23,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -78,10 +77,7 @@ var (
 //	    "EXITCODE is not the expected one")
 //	}
 func LaceworkCLI(args ...string) (bytes.Buffer, bytes.Buffer, int) {
-	dir, err := ioutil.TempDir("", "lacework-cli")
-	if err != nil {
-		panic(err)
-	}
+	dir := os.TempDir()
 	defer os.RemoveAll(dir)
 	return runLaceworkCLI(dir, args...)
 }
@@ -173,7 +169,7 @@ func runLaceworkCLIFromCmd(cmd *exec.Cmd) (int, error) {
 }
 
 func Version(t *testing.T) string {
-	repoVersion, err := ioutil.ReadFile("../VERSION")
+	repoVersion, err := os.ReadFile("../VERSION")
 	if err != nil {
 		t.Logf("Unable to read VERSION file, error: '%s'", err.Error())
 		t.Fail()
@@ -201,11 +197,7 @@ func createTOMLConfigFromCIvars() string {
 		log.Fatal(missingCIEnvironmentVariables())
 	}
 
-	dir, err := ioutil.TempDir("", "lacework-toml")
-	if err != nil {
-		panic(err)
-	}
-
+	dir := os.TempDir()
 	configFile := filepath.Join(dir, ".lacework.toml")
 	c := []byte(`[default]
 account = '` + os.Getenv("CI_ACCOUNT") + `'
@@ -214,7 +206,7 @@ api_key = '` + os.Getenv("CI_API_KEY") + `'
 api_secret = '` + os.Getenv("CI_API_SECRET") + `'
 version = 2
 `)
-	err = ioutil.WriteFile(configFile, c, 0644)
+	err := os.WriteFile(configFile, c, 0644)
 	if err != nil {
 		panic(err)
 	}
@@ -234,11 +226,7 @@ ERROR
 }
 
 func createDummyTOMLConfig() string {
-	dir, err := ioutil.TempDir("", "lacework-toml")
-	if err != nil {
-		panic(err)
-	}
-
+	dir := os.TempDir()
 	configFile := filepath.Join(dir, ".lacework.toml")
 	c := []byte(`[default]
 account = 'dummy'
@@ -271,7 +259,7 @@ api_key = 'DEVDEV_ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890AAABBBCCC000'
 api_secret = '_11111111111111111111111111111111'
 version = 2
 `)
-	err = ioutil.WriteFile(configFile, c, 0644)
+	err = os.WriteFile(configFile, c, 0644)
 	if err != nil {
 		panic(err)
 	}
@@ -317,7 +305,7 @@ func laceworkIntegrationTestClient() (*api.Client, error) {
 
 func createTemporaryFile(name, content string) (*os.File, error) {
 	// get temp file
-	file, err := ioutil.TempFile("", name)
+	file, err := os.CreateTemp("", name)
 	if err != nil {
 		return nil, err
 	}

--- a/integration/gcp_generation_test.go
+++ b/integration/gcp_generation_test.go
@@ -4,7 +4,6 @@ package integration
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -298,10 +297,7 @@ func TestGenerationSACredsGcp(t *testing.T) {
 			"client_email": "test_email@lacework.iam.gserviceaccount.com"
 	}`)
 
-	dir, err := ioutil.TempDir("", "lacework-cli")
-	if err != nil {
-		panic(err)
-	}
+	dir := os.TempDir()
 	defer os.RemoveAll(dir)
 
 	serviceAccountFilePath := filepath.Join(dir, "service_account_creds.json")
@@ -676,10 +672,7 @@ func TestGenerationCustomizedOutputLocationGcp(t *testing.T) {
 	defer os.Setenv("LW_NOCACHE", "")
 	var final string
 
-	dir, err := ioutil.TempDir("", "lacework-cli")
-	if err != nil {
-		panic(err)
-	}
+	dir := os.TempDir()
 	defer os.RemoveAll(dir)
 
 	runGcpGenerateTest(t,
@@ -705,7 +698,7 @@ func TestGenerationCustomizedOutputLocationGcp(t *testing.T) {
 
 	assertTerraformSaved(t, final)
 
-	result, _ := ioutil.ReadFile(filepath.FromSlash(fmt.Sprintf("%s/main.tf", dir)))
+	result, _ := os.ReadFile(filepath.FromSlash(fmt.Sprintf("%s/main.tf", dir)))
 
 	buildTf, _ := gcp.NewTerraform(true, true,
 		gcp.WithProjectId(projectId),
@@ -784,10 +777,7 @@ func TestGenerationWithExistingTerraformGcp(t *testing.T) {
 	defer os.Setenv("LW_NOCACHE", "")
 
 	// Tempdir for test
-	dir, err := ioutil.TempDir("", "lacework-cli")
-	if err != nil {
-		panic(err)
-	}
+	dir := os.TempDir()
 	defer os.RemoveAll(dir)
 
 	// Create fake main.tf
@@ -1238,7 +1228,7 @@ func runGcpGenerateTest(t *testing.T, conditions func(*expect.Console), args ...
 	os.Setenv("HOME", tfPath)
 
 	runFakeTerminalTestFromDir(t, tfPath, conditions, args...)
-	out, err := ioutil.ReadFile(filepath.Join(tfPath, gcpPath, "main.tf"))
+	out, err := os.ReadFile(filepath.Join(tfPath, gcpPath, "main.tf"))
 	if err != nil {
 		return fmt.Sprintf("main.tf not found: %s", err)
 	}

--- a/integration/gke_generation_test.go
+++ b/integration/gke_generation_test.go
@@ -4,7 +4,6 @@ package integration
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -32,7 +31,7 @@ func runGkeGenerateTest(t *testing.T, conditions func(*expect.Console), args ...
 	hcl_path := filepath.Join(tfPath, gkePath, "main.tf")
 
 	runFakeTerminalTestFromDir(t, tfPath, conditions, args...)
-	out, err := ioutil.ReadFile(hcl_path)
+	out, err := os.ReadFile(hcl_path)
 	if err != nil {
 		return fmt.Sprintf("main.tf not found: %s", err)
 	}
@@ -118,10 +117,7 @@ func TestGenerationSACredsGke(t *testing.T) {
 			"client_email": "test_email@lacework.iam.gserviceaccount.com"
 	}`)
 
-	dir, err := ioutil.TempDir("", "lacework-cli")
-	if err != nil {
-		panic(err)
-	}
+	dir := os.TempDir()
 	defer os.RemoveAll(dir)
 
 	serviceAccountFilePath := filepath.Join(dir, "service_account_creds.json")
@@ -268,10 +264,7 @@ func TestGenerationCustomizedOutputLocationGke(t *testing.T) {
 	defer os.Setenv("LW_NOCACHE", "")
 	var final string
 
-	dir, err := ioutil.TempDir("", "lacework-cli")
-	if err != nil {
-		panic(err)
-	}
+	dir := os.TempDir()
 	defer os.RemoveAll(dir)
 
 	runGkeGenerateTest(t,
@@ -295,7 +288,7 @@ func TestGenerationCustomizedOutputLocationGke(t *testing.T) {
 
 	assertGkeTerraformSaved(t, final)
 
-	result, _ := ioutil.ReadFile(filepath.FromSlash(fmt.Sprintf("%s/main.tf", dir)))
+	result, _ := os.ReadFile(filepath.FromSlash(fmt.Sprintf("%s/main.tf", dir)))
 
 	buildTf, _ := gcp.NewGkeTerraform(
 		gcp.WithGkeProjectId(gkeProjId),
@@ -337,10 +330,7 @@ func TestGenerationWithGkeExistingTerraformGke(t *testing.T) {
 	os.Setenv("LW_NOCACHE", "true")
 	defer os.Setenv("LW_NOCACHE", "")
 
-	dir, err := ioutil.TempDir("", "lacework-cli")
-	if err != nil {
-		panic(err)
-	}
+	dir := os.TempDir()
 	defer os.RemoveAll(dir)
 
 	if err := os.WriteFile(filepath.FromSlash(fmt.Sprintf("%s/main.tf", dir)), []byte{}, 0644); err != nil {

--- a/integration/lwupdater_test.go
+++ b/integration/lwupdater_test.go
@@ -19,7 +19,6 @@
 package integration_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"runtime"
@@ -70,10 +69,7 @@ func TestCheckDisabled(t *testing.T) {
 }
 
 func TestVersionLoadCacheError(t *testing.T) {
-	dir, err := ioutil.TempDir("", "version_cache")
-	if err != nil {
-		panic(err)
-	}
+	dir := os.TempDir()
 	defer os.RemoveAll(dir)
 
 	cacheFile := path.Join(dir, "version_cache")
@@ -89,10 +85,7 @@ func TestVersionLoadCacheError(t *testing.T) {
 }
 
 func TestVersionStoreLoadCache(t *testing.T) {
-	dir, err := ioutil.TempDir("", "version_cache")
-	if err != nil {
-		panic(err)
-	}
+	dir := os.TempDir()
 	defer os.RemoveAll(dir)
 
 	cacheFile := path.Join(dir, "version_cache")

--- a/integration/team_members_test.go
+++ b/integration/team_members_test.go
@@ -20,7 +20,6 @@
 package integration
 
 import (
-	"io/ioutil"
 	"log"
 	"os"
 	"strings"
@@ -34,10 +33,7 @@ import (
 func TestCreateTeamMember(t *testing.T) {
 	os.Setenv("LW_NOCACHE", "true")
 	defer os.Setenv("LW_NOCACHE", "")
-	dir, err := ioutil.TempDir("", "lacework-cli")
-	if err != nil {
-		panic(err)
-	}
+	dir := os.TempDir()
 	defer os.RemoveAll(dir)
 
 	tmResult, err := runTeamMembersTest(t,
@@ -64,10 +60,7 @@ func TestCreateTeamMember(t *testing.T) {
 func TestTeamMemberValidateEmail(t *testing.T) {
 	os.Setenv("LW_NOCACHE", "true")
 	defer os.Setenv("LW_NOCACHE", "")
-	dir, err := ioutil.TempDir("", "lacework-cli")
-	if err != nil {
-		panic(err)
-	}
+	dir := os.TempDir()
 	defer os.RemoveAll(dir)
 
 	tmResult, err := runTeamMembersTest(t,

--- a/integration/version_test.go
+++ b/integration/version_test.go
@@ -21,7 +21,6 @@ package integration
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"path"
 	"strings"
@@ -60,7 +59,7 @@ func TestDailyVersionCheckEndToEnd(t *testing.T) {
 	assert.FileExists(t, versionCacheFile, "the version_cache file is missing")
 
 	var actualCache lwupdater.Version
-	cacheJSON, err := ioutil.ReadFile(versionCacheFile)
+	cacheJSON, err := os.ReadFile(versionCacheFile)
 	if assert.Nil(t, err) {
 		err := json.Unmarshal(cacheJSON, &actualCache)
 		if assert.Nil(t, err) {
@@ -83,7 +82,7 @@ func TestDailyVersionCheckEndToEnd(t *testing.T) {
 	assert.FileExists(t, versionCacheFile, "the version_cache file is missing")
 
 	var nextCache lwupdater.Version
-	cacheJSON, err = ioutil.ReadFile(versionCacheFile)
+	cacheJSON, err = os.ReadFile(versionCacheFile)
 	if assert.Nil(t, err) {
 		err := json.Unmarshal(cacheJSON, &nextCache)
 		if assert.Nil(t, err) {
@@ -110,7 +109,7 @@ func TestDailyVersionCheckEndToEnd(t *testing.T) {
 	assert.FileExists(t, versionCacheFile, "the version_cache file is missing")
 
 	var lastCache lwupdater.Version
-	cacheJSON, err = ioutil.ReadFile(versionCacheFile)
+	cacheJSON, err = os.ReadFile(versionCacheFile)
 	if assert.Nil(t, err) {
 		err := json.Unmarshal(cacheJSON, &lastCache)
 		if assert.Nil(t, err) {

--- a/internal/databox/generator/main.go
+++ b/internal/databox/generator/main.go
@@ -22,7 +22,6 @@ import (
 	"bytes"
 	"fmt"
 	"go/format"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -73,7 +72,7 @@ func main() {
 			// only box files
 			log.Println(path, "is a file, boxing it...")
 
-			b, err := ioutil.ReadFile(path)
+			b, err := os.ReadFile(path)
 			if err != nil {
 				log.Printf("Error reading %s: %s", path, err)
 				return err
@@ -106,7 +105,7 @@ func main() {
 		log.Fatal("Error formatting generated code", err)
 	}
 
-	if err = ioutil.WriteFile(blobGo, data, os.ModePerm); err != nil {
+	if err = os.WriteFile(blobGo, data, os.ModePerm); err != nil {
 		log.Fatal("Error writing blob file", err)
 	}
 }

--- a/internal/file/file.go
+++ b/internal/file/file.go
@@ -19,7 +19,6 @@
 package file
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 )
@@ -47,10 +46,10 @@ func Copy(src, dst string) error {
 		return err
 	}
 
-	input, err := ioutil.ReadFile(srcAbs) // guardrails-disable-line
+	input, err := os.ReadFile(srcAbs)
 	if err != nil {
 		return err
 	}
 
-	return ioutil.WriteFile(dstAbs, input, 0755)
+	return os.WriteFile(dstAbs, input, 0755)
 }

--- a/internal/file/file_test.go
+++ b/internal/file/file_test.go
@@ -19,7 +19,6 @@
 package file_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"testing"
@@ -29,7 +28,7 @@ import (
 )
 
 func TestFileExistsWhenFileActuallyExists(t *testing.T) {
-	f, err := ioutil.TempFile("", "bar")
+	f, err := os.CreateTemp("", "bar")
 	if assert.Nil(t, err) {
 		assert.True(t, file.FileExists(f.Name()))
 		os.Remove(f.Name())
@@ -37,12 +36,9 @@ func TestFileExistsWhenFileActuallyExists(t *testing.T) {
 }
 
 func TestFileExistsWhenFileIsADirectory(t *testing.T) {
-	dir, err := ioutil.TempDir("", "bar")
-
-	if assert.Nil(t, err) {
-		assert.False(t, file.FileExists(dir))
-		os.RemoveAll(dir)
-	}
+	dir := os.TempDir()
+	assert.False(t, file.FileExists(dir))
+	os.RemoveAll(dir)
 }
 
 func TestFileExistsButWeDontHavePermissions(t *testing.T) {
@@ -53,17 +49,15 @@ func TestFileExistsButWeDontHavePermissions(t *testing.T) {
 		return
 	}
 
-	dir, err := ioutil.TempDir("", "root")
+	dir := os.TempDir()
+	defer os.RemoveAll(dir)
 
 	// create a directory that we can't read
 	os.Mkdir(path.Join(dir, "protected"), 0700)
 	os.WriteFile(path.Join(dir, "protected", "bubulubu"), []byte("data"), 0644)
 	os.Chmod(path.Join(dir, "protected"), 0000)
 
-	if assert.Nil(t, err) {
-		assert.False(t, file.FileExists(path.Join(dir, "protected", "bubulubu")))
-		os.RemoveAll(dir)
-	}
+	assert.False(t, file.FileExists(path.Join(dir, "protected", "bubulubu")))
 }
 
 func TestFileExistsWhenFileDoesNotExists(t *testing.T) {

--- a/lwcloud/gcp/resources/folders/folders.go
+++ b/lwcloud/gcp/resources/folders/folders.go
@@ -37,7 +37,9 @@ type FolderInfo struct {
 	Ancestory   string
 }
 
-func EnumerateFolders(ctx context.Context, clientOptions option.ClientOption, ParentId string, Ancestory string, skipList, allowList map[string]bool) ([]FolderInfo, error) {
+func EnumerateFolders(ctx context.Context,
+	clientOptions option.ClientOption, ParentId string, Ancestory string,
+	skipList, allowList map[string]bool) ([]FolderInfo, error) {
 
 	var (
 		client *resourcemanager.FoldersClient

--- a/lwcloud/gcp/resources/instances/instances.go
+++ b/lwcloud/gcp/resources/instances/instances.go
@@ -131,7 +131,10 @@ func EnumerateInstancesInProject(ctx context.Context, clientOption option.Client
 	return instances, nil
 }
 
-func EnumerateInstancesInOrg(ctx context.Context, clientOption option.ClientOption, region string, OrgId string, skipList map[string]bool, allowList map[string]bool) (map[string][]models.InstanceDetails, error) {
+func EnumerateInstancesInOrg(
+	ctx context.Context, clientOption option.ClientOption, region string,
+	OrgId string, skipList map[string]bool, allowList map[string]bool,
+) (map[string][]models.InstanceDetails, error) {
 
 	projects, err := projects.EnumerateProjects(ctx, clientOption, OrgId, OrgId, skipList, allowList)
 	if err != nil {

--- a/lwcloud/gcp/resources/projects/projects.go
+++ b/lwcloud/gcp/resources/projects/projects.go
@@ -38,7 +38,11 @@ type ProjectInfo struct {
 	ProjectId   string
 }
 
-func enumerateTopLevelProjects(ctx context.Context, clientOption option.ClientOption, ParentId string, Ancestory string, skipList, allowList map[string]bool) ([]ProjectInfo, error) {
+func enumerateTopLevelProjects(
+	ctx context.Context, clientOption option.ClientOption, ParentId string,
+	Ancestory string, skipList, allowList map[string]bool,
+) ([]ProjectInfo, error) {
+
 	var (
 		client *resourcemanager.ProjectsClient
 		err    error
@@ -93,7 +97,10 @@ func enumerateTopLevelProjects(ctx context.Context, clientOption option.ClientOp
 	return projects, nil
 }
 
-func EnumerateProjects(ctx context.Context, clientOptions option.ClientOption, ParentId string, Ancestory string, skipList, allowList map[string]bool) ([]ProjectInfo, error) {
+func EnumerateProjects(
+	ctx context.Context, clientOptions option.ClientOption, ParentId string,
+	Ancestory string, skipList, allowList map[string]bool,
+) ([]ProjectInfo, error) {
 
 	// find top level projects under Parent first
 	projects, err := enumerateTopLevelProjects(ctx, clientOptions, ParentId, Ancestory, skipList, allowList)
@@ -110,7 +117,8 @@ func EnumerateProjects(ctx context.Context, clientOptions option.ClientOption, P
 	// list all projects in the nested folders
 	var retError error
 	for _, folder := range subFolders {
-		nested_projects, err := enumerateTopLevelProjects(ctx, clientOptions, folder.Name, folder.Ancestory+" -> "+folder.DisplayName+" ("+folder.Name+")", skipList, allowList)
+		nested_projects, err := enumerateTopLevelProjects(ctx, clientOptions, folder.Name,
+			folder.Ancestory+" -> "+folder.DisplayName+" ("+folder.Name+")", skipList, allowList)
 		if err != nil {
 			// combine errors
 			retError = helpers.CombineErrors(retError, err)

--- a/lwcomponent/component.go
+++ b/lwcomponent/component.go
@@ -25,7 +25,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -143,7 +142,7 @@ func LocalState() (*State, error) {
 
 	stateFile := filepath.Join(componentsFile, "state")
 
-	stateBytes, err := ioutil.ReadFile(stateFile)
+	stateBytes, err := os.ReadFile(stateFile)
 	if err != nil {
 		return state, err
 	}
@@ -187,7 +186,7 @@ func (s State) WriteState() error {
 		return err
 	}
 
-	if err := ioutil.WriteFile(stateFile, buf.Bytes(), 0644); err != nil {
+	if err := os.WriteFile(stateFile, buf.Bytes(), 0644); err != nil {
 		return err
 	}
 
@@ -458,7 +457,7 @@ func (c Component) WriteSignature(signature []byte) error {
 		return err
 	}
 
-	return ioutil.WriteFile(cvPath, signature, 0644)
+	return os.WriteFile(cvPath, signature, 0644)
 }
 
 // WriteVersion stores the component version on disk
@@ -477,7 +476,7 @@ func (c Component) WriteVersion(installed string) error {
 	if installed == "" {
 		installed = c.LatestVersion.String()
 	}
-	return ioutil.WriteFile(cvPath, []byte(installed), 0644)
+	return os.WriteFile(cvPath, []byte(installed), 0644)
 }
 
 // UpdateAvailable returns true if there is a newer version of the component
@@ -528,7 +527,7 @@ func (c *Component) loadDevSpecs() error {
 
 	devSpecs := filepath.Join(dir, ".dev")
 	if file.FileExists(devSpecs) {
-		devSpecsBytes, err := ioutil.ReadFile(devSpecs)
+		devSpecsBytes, err := os.ReadFile(devSpecs)
 		if err != nil {
 			return errors.Errorf("unable to read %s file", devSpecs)
 		}
@@ -625,7 +624,7 @@ func (c Component) EnterDevelopmentMode() error {
 			return err
 		}
 
-		return ioutil.WriteFile(devSpecs, buf.Bytes(), 0644)
+		return os.WriteFile(devSpecs, buf.Bytes(), 0644)
 	}
 
 	return nil

--- a/lwconfig/config.go
+++ b/lwconfig/config.go
@@ -22,7 +22,6 @@ package lwconfig
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 
@@ -181,5 +180,5 @@ func StoreAt(configPath string, profiles Profiles) error {
 		return err
 	}
 
-	return ioutil.WriteFile(configPath, buf.Bytes(), 0600)
+	return os.WriteFile(configPath, buf.Bytes(), 0600)
 }

--- a/lwgenerate/gcp/service_account.go
+++ b/lwgenerate/gcp/service_account.go
@@ -3,7 +3,7 @@ package gcp
 import (
 	"encoding/base64"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"os"
 
 	"github.com/lacework/go-sdk/internal/file"
@@ -46,7 +46,7 @@ func ValidateServiceAccountCredentialsFile(credFile string) error {
 		}
 		defer jsonFile.Close()
 
-		byteValue, err := ioutil.ReadAll(jsonFile)
+		byteValue, err := io.ReadAll(jsonFile)
 		if err != nil {
 			return errors.Wrap(err, "unable to parse credentials file")
 		}

--- a/lwlogger/logger_test.go
+++ b/lwlogger/logger_test.go
@@ -20,7 +20,6 @@ package lwlogger_test
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"syscall"
 	"testing"
@@ -191,7 +190,7 @@ func TestLoggerNewLogFormatEnv(t *testing.T) {
 
 func TestLoggerNewWithWriter(t *testing.T) {
 	// create a temporal file to write the logs
-	tmpfile, err := ioutil.TempFile("", "logger")
+	tmpfile, err := os.CreateTemp("", "logger")
 	assert.Nil(t, err)
 	defer os.Remove(tmpfile.Name())
 	logOutput, err := os.OpenFile(tmpfile.Name(), syscall.O_CREAT|syscall.O_RDWR|syscall.O_APPEND, 0666)
@@ -201,7 +200,7 @@ func TestLoggerNewWithWriter(t *testing.T) {
 	lwlogger.NewWithWriter("DEBUG", logOutput).Debug("we are debugging")
 
 	// after writing the log message, read the file and assert its content
-	logContentB, err := ioutil.ReadFile(tmpfile.Name())
+	logContentB, err := os.ReadFile(tmpfile.Name())
 	assert.Nil(t, err)
 	logContent := string(logContentB)
 	assert.Contains(t, logContent, "we are debugging")

--- a/lwrunner/awsrunner.go
+++ b/lwrunner/awsrunner.go
@@ -45,7 +45,11 @@ type AWSRunner struct {
 	ImageName        string
 }
 
-func NewAWSRunner(amiImageId, userFromCLIArg, host, region, availabilityZone, instanceID string, filterSSH bool, callback ssh.HostKeyCallback) (*AWSRunner, error) {
+func NewAWSRunner(
+	amiImageId, userFromCLIArg, host, region, availabilityZone, instanceID string,
+	filterSSH bool, callback ssh.HostKeyCallback,
+) (*AWSRunner, error) {
+
 	// Look up the AMI name of the runner
 	imageName, err := getAMIName(amiImageId, region)
 	if err != nil {

--- a/lwrunner/runner.go
+++ b/lwrunner/runner.go
@@ -23,7 +23,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"os"
 	"path"
@@ -218,7 +218,7 @@ func newSignerFromFile(keyname string) (ssh.Signer, error) {
 	}
 	defer fp.Close()
 
-	buf, err := ioutil.ReadAll(fp)
+	buf, err := io.ReadAll(fp)
 	if err != nil {
 		return nil, err
 	}

--- a/lwrunner/runner_test.go
+++ b/lwrunner/runner_test.go
@@ -21,7 +21,6 @@ package lwrunner_test
 import (
 	"crypto/rand"
 	"crypto/rsa"
-	"io/ioutil"
 	"net"
 	"os"
 	"path"
@@ -114,10 +113,7 @@ func TestDefaultIdentityFilePathEnvVariable(t *testing.T) {
 }
 
 func TestLwRunnerAddKnownHostNoSSHDir(t *testing.T) {
-	mockHome, err := ioutil.TempDir("", "lwrunner")
-	if err != nil {
-		panic(err)
-	}
+	mockHome := os.TempDir()
 	defer os.RemoveAll(mockHome)
 
 	knownFile := path.Join(mockHome, ".ssh", "known_hosts")
@@ -134,7 +130,7 @@ func TestLwRunnerAddKnownHostNoSSHDir(t *testing.T) {
 	assert.NoError(t, subject)
 
 	// Check the known host file
-	content, err := ioutil.ReadFile(knownFile)
+	content, err := os.ReadFile(knownFile)
 	assert.NoError(t, err)
 	assert.Contains(t, string(content), "mock-test")
 
@@ -144,20 +140,17 @@ func TestLwRunnerAddKnownHostNoSSHDir(t *testing.T) {
 	assert.NoError(t, subject)
 
 	// Check the known host file
-	content, err = ioutil.ReadFile(knownFile)
+	content, err = os.ReadFile(knownFile)
 	assert.NoError(t, err)
 	assert.Contains(t, string(content), "second-time")
 }
 
 func TestLwRunnerAddKnownWithSSHDir(t *testing.T) {
-	mockHome, err := ioutil.TempDir("", "lwrunner")
-	if err != nil {
-		panic(err)
-	}
+	mockHome := os.TempDir()
 	defer os.RemoveAll(mockHome)
 
 	// Mock that the ~/.ssh dir exists
-	err = os.Mkdir(path.Join(mockHome, ".ssh"), 0700)
+	err := os.Mkdir(path.Join(mockHome, ".ssh"), 0700)
 	if err != nil {
 		panic(err)
 	}
@@ -176,7 +169,7 @@ func TestLwRunnerAddKnownWithSSHDir(t *testing.T) {
 	assert.NoError(t, subject)
 
 	// Check the known host file
-	content, err := ioutil.ReadFile(knownFile)
+	content, err := os.ReadFile(knownFile)
 	assert.NoError(t, err)
 	assert.Contains(t, string(content), "mock-test")
 }
@@ -191,18 +184,15 @@ func (m mockNetAddr) String() string {
 }
 
 func TestLwRunnerDefaultKnownHosts(t *testing.T) {
-	mockHome, err := ioutil.TempDir("", "lwrunner")
-	if err != nil {
-		panic(err)
-	}
+	mockHome := os.TempDir()
 	defer os.RemoveAll(mockHome)
 
-	err = os.Mkdir(path.Join(mockHome, ".ssh"), 0755)
+	err := os.Mkdir(path.Join(mockHome, ".ssh"), 0755)
 	if err != nil {
 		panic(err)
 	}
 
-	err = ioutil.WriteFile(path.Join(mockHome, ".ssh", "known_hosts"), []byte(""), 0600)
+	err = os.WriteFile(path.Join(mockHome, ".ssh", "known_hosts"), []byte(""), 0600)
 	if err != nil {
 		panic(err)
 	}

--- a/lwupdater/updater.go
+++ b/lwupdater/updater.go
@@ -22,7 +22,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -59,7 +58,7 @@ func (cache *Version) StoreCache(path string) error {
 		return err
 	}
 
-	err := ioutil.WriteFile(path, buf.Bytes(), 0644)
+	err := os.WriteFile(path, buf.Bytes(), 0644)
 	if err != nil {
 		return err
 	}
@@ -94,7 +93,7 @@ func Check(project, current string) (*Version, error) {
 
 // LoadCache loads a version cache file from the provided path
 func LoadCache(path string) (*Version, error) {
-	cacheJSON, err := ioutil.ReadFile(path)
+	cacheJSON, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

This PR enables line length check and fixes a bunch of lint issues.

## How did you test this change?

All tests should pass.

<img src="https://media1.giphy.com/media/H7Fbn0QHGDWW4/giphy.gif"/>

## Issue

Closes https://github.com/lacework/go-sdk/issues/941
