### PR TITLE
fix(cli): inline/proxy scanner Ok state

### DIFF
--- a/api/alerts_details_integrations.go
+++ b/api/alerts_details_integrations.go
@@ -54,7 +54,7 @@ func (c AlertIntegrationChannel) StateString() string {
 	if c.State.Ok {
 		return "Ok"
 	}
-	return "Check"
+	return "Pending"
 }
 
 type AlertIntegrationContext struct {

--- a/api/cloud_accounts.go
+++ b/api/cloud_accounts.go
@@ -238,7 +238,7 @@ func (c v2CommonIntegrationData) StateString() string {
 	if c.State != nil && c.State.Ok {
 		return "Ok"
 	}
-	return "Check"
+	return "Pending"
 }
 
 type V2IntegrationState struct {

--- a/api/container_registries.go
+++ b/api/container_registries.go
@@ -190,6 +190,16 @@ type ContainerRegistryRaw struct {
 	Data        interface{}    `json:"data,omitempty"`
 	ServerToken *V2ServerToken `json:"serverToken,omitempty"`
 }
+
+func (reg ContainerRegistryRaw) StateString() string {
+	switch reg.ContainerRegistryType() {
+	case InlineScannerContainerRegistry, ProxyScannerContainerRegistry:
+		return "Ok"
+	default:
+		return reg.v2CommonIntegrationData.StateString()
+	}
+}
+
 type V2ServerToken struct {
 	ServerToken string `json:"serverToken"`
 	Uri         string `json:"uri"`

--- a/cli/cmd/container_registry_test.go
+++ b/cli/cmd/container_registry_test.go
@@ -1,0 +1,61 @@
+//
+// Author:: Salim Afiune Maya (<afiune@lacework.net>)
+// Copyright:: Copyright 2023, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cmd
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/lacework/go-sdk/api"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestContainerRegistriesToTable(t *testing.T) {
+	cases := []struct {
+		Data          []api.ContainerRegistryRaw
+		expectedTable [][]string
+	}{
+		{nil, nil},
+		{[]api.ContainerRegistryRaw{
+			api.NewContainerRegistry("mock1", api.InlineScannerContainerRegistry, api.InlineScannerData{}),
+		}, [][]string{[]string{"", "mock1", "ContVulnCfg", "Enabled", "Ok"}}},
+		{[]api.ContainerRegistryRaw{
+			api.NewContainerRegistry("mock2", api.ProxyScannerContainerRegistry, api.ProxyScannerData{}),
+		}, [][]string{[]string{"", "mock2", "ContVulnCfg", "Enabled", "Ok"}}},
+		{[]api.ContainerRegistryRaw{
+			api.NewContainerRegistry("mock3", api.GcpGarContainerRegistry, api.GcpGcrData{}),
+		}, [][]string{[]string{"", "mock3", "ContVulnCfg", "Enabled", "Pending"}}},
+		{[]api.ContainerRegistryRaw{
+			api.NewContainerRegistry("mock1", api.InlineScannerContainerRegistry, api.InlineScannerData{}),
+			api.NewContainerRegistry("mock2", api.ProxyScannerContainerRegistry, api.ProxyScannerData{}),
+			api.NewContainerRegistry("mock3", api.GcpGarContainerRegistry, api.GcpGcrData{}),
+		}, [][]string{
+			[]string{"", "mock1", "ContVulnCfg", "Enabled", "Ok"},
+			[]string{"", "mock2", "ContVulnCfg", "Enabled", "Ok"},
+			[]string{"", "mock3", "ContVulnCfg", "Enabled", "Pending"},
+		}},
+	}
+
+	for i, kase := range cases {
+		t.Run(fmt.Sprintf("test case %d", i), func(t *testing.T) {
+			subjectTable := containerRegistriesToTable(kase.Data)
+			assert.Equal(t, kase.expectedTable, subjectTable)
+		})
+	}
+}


### PR DESCRIPTION


## Summary
Both, inline/proxy scanner integrations don’t have a `state`
object at all- so we will hard code them to be always `Ok`.

## How did you test this change?
Added tests.

## Issue
https://lacework.atlassian.net/browse/LINK-1361

