### PR TITLE
fix(lwtime): natural/relative time to use UTC instead of local time

### DIFF
--- a/lwtime/nattime.go
+++ b/lwtime/nattime.go
@@ -178,13 +178,18 @@ func (nt natural) getRelativeRange() (relStart string, relEnd string, err error)
 }
 
 // Parse the string representation of a Lacework natural time
+// Start and End time objects are returned in UTC
 //
 // start, end, err := lwtime.ParseNatural("this year")
-// if err != nil {
-// 	...
-// }
+//
+//	if err != nil {
+//		...
+//	}
 func ParseNatural(n string) (time.Time, time.Time, error) {
-	return parseNaturalFromTime(n, time.Now())
+	// time.Now() is intentional here such that snaps work properly
+	// For instance snapping to @d should snap to the start of the local day
+	startLocal, endLocal, err := parseNaturalFromTime(n, time.Now())
+	return startLocal.UTC(), endLocal.UTC(), err
 }
 
 func parseNaturalFromTime(n string, fromTime time.Time) (time.Time, time.Time, error) {

--- a/lwtime/nattime.go
+++ b/lwtime/nattime.go
@@ -181,10 +181,9 @@ func (nt natural) getRelativeRange() (relStart string, relEnd string, err error)
 // Start and End time objects are returned in UTC
 //
 // start, end, err := lwtime.ParseNatural("this year")
-//
-//	if err != nil {
-//		...
-//	}
+// if err != nil {
+// 	...
+// }
 func ParseNatural(n string) (time.Time, time.Time, error) {
 	// time.Now() is intentional here such that snaps work properly
 	// For instance snapping to @d should snap to the start of the local day

--- a/lwtime/reltime.go
+++ b/lwtime/reltime.go
@@ -219,10 +219,9 @@ func (rel relative) time(inTime time.Time) (outTime time.Time, err error) {
 // Time object is returned in UTC
 //
 // t, err := lwtime.ParseRelative("-1y@y")
-//
-//	if err != nil {
-//		...
-//	}
+// if err != nil {
+// 	...
+// }
 func ParseRelative(s string) (time.Time, error) {
 	// time.Now() is intentional here such that snaps work properly
 	// For instance snapping to @d should snap to the start of the local day

--- a/lwtime/reltime.go
+++ b/lwtime/reltime.go
@@ -216,13 +216,18 @@ func (rel relative) time(inTime time.Time) (outTime time.Time, err error) {
 }
 
 // Parse the string representation of a Lacework relative time
+// Time object is returned in UTC
 //
 // t, err := lwtime.ParseRelative("-1y@y")
-// if err != nil {
-// 	...
-// }
+//
+//	if err != nil {
+//		...
+//	}
 func ParseRelative(s string) (time.Time, error) {
-	return parseRelativeFromTime(s, time.Now().UTC())
+	// time.Now() is intentional here such that snaps work properly
+	// For instance snapping to @d should snap to the start of the local day
+	localTime, err := parseRelativeFromTime(s, time.Now())
+	return localTime.UTC(), err
 }
 
 func parseRelativeFromTime(s string, fromTime time.Time) (time.Time, error) {


### PR DESCRIPTION
## Summary
The lwtime package should be returning relative and natural times universally UTC().  

## How did you test this change?

Set timezone to gmt +1, then run
lacework vuln ctr list-assessments


```
~/Applications/src/lacework/go-sdk GROW-1393-duex
❯ lacework-dev vuln ctr list-assessments
There are no assessments in your environment.

~/Applications/src/lacework/go-sdk GROW-1393-duex 9s
❯ lacework vuln ctr list-assessments 
Usage:
  lacework vulnerability container list-assessments [flags]
...
ERROR unable to search for active containers: 
  [POST] https://dev7.dev7.corp.lacework.net/api/v2/Entities/Containers/search
  [400] endTime cannot be after current time
```

## Issue
https://lacework.atlassian.net/browse/GROW-1393