### PR TITLE
[CLI] Query/Policy Output Improvements

### DIFF
--- a/cli/cmd/lql_show.go
+++ b/cli/cmd/lql_show.go
@@ -57,7 +57,7 @@ func init() {
 func showQuery(_ *cobra.Command, args []string) error {
 	cli.Log.Debugw("retrieving query", "id", args[0])
 
-	cli.StartProgress(" Retrieving query...")
+	cli.StartProgress("Retrieving query...")
 	queryResponse, err := cli.LwApi.V2.Query.Get(args[0])
 	cli.StopProgress()
 

--- a/cli/cmd/lql_sources_internal_test.go
+++ b/cli/cmd/lql_sources_internal_test.go
@@ -39,19 +39,19 @@ var querySourcesTableTests = []querySourcesTableTest{
 	querySourcesTableTest{
 		Name: "one",
 		Input: []api.Datasource{
-			api.Datasource{Name: "mySource"},
+			api.Datasource{Name: "mySource", Description: "abc"},
 		},
-		Expected: [][]string{{"mySource", ""}},
+		Expected: [][]string{{"mySource\nabc"}},
 	},
 	querySourcesTableTest{
 		Name: "sort",
 		Input: []api.Datasource{
-			api.Datasource{Name: "mySource"},
-			api.Datasource{Name: "aSource"},
+			api.Datasource{Name: "mySource", Description: "abc"},
+			api.Datasource{Name: "aSource", Description: "xyz"},
 		},
 		Expected: [][]string{
-			{"aSource", ""},
-			{"mySource", ""},
+			{"aSource\nxyz"},
+			{"mySource\nabc"},
 		},
 	},
 }

--- a/cli/cmd/policy.go
+++ b/cli/cmd/policy.go
@@ -30,7 +30,6 @@ import (
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/lacework/go-sdk/api"
-	"github.com/lacework/go-sdk/internal/array"
 	"github.com/lacework/go-sdk/internal/pointer"
 	"github.com/lacework/go-sdk/lwseverity"
 	"github.com/olekukonko/tablewriter"
@@ -107,12 +106,10 @@ To view the LQL query associated with the policy, use the query ID.
 		Long:    `List all registered policies in your Lacework account.`,
 		Args:    cobra.NoArgs,
 		PreRunE: func(_ *cobra.Command, _ []string) error {
-			if policyCmdState.Severity != "" && !array.ContainsStr(
-				api.ValidPolicySeverities, policyCmdState.Severity) {
-				return errors.Wrap(
-					errors.New(fmt.Sprintf("the severity %s is not valid, use one of %s",
-						policyCmdState.Severity, strings.Join(api.ValidPolicySeverities, ", "))),
-					"unable to list policies",
+			if policyCmdState.Severity != "" &&
+				!lwseverity.IsValid(policyCmdState.Severity) {
+				return errors.Errorf("the severity %s is not valid, use one of %s",
+					policyCmdState.Severity, lwseverity.ValidSeverities.String(),
 				)
 			}
 			return nil

--- a/cli/cmd/policy.go
+++ b/cli/cmd/policy.go
@@ -511,22 +511,21 @@ func listPolicies(_ *cobra.Command, _ []string) error {
 	return nil
 }
 
-func showPolicy(cmd *cobra.Command, args []string) error {
+func showPolicy(_ *cobra.Command, args []string) error {
 	var (
 		msg            string = "unable to show policy"
 		policyResponse api.PolicyResponse
 		err            error
 	)
 
-	cli.Log.Debugw("retrieving policy", "policyID", args[0])
+	cli.Log.Infow("retrieving policy", "id", args[0])
 	cli.StartProgress("Retrieving policy...")
 	policyResponse, err = cli.LwApi.V2.Policy.Get(args[0])
 	cli.StopProgress()
-
-	// output policy
 	if err != nil {
 		return errors.Wrap(err, msg)
 	}
+
 	if cli.JSONOutput() {
 		return cli.OutputJSON(policyResponse.Data)
 	}
@@ -549,10 +548,31 @@ func showPolicy(cmd *cobra.Command, args []string) error {
 		})
 	}
 
-	cli.OutputHuman(
-		renderSimpleTable(policyTableHeaders, policyTable([]api.Policy{policyResponse.Data})))
+	cli.OutputHuman(renderSimpleTable(policyTableHeaders, policyTable([]api.Policy{policyResponse.Data})))
 	cli.OutputHuman("\n")
 	cli.OutputHuman(buildPolicyDetailsTable(policyResponse.Data))
+	cli.OutputHuman("\n")
+	cli.OutputHuman(renderOneLineCustomTable("DESCRIPTION",
+		policyResponse.Data.Description,
+		tableFunc(func(t *tablewriter.Table) {
+			t.SetAlignment(tablewriter.ALIGN_LEFT)
+			t.SetColWidth(120)
+			t.SetBorder(false)
+			t.SetAutoWrapText(true)
+		}),
+	))
+	cli.OutputHuman("\n")
+	cli.OutputHuman(renderOneLineCustomTable("REMEDIATION",
+		policyResponse.Data.Remediation,
+		tableFunc(func(t *tablewriter.Table) {
+			t.SetAlignment(tablewriter.ALIGN_LEFT)
+			t.SetColWidth(120)
+			t.SetBorder(false)
+			t.SetAutoWrapText(true)
+			t.SetReflowDuringAutoWrap(false)
+		}),
+	))
+	cli.OutputHuman("\n")
 	return nil
 }
 

--- a/cli/cmd/policy_internal_test.go
+++ b/cli/cmd/policy_internal_test.go
@@ -77,7 +77,7 @@ var policyTableTests = []policyTableTest{
 			api.Policy{PolicyID: "my-policy-1"},
 		},
 		Expected: [][]string{
-			[]string{"my-policy-1", "", "", "disabled", "disabled", "", "", ""},
+			[]string{"my-policy-1", "", "", "Disabled", "Disabled", "", ""},
 		},
 	},
 	policyTableTest{
@@ -87,8 +87,8 @@ var policyTableTests = []policyTableTest{
 			api.Policy{PolicyID: "my-policy-3"},
 		},
 		Expected: [][]string{
-			[]string{"my-policy-3", "", "", "disabled", "disabled", "", "", ""},
-			[]string{"my-policy-10", "", "", "disabled", "disabled", "", "", ""},
+			[]string{"my-policy-3", "", "", "Disabled", "Disabled", "", ""},
+			[]string{"my-policy-10", "", "", "Disabled", "Disabled", "", ""},
 		},
 	},
 }

--- a/integration/policy_test.go
+++ b/integration/policy_test.go
@@ -448,14 +448,14 @@ func TestPolicyDisableEnable(t *testing.T) {
 	assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
 
 	out, err, exitcode = LaceworkCLIWithTOMLConfig("policy", "show", "lacework-global-1")
-	assert.Contains(t, out.String(), "disabled")
+	assert.Contains(t, out.String(), "Disabled")
 
 	out, err, exitcode = LaceworkCLIWithTOMLConfig("policy", "enable", "lacework-global-1")
 	assert.Empty(t, err.String(), "STDERR should be empty")
 	assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
 
 	out, err, exitcode = LaceworkCLIWithTOMLConfig("policy", "show", "lacework-global-1")
-	assert.Contains(t, out.String(), "enabled")
+	assert.Contains(t, out.String(), "Enabled")
 }
 
 func TestPolicyBulkDisableEnable(t *testing.T) {
@@ -464,20 +464,20 @@ func TestPolicyBulkDisableEnable(t *testing.T) {
 	assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
 
 	out, err, exitcode = LaceworkCLIWithTOMLConfig("policy", "show", "lacework-global-1")
-	assert.Contains(t, out.String(), "disabled")
+	assert.Contains(t, out.String(), "Disabled")
 
 	out, err, exitcode = LaceworkCLIWithTOMLConfig("policy", "show", "lacework-global-2")
-	assert.Contains(t, out.String(), "disabled")
+	assert.Contains(t, out.String(), "Disabled")
 
 	out, err, exitcode = LaceworkCLIWithTOMLConfig("policy", "enable", "lacework-global-1", "lacework-global-2")
 	assert.Empty(t, err.String(), "STDERR should be empty")
 	assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
 
 	out, err, exitcode = LaceworkCLIWithTOMLConfig("policy", "show", "lacework-global-1")
-	assert.Contains(t, out.String(), "enabled")
+	assert.Contains(t, out.String(), "Enabled")
 
 	out, err, exitcode = LaceworkCLIWithTOMLConfig("policy", "show", "lacework-global-2")
-	assert.Contains(t, out.String(), "enabled")
+	assert.Contains(t, out.String(), "Enabled")
 }
 
 func TestPolicyBulksUpdate(t *testing.T) {


### PR DESCRIPTION
## Summary

Output improvement for a few query and policy commands. 

* refactor(cli): improve `policy list` command output
* refactor(cli): improve `policy show` command output
* feat(cli): display query inside `policy show` command
* refactor(cli): `query list-sources` and `query show-source` output

Look at the before and after and suggest any modification.

## `lacework policy list`

Main change here is the removal of the Query ID since it is way too long.

### Before
![Screen Shot 2023-02-28 at 5 52 08 PM](https://user-images.githubusercontent.com/5712253/222024436-76bb1fa5-10df-4ba3-b965-de6c7917d599.png)
### After
![Screen Shot 2023-02-28 at 5 54 15 PM](https://user-images.githubusercontent.com/5712253/222024604-73f1b2d1-6308-459f-b811-7070a5c4ffb1.png)


## `lacework policy show <id>`

Main change here is the display of the Query Text.

### Before
![Screen Shot 2023-02-28 at 5 58 23 PM](https://user-images.githubusercontent.com/5712253/222025192-4d7854b2-df79-4cae-a23b-1e15fa779d90.png)

### After
![Screen Shot 2023-02-28 at 5 58 42 PM](https://user-images.githubusercontent.com/5712253/222025220-bc3253ee-bee5-44b7-b086-96c642defddf.png)

And when a query is configured into the policy, we automatically display it.

![Screen Shot 2023-02-28 at 6 00 12 PM](https://user-images.githubusercontent.com/5712253/222025419-fd3fc3d9-9604-4cb4-8339-90819fb0ecf3.png)


## `lacework query list-sources`

Major refactor here is that we are printing a single column table and inside we are printing both, the datasource name and the description. This is the best way I can think of to print such loooong strings (150+ chars).

### Before
![Screen Shot 2023-02-28 at 6 02 13 PM](https://user-images.githubusercontent.com/5712253/222025639-426ba990-06a3-4351-94ee-8074b33f6a75.png)

### After
![Screen Shot 2023-02-28 at 6 02 42 PM](https://user-images.githubusercontent.com/5712253/222025682-31d7d4fc-bcae-44b6-a931-f54ee37bbad6.png)

## `lacework query show-source <id>`

No big change here, just following the pattern.

### Before
![Screen Shot 2023-02-28 at 6 05 12 PM](https://user-images.githubusercontent.com/5712253/222026034-8b4dfeb2-a37b-4093-91d3-02b5e4accaf4.png)

### After
![Screen Shot 2023-02-28 at 6 05 31 PM](https://user-images.githubusercontent.com/5712253/222026061-aa1d4477-ea91-4814-95e8-82ed86e06c03.png)

