### PR TITLE
fix(cli): vuln ctr show-assessment not showing cve's with the same cv…

### DIFF
--- a/cli/cmd/vuln_container_show_assessments.go
+++ b/cli/cmd/vuln_container_show_assessments.go
@@ -453,7 +453,8 @@ func filterVulnerabilityContainer(image []api.VulnerabilityContainer) filteredIm
 	)
 
 	for _, i := range image {
-		vulnIDs = append(vulnIDs, fmt.Sprintf("%s-%s", i.VulnID, i.FeatureKey.Name))
+		vulnKey := fmt.Sprintf("%s-%s-%s", i.VulnID, i.FeatureKey.Name, i.FeatureProps.IntroducedIn)
+		vulnIDs = append(vulnIDs, vulnKey)
 		// filter: severity
 		if vulCmdState.Severity != "" {
 			if filterSeverity(i.Severity, vulCmdState.Severity) {
@@ -469,8 +470,8 @@ func filterVulnerabilityContainer(image []api.VulnerabilityContainer) filteredIm
 		regex := regexp.MustCompile(regexAllTabs)
 		introducedIn := regex.ReplaceAllString(i.FeatureProps.IntroducedIn, "\n")
 
-		if _, ok := vulns[fmt.Sprintf("%s-%s", i.VulnID, i.FeatureKey.Name)]; !ok {
-			vulns[fmt.Sprintf("%s-%s", i.VulnID, i.FeatureKey.Name)] = vulnTable{
+		if _, ok := vulns[vulnKey]; !ok {
+			vulns[vulnKey] = vulnTable{
 				Name:           i.VulnID,
 				Severity:       i.Severity,
 				PackageName:    i.FeatureKey.Name,

--- a/cli/cmd/vuln_container_show_assessments.go
+++ b/cli/cmd/vuln_container_show_assessments.go
@@ -480,7 +480,6 @@ func filterVulnerabilityContainer(image []api.VulnerabilityContainer) filteredIm
 				PackageName:    i.FeatureKey.Name,
 				CurrentVersion: i.FeatureKey.Version,
 				FixVersion:     i.FixInfo.FixedVersion,
-				CreatedBy:      introducedInMap[vulnKey],
 				// Todo(v2): CVSSv3Score is missing from V2
 				CVSSv3Score: 0,
 				// Todo(v2): CVSSv2Score is missing from V2

--- a/cli/cmd/vuln_container_show_assessments.go
+++ b/cli/cmd/vuln_container_show_assessments.go
@@ -251,7 +251,7 @@ func buildVulnContainerAssessmentReports(response api.VulnerabilitiesContainersR
 	default:
 		if len(response.Data) == 0 {
 			if vulCmdState.Severity != "" {
-				cli.OutputHuman("There are no vulnerabilties found for this severity")
+				cli.OutputHuman("There are no vulnerabilities found for this severity")
 			}
 
 			cli.OutputHuman(
@@ -445,15 +445,16 @@ func vulContainerImagePackagesToTable(packageTable filteredPackageTable) [][]str
 
 func filterVulnerabilityContainer(image []api.VulnerabilityContainer) filteredImageTable {
 	var (
-		vulns      = make(map[string]vulnTable)
-		vulnIDs    []string
-		vulnsCount int
-		vulnList   []vulnTable
-		filtered   []api.VulnerabilityContainer
+		vulns           = make(map[string]vulnTable)
+		introducedInMap = make(map[string][]string)
+		vulnIDs         []string
+		vulnsCount      int
+		vulnList        []vulnTable
+		filtered        []api.VulnerabilityContainer
 	)
 
 	for _, i := range image {
-		vulnKey := fmt.Sprintf("%s-%s-%s", i.VulnID, i.FeatureKey.Name, i.FeatureProps.IntroducedIn)
+		vulnKey := fmt.Sprintf("%s-%s", i.VulnID, i.FeatureKey.Name)
 		vulnIDs = append(vulnIDs, vulnKey)
 		// filter: severity
 		if vulCmdState.Severity != "" {
@@ -470,6 +471,8 @@ func filterVulnerabilityContainer(image []api.VulnerabilityContainer) filteredIm
 		regex := regexp.MustCompile(regexAllTabs)
 		introducedIn := regex.ReplaceAllString(i.FeatureProps.IntroducedIn, "\n")
 
+		introducedInMap[vulnKey] = append(introducedInMap[vulnKey], introducedIn)
+
 		if _, ok := vulns[vulnKey]; !ok {
 			vulns[vulnKey] = vulnTable{
 				Name:           i.VulnID,
@@ -477,7 +480,7 @@ func filterVulnerabilityContainer(image []api.VulnerabilityContainer) filteredIm
 				PackageName:    i.FeatureKey.Name,
 				CurrentVersion: i.FeatureKey.Version,
 				FixVersion:     i.FixInfo.FixedVersion,
-				CreatedBy:      introducedIn,
+				CreatedBy:      introducedInMap[vulnKey],
 				// Todo(v2): CVSSv3Score is missing from V2
 				CVSSv3Score: 0,
 				// Todo(v2): CVSSv2Score is missing from V2
@@ -486,6 +489,13 @@ func filterVulnerabilityContainer(image []api.VulnerabilityContainer) filteredIm
 			}
 			filtered = append(filtered, i)
 		}
+	}
+
+	// Set the aggregated introduced by layers for each vuln
+	for k, v := range introducedInMap {
+		vulnTable := vulns[k]
+		vulnTable.CreatedBy = v
+		vulns[k] = vulnTable
 	}
 
 	var uniqueIDs []string = array.Unique(vulnIDs)
@@ -514,7 +524,7 @@ func vulContainerImageLayersToCSV(imageTable filteredImageTable) [][]string {
 			vuln.PackageName,
 			vuln.CurrentVersion,
 			vuln.FixVersion,
-			vuln.CreatedBy,
+			strings.Join(vuln.CreatedBy, ", "),
 		})
 	}
 
@@ -527,16 +537,28 @@ func vulContainerImageLayersToCSV(imageTable filteredImageTable) [][]string {
 
 func vulContainerImageLayersToTable(imageTable filteredImageTable) [][]string {
 	var out [][]string
+	var createdByKeys = make(map[string]bool)
+
 	for _, vuln := range imageTable.Vulnerabilities {
-		out = append(out, []string{
-			vuln.Name,
-			vuln.Severity,
-			vuln.PackageName,
-			vuln.CurrentVersion,
-			vuln.FixVersion,
-			vuln.CreatedBy,
-			vuln.Status,
-		})
+		introducedBy := strings.Join(vuln.CreatedBy, ",")
+		// if the same vuln is introduced in more than 1 layer, only display the number of layers
+		if len(vuln.CreatedBy) > 1 {
+			introducedBy = fmt.Sprintf("introduced in %d layers...", len(vuln.CreatedBy))
+		}
+
+		if !createdByKeys[fmt.Sprintf("%s-%s", vuln.Name, vuln.CurrentVersion)] {
+			out = append(out, []string{
+				vuln.Name,
+				vuln.Severity,
+				vuln.PackageName,
+				vuln.CurrentVersion,
+				vuln.FixVersion,
+				introducedBy,
+				vuln.Status,
+			})
+		}
+
+		createdByKeys[fmt.Sprintf("%s-%s", vuln.Name, vuln.CurrentVersion)] = true
 	}
 
 	sort.Slice(out, func(i, j int) bool {
@@ -604,7 +626,7 @@ type vulnTable struct {
 	PackageName    string
 	CurrentVersion string
 	FixVersion     string
-	CreatedBy      string
+	CreatedBy      []string
 	CVSSv2Score    float64
 	CVSSv3Score    float64
 	Status         string

--- a/cli/cmd/vuln_container_test.go
+++ b/cli/cmd/vuln_container_test.go
@@ -118,6 +118,29 @@ CVE-2029-21234,Medium,0.0,0.0,example-1,1.0.0,2.2.0-11+deb9u4,example introduced
 	assert.Equal(t, strings.TrimPrefix(expected, "\n"), cliOutput)
 }
 
+func TestBuildVulnCtrReportWithAggregatedIntroducedInLayerCSV(t *testing.T) {
+	cli.EnableCSVOutput()
+	vulCmdState.Details = true
+	defer func() {
+		cli.csvOutput = false
+		vulCmdState.Details = false
+	}()
+
+	var response api.VulnerabilitiesContainersResponse
+	if err := json.Unmarshal([]byte(mockIntroducedInLayerResponse), &response); err != nil {
+		panic(err)
+	}
+	cliOutput := capturer.CaptureOutput(func() {
+		assert.Nil(t, buildVulnContainerAssessmentReports(response))
+	})
+
+	expected := `
+CVE ID,Severity,CVSSv2,CVSSv3,Package,Current Version,Fix Version,Introduced in Layer
+CVE-2029-21234,Medium,0.0,0.0,example-1,1.0.0,2.2.0-11+deb9u4,"example introduced in layer 1, example introduced in layer 2"
+`
+	assert.Equal(t, strings.TrimPrefix(expected, "\n"), cliOutput)
+}
+
 func TestBuildVulnCtrReportWithAggregatedIntroducedInLayer(t *testing.T) {
 	vulCmdState.Details = true
 	defer func() {

--- a/cli/cmd/vuln_container_test.go
+++ b/cli/cmd/vuln_container_test.go
@@ -118,6 +118,23 @@ CVE-2029-21234,Medium,0.0,0.0,example-1,1.0.0,2.2.0-11+deb9u4,example introduced
 	assert.Equal(t, strings.TrimPrefix(expected, "\n"), cliOutput)
 }
 
+func TestBuildVulnCtrReportWithAggregatedIntroducedInLayer(t *testing.T) {
+	vulCmdState.Details = true
+	defer func() {
+		vulCmdState.Details = false
+	}()
+
+	var response api.VulnerabilitiesContainersResponse
+	if err := json.Unmarshal([]byte(mockIntroducedInLayerResponse), &response); err != nil {
+		panic(err)
+	}
+	cliOutput := capturer.CaptureOutput(func() {
+		assert.Nil(t, buildVulnContainerAssessmentReports(response))
+	})
+
+	assert.Contains(t, cliOutput, "introduced in 2 layers...")
+}
+
 func TestVulnCtrIntroducedInRegex(t *testing.T) {
 	tabsRegexTableTest := []struct {
 		Name     string
@@ -370,5 +387,166 @@ var rawListAssessments = `
             "status": "VULNERABLE",
             "vulnId": "CVE-2020-12345"
         }
+]
+}`
+
+var mockIntroducedInLayerResponse = `
+{
+    "paging": {
+        "rows": 5000,
+        "totalRows": 6419,
+        "urls": {
+            "nextPage": "https://example.lacework.net/api/v2/Vulnerabilities/Containers/"
+        }
+    },
+"data": [
+{
+            "evalCtx": {
+                "cve_batch_info": [
+                    {
+                        "cve_created_time": "2022-11-21 00:21:41.678000000"
+                    }
+                ],
+                "exception_props": [
+                    {
+                        "exception_guid": "VULN_C44BF2CBE09F0E705565BEA1A0C1D2A5D1534857F2C7CDF8381",
+                        "exception_name": "registry index.docker.io severity Low",
+                        "exception_reason": "Accepted Risk"
+                    }
+                ],
+                "image_info": {
+                    "created_time": 1605140985874,
+                    "digest": "sha256:77b2d2246518044ef95e3dbd029e51dd477788e5bf8e278e418685aabc3fe28a",
+                    "id": "sha256:a65572164cb78c4d04f57bd66201c775e2dab08fce394806a03a933c5daf9e48",
+                    "registry": "index.docker.io",
+                    "repo": "techally-test/test-cli",
+                    "scan_created_time": 1669055600,
+                    "size": 360608563,
+                    "status": "Success",
+                    "tags": [
+                        "latest"
+                    ],
+                    "type": "Docker"
+                },
+                "integration_props": {
+                    "INTG_GUID": "TECHALLY_FC5485B5ACFF3DAFE77E8C8A734C6C2FAD7CAAC9F01313C",
+                    "NAME": "Terraform-Dockerhub",
+                    "REGISTRY_TYPE": "DOCKERHUB"
+                },
+                "is_reeval": false,
+                "request_source": "PLATFORM_SCANNER",
+                "scan_batch_id": "467a274c-f847-456b-b62d-13f9d88988cc-1669055607923432004",
+                "scan_request_props": {
+                    "data_format_version": "1.0",
+                    "props": {
+                        "data_format_version": "1.0",
+                        "scanner_version": "10.0.155"
+                    },
+                    "reqId": "2ac494a9-b7be-453a-81b9-7a2f1f9e2113",
+                    "reqSource": "ondemand",
+                    "scanCompletionUtcTime": 1669055607,
+                    "scan_start_time": 1669055600,
+                    "scanner_version": "10.0.155"
+                },
+                "vuln_batch_id": "7B2EDDD2D2D140ECA6B85001FC62AE45",
+                "vuln_created_time": "2022-11-21 00:21:41.678000000"
+            },
+            "evalGuid": "781865fdff984def2587b5f05065f0db",
+            "featureKey": {
+                "name": "example-1",
+                "namespace": "debian:9",
+                "version": "1.0.0"
+            },
+            "featureProps": {
+                "feed": "lacework",
+                "introduced_in": "example introduced in layer 1",
+                "layer": "sha256:sha256:572866ab72a68759e23b071fbbdce6341137c9606936b4fff9846f74997bbaac",
+                "src": "var/lib/dpkg/status",
+                "version_format": "dpkg"
+            },
+            "fixInfo": {
+                "fix_available": 1,
+                "fixed_version": "2.2.0-11+deb9u4"
+            },
+            "imageId": "sha256:a65572164cb78c4d04f57bd66201c775e2dab08fce394806a03a933c5daf9e48",
+            "severity": "Medium",
+            "startTime": "2022-11-21T18:33:28.076Z",
+            "status": "VULNERABLE",
+            "vulnId": "CVE-2029-21234"
+        },{
+            "evalCtx": {
+                "cve_batch_info": [
+                    {
+                        "cve_created_time": "2022-11-21 00:21:41.678000000"
+                    }
+                ],
+                "exception_props": [
+                    {
+                        "exception_guid": "VULN_C44BF2CBE09F0E705565BEA1A0C1D2A5D1534857F2C7CDF8381",
+                        "exception_name": "registry index.docker.io severity Low",
+                        "exception_reason": "Accepted Risk"
+                    }
+                ],
+                "image_info": {
+                    "created_time": 1605140985874,
+                    "digest": "sha256:77b2d2246518044ef95e3dbd029e51dd477788e5bf8e278e418685aabc3fe28a",
+                    "id": "sha256:a65572164cb78c4d04f57bd66201c775e2dab08fce394806a03a933c5daf9e48",
+                    "registry": "index.docker.io",
+                    "repo": "techally-test/test-cli",
+                    "scan_created_time": 1669055600,
+                    "size": 360608563,
+                    "status": "Success",
+                    "tags": [
+                        "latest"
+                    ],
+                    "type": "Docker"
+                },
+                "integration_props": {
+                    "INTG_GUID": "TECHALLY_FC5485B5ACFF3DAFE77E8C8A734C6C2FAD7CAAC9F01313C",
+                    "NAME": "Terraform-Dockerhub",
+                    "REGISTRY_TYPE": "DOCKERHUB"
+                },
+                "is_reeval": false,
+                "request_source": "PLATFORM_SCANNER",
+                "scan_batch_id": "467a274c-f847-456b-b62d-13f9d88988cc-1669055607923432004",
+                "scan_request_props": {
+                    "data_format_version": "1.0",
+                    "props": {
+                        "data_format_version": "1.0",
+                        "scanner_version": "10.0.155"
+                    },
+                    "reqId": "2ac494a9-b7be-453a-81b9-7a2f1f9e2113",
+                    "reqSource": "ondemand",
+                    "scanCompletionUtcTime": 1669055607,
+                    "scan_start_time": 1669055600,
+                    "scanner_version": "10.0.155"
+                },
+                "vuln_batch_id": "7B2EDDD2D2D140ECA6B85001FC62AE45",
+                "vuln_created_time": "2022-11-21 00:21:41.678000000"
+            },
+            "evalGuid": "781865fdff984def2587b5f05065f0db",
+            "featureKey": {
+                "name": "example-1",
+                "namespace": "debian:9",
+                "version": "1.0.0"
+            },
+            "featureProps": {
+                "feed": "lacework",
+                "introduced_in": "example introduced in layer 2",
+                "layer": "sha256:sha256:572866ab72a68759e23b071fbbdce6341137c9606936b4fff9846f74997bbaac",
+                "src": "var/lib/dpkg/status",
+                "version_format": "dpkg"
+            },
+            "fixInfo": {
+                "fix_available": 1,
+                "fixed_version": "2.2.0-11+deb9u4"
+            },
+            "imageId": "sha256:a65572164cb78c4d04f57bd66201c775e2dab08fce394806a03a933c5daf9e48",
+            "severity": "Medium",
+            "startTime": "2022-11-21T18:33:28.076Z",
+            "status": "VULNERABLE",
+            "vulnId": "CVE-2029-21234"
+        }
+
 ]
 }`


### PR DESCRIPTION
…eid introduced in different layers

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/lacework/go-sdk) and create your branch from `main`
  2. Run `make prepare` in the repository root
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`make test`)
  5. Format your code (`make fmt`)
  6. Make sure your code lints (`make lint`)
  7. If you are updating the Lacework CLI, make sure it compiles (`make build-cli-cross-platform`)
  8. Follow the commit message standard (`type(scope): subject`) documented in [DEVELOPER_GUIDELINES.md](https://github.com/lacework/go-sdk/blob/main/DEVELOPER_GUIDELINES.md#commit-message-standard)
  9. If you haven't already, configure signed commits by [telling git about your signing key](https://docs.github.com/en/github/authenticating-to-github/managing-commit-signature-verification/telling-git-about-your-signing-key) and [signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)

  Learn more about contributing: https://github.com/lacework/go-sdk/blob/main/CONTRIBUTING.md
-->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

We were not showing all introduced in layers data  when a assessment results contained CVEs with multiple layers.

This change will:
- Display only one row for the CVE and the INTRODUCED IN LAYER column will show Introduced in X layers if there are more than 1.
- The JSON output will show all layers
- The CSV output will show all layers


## How did you test this change?

<!--
  How exactly did you verify that your PR solves the issue you wanted to solve?
  Include any other relevant information such as how to use the new functionality, screenshots, etc.
-->

Manually 
- [x] Run `lacework vuln ctr show <assessmentID> --details`
- [x] Run `lacework vuln ctr show <assessmentID> --details --json`
- [x] Run `lacework vuln ctr show <assessmentID> --details --csv`

Unit Test
- [x] Add new unit tests `TestBuildVulnCtrReportWithAggregatedIntroducedInLayer` `TestBuildVulnCtrReportWithAggregatedIntroducedInLayerCSV`

## Issue

<!--
  Include the link to a Jira/Github issue
-->

https://lacework.atlassian.net/browse/GROW-1426
