### PR TITLE
fix(cli): gRPC port collision

### DIFF
--- a/cli/cmd/cdk.go
+++ b/cli/cmd/cdk.go
@@ -115,7 +115,7 @@ func (c *cliState) Serve() error {
 			return err
 		}
 	}
-	return err
+	return errors.Wrap(err, fmt.Sprintf("unable to start gRPC server (attempts: %d)", maxAttempts))
 }
 
 func (c *cliState) serve(target string) error {

--- a/cli/cmd/cdk.go
+++ b/cli/cmd/cdk.go
@@ -30,7 +30,7 @@ import (
 )
 
 // default gRPC target if not specified via LW_CDK_TARGET
-const defaultGrpcTarget string = "localhost:1123"
+const defaultGrpcPort int = 1123
 
 // envs are all the environment variables passed to CDK components
 func (c *cliState) envs() []string {
@@ -58,7 +58,7 @@ func (c *cliState) GrpcTarget() string {
 	if target := os.Getenv("LW_CDK_TARGET"); target != "" {
 		return target
 	}
-	return defaultGrpcTarget
+	return fmt.Sprintf("localhost:%v", c.cdkServerPort)
 }
 
 // Ping implements CDK.Ping
@@ -97,8 +97,28 @@ func (c *cliState) Honeyvent(ctx context.Context, in *cdk.HoneyventRequest) (*cd
 	return &cdk.Reply{}, nil
 }
 
-// Serve will start the CDK gRPC server at the provided port and log level
-func (c *cliState) Serve(target string) error {
+// Serve will start the CDK gRPC server
+func (c *cliState) Serve() error {
+	// Start the gRPC server for components to communicate back
+	const max_attempts = 5
+
+	if target := os.Getenv("LW_CDK_TARGET"); target != "" {
+		return c.serve(target)
+	}
+
+	// Try a range of port numbers in case the default one is not available
+	var err error
+	for i := 0; i < max_attempts; i++ {
+		err = c.serve(fmt.Sprintf("localhost:%v", defaultGrpcPort+i))
+		if err == nil {
+			c.cdkServerPort = defaultGrpcPort + i
+			return err
+		}
+	}
+	return err
+}
+
+func (c *cliState) serve(target string) error {
 	c.Stop() // make sure server is not running
 
 	lis, err := net.Listen("tcp", target)

--- a/cli/cmd/cdk.go
+++ b/cli/cmd/cdk.go
@@ -100,7 +100,7 @@ func (c *cliState) Honeyvent(ctx context.Context, in *cdk.HoneyventRequest) (*cd
 // Serve will start the CDK gRPC server
 func (c *cliState) Serve() error {
 	// Start the gRPC server for components to communicate back
-	const max_attempts = 5
+	const maxAttempts = 20
 
 	if target := os.Getenv("LW_CDK_TARGET"); target != "" {
 		return c.serve(target)

--- a/cli/cmd/cdk.go
+++ b/cli/cmd/cdk.go
@@ -108,7 +108,7 @@ func (c *cliState) Serve() error {
 
 	// Try a range of port numbers in case the default one is not available
 	var err error
-	for i := 0; i < max_attempts; i++ {
+	for i := 0; i < maxAttempts; i++ {
 		err = c.serve(fmt.Sprintf("localhost:%v", defaultGrpcPort+i))
 		if err == nil {
 			c.cdkServerPort = defaultGrpcPort + i

--- a/cli/cmd/cdk_test.go
+++ b/cli/cmd/cdk_test.go
@@ -20,6 +20,7 @@ package cmd
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -30,13 +31,13 @@ import (
 )
 
 func TestCDKServer(t *testing.T) {
-	go cli.Serve(defaultGrpcTarget)
+	go cli.Serve()
 	defer cli.Stop()
 
 	// wait for the gRPC server to come online
 	time.Sleep(time.Millisecond * 200)
 
-	conn, err := grpc.Dial(defaultGrpcTarget,
+	conn, err := grpc.Dial(fmt.Sprintf("localhost:%v", defaultGrpcPort),
 		grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if assert.Nil(t, err) {
 		defer conn.Close()

--- a/cli/cmd/cli_state.go
+++ b/cli/cmd/cli_state.go
@@ -83,7 +83,8 @@ type cliState struct {
 	cdk.UnimplementedCoreServer
 
 	// Allows only one gRPC Server
-	cdkServer *grpc.Server
+	cdkServer     *grpc.Server
+	cdkServerPort int
 }
 
 // NewDefaultState creates a new cliState with some defaults
@@ -104,6 +105,7 @@ func NewDefaultState() *cliState {
 			Newline:     "\n",
 		},
 		nonInteractive: !isatty.IsTerminal(os.Stdout.Fd()),
+		cdkServerPort:  defaultGrpcPort,
 	}
 
 	// initialize honeycomb library and honeyvent

--- a/cli/cmd/component.go
+++ b/cli/cmd/component.go
@@ -196,7 +196,7 @@ func (c *cliState) LoadComponents() {
 					RunE: func(cmd *cobra.Command, args []string) error {
 						go func() {
 							// Start the gRPC server for components to communicate back
-							if err := c.Serve(c.GrpcTarget()); err != nil {
+							if err := c.Serve(); err != nil {
 								c.Log.Errorw("couldn't serve gRPC server", "error", err)
 							}
 						}()


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/lacework/go-sdk) and create your branch from `main`
  2. Run `make prepare` in the repository root
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`make test`)
  5. Format your code (`make fmt`)
  6. Make sure your code lints (`make lint`)
  7. If you are updating the Lacework CLI, make sure it compiles (`make build-cli-cross-platform`)
  8. Follow the commit message standard (`type(scope): subject`) documented in [DEVELOPER_GUIDELINES.md](https://github.com/lacework/go-sdk/blob/main/DEVELOPER_GUIDELINES.md#commit-message-standard)
  9. If you haven't already, configure signed commits by [telling git about your signing key](https://docs.github.com/en/github/authenticating-to-github/managing-commit-signature-verification/telling-git-about-your-signing-key) and [signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)

  Learn more about contributing: https://github.com/lacework/go-sdk/blob/main/CONTRIBUTING.md
-->

## Summary
There is a port collision when running multiple instances of the Lacework CLI when invoking components. Each instance of the Lacework CLI attempts to start a gRPC server on the same port, 1123, and only one of them succeeds. To reproduce:

```
lacework remediate version & lacework remediate version
```

The above command starts two instances of the Lacework CLI in parallel. The end result:
```
[1] 283414
{"level":"error","ts":"2023-02-08T15:04:15Z","caller":"cmd/component.go:200","msg":"couldn't serve gRPC server","error":"failed to listen: listen tcp 127.0.0.1:1123: bind: address already in use","errorVerbose":"listen tcp 127.0.0.1:1123: bind: address already in use\nfailed to listen\ngithub.com/lacework/go-sdk/cli/cmd.(*cliState).Serve\n\t/codefresh/volume/go-sdk/cli/cmd/cdk.go:106\ngithub.com/lacework/go-sdk/cli/cmd.(*cliState).LoadComponents.func1.1\n\t/codefresh/volume/go-sdk/cli/cmd/component.go:199\nruntime.goexit\n\t/usr/local/go/src/runtime/asm_amd64.s:1571","stacktrace":"github.com/lacework/go-sdk/cli/cmd.(*cliState).LoadComponents.func1.1\n\t/codefresh/volume/go-sdk/cli/cmd/component.go:200"}
0.1
0.1
[1]+  Done                    lacework remediate version
```

This particular command succeeded despite the error message, but anything that relies on the gRPC communication between the main CLI and the component will not work. This PR makes it so that the Lacework CLI will try a range of ports, starting with 1123. If the first one is already in use, move on to 1124, and so on, until we reach the maximum number of attempts. 

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## How did you test this change?

Build the CLI and attempt to reproduce the error as above:
```
make build-cli-cross-platform
cp bin/lacework-cli-linux-amd64 ~/bin/lacework-dev
lacework-dev remediate version & lacework-dev remediate version
```

Then the output I got was 

```
[1] 283621
0.1
0.1
[1]+  Done                    lacework-dev remediate version
```
Just the versions without the error messages. 
<!--
  How exactly did you verify that your PR solves the issue you wanted to solve?
  Include any other relevant information such as how to use the new functionality, screenshots, etc.
-->

## Issue

<!--
  Include the link to a Jira/Github issue
-->
