### PR TITLE
feat(api): Add support for the `ComponentData` API end-points

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -77,6 +77,9 @@ const (
 
 	apiV2ComplianceEvaluationsSearch = "v2/Configs/ComplianceEvaluations/search"
 
+	apiV2ComponentDataRequest  = "v2/ComponentData/requestUpload"
+	apiV2ComponentDataComplete = "v2/ComponentData/completeUpload"
+
 	apiV2ConfigsAzure              = "v2/Configs/AzureSubscriptions"
 	apiV2ConfigsAzureSubscriptions = "v2/Configs/AzureSubscriptions?tenantId=%s"
 	apiV2ConfigsGcp                = "v2/Configs/GcpProjects"

--- a/api/component_data.go
+++ b/api/component_data.go
@@ -1,0 +1,149 @@
+package api
+
+import (
+	"net/http"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+type ComponentDataService struct {
+	client *Client
+}
+
+type ComponentDataInitialRequest struct {
+	Name             string          `json:"name"`
+	Tags             []string        `json:"tags"`
+	SupportedMethods []string        `json:"supportedMethods"`
+	Documents        []*DocumentSpec `json:"documents"`
+}
+
+type DocumentSpec struct {
+	Name string `json:"name"`
+	Size int64  `json:"size"`
+}
+
+type InitialResponseRaw struct {
+	Data *InitialResponse `json:"data,omitempty"`
+}
+
+type InitialResponse struct {
+	Guid          string          `json:"guid,omitempty"`
+	UploadMethods []*UploadMethod `json:"uploadMethods,omitempty"`
+}
+
+type UploadMethod struct {
+	Method string            `json:"method,omitempty"`
+	Info   map[string]string `json:"info,omitempty"`
+}
+
+type CompleteRequest struct {
+	Guid string `json:"guid"`
+}
+
+type CompleteResponseRaw struct {
+	Data *CompleteResponse `json:"data,omitempty"`
+}
+
+type CompleteResponse struct {
+	Guid string `json:"guid,omitempty"`
+}
+
+func (svc *ComponentDataService) UploadFiles(name string, tags []string, paths []string) (string, error) {
+	initialRequest, err := buildInitialRequest(name, tags, paths)
+	if err != nil {
+		return "", err
+	}
+	var initialResponse InitialResponseRaw
+	err = doWithExponentialBackoff(func() error {
+		return svc.client.RequestEncoderDecoder(http.MethodPost, "v2/ComponentData/requestUpload", initialRequest, &initialResponse)
+	})
+	if err != nil {
+		return "", err
+	}
+	var chosenMethod *UploadMethod
+	for _, method := range initialResponse.Data.UploadMethods {
+		if method.Method == "AwsS3" {
+			chosenMethod = method
+		}
+	}
+	if chosenMethod == nil {
+		return "", errors.New("couldn't find a supported upload method in the upload request response")
+	}
+	for _, path := range paths {
+		err = doWithExponentialBackoff(func() error {
+			return putFileToS3(svc, path, chosenMethod.Info)
+		})
+		if err != nil {
+			return "", err
+		}
+	}
+	completeRequest := CompleteRequest{
+		Guid: initialResponse.Data.Guid,
+	}
+	var completeResponse CompleteResponseRaw
+	err = doWithExponentialBackoff(func() error {
+		return svc.client.RequestEncoderDecoder(http.MethodPost, "v2/ComponentData/completeUpload", completeRequest, &completeResponse)
+	})
+	if err != nil {
+		return "", err
+	}
+	if initialResponse.Data.Guid != completeResponse.Data.Guid {
+		return "", errors.New("expected the initial GUID and the one returned on completion to match")
+	}
+	return initialResponse.Data.Guid, nil
+}
+
+func buildInitialRequest(name string, tags []string, paths []string) (*ComponentDataInitialRequest, error) {
+	documents := make([]*DocumentSpec, 0, len(paths))
+	for _, path := range paths {
+		info, err := os.Lstat(path)
+		if err != nil {
+			return nil, err
+		}
+		documents = append(documents, &DocumentSpec{
+			Name: filepath.Base(path),
+			Size: info.Size(),
+		})
+	}
+	return &ComponentDataInitialRequest{
+		Name:             name,
+		Tags:             tags,
+		SupportedMethods: []string{"AwsS3"},
+		Documents:        documents,
+	}, nil
+}
+
+func putFileToS3(svc *ComponentDataService, path string, uploadUrls map[string]string) error {
+	file, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	req, err := http.NewRequest(http.MethodPut, uploadUrls[filepath.Base(path)], file)
+	if err != nil {
+		return err
+	}
+	_, err = svc.client.Do(req)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func doWithExponentialBackoff(f func() error) error {
+	err := f()
+	if err == nil {
+		return nil
+	}
+	for wait := 2; wait < 60; wait *= 2 {
+		time.Sleep(time.Duration(wait) * time.Second)
+		err := f()
+		if err == nil {
+			return nil
+		}
+	}
+	return err
+}

--- a/api/component_data_test.go
+++ b/api/component_data_test.go
@@ -1,0 +1,70 @@
+package api_test
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/lacework/go-sdk/api"
+	"github.com/lacework/go-sdk/internal/lacework"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUploadFiles(t *testing.T) {
+	fakeServer := lacework.MockServer()
+	fakeServer.UseApiV2()
+	fakeServer.MockToken("TOKEN")
+	defer fakeServer.Close()
+	fakeServer.MockAPI("ComponentData/requestUpload", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+		assert.NotNil(t, r.Body)
+		body := httpBodySniffer(r)
+		assert.Contains(t, body, "sast")
+		assert.Contains(t, body, "doc-set")
+		_, err := fmt.Fprintf(w, generateInitialResponse())
+		assert.Nil(t, err)
+	})
+	fakeServer.MockAPI("ComponentData/completeUpload", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+		assert.NotNil(t, r.Body)
+		body := httpBodySniffer(r)
+		assert.Contains(t, body, "SOME-GUID")
+		_, err := fmt.Fprintf(w, generateCompleteResponse())
+		assert.Nil(t, err)
+	})
+	c, err := api.NewClient("test",
+		api.WithApiV2(),
+		api.WithToken("TOKEN"),
+		api.WithURL(fakeServer.URL()),
+	)
+	assert.Nil(t, err)
+	guid, err := c.V2.ComponentData.UploadFiles("doc-set", []string{"sast"}, []string{})
+	assert.Nil(t, err)
+	assert.Equal(t, "SOME-GUID", guid)
+}
+
+func generateInitialResponse() string {
+	return `
+{
+	"data": {
+		"guid": "SOME-GUID",
+		"uploadMethods": [
+			{
+				"method": "AwsS3",
+				"info": {}
+			}
+		]
+	}
+}
+`
+}
+
+func generateCompleteResponse() string {
+	return `
+{
+	"data": {
+		"guid": "SOME-GUID"
+	}
+}
+`
+}

--- a/api/v2.go
+++ b/api/v2.go
@@ -38,6 +38,7 @@ type V2Endpoints struct {
 	AlertRules              *AlertRulesService
 	ReportRules             *ReportRulesService
 	CloudAccounts           *CloudAccountsService
+	ComponentData           *ComponentDataService
 	ContainerRegistries     *ContainerRegistriesService
 	Configs                 *v2ConfigService
 	ResourceGroups          *ResourceGroupsService
@@ -70,6 +71,7 @@ func NewV2Endpoints(c *Client) *V2Endpoints {
 		&AlertRulesService{c},
 		&ReportRulesService{c},
 		&CloudAccountsService{c},
+		&ComponentDataService{c},
 		&ContainerRegistriesService{c},
 		NewV2ConfigService(c),
 		&ResourceGroupsService{c},


### PR DESCRIPTION
## Summary

This PR adds support in the Go SDK for having components upload data back to the Lacework platform via the new `/v2/ComponentData` API end-points (added in https://github.com/lacework/rainbow/pull/11260). Rather than allowing the end-points to be called individually (which there is no intended use-case for), this adds a single new function which handles the whole flow of performing an upload: that is, requesting from the API server some pre-signed URLs to upload data to S3, performing the upload, and then sending the API server a confirmation that the upload was completed successfully. This encapsulates this flow in the SDK rather than duplicating it accross components so that if we need to change it in future we only need to change it here.

Each of the network steps includes retrying with an expontential back-off, and if any step fails after this retrying then we abort and return that error. This may leave a partially completed upload in S3, which is okay: without sending the final confirmation the upload won't be consumed and the failed attempt will get removed automatically after our (fairly short) retention period expires.

## How did you test this change?

New unit tests that call a mock API. Also, manual end-to-end testing against one of our development instances (still in progress at time of writing, but I won't merge until that's completed successfully).

Edit: Manual testing is now complete and working 🎉

## Issue

https://lacework.atlassian.net/browse/RAIN-46483
