### PR TITLE
fix(lwseverity): use stable sorting for severity 

### DIFF
--- a/lwseverity/severity.go
+++ b/lwseverity/severity.go
@@ -153,7 +153,7 @@ func ShouldFilter(severity, threshold string) bool {
 
 // Sort a slice of Severity interfaces from critical -> info
 func SortSlice[S Severity](s []S) {
-	sort.Slice(s, func(i, j int) bool {
+	sort.SliceStable(s, func(i, j int) bool {
 		sevI, _ := Normalize(s[i].GetSeverity())
 		sevJ, _ := Normalize(s[j].GetSeverity())
 		return sevI < sevJ
@@ -162,7 +162,7 @@ func SortSlice[S Severity](s []S) {
 
 // Sort a slice of Severity interfaces from info -> critical
 func SortSliceA[S Severity](s []S) {
-	sort.Slice(s, func(i, j int) bool {
+	sort.SliceStable(s, func(i, j int) bool {
 		sevI, _ := Normalize(s[i].GetSeverity())
 		sevJ, _ := Normalize(s[j].GetSeverity())
 		return sevI > sevJ

--- a/lwseverity/severity_test.go
+++ b/lwseverity/severity_test.go
@@ -89,6 +89,7 @@ func TestShouldFilterTest(t *testing.T) {
 }
 
 type myStruct struct {
+	alertID  int
 	severity string
 }
 
@@ -100,31 +101,28 @@ type myStructs []myStruct
 
 func TestSort(t *testing.T) {
 	m := myStructs{
-		myStruct{
-			severity: "Low",
-		},
-		myStruct{
-			severity: "High",
-		},
+		myStruct{alertID: 6, severity: "Low"},
+		myStruct{alertID: 9, severity: "High"},
+		myStruct{alertID: 1, severity: "Low"},
+		myStruct{alertID: 3, severity: "Low"},
+		myStruct{alertID: 8, severity: "Low"},
 	}
 	expected := myStructs{
-		myStruct{
-			severity: "High",
-		},
-		myStruct{
-			severity: "Low",
-		},
+		myStruct{alertID: 9, severity: "High"},
+		myStruct{alertID: 6, severity: "Low"},
+		myStruct{alertID: 1, severity: "Low"},
+		myStruct{alertID: 3, severity: "Low"},
+		myStruct{alertID: 8, severity: "Low"},
 	}
 	lwseverity.SortSlice(m)
 	assert.Equal(t, expected, m)
 
 	expected = myStructs{
-		myStruct{
-			severity: "Low",
-		},
-		myStruct{
-			severity: "High",
-		},
+		myStruct{alertID: 6, severity: "Low"},
+		myStruct{alertID: 1, severity: "Low"},
+		myStruct{alertID: 3, severity: "Low"},
+		myStruct{alertID: 8, severity: "Low"},
+		myStruct{alertID: 9, severity: "High"},
 	}
 	lwseverity.SortSliceA(m)
 	assert.Equal(t, expected, m)


### PR DESCRIPTION
## Summary
Use stable sorting for severity sorting.  This preserves the order of items coming in such that if we first sort by ID this will become a secondary sort once sorting by severity.  This is needed since severities are not unique.

## How did you test this change?
Unit testing added

## Issue
https://lacework.atlassian.net/browse/GROW-1432