### PR TITLE
fix: parsing of account names containing `lacework.net`

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -80,7 +80,7 @@ func NewClient(account string, opts ...Option) (*Client, error) {
 		if err != nil {
 			return nil, err
 		}
-		account = domain.Account
+		account = domain.String()
 	}
 
 	baseURL, err := url.Parse(fmt.Sprintf("https://%s.lacework.net", account))

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -45,6 +45,27 @@ func TestNewClientFullDomainURL(t *testing.T) {
 	}
 }
 
+func TestNewClientUrlInternal(t *testing.T) {
+	c, err := api.NewClient("account.corp.lacework.net")
+	if assert.Nil(t, err) {
+		assert.Equal(t, "https://account.corp.lacework.net", c.URL(), "domain should be detected and correctly configured")
+	}
+}
+
+func TestNewClientUrlWithSubaccount(t *testing.T) {
+	c, err := api.NewClient("subaccount.account.lacework.net")
+	if assert.Nil(t, err) {
+		assert.Equal(t, "https://subaccount.account.lacework.net", c.URL(), "domain should be detected and correctly configured")
+	}
+}
+
+func TestNewClientUrlInternalWithSubaccount(t *testing.T) {
+	c, err := api.NewClient("subaccount.account.corp.lacework.net")
+	if assert.Nil(t, err) {
+		assert.Equal(t, "https://subaccount.account.corp.lacework.net", c.URL(), "domain should be detected and correctly configured")
+	}
+}
+
 func TestNewClientAccountEmptyError(t *testing.T) {
 	c, err := api.NewClient("")
 	assert.Nil(t, c)


### PR DESCRIPTION
If the account name contains `lacework.net`, we were using `lwdomain.New(...)` to parse it. But then we were only using `.Account` from the result, and discarding `.Cluster` and `.Internal` which are also needed to construct the proper URL. Instead, let's call `.String()` which [correctly](https://github.com/lacework/go-sdk/blob/19f1f3ca3d4e8d989ac4fae25830874e23a72731/lwdomain/domain.go#L91-L101) builds a string including all of those parts. Also adds full unit test coverage of all these cases.

~~Moderately urgent: Internal usage of SAST and SCA is currently broken due to this.~~ We worked around this, so it is no longer causing an incident for us. Still, it would be nice to get a fix in so others can avoid issues due to this in the future.