### PR TITLE
fix(cli): fix gcp report query params --pdf cmd

### DIFF
--- a/api/reports_gcp.go
+++ b/api/reports_gcp.go
@@ -91,7 +91,7 @@ func (svc *gcpReportsService) DownloadPDF(filepath string, config GcpReportConfi
 		return errors.New("project id and org id are required")
 	}
 
-	apiPath := fmt.Sprintf(apiV2ReportsSecondaryQuery, config.ProjectID, config.OrganizationID, "pdf", config.Type)
+	apiPath := fmt.Sprintf(apiV2ReportsSecondaryQuery, config.OrganizationID, config.ProjectID, "pdf", config.Type)
 
 	request, err := svc.client.NewRequest("GET", apiPath, nil)
 	if err != nil {


### PR DESCRIPTION
fix query parameters not set correctly when --pdf flag is used in `lacework compliance gcp get-report` cmd