### PR TITLE
fix(ec2ssm): safely dereference SSM command output

### DIFF
--- a/cli/cmd/agent_aws-install_ec2ssm.go
+++ b/cli/cmd/agent_aws-install_ec2ssm.go
@@ -313,7 +313,7 @@ func installAWSSSM(_ *cobra.Command, _ []string) error {
 					cli.OutputHuman(
 						"Unexpected SSM command exit %v, stderr %s, skipping instance %s\n",
 						commandOutput.ResponseCode,
-						*commandOutput.StandardErrorContent,
+						lwrunner.GetSSMCommandInvocationStdErr(commandOutput),
 						threadRunner.InstanceID,
 					)
 					return
@@ -352,12 +352,12 @@ func installAWSSSM(_ *cobra.Command, _ []string) error {
 					"Install failed on instance %s with error %v, stdout %s, stderr %s\n",
 					threadRunner.InstanceID,
 					err,
-					*commandOutput.StandardOutputContent,
-					*commandOutput.StandardErrorContent,
+					lwrunner.GetSSMCommandInvocationStdOut(commandOutput),
+					lwrunner.GetSSMCommandInvocationStdErr(commandOutput),
 				)
 			} else if commandOutput.Status == ssmtypes.CommandInvocationStatusSuccess {
 				cli.OutputHuman("Lacework agent installed successfully on host %s\n\n", threadRunner.InstanceID)
-				cli.OutputHuman(fmtSuccessfulAgentInstallString(*commandOutput.StandardOutputContent))
+				cli.OutputHuman(fmtSuccessfulAgentInstallString(lwrunner.GetSSMCommandInvocationStdOut(commandOutput)))
 				atomic.AddInt32(&successfulCount, 1)
 			} else {
 				cli.Log.Warnw("Install command did not return `Success` exit status for this instance",
@@ -367,8 +367,8 @@ func installAWSSSM(_ *cobra.Command, _ []string) error {
 				cli.OutputHuman(
 					"Install command failed with %s exit status, %s stdout, %s stderr for instance %s\n",
 					commandOutput.Status,
-					*commandOutput.StandardOutputContent,
-					*commandOutput.StandardErrorContent,
+					lwrunner.GetSSMCommandInvocationStdOut(commandOutput),
+					lwrunner.GetSSMCommandInvocationStdErr(commandOutput),
 					threadRunner.InstanceID,
 				)
 			}

--- a/lwrunner/awsrunner.go
+++ b/lwrunner/awsrunner.go
@@ -324,8 +324,8 @@ func (run AWSRunner) RunSSMCommandOnRemoteHost(cfg aws.Config, operation string)
 		*sendCommandOutput.Command.CommandId,
 		durationTensOfSeconds/6,
 		*getCommandInvocationOutput,
-		*getCommandInvocationOutput.StandardOutputContent,
-		*getCommandInvocationOutput.StandardErrorContent,
+		GetSSMCommandInvocationStdOut(*getCommandInvocationOutput),
+		GetSSMCommandInvocationStdErr(*getCommandInvocationOutput),
 	)
 }
 
@@ -388,5 +388,25 @@ func getSSHUsernameLookupTable() []func(string) (bool, string) {
 			return strings.Contains(imageName, "amazon_linux"), "ec2-user"
 		},
 		func(imageName string) (bool, string) { return strings.Contains(imageName, "amzn2-ami"), "ec2-user" },
+	}
+}
+
+// GetSSMCommandInvocationStdOut is a helper function to safely deference the
+// SSM struct we receive from the AWS API.
+func GetSSMCommandInvocationStdOut(out ssm.GetCommandInvocationOutput) string {
+	if out.StandardOutputContent != nil {
+		return *out.StandardOutputContent
+	} else {
+		return ""
+	}
+}
+
+// GetSSMCommandInvocationStdErr is a helper function to safely deference the
+// SSM struct we receive from the AWS API.
+func GetSSMCommandInvocationStdErr(out ssm.GetCommandInvocationOutput) string {
+	if out.StandardErrorContent != nil {
+		return *out.StandardErrorContent
+	} else {
+		return ""
 	}
 }

--- a/lwrunner/awsrunner_test.go
+++ b/lwrunner/awsrunner_test.go
@@ -19,8 +19,11 @@
 package lwrunner
 
 import (
+	"strconv"
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ssm"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -52,4 +55,70 @@ func TestSSHUsernameFromAmazonLinuxIsEC2User(t *testing.T) {
 	user, err := getSSHUsername("", "amzn2-ami-hvm-x86_64-gp2")
 	assert.NoError(t, err)
 	assert.Equal(t, "ec2-user", user)
+}
+
+func TestGetSSMCommandInvocationStdOut(t *testing.T) {
+	cases := []struct {
+		mockCommandOutput *ssm.GetCommandInvocationOutput
+		expectedResult    string
+	}{
+		{
+			mockCommandOutput: &ssm.GetCommandInvocationOutput{
+				StandardOutputContent: aws.String("foobarbaz"),
+			},
+			expectedResult: "foobarbaz",
+		},
+		{
+			mockCommandOutput: &ssm.GetCommandInvocationOutput{
+				StandardOutputContent: aws.String(""),
+			},
+			expectedResult: "",
+		},
+		{
+			mockCommandOutput: &ssm.GetCommandInvocationOutput{
+				StandardOutputContent: nil,
+			},
+			expectedResult: "",
+		},
+	}
+
+	for i, tt := range cases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			stdoutContent := GetSSMCommandInvocationStdOut(*tt.mockCommandOutput)
+			assert.Equal(t, tt.expectedResult, stdoutContent)
+		})
+	}
+}
+
+func TestGetSSMCommandInvocationStdErr(t *testing.T) {
+	cases := []struct {
+		mockCommandOutput *ssm.GetCommandInvocationOutput
+		expectedResult    string
+	}{
+		{
+			mockCommandOutput: &ssm.GetCommandInvocationOutput{
+				StandardErrorContent: aws.String("foobarbaz"),
+			},
+			expectedResult: "foobarbaz",
+		},
+		{
+			mockCommandOutput: &ssm.GetCommandInvocationOutput{
+				StandardErrorContent: aws.String(""),
+			},
+			expectedResult: "",
+		},
+		{
+			mockCommandOutput: &ssm.GetCommandInvocationOutput{
+				StandardErrorContent: nil,
+			},
+			expectedResult: "",
+		},
+	}
+
+	for i, tt := range cases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			stdoutContent := GetSSMCommandInvocationStdErr(*tt.mockCommandOutput)
+			assert.Equal(t, tt.expectedResult, stdoutContent)
+		})
+	}
 }


### PR DESCRIPTION
In rare cases, `ssm.GetCommandInvocationOutput` has `nil` fields. This
often occurs when there was also an error returned.

This commit adds helper functions to safely get stdout and stderr from
SSM commands, as well as unit tests for these functions. This commit
also calls these functions where `ec2ssm` reads SSM command output.

Fixes RAIN-47644

Signed-off-by: Nick Schmeller <nick.schmeller@lacework.net>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/lacework/go-sdk) and create your branch from `main`
  2. Run `make prepare` in the repository root
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`make test`)
  5. Format your code (`make fmt`)
  6. Make sure your code lints (`make lint`)
  7. If you are updating the Lacework CLI, make sure it compiles (`make build-cli-cross-platform`)
  8. Follow the commit message standard (`type(scope): subject`) documented in [DEVELOPER_GUIDELINES.md](https://github.com/lacework/go-sdk/blob/main/DEVELOPER_GUIDELINES.md#commit-message-standard)
  9. If you haven't already, configure signed commits by [telling git about your signing key](https://docs.github.com/en/github/authenticating-to-github/managing-commit-signature-verification/telling-git-about-your-signing-key) and [signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)

  Learn more about contributing: https://github.com/lacework/go-sdk/blob/main/CONTRIBUTING.md
-->

## How did you test this change?

<!--
  How exactly did you verify that your PR solves the issue you wanted to solve?
  Include any other relevant information such as how to use the new functionality, screenshots, etc.
-->
Added unit tests for new code, checking that integration tests pass.

## Issue

<!--
  Include the link to a Jira/Github issue
-->
https://lacework.atlassian.net/browse/RAIN-47644
