### PR TITLE
fix: resolve supported aws report types in cli and api packages

### DIFF
--- a/api/reports_aws.go
+++ b/api/reports_aws.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"sort"
 	"time"
 
 	"github.com/pkg/errors"
@@ -59,6 +60,7 @@ func AwsReportTypes() []string {
 		reportTypes = append(reportTypes, report)
 	}
 
+	sort.Strings(reportTypes)
 	return reportTypes
 }
 

--- a/api/reports_aws.go
+++ b/api/reports_aws.go
@@ -52,12 +52,24 @@ func NewAwsReportType(report string) (AwsReportType, error) {
 	return NONE_AWS_REPORT, errors.Errorf("no report type found for %s", report)
 }
 
+func AwsReportTypes() []string {
+	reportTypes := make([]string, 0, len(awsReportTypes))
+
+	for _, report := range awsReportTypes {
+		reportTypes = append(reportTypes, report)
+	}
+
+	return reportTypes
+}
+
 var awsReportTypes = map[AwsReportType]string{AWS_CIS_S3: "AWS_CIS_S3", NIST_800_53_Rev4: "NIST_800-53_Rev4",
 	NIST_800_171_Rev2: "NIST_800-171_Rev2", ISO_2700: "ISO_2700", HIPAA: "HIPAA", SOC: "SOC",
 	AWS_SOC_Rev2: "AWS_SOC_Rev2", PCI: "PCI", AWS_CIS_14: "AWS_CIS_14", AWS_CMMC_1_02: "AWS_CMMC_1.02",
 	AWS_ISO_27001_2013: "AWS_ISO_27001:2013", AWS_NIST_CSF: "AWS_NIST_CSF", AWS_HIPAA: "AWS_HIPAA",
 	AWS_NIST_800_53_rev5: "AWS_NIST_800-53_rev5", AWS_NIST_800_171_rev2: "AWS_NIST_800-171_rev2",
-	AWS_PCI_DSS_3_2_1: "AWS_PCI_DSS_3.2.1", AWS_SOC_2: "AWS_SOC_2", LW_AWS_SEC_ADD_1_0: "LW_AWS_SEC_ADD_1_0"}
+	AWS_PCI_DSS_3_2_1: "AWS_PCI_DSS_3.2.1", AWS_SOC_2: "AWS_SOC_2", LW_AWS_SEC_ADD_1_0: "LW_AWS_SEC_ADD_1_0",
+	AWS_CIS_1_4_ISO_IEC_27002_2022: "AWS_CIS_1_4_ISO_IEC_27002_2022", AWS_CYBER_ESSENTIALS_2_2: "AWS_Cyber_Essentials_2_2",
+	AWS_CSA_CCM_4_0_5: "AWS_CSA_CCM_4_0_5"}
 
 const (
 	NONE_AWS_REPORT AwsReportType = iota
@@ -79,6 +91,9 @@ const (
 	AWS_PCI_DSS_3_2_1
 	AWS_SOC_2
 	LW_AWS_SEC_ADD_1_0
+	AWS_CIS_1_4_ISO_IEC_27002_2022
+	AWS_CYBER_ESSENTIALS_2_2
+	AWS_CSA_CCM_4_0_5
 )
 
 // Get returns an AwsReportResponse

--- a/api/reports_azure.go
+++ b/api/reports_azure.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"sort"
 	"time"
 
 	"github.com/pkg/errors"
@@ -60,6 +61,7 @@ func AzureReportTypes() []string {
 		reportTypes = append(reportTypes, report)
 	}
 
+	sort.Strings(reportTypes)
 	return reportTypes
 }
 

--- a/api/reports_azure.go
+++ b/api/reports_azure.go
@@ -53,6 +53,16 @@ func NewAzureReportType(report string) (AzureReportType, error) {
 	return NONE_AZURE_REPORT, errors.Errorf("no report type found for %s", report)
 }
 
+func AzureReportTypes() []string {
+	reportTypes := make([]string, 0, len(azureReportTypes))
+
+	for _, report := range azureReportTypes {
+		reportTypes = append(reportTypes, report)
+	}
+
+	return reportTypes
+}
+
 var azureReportTypes = map[AzureReportType]string{
 	AZURE_CIS: "AZURE_CIS", AZURE_CIS_131: "AZURE_CIS_131", AZURE_SOC: "AZURE_SOC", AZURE_SOC_Rev2: "AZURE_SOC_Rev2",
 	AZURE_PCI: "AZURE_PCI", AZURE_PCI_Rev2: "AZURE_PCI_Rev2", AZURE_ISO_27001: "AZURE_ISO_27001", AZURE_NIST_CSF: "AZURE_NIST_CSF",

--- a/api/reports_gcp.go
+++ b/api/reports_gcp.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"sort"
 	"time"
 
 	"github.com/pkg/errors"
@@ -59,7 +60,7 @@ func GcpReportTypes() []string {
 	for _, report := range gcpReportTypes {
 		reportTypes = append(reportTypes, report)
 	}
-
+	sort.Strings(reportTypes)
 	return reportTypes
 }
 

--- a/api/reports_gcp.go
+++ b/api/reports_gcp.go
@@ -53,9 +53,22 @@ func NewGcpReportType(report string) (GcpReportType, error) {
 	return NONE_GCP_REPORT, errors.Errorf("no report type found for %s", report)
 }
 
+func GcpReportTypes() []string {
+	reportTypes := make([]string, 0, len(gcpReportTypes))
+
+	for _, report := range gcpReportTypes {
+		reportTypes = append(reportTypes, report)
+	}
+
+	return reportTypes
+}
+
 var gcpReportTypes = map[GcpReportType]string{GCP_HIPAA: "GCP_HIPAA", GCP_CIS: "GCP_CIS", GCP_SOC: "GCP_SOC", GCP_CIS12: "GCP_CIS12",
 	GCP_K8S: "GCP_K8S", GCP_PCI_Rev2: "GCP_PCI_Rev2", GCP_SOC_Rev2: "GCP_SOC_Rev2", GCP_HIPAA_Rev2: "GCP_HIPAA_Rev2", GCP_ISO_27001: "GCP_ISO_27001",
-	GCP_NIST_CSF: "GCP_NIST_CSF", GCP_NIST_800_53_REV4: "GCP_NIST_800_53_REV4", GCP_NIST_800_171_REV2: "GCP_NIST_800_171_REV2", GCP_PCI: "GCP_PCI", GCP_CIS13: "GCP_CIS13"}
+	GCP_NIST_CSF: "GCP_NIST_CSF", GCP_NIST_800_53_REV4: "GCP_NIST_800_53_REV4", GCP_NIST_800_171_REV2: "GCP_NIST_800_171_REV2", GCP_PCI: "GCP_PCI", GCP_CIS13: "GCP_CIS13",
+	GCP_CIS_1_3_0_NIST_800_171_rev2: "GCP_CIS_1_3_0_NIST_800_171_rev2", GCP_CIS_1_3_0_NIST_800_53_rev5: "GCP_CIS_1_3_0_NIST_800_53_rev5",
+	GCP_CIS_1_3_0_NIST_CSF: "GCP_CIS_1_3_0_NIST_CSF", GCP_PCI_DSS_3_2_1: "GCP_PCI_DSS_3_2_1", GCP_HIPAA_2013: "GCP_HIPAA_2013", GCP_ISO_27001_2013: "GCP_ISO_27001_2013",
+	GCP_CMMC_1_02: "GCP_CMMC_1_02", GCP_SOC_2: "GCP_SOC_2"}
 
 const (
 	NONE_GCP_REPORT GcpReportType = iota
@@ -73,6 +86,14 @@ const (
 	GCP_NIST_800_171_REV2
 	GCP_PCI
 	GCP_CIS13
+	GCP_CIS_1_3_0_NIST_800_171_rev2
+	GCP_CIS_1_3_0_NIST_800_53_rev5
+	GCP_CIS_1_3_0_NIST_CSF
+	GCP_PCI_DSS_3_2_1
+	GCP_HIPAA_2013
+	GCP_ISO_27001_2013
+	GCP_CMMC_1_02
+	GCP_SOC_2
 )
 
 // Get returns a GcpReportResponse

--- a/cli/cmd/compliance_aws.go
+++ b/cli/cmd/compliance_aws.go
@@ -40,11 +40,6 @@ var (
 		Type string
 	}{Type: "AWS_CIS_14"}
 
-	validAwsReportTypes = []string{"AWS_NIST_CSF", "AWS_NIST_800-53_rev5", "AWS_HIPAA", "NIST_800-53_Rev4", "LW_AWS_SEC_ADD_1_0",
-		"AWS_SOC_Rev2", "AWS_PCI_DSS_3.2.1", "AWS_CIS_S3", "ISO_2700", "SOC", "AWS_CSA_CCM_4_0_5", "PCI", "AWS_Cyber_Essentials_2_2",
-		"AWS_ISO_27001:2013", "AWS_CIS_14", "AWS_CMMC_1.02", "HIPAA", "AWS_SOC_2", "AWS_CIS_1_4_ISO_IEC_27002_2022", "NIST_800-171_Rev2",
-		"AWS_NIST_800-171_rev"}
-
 	// complianceAwsListAccountsCmd represents the list-accounts inside the aws command
 	complianceAwsListAccountsCmd = &cobra.Command{
 		Use:     "list-accounts",
@@ -85,10 +80,10 @@ var (
 			//	 return errors.Wrap(err, "unable to retrieve valid report types")
 			// }
 
-			if array.ContainsStr(validAwsReportTypes, compAwsCmdState.Type) {
+			if array.ContainsStr(api.AwsReportTypes(), compAwsCmdState.Type) {
 				return nil
 			} else {
-				return errors.Errorf(`supported report types are: %s'`, strings.Join(validAwsReportTypes, ", "))
+				return errors.Errorf(`supported report types are: %s'`, strings.Join(api.AwsReportTypes(), ", "))
 			}
 		},
 		Short: "Get the latest AWS compliance report",
@@ -523,7 +518,7 @@ func init() {
 	//AWS_NIST_800-171_rev2'
 	complianceAwsGetReportCmd.Flags().StringVar(&compAwsCmdState.Type, "type", "AWS_CIS_14",
 		fmt.Sprintf(`report type to display, run 'lacework report-definitions list' for more information.
-valid types:%s`, prettyPrintReportTypes(validAwsReportTypes)))
+valid types:%s`, prettyPrintReportTypes(api.AwsReportTypes())))
 
 	complianceAwsGetReportCmd.Flags().StringSliceVar(&compCmdState.Category, "category", []string{},
 		"filter report details by category (identity-and-access-management, s3, logging...)",

--- a/cli/cmd/compliance_azure.go
+++ b/cli/cmd/compliance_azure.go
@@ -41,9 +41,6 @@ var (
 		Type string
 	}{Type: "AZURE_CIS_131"}
 
-	validAzureReportTypes = []string{"AZURE_CIS_131", "AZURE_NIST_800_171_REV2", "AZURE_NIST_800_53_REV5", "AZURE_NIST_CSF",
-		"AZURE_PCI", "AZURE_SOC_Rev2", "AZURE_ISO_27001", "AZURE_SOC", "AZURE_HIPAA", "AZURE_CIS", "AZURE_PCI_Rev2"}
-
 	// complianceAzureListSubsCmd represents the list-subscriptions sub-command inside the azure command
 	complianceAzureListSubsCmd = &cobra.Command{
 		Use:     "list-subscriptions",
@@ -136,10 +133,10 @@ Use the following command to list all Azure Tenants configured in your account:
 			//	return errors.Wrap(err, "unable to retrieve valid report types")
 			//}
 
-			if array.ContainsStr(validAzureReportTypes, compAzCmdState.Type) {
+			if array.ContainsStr(api.AzureReportTypes(), compAzCmdState.Type) {
 				return nil
 			} else {
-				return errors.Errorf("supported report types are: %s", strings.Join(validAzureReportTypes, ", "))
+				return errors.Errorf("supported report types are: %s", strings.Join(api.AzureReportTypes(), ", "))
 			}
 		},
 		Short: "Get the latest Azure compliance report",
@@ -483,7 +480,7 @@ func init() {
 	//AZURE_PCI, AZURE_SOC_Rev2, AZURE_ISO_27001, AZURE_SOC, AZURE_HIPAA, AZURE_CIS, AZURE_PCI_Rev2
 	complianceAzureGetReportCmd.Flags().StringVar(&compAzCmdState.Type, "type", "AZURE_CIS_131",
 		fmt.Sprintf(`report type to display, run 'lacework report-definitions list' for more information.
-valid types:%s`, prettyPrintReportTypes(validAzureReportTypes)),
+valid types:%s`, prettyPrintReportTypes(api.AzureReportTypes())),
 	)
 
 	complianceAzureGetReportCmd.Flags().StringSliceVar(&compCmdState.Category, "category", []string{},

--- a/cli/cmd/compliance_gcp.go
+++ b/cli/cmd/compliance_gcp.go
@@ -43,11 +43,6 @@ var (
 		Type string
 	}{Type: "GCP_CIS13"}
 
-	validGcpReportTypes = []string{"GCP_ISO_27001_2013", "GCP_NIST_800_171_REV2", "GCP_CMMC_1_02", "GCP_PCI_DSS_3_2_1", "GCP_PCI_Rev2",
-		"GCP_NIST_CSF", "GCP_CIS13", "GCP_HIPAA_2013", "GCP_CIS12", "GCP_CIS", "GCP_SOC_2", "GCP_ISO_27001", "GCP_NIST_800_53_REV4",
-		"GCP_CIS_1_3_0_NIST_800_53_rev5", "GCP_CIS_1_3_0_NIST_CSF", "GCP_HIPAA", "GCP_HIPAA_Rev2", "GCP_CIS_1_3_0_NIST_800_171_rev2",
-		"GCP_SOC", "GCP_K8S", "GCP_SOC_Rev2", "GCP_PCI"}
-
 	// complianceGcpListCmd represents the list sub-command inside the gcp command
 	complianceGcpListCmd = &cobra.Command{
 		Use:     "list",
@@ -140,10 +135,10 @@ Then, select one GUID from an integration and visualize its details using the co
 			//	return errors.Wrap(err, "unable to retrieve valid report types")
 			//}
 
-			if array.ContainsStr(validGcpReportTypes, compGcpCmdState.Type) {
+			if array.ContainsStr(api.GcpReportTypes(), compGcpCmdState.Type) {
 				return nil
 			} else {
-				return errors.Errorf("supported report types are: %s", strings.Join(validGcpReportTypes, ", "))
+				return errors.Errorf("supported report types are: %s", strings.Join(api.GcpReportTypes(), ", "))
 			}
 		},
 		Short: "Get the latest GCP compliance report",
@@ -496,7 +491,7 @@ func init() {
 	//GCP_SOC, GCP_K8S, GCP_SOC_Rev2, GCP_PCI
 	complianceGcpGetReportCmd.Flags().StringVar(&compGcpCmdState.Type, "type", "GCP_CIS13",
 		fmt.Sprintf(`report type to display, run 'lacework report-definitions list' for more information.
-valid types:%s`, prettyPrintReportTypes(validGcpReportTypes)),
+valid types:%s`, prettyPrintReportTypes(api.GcpReportTypes())),
 	)
 
 	complianceGcpGetReportCmd.Flags().StringSliceVar(&compCmdState.Category, "category", []string{},

--- a/integration/compliance_aws_test.go
+++ b/integration/compliance_aws_test.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/lacework/go-sdk/api"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -133,6 +134,19 @@ func TestComplianceAwsGetReportTypeAWS_SOC_Rev2(t *testing.T) {
 		"STDOUT table headers changed, please check")
 	assert.Contains(t, out.String(), account,
 		"Account ID in compliance report is not correct")
+}
+
+func TestComplianceAwsGetAllReportType(t *testing.T) {
+	account := os.Getenv("LW_INT_TEST_AWS_ACC")
+	for _, reportType := range api.AwsReportTypes() {
+		t.Run(reportType, func(t *testing.T) {
+			out, err, exitcode := LaceworkCLIWithTOMLConfig("compliance", "aws", "get-report", account, "--type", reportType)
+			assert.Empty(t, err.String(), "STDERR should be empty")
+			assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
+			assert.Contains(t, out.String(), "RECOMMENDATION DETAILS",
+				"STDOUT table headers changed, please check")
+		})
+	}
 }
 
 func TestComplianceAwsGetReportRecommendationID(t *testing.T) {

--- a/integration/compliance_aws_test.go
+++ b/integration/compliance_aws_test.go
@@ -143,7 +143,7 @@ func TestComplianceAwsGetAllReportType(t *testing.T) {
 			out, err, exitcode := LaceworkCLIWithTOMLConfig("compliance", "aws", "get-report", account, "--type", reportType)
 			assert.Empty(t, err.String(), "STDERR should be empty")
 			assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
-			assert.Contains(t, out.String(), "RECOMMENDATION DETAILS",
+			assert.Contains(t, out.String(), "COMPLIANCE REPORT DETAILS",
 				"STDOUT table headers changed, please check")
 		})
 	}

--- a/integration/test_resources/help/compliance_aws_get-report
+++ b/integration/test_resources/help/compliance_aws_get-report
@@ -27,11 +27,11 @@ Flags:
       --status string      filter report details by status (non-compliant, requires-manual-assessment, suppressed, compliant, could-not-assess)
       --type string        report type to display, run 'lacework report-definitions list' for more information.
                            valid types:
-                           'AWS_Cyber_Essentials_2_2','PCI','AWS_ISO_27001:2013','AWS_HIPAA','AWS_NIST_800-53_rev5',
-                           'LW_AWS_SEC_ADD_1_0','AWS_CIS_1_4_ISO_IEC_27002_2022','AWS_CIS_S3','NIST_800-53_Rev4','ISO_2700',
-                           'AWS_NIST_800-171_rev2','HIPAA','SOC','AWS_SOC_Rev2','AWS_NIST_CSF',
-                           'AWS_SOC_2','AWS_CSA_CCM_4_0_5','NIST_800-171_Rev2','AWS_CIS_14','AWS_CMMC_1.02',
-                           'AWS_PCI_DSS_3.2.1', (default "AWS_CIS_14")
+                           'AWS_CIS_14','AWS_CIS_1_4_ISO_IEC_27002_2022','AWS_CIS_S3','AWS_CMMC_1.02','AWS_CSA_CCM_4_0_5',
+                           'AWS_Cyber_Essentials_2_2','AWS_HIPAA','AWS_ISO_27001:2013','AWS_NIST_800-171_rev2','AWS_NIST_800-53_rev5',
+                           'AWS_NIST_CSF','AWS_PCI_DSS_3.2.1','AWS_SOC_2','AWS_SOC_Rev2','HIPAA',
+                           'ISO_2700','LW_AWS_SEC_ADD_1_0','NIST_800-171_Rev2','NIST_800-53_Rev4','PCI',
+                           'SOC', (default "AWS_CIS_14")
 
 Global Flags:
   -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)

--- a/integration/test_resources/help/compliance_aws_get-report
+++ b/integration/test_resources/help/compliance_aws_get-report
@@ -27,11 +27,11 @@ Flags:
       --status string      filter report details by status (non-compliant, requires-manual-assessment, suppressed, compliant, could-not-assess)
       --type string        report type to display, run 'lacework report-definitions list' for more information.
                            valid types:
-                           'AWS_NIST_CSF','AWS_NIST_800-53_rev5','AWS_HIPAA','NIST_800-53_Rev4','LW_AWS_SEC_ADD_1_0',
-                           'AWS_SOC_Rev2','AWS_PCI_DSS_3.2.1','AWS_CIS_S3','ISO_2700','SOC',
-                           'AWS_CSA_CCM_4_0_5','PCI','AWS_Cyber_Essentials_2_2','AWS_ISO_27001:2013','AWS_CIS_14',
-                           'AWS_CMMC_1.02','HIPAA','AWS_SOC_2','AWS_CIS_1_4_ISO_IEC_27002_2022','NIST_800-171_Rev2',
-                           'AWS_NIST_800-171_rev', (default "AWS_CIS_14")
+                           'AWS_Cyber_Essentials_2_2','PCI','AWS_ISO_27001:2013','AWS_HIPAA','AWS_NIST_800-53_rev5',
+                           'LW_AWS_SEC_ADD_1_0','AWS_CIS_1_4_ISO_IEC_27002_2022','AWS_CIS_S3','NIST_800-53_Rev4','ISO_2700',
+                           'AWS_NIST_800-171_rev2','HIPAA','SOC','AWS_SOC_Rev2','AWS_NIST_CSF',
+                           'AWS_SOC_2','AWS_CSA_CCM_4_0_5','NIST_800-171_Rev2','AWS_CIS_14','AWS_CMMC_1.02',
+                           'AWS_PCI_DSS_3.2.1', (default "AWS_CIS_14")
 
 Global Flags:
   -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)

--- a/integration/test_resources/help/compliance_azure_get-report
+++ b/integration/test_resources/help/compliance_azure_get-report
@@ -26,9 +26,9 @@ Flags:
       --status string      filter report details by status (non-compliant, requires-manual-assessment, suppressed, compliant, could-not-assess)
       --type string        report type to display, run 'lacework report-definitions list' for more information.
                            valid types:
-                           'AZURE_PCI_Rev2','AZURE_ISO_27001','AZURE_NIST_CSF','AZURE_NIST_800_171_REV2','AZURE_PCI',
-                           'AZURE_CIS_131','AZURE_SOC','AZURE_SOC_Rev2','AZURE_NIST_800_53_REV5','AZURE_HIPAA',
-                           'AZURE_CIS', (default "AZURE_CIS_131")
+                           'AZURE_CIS','AZURE_CIS_131','AZURE_HIPAA','AZURE_ISO_27001','AZURE_NIST_800_171_REV2',
+                           'AZURE_NIST_800_53_REV5','AZURE_NIST_CSF','AZURE_PCI','AZURE_PCI_Rev2','AZURE_SOC',
+                           'AZURE_SOC_Rev2', (default "AZURE_CIS_131")
 
 Global Flags:
   -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)

--- a/integration/test_resources/help/compliance_azure_get-report
+++ b/integration/test_resources/help/compliance_azure_get-report
@@ -26,9 +26,9 @@ Flags:
       --status string      filter report details by status (non-compliant, requires-manual-assessment, suppressed, compliant, could-not-assess)
       --type string        report type to display, run 'lacework report-definitions list' for more information.
                            valid types:
-                           'AZURE_CIS_131','AZURE_NIST_800_171_REV2','AZURE_NIST_800_53_REV5','AZURE_NIST_CSF','AZURE_PCI',
-                           'AZURE_SOC_Rev2','AZURE_ISO_27001','AZURE_SOC','AZURE_HIPAA','AZURE_CIS',
-                           'AZURE_PCI_Rev2', (default "AZURE_CIS_131")
+                           'AZURE_PCI_Rev2','AZURE_ISO_27001','AZURE_NIST_CSF','AZURE_NIST_800_171_REV2','AZURE_PCI',
+                           'AZURE_CIS_131','AZURE_SOC','AZURE_SOC_Rev2','AZURE_NIST_800_53_REV5','AZURE_HIPAA',
+                           'AZURE_CIS', (default "AZURE_CIS_131")
 
 Global Flags:
   -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)

--- a/integration/test_resources/help/compliance_google_get-report
+++ b/integration/test_resources/help/compliance_google_get-report
@@ -26,11 +26,11 @@ Flags:
       --status string      filter report details by status (non-compliant, requires-manual-assessment, suppressed, compliant, could-not-assess)
       --type string        report type to display, run 'lacework report-definitions list' for more information.
                            valid types:
-                           'GCP_HIPAA','GCP_PCI_DSS_3_2_1','GCP_CIS_1_3_0_NIST_CSF','GCP_HIPAA_2013','GCP_CIS',
-                           'GCP_SOC','GCP_PCI_Rev2','GCP_HIPAA_Rev2','GCP_NIST_800_53_REV4','GCP_CIS13',
-                           'GCP_K8S','GCP_ISO_27001','GCP_NIST_800_171_REV2','GCP_CIS_1_3_0_NIST_800_53_rev5','GCP_ISO_27001_2013',
-                           'GCP_SOC_2','GCP_CIS12','GCP_SOC_Rev2','GCP_NIST_CSF','GCP_PCI',
-                           'GCP_CIS_1_3_0_NIST_800_171_rev2','GCP_CMMC_1_02', (default "GCP_CIS13")
+                           'GCP_CIS','GCP_CIS12','GCP_CIS13','GCP_CIS_1_3_0_NIST_800_171_rev2','GCP_CIS_1_3_0_NIST_800_53_rev5',
+                           'GCP_CIS_1_3_0_NIST_CSF','GCP_CMMC_1_02','GCP_HIPAA','GCP_HIPAA_2013','GCP_HIPAA_Rev2',
+                           'GCP_ISO_27001','GCP_ISO_27001_2013','GCP_K8S','GCP_NIST_800_171_REV2','GCP_NIST_800_53_REV4',
+                           'GCP_NIST_CSF','GCP_PCI','GCP_PCI_DSS_3_2_1','GCP_PCI_Rev2','GCP_SOC',
+                           'GCP_SOC_2','GCP_SOC_Rev2', (default "GCP_CIS13")
 
 Global Flags:
   -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)

--- a/integration/test_resources/help/compliance_google_get-report
+++ b/integration/test_resources/help/compliance_google_get-report
@@ -26,11 +26,11 @@ Flags:
       --status string      filter report details by status (non-compliant, requires-manual-assessment, suppressed, compliant, could-not-assess)
       --type string        report type to display, run 'lacework report-definitions list' for more information.
                            valid types:
-                           'GCP_ISO_27001_2013','GCP_NIST_800_171_REV2','GCP_CMMC_1_02','GCP_PCI_DSS_3_2_1','GCP_PCI_Rev2',
-                           'GCP_NIST_CSF','GCP_CIS13','GCP_HIPAA_2013','GCP_CIS12','GCP_CIS',
-                           'GCP_SOC_2','GCP_ISO_27001','GCP_NIST_800_53_REV4','GCP_CIS_1_3_0_NIST_800_53_rev5','GCP_CIS_1_3_0_NIST_CSF',
-                           'GCP_HIPAA','GCP_HIPAA_Rev2','GCP_CIS_1_3_0_NIST_800_171_rev2','GCP_SOC','GCP_K8S',
-                           'GCP_SOC_Rev2','GCP_PCI', (default "GCP_CIS13")
+                           'GCP_HIPAA','GCP_PCI_DSS_3_2_1','GCP_CIS_1_3_0_NIST_CSF','GCP_HIPAA_2013','GCP_CIS',
+                           'GCP_SOC','GCP_PCI_Rev2','GCP_HIPAA_Rev2','GCP_NIST_800_53_REV4','GCP_CIS13',
+                           'GCP_K8S','GCP_ISO_27001','GCP_NIST_800_171_REV2','GCP_CIS_1_3_0_NIST_800_53_rev5','GCP_ISO_27001_2013',
+                           'GCP_SOC_2','GCP_CIS12','GCP_SOC_Rev2','GCP_NIST_CSF','GCP_PCI',
+                           'GCP_CIS_1_3_0_NIST_800_171_rev2','GCP_CMMC_1_02', (default "GCP_CIS13")
 
 Global Flags:
   -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/lacework/go-sdk) and create your branch from `main`
  2. Run `make prepare` in the repository root
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`make test`)
  5. Format your code (`make fmt`)
  6. Make sure your code lints (`make lint`)
  7. If you are updating the Lacework CLI, make sure it compiles (`make build-cli-cross-platform`)
  8. Follow the commit message standard (`type(scope): subject`) documented in [DEVELOPER_GUIDELINES.md](https://github.com/lacework/go-sdk/blob/main/DEVELOPER_GUIDELINES.md#commit-message-standard)
  9. If you haven't already, configure signed commits by [telling git about your signing key](https://docs.github.com/en/github/authenticating-to-github/managing-commit-signature-verification/telling-git-about-your-signing-key) and [signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)

  Learn more about contributing: https://github.com/lacework/go-sdk/blob/main/CONTRIBUTING.md
-->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

Resolve conflicting supported report types in cli and api packages

- Remove list of supported report types from cli package.
- Only use list of support report types from api package in `lacework compliance` input validation

## How did you test this change?

<!--
  How exactly did you verify that your PR solves the issue you wanted to solve?
  Include any other relevant information such as how to use the new functionality, screenshots, etc.
-->

- Add new integration test for all `aws` report types
- Manually verify there is no error submitting valid report types for `gcp` & `azure`
`lacework compliance gcp get-report <project-id> <org-id> --type GCP_CMMC_1_02`
`lacework comp az get-report <tenant-id> <org-id>`

## Issue

<!--
  Include the link to a Jira/Github issue
-->
https://lacework.atlassian.net/browse/GROW-1427
