### PR TITLE
fix: change ParseRelative time to use UTC instead of local time

### DIFF
--- a/lwtime/reltime.go
+++ b/lwtime/reltime.go
@@ -222,7 +222,7 @@ func (rel relative) time(inTime time.Time) (outTime time.Time, err error) {
 // 	...
 // }
 func ParseRelative(s string) (time.Time, error) {
-	return parseRelativeFromTime(s, time.Now())
+	return parseRelativeFromTime(s, time.Now().UTC())
 }
 
 func parseRelativeFromTime(s string, fromTime time.Time) (time.Time, error) {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/lacework/go-sdk) and create your branch from `main`
  2. Run `make prepare` in the repository root
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`make test`)
  5. Format your code (`make fmt`)
  6. Make sure your code lints (`make lint`)
  7. If you are updating the Lacework CLI, make sure it compiles (`make build-cli-cross-platform`)
  8. Follow the commit message standard (`type(scope): subject`) documented in [DEVELOPER_GUIDELINES.md](https://github.com/lacework/go-sdk/blob/main/DEVELOPER_GUIDELINES.md#commit-message-standard)
  9. If you haven't already, configure signed commits by [telling git about your signing key](https://docs.github.com/en/github/authenticating-to-github/managing-commit-signature-verification/telling-git-about-your-signing-key) and [signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)

  Learn more about contributing: https://github.com/lacework/go-sdk/blob/main/CONTRIBUTING.md
-->

## Summary

Relative time function sets "now" to local time rather than UTC

This has been causing issues in search apis where time filter is provided.
```
  [400] endTime cannot be after current time
```
## How did you test this change?

Set timezone to gmt +1, then run 
`lacework vuln ctr list-assessments`
<!--
  How exactly did you verify that your PR solves the issue you wanted to solve?
  Include any other relevant information such as how to use the new functionality, screenshots, etc.
-->

## Issue

- https://lacework.atlassian.net/browse/GROW-1393
- https://lacework.atlassian.net/browse/LINK-1322
