### PR TITLE
feat(cli): Add 'subtype' filter flag to 'lacework report-definitions …

### DIFF
--- a/api/reports_definitions.go
+++ b/api/reports_definitions.go
@@ -74,6 +74,8 @@ func NewReportDefinition(cfg ReportDefinitionConfig) ReportDefinition {
 	}
 }
 
+var ReportDefinitionSubtypes = []string{"AWS", "Azure", "GCP"}
+
 type ReportDefinitionConfig struct {
 	ReportName       string                      `json:"reportName"`
 	ReportType       string                      `json:"reportType"`

--- a/cli/cmd/report_definitions.go
+++ b/cli/cmd/report_definitions.go
@@ -22,12 +22,18 @@ import (
 	"strings"
 
 	"github.com/lacework/go-sdk/api"
+	"github.com/lacework/go-sdk/internal/array"
 	"github.com/olekukonko/tablewriter"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
 var (
+	reportDefinitionsCmdState = struct {
+		// filter report definitions by subtype. 'Aws', 'GCP' or 'Azure'
+		SubType string
+	}{}
+
 	// report-definitions command is used to manage lacework report definitions
 	reportDefinitionsCommand = &cobra.Command{
 		Use:     "report-definition",
@@ -44,6 +50,12 @@ var (
 		Short:   "List all report definitions",
 		Long:    "List all report definitions configured in your Lacework account.",
 		Args:    cobra.NoArgs,
+		PreRunE: func(_ *cobra.Command, _ []string) error {
+			if reportDefinitionsCmdState.SubType != "" && !array.ContainsStr(api.ReportDefinitionSubtypes, reportDefinitionsCmdState.SubType) {
+				return errors.Errorf("'%s' is not valid. Report definitions subtype can be %s", reportDefinitionsCmdState.SubType, api.ReportDefinitionSubtypes)
+			}
+			return nil
+		},
 		RunE: func(_ *cobra.Command, _ []string) error {
 			cli.StartProgress(" Fetching report definitions...")
 			reportDefinitions, err := cli.LwApi.V2.ReportDefinitions.List()
@@ -56,6 +68,12 @@ var (
 				cli.OutputHuman("There are no report definitions configured in your account.\n")
 				return nil
 			}
+
+			// filter definitions by subtype
+			if reportDefinitionsCmdState.SubType != "" {
+				filterReportDefinitions(&reportDefinitions)
+			}
+
 			if cli.JSONOutput() {
 				return cli.OutputJSON(reportDefinitions)
 			}
@@ -122,6 +140,16 @@ var (
 	}
 )
 
+func filterReportDefinitions(reportDefinitions *api.ReportDefinitionsResponse) {
+	var filteredDefinitions []api.ReportDefinition
+	for _, rd := range reportDefinitions.Data {
+		if rd.SubReportType == reportDefinitionsCmdState.SubType {
+			filteredDefinitions = append(filteredDefinitions, rd)
+		}
+	}
+	reportDefinitions.Data = filteredDefinitions
+}
+
 func init() {
 	// add the report-definition command
 	rootCmd.AddCommand(reportDefinitionsCommand)
@@ -130,6 +158,11 @@ func init() {
 	reportDefinitionsCommand.AddCommand(reportDefinitionsListCommand)
 	reportDefinitionsCommand.AddCommand(reportDefinitionsShowCommand)
 	reportDefinitionsCommand.AddCommand(reportDefinitionsDeleteCommand)
+
+	// add flags to report-definition commands
+	reportDefinitionsListCommand.Flags().StringVar(&reportDefinitionsCmdState.SubType,
+		"subtype", "", "filter report definitions by subtype. 'Aws', 'GCP' or 'Azure'",
+	)
 }
 
 func buildReportDefinitionDetailsTable(definition api.ReportDefinition) string {

--- a/cli/cmd/report_definitions.go
+++ b/cli/cmd/report_definitions.go
@@ -30,7 +30,7 @@ import (
 
 var (
 	reportDefinitionsCmdState = struct {
-		// filter report definitions by subtype. 'Aws', 'GCP' or 'Azure'
+		// filter report definitions by subtype. 'AWS', 'GCP' or 'Azure'
 		SubType string
 	}{}
 
@@ -161,7 +161,7 @@ func init() {
 
 	// add flags to report-definition commands
 	reportDefinitionsListCommand.Flags().StringVar(&reportDefinitionsCmdState.SubType,
-		"subtype", "", "filter report definitions by subtype. 'Aws', 'GCP' or 'Azure'",
+		"subtype", "", "filter report definitions by subtype. 'AWS', 'GCP' or 'Azure'",
 	)
 }
 

--- a/cli/cmd/report_definitions_test.go
+++ b/cli/cmd/report_definitions_test.go
@@ -31,6 +31,48 @@ func TestBuildReportDefinitions(t *testing.T) {
 	assert.Equal(t, reportDetails, reportDefinitionOutput)
 }
 
+func TestFilterReportDefinitionsWithSubType(t *testing.T) {
+	defer func() { reportDefinitionsCmdState.SubType = "" }()
+	var reportDefinitionResponse api.ReportDefinitionsResponse
+	reportDefinitionResponse.Data = []api.ReportDefinition{mockReportDefinition, mockReportDefinitionGCP, mockReportDefinitionAzure}
+
+	reportDefinitionsTableTest := []struct {
+		Name     string
+		Input    api.ReportDefinitionsResponse
+		Expected []api.ReportDefinition
+		Cloud    string
+	}{
+		{
+			Name:     "Test Filter AWS report Definitions",
+			Input:    reportDefinitionResponse,
+			Expected: []api.ReportDefinition{mockReportDefinition},
+			Cloud:    "AWS",
+		},
+		{
+			Name:     "Test Filter GCP report Definitions",
+			Input:    reportDefinitionResponse,
+			Expected: []api.ReportDefinition{mockReportDefinitionGCP},
+			Cloud:    "GCP",
+		},
+		{
+			Name:     "Test Filter Azure report Definitions",
+			Input:    reportDefinitionResponse,
+			Expected: []api.ReportDefinition{mockReportDefinitionAzure},
+			Cloud:    "Azure",
+		},
+	}
+
+	for _, rdtt := range reportDefinitionsTableTest {
+		t.Run(rdtt.Name, func(t *testing.T) {
+			reportDefinitionsCmdState.SubType = rdtt.Cloud
+			filterReportDefinitions(&rdtt.Input)
+			assert.Len(t, rdtt.Input.Data, 1)
+			assert.Equal(t, rdtt.Input.Data, rdtt.Expected)
+		})
+	}
+
+}
+
 var created, _ = time.Parse(time.RFC3339, "2022-09-09T10:35:16Z")
 
 var (
@@ -40,6 +82,52 @@ var (
 		DisplayName:          "My Custom Report Display",
 		ReportType:           "Compliance",
 		SubReportType:        "AWS",
+		ReportDefinitionDetails: api.ReportDefinitionDetails{
+			Sections: []api.ReportDefinitionSection{{
+				Category: "1.0.0",
+				Title:    "Example Section",
+				Policies: []string{"lacework-global-22", "lacework-global-78"},
+			}},
+		},
+		Props: api.ReportDefinitionProps{
+			Engine: "lpp",
+		},
+		DistributionType: "pdf",
+		Frequency:        "daily",
+		Version:          2,
+		CreatedBy:        "SYSTEM",
+		CreatedTime:      &created,
+		Enabled:          1,
+	}
+	mockReportDefinitionGCP = api.ReportDefinition{
+		ReportDefinitionGuid: "EXAMPLE_GUID",
+		ReportName:           "My Custom Report",
+		DisplayName:          "My Custom Report Display",
+		ReportType:           "Compliance",
+		SubReportType:        "GCP",
+		ReportDefinitionDetails: api.ReportDefinitionDetails{
+			Sections: []api.ReportDefinitionSection{{
+				Category: "1.0.0",
+				Title:    "Example Section",
+				Policies: []string{"lacework-global-22", "lacework-global-78"},
+			}},
+		},
+		Props: api.ReportDefinitionProps{
+			Engine: "lpp",
+		},
+		DistributionType: "pdf",
+		Frequency:        "daily",
+		Version:          2,
+		CreatedBy:        "SYSTEM",
+		CreatedTime:      &created,
+		Enabled:          1,
+	}
+	mockReportDefinitionAzure = api.ReportDefinition{
+		ReportDefinitionGuid: "EXAMPLE_GUID",
+		ReportName:           "My Custom Report",
+		DisplayName:          "My Custom Report Display",
+		ReportType:           "Compliance",
+		SubReportType:        "Azure",
 		ReportDefinitionDetails: api.ReportDefinitionDetails{
 			Sections: []api.ReportDefinitionSection{{
 				Category: "1.0.0",

--- a/integration/report_definitions_test.go
+++ b/integration/report_definitions_test.go
@@ -21,6 +21,22 @@ func TestReportDefintionsList(t *testing.T) {
 	assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
 }
 
+func TestReportDefintionsListWithSubtype(t *testing.T) {
+	out, err, exitcode := LaceworkCLIWithTOMLConfig("report-definitions", "list", "--subtype", "AWS")
+	// assert response contains table headers
+	assert.Contains(t, out.String(), "GUID")
+	assert.Contains(t, out.String(), "NAME")
+	assert.Contains(t, out.String(), "TYPE")
+	assert.Contains(t, out.String(), "SUB-TYPE")
+
+	assert.Contains(t, out.String(), "AWS")
+	assert.NotContains(t, out.String(), "GCP")
+	assert.NotContains(t, out.String(), "AZURE")
+
+	assert.Empty(t, err.String(), "STDERR should be empty")
+	assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
+}
+
 func TestReportDefintionsListJson(t *testing.T) {
 	out, err, exitcode := LaceworkCLIWithTOMLConfig("report-definitions", "list", "--json")
 	// assert response contains json fields
@@ -30,6 +46,24 @@ func TestReportDefintionsListJson(t *testing.T) {
 	assert.Contains(t, out.String(), "\"reportDefinition\"")
 	assert.Contains(t, out.String(), "\"category\"")
 	assert.Contains(t, out.String(), "\"policies\"")
+
+	assert.Empty(t, err.String(), "STDERR should be empty")
+	assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
+}
+
+func TestReportDefintionsListJsonWithSubtype(t *testing.T) {
+	out, err, exitcode := LaceworkCLIWithTOMLConfig("report-definitions", "list", "--json", "--subtype", "GCP")
+	// assert response contains json fields
+	assert.Contains(t, out.String(), "\"data\"")
+	assert.Contains(t, out.String(), "\"createdBy\"")
+	assert.Contains(t, out.String(), "\"displayName\"")
+	assert.Contains(t, out.String(), "\"reportDefinition\"")
+	assert.Contains(t, out.String(), "\"category\"")
+	assert.Contains(t, out.String(), "\"policies\"")
+
+	assert.Contains(t, out.String(), "\"GCP\"")
+	assert.NotContains(t, out.String(), "\"Azure\"")
+	assert.NotContains(t, out.String(), "\"AWS\"")
 
 	assert.Empty(t, err.String(), "STDERR should be empty")
 	assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")

--- a/integration/test_resources/help/report-definition_list
+++ b/integration/test_resources/help/report-definition_list
@@ -7,7 +7,8 @@ Aliases:
   list, ls
 
 Flags:
-  -h, --help   help for list
+  -h, --help             help for list
+      --subtype string   filter report definitions by subtype. 'Aws', 'GCP' or 'Azure'
 
 Global Flags:
   -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)

--- a/integration/test_resources/help/report-definition_list
+++ b/integration/test_resources/help/report-definition_list
@@ -8,7 +8,7 @@ Aliases:
 
 Flags:
   -h, --help             help for list
-      --subtype string   filter report definitions by subtype. 'Aws', 'GCP' or 'Azure'
+      --subtype string   filter report definitions by subtype. 'AWS', 'GCP' or 'Azure'
 
 Global Flags:
   -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)


### PR DESCRIPTION
…list' cmd

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/lacework/go-sdk) and create your branch from `main`
  2. Run `make prepare` in the repository root
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`make test`)
  5. Format your code (`make fmt`)
  6. Make sure your code lints (`make lint`)
  7. If you are updating the Lacework CLI, make sure it compiles (`make build-cli-cross-platform`)
  8. Follow the commit message standard (`type(scope): subject`) documented in [DEVELOPER_GUIDELINES.md](https://github.com/lacework/go-sdk/blob/main/DEVELOPER_GUIDELINES.md#commit-message-standard)
  9. If you haven't already, configure signed commits by [telling git about your signing key](https://docs.github.com/en/github/authenticating-to-github/managing-commit-signature-verification/telling-git-about-your-signing-key) and [signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)

  Learn more about contributing: https://github.com/lacework/go-sdk/blob/main/CONTRIBUTING.md
-->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

Add a new filter flag to report-definitions list cmd to filter only specified clouds
`lacework report-definitions list --subtype AWS`
`lacework report-definitions list --subtype GCP`
`lacework report-definitions list --subtype Azure`


## How did you test this change?

<!--
  How exactly did you verify that your PR solves the issue you wanted to solve?
  Include any other relevant information such as how to use the new functionality, screenshots, etc.
-->

- [x] Manually run `lacework report-definitions list --subtype <cloud>`
- [x] Unit test `TestFilterReportDefinitionsWithSubType`
- [x] Integrations Tests `TestReportDefintionsListWithSubtype` `TestReportDefintionsListJsonWithSubtype` 


## Issue

<!--
  Include the link to a Jira/Github issue
-->

https://lacework.atlassian.net/browse/GROW-1403
