### PR TITLE
feat(cli): support fetching AWS compliance reports by 'report_name'

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -90,8 +90,8 @@ const (
 	apiV2QueriesExecute  = "v2/Queries/execute"
 	apiV2QueriesValidate = "v2/Queries/validate"
 
-	apiV2Reports               = "v2/Reports?primaryQueryId=%s&format=%s&reportType=%s"
-	apiV2ReportsSecondaryQuery = "v2/Reports?primaryQueryId=%s&secondaryQueryId=%s&format=%s&reportType=%s"
+	apiV2Reports               = "v2/Reports?primaryQueryId=%s&format=%s&%s=%s"
+	apiV2ReportsSecondaryQuery = "v2/Reports?primaryQueryId=%s&secondaryQueryId=%s&format=%s&%s=%s"
 
 	apiV2ReportDefinitions         = "v2/ReportDefinitions"
 	apiV2ReportDefinitionsFromGUID = "v2/ReportDefinitions/%s"

--- a/api/reports.go
+++ b/api/reports.go
@@ -35,6 +35,25 @@ func NewReportsService(c *Client) *ReportsService {
 	}
 }
 
+// The method by which a report can be retrieved from v2/Reports/ api
+// can be 'reportName' or 'reportType'
+type reportFilter int
+
+const (
+	ReportFilterType reportFilter = iota
+	ReportFilterName
+)
+
+// reportFilterTypes is the list of available report filter types
+var reportFilterTypes = map[reportFilter]string{
+	ReportFilterType: "reportType",
+	ReportFilterName: "reportName",
+}
+
+func (r reportFilter) String() string {
+	return reportFilterTypes[r]
+}
+
 type ReportSummary struct {
 	NumRecommendations        int `json:"NUM_RECOMMENDATIONS"`
 	NumSeverity2NonCompliance int `json:"NUM_SEVERITY_2_NON_COMPLIANCE"`

--- a/api/reports_aws.go
+++ b/api/reports_aws.go
@@ -35,7 +35,8 @@ type awsReportsService struct {
 
 type AwsReportConfig struct {
 	AccountID string
-	Type      AwsReportType
+	Value     string
+	Parameter reportFilter
 }
 
 type AwsReportType int
@@ -103,7 +104,8 @@ func (svc *awsReportsService) Get(reportCfg AwsReportConfig) (response AwsReport
 	if reportCfg.AccountID == "" {
 		return AwsReportResponse{}, errors.New("specify an account id")
 	}
-	apiPath := fmt.Sprintf(apiV2Reports, reportCfg.AccountID, "json", reportCfg.Type.String())
+
+	apiPath := fmt.Sprintf(apiV2Reports, reportCfg.AccountID, "json", reportCfg.Parameter.String(), reportCfg.Value)
 	err = svc.client.RequestDecoder("GET", apiPath, nil, &response)
 	return
 }
@@ -113,7 +115,8 @@ func (svc *awsReportsService) DownloadPDF(filepath string, config AwsReportConfi
 		return errors.New("account id is required")
 	}
 
-	apiPath := fmt.Sprintf(apiV2Reports, config.AccountID, "pdf", config.Type)
+	// if name is set in config, fetch report by case
+	apiPath := fmt.Sprintf(apiV2Reports, config.AccountID, "pdf", config.Parameter.String(), config.Value)
 
 	request, err := svc.client.NewRequest("GET", apiPath, nil)
 	if err != nil {

--- a/api/reports_azure.go
+++ b/api/reports_azure.go
@@ -36,7 +36,8 @@ type azureReportsService struct {
 type AzureReportConfig struct {
 	TenantID       string
 	SubscriptionID string
-	Type           AzureReportType
+	Value          string
+	Parameter      reportFilter
 }
 
 type AzureReportType int
@@ -91,7 +92,7 @@ func (svc *azureReportsService) Get(reportCfg AzureReportConfig) (response Azure
 		return AzureReportResponse{}, errors.New("specify an account id")
 	}
 
-	apiPath := fmt.Sprintf(apiV2ReportsSecondaryQuery, reportCfg.TenantID, reportCfg.SubscriptionID, "json", reportCfg.Type.String())
+	apiPath := fmt.Sprintf(apiV2ReportsSecondaryQuery, reportCfg.TenantID, reportCfg.SubscriptionID, "json", reportCfg.Parameter.String(), reportCfg.Value)
 	err = svc.client.RequestDecoder("GET", apiPath, nil, &response)
 	return
 }
@@ -101,7 +102,7 @@ func (svc *azureReportsService) DownloadPDF(filepath string, config AzureReportC
 		return errors.New("tenant_id and subscription_id are required")
 	}
 
-	apiPath := fmt.Sprintf(apiV2Reports, config.TenantID, "pdf", config.SubscriptionID)
+	apiPath := fmt.Sprintf(apiV2ReportsSecondaryQuery, config.TenantID, config.SubscriptionID, "pdf", config.Parameter.String(), config.Value)
 
 	request, err := svc.client.NewRequest("GET", apiPath, nil)
 	if err != nil {

--- a/api/reports_gcp.go
+++ b/api/reports_gcp.go
@@ -36,7 +36,8 @@ type gcpReportsService struct {
 type GcpReportConfig struct {
 	OrganizationID string
 	ProjectID      string
-	Type           GcpReportType
+	Value          string
+	Parameter      reportFilter
 }
 
 type GcpReportType int
@@ -103,7 +104,7 @@ func (svc *gcpReportsService) Get(reportCfg GcpReportConfig) (response GcpReport
 		return GcpReportResponse{}, errors.New("project id and org id are required")
 	}
 
-	apiPath := fmt.Sprintf(apiV2ReportsSecondaryQuery, reportCfg.OrganizationID, reportCfg.ProjectID, "json", reportCfg.Type.String())
+	apiPath := fmt.Sprintf(apiV2ReportsSecondaryQuery, reportCfg.OrganizationID, reportCfg.ProjectID, "json", reportCfg.Parameter.String(), reportCfg.Value)
 	err = svc.client.RequestDecoder("GET", apiPath, nil, &response)
 	return
 }
@@ -113,7 +114,7 @@ func (svc *gcpReportsService) DownloadPDF(filepath string, config GcpReportConfi
 		return errors.New("project id and org id are required")
 	}
 
-	apiPath := fmt.Sprintf(apiV2ReportsSecondaryQuery, config.OrganizationID, config.ProjectID, "pdf", config.Type)
+	apiPath := fmt.Sprintf(apiV2ReportsSecondaryQuery, config.OrganizationID, config.ProjectID, "pdf", config.Parameter.String(), config.Value)
 
 	request, err := svc.client.NewRequest("GET", apiPath, nil)
 	if err != nil {

--- a/api/reports_test.go
+++ b/api/reports_test.go
@@ -29,7 +29,7 @@ func TestV2ReportsAwsGet(t *testing.T) {
 	)
 	assert.NoError(t, err)
 
-	response, err := c.V2.Reports.Aws.Get(api.AwsReportConfig{AccountID: "123456789", Type: api.AWS_CIS_14})
+	response, err := c.V2.Reports.Aws.Get(api.AwsReportConfig{AccountID: "123456789", Value: api.AWS_CIS_14.String(), Parameter: api.ReportFilterType})
 	assert.NoError(t, err)
 	assert.NotNil(t, response)
 	if assert.Equal(t, 1, len(response.Data)) {

--- a/api/reports_test.go
+++ b/api/reports_test.go
@@ -41,6 +41,37 @@ func TestV2ReportsAwsGet(t *testing.T) {
 	}
 }
 
+func TestV2ReportsAwsGetByName(t *testing.T) {
+	fakeServer := lacework.MockServer()
+	fakeServer.UseApiV2()
+	fakeServer.MockToken("TOKEN")
+	fakeServer.MockAPI("Reports",
+		func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "GET", r.Method, "Get() should be a GET method")
+			fmt.Fprintf(w, mockAwsReport)
+		},
+	)
+	defer fakeServer.Close()
+
+	c, err := api.NewClient("test",
+		api.WithApiV2(),
+		api.WithToken("TOKEN"),
+		api.WithURL(fakeServer.URL()),
+	)
+	assert.NoError(t, err)
+
+	response, err := c.V2.Reports.Aws.Get(api.AwsReportConfig{AccountID: "123456789", Value: "AWS CIS Benchmark and S3", Parameter: api.ReportFilterName})
+	assert.NoError(t, err)
+	assert.NotNil(t, response)
+	if assert.Equal(t, 1, len(response.Data)) {
+		assert.Equal(t, "123456789", response.Data[0].AccountID)
+		assert.Equal(t, 44, response.Data[0].Summary[0].NumCompliant)
+		assert.Equal(t, "AWS PCI DSS Report", response.Data[0].ReportTitle)
+		assert.Equal(t, "test", response.Data[0].AccountAlias)
+		assert.Equal(t, "example-region", response.Data[0].Recommendations[1].Violations[0].Region)
+	}
+}
+
 func TestV2ReportsAzureGet(t *testing.T) {
 	fakeServer := lacework.MockServer()
 	fakeServer.UseApiV2()
@@ -60,7 +91,38 @@ func TestV2ReportsAzureGet(t *testing.T) {
 	)
 	assert.NoError(t, err)
 
-	response, err := c.V2.Reports.Azure.Get(api.AzureReportConfig{TenantID: "example-tenant", SubscriptionID: "example-subscription", Type: api.AZURE_CIS})
+	response, err := c.V2.Reports.Azure.Get(api.AzureReportConfig{TenantID: "example-tenant", SubscriptionID: "example-subscription", Value: api.AZURE_CIS.String(), Parameter: api.ReportFilterType})
+	assert.NoError(t, err)
+	assert.NotNil(t, response)
+	if assert.Equal(t, 1, len(response.Data)) {
+		assert.Equal(t, "abcdefg-1234", response.Data[0].TenantID)
+		assert.Equal(t, 13, response.Data[0].Summary[0].NumCompliant)
+		assert.Equal(t, "Azure CIS Benchmark", response.Data[0].ReportTitle)
+		assert.Equal(t, "123456-123456", response.Data[0].SubscriptionID)
+		assert.Equal(t, "my-invalid-custom-role-12345", response.Data[0].Recommendations[1].Violations[0].Resource)
+	}
+}
+
+func TestV2ReportsAzureGetByName(t *testing.T) {
+	fakeServer := lacework.MockServer()
+	fakeServer.UseApiV2()
+	fakeServer.MockToken("TOKEN")
+	fakeServer.MockAPI("Reports",
+		func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "GET", r.Method, "Get() should be a GET method")
+			fmt.Fprintf(w, mockAzureReport)
+		},
+	)
+	defer fakeServer.Close()
+
+	c, err := api.NewClient("test",
+		api.WithApiV2(),
+		api.WithToken("TOKEN"),
+		api.WithURL(fakeServer.URL()),
+	)
+	assert.NoError(t, err)
+
+	response, err := c.V2.Reports.Azure.Get(api.AzureReportConfig{TenantID: "example-tenant", SubscriptionID: "example-subscription", Value: "Azure CIS 1.3.1 Report", Parameter: api.ReportFilterName})
 	assert.NoError(t, err)
 	assert.NotNil(t, response)
 	if assert.Equal(t, 1, len(response.Data)) {
@@ -91,7 +153,38 @@ func TestV2ReportsGcpGet(t *testing.T) {
 	)
 	assert.NoError(t, err)
 
-	response, err := c.V2.Reports.Gcp.Get(api.GcpReportConfig{OrganizationID: "example-org", ProjectID: "example-project", Type: api.GCP_CIS})
+	response, err := c.V2.Reports.Gcp.Get(api.GcpReportConfig{OrganizationID: "example-org", ProjectID: "example-project", Value: api.GCP_CIS.String(), Parameter: api.ReportFilterType})
+	assert.NoError(t, err)
+	assert.NotNil(t, response)
+	if assert.Equal(t, 1, len(response.Data)) {
+		assert.Equal(t, "123456789", response.Data[0].OrganizationID)
+		assert.Equal(t, 36, response.Data[0].Summary[0].NumCompliant)
+		assert.Equal(t, "GCP CIS Benchmark", response.Data[0].ReportTitle)
+		assert.Equal(t, "test", response.Data[0].ProjectID)
+		assert.Equal(t, "ServiceAccountHasAdminPrivileges", response.Data[0].Recommendations[1].Violations[0].Reasons[0])
+	}
+}
+
+func TestV2ReportsGcpGetByName(t *testing.T) {
+	fakeServer := lacework.MockServer()
+	fakeServer.UseApiV2()
+	fakeServer.MockToken("TOKEN")
+	fakeServer.MockAPI("Reports",
+		func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "GET", r.Method, "Get() should be a GET method")
+			fmt.Fprintf(w, mockGcpReport)
+		},
+	)
+	defer fakeServer.Close()
+
+	c, err := api.NewClient("test",
+		api.WithApiV2(),
+		api.WithToken("TOKEN"),
+		api.WithURL(fakeServer.URL()),
+	)
+	assert.NoError(t, err)
+
+	response, err := c.V2.Reports.Gcp.Get(api.GcpReportConfig{OrganizationID: "example-org", ProjectID: "example-project", Value: "GCP CIS Benchmark 1.3", Parameter: api.ReportFilterName})
 	assert.NoError(t, err)
 	assert.NotNil(t, response)
 	if assert.Equal(t, 1, len(response.Data)) {

--- a/cli/cmd/compliance.go
+++ b/cli/cmd/compliance.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/olekukonko/tablewriter"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	"github.com/lacework/go-sdk/api"
@@ -521,4 +522,24 @@ func prettyPrintReportTypes(reportTypes []string) string {
 		sb.WriteString(fmt.Sprintf("'%s',", r))
 	}
 	return sb.String()
+}
+
+func validReportName(cloud string, name string) error {
+	var validReportNames []string
+	definitions, err := cli.LwApi.V2.ReportDefinitions.List()
+	if err != nil {
+		return errors.Wrap(err, "unable to list report definitions")
+	}
+
+	for _, d := range definitions.Data {
+		if d.SubReportType == cloud {
+			validReportNames = append(validReportNames, d.ReportName)
+		}
+	}
+
+	if array.ContainsStr(validReportNames, name) {
+		return nil
+	} else {
+		return errors.Errorf("'%s' is not a valid report name.\nRun 'lacework report-definition list --subtype %s' for a list of valid report names", name, cloud)
+	}
 }

--- a/cli/cmd/compliance_aws.go
+++ b/cli/cmd/compliance_aws.go
@@ -82,7 +82,7 @@ var (
 
 			// validate report_name
 			if cmd.Flags().Changed("report_name") {
-				return validReportName(api.ReportDefinitionNotificationTypeAws, compGcpCmdState.Name)
+				return validReportName(api.ReportDefinitionNotificationTypeAws, compAwsCmdState.ReportName)
 			}
 
 			if array.ContainsStr(api.AwsReportTypes(), compAwsCmdState.Type) {

--- a/cli/cmd/compliance_aws.go
+++ b/cli/cmd/compliance_aws.go
@@ -103,6 +103,10 @@ To list all AWS accounts configured in your account:
 To show recommendation details and affected resources for a recommendation id:
 
     lacework compliance aws get-report <account_id> [recommendation_id]
+
+To retrieve a specific report by its report name:
+
+    lacework compliance aws get-report <account_id> --report_name 'AWS CSA CCM 4.0.5'
 `,
 		Args: cobra.RangeArgs(1, 2),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -162,7 +166,6 @@ To show recommendation details and affected resources for a recommendation id:
 				}
 			}
 
-			// TODO Hashing of cache keys
 			var (
 				report   api.AwsReport
 				cacheKey = fmt.Sprintf("compliance/aws/v2/%s/%s", config.AccountID, config.Value)
@@ -535,7 +538,7 @@ valid types:%s`, prettyPrintReportTypes(api.AwsReportTypes())))
 
 	// Run 'lacework report-definition --subtype AWS' for a full list of AWS report names
 	complianceAwsGetReportCmd.Flags().StringVar(&compAwsCmdState.ReportName, "report_name", "",
-		fmt.Sprintf("report name to display, run 'lacework report-definitions list' for more information."))
+		"report name to display, run 'lacework report-definitions list' for more information.")
 
 	complianceAwsGetReportCmd.Flags().StringSliceVar(&compCmdState.Category, "category", []string{},
 		"filter report details by category (identity-and-access-management, s3, logging...)",

--- a/cli/cmd/compliance_gcp.go
+++ b/cli/cmd/compliance_gcp.go
@@ -158,6 +158,10 @@ To list all GCP projects and organizations configured in your account:
 To show recommendation details and affected resources for a recommendation id:
 
     lacework compliance gcp get-report <organization_id> <project_id> [recommendation_id]
+
+To retrieve a specific report by its report name:
+
+    lacework compliance gcp get-report <organization_id> <project_id> --report_name 'GCP Cybersecurity Maturity'
 `,
 		Args: cobra.RangeArgs(2, 3),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -509,7 +513,7 @@ valid types:%s`, prettyPrintReportTypes(api.GcpReportTypes())),
 
 	// Run 'lacework report-definition --subtype GCP' for a full list of GCP report names
 	complianceGcpGetReportCmd.Flags().StringVar(&compGcpCmdState.ReportName, "report_name", "",
-		fmt.Sprintf("report name to display, run 'lacework report-definitions list' for more information."))
+		"report name to display, run 'lacework report-definitions list' for more information.")
 
 	complianceGcpGetReportCmd.Flags().StringSliceVar(&compCmdState.Category, "category", []string{},
 		"filter report details by category (storage, networking, identity-and-access-management, ...)",

--- a/integration/compliance_aws_test.go
+++ b/integration/compliance_aws_test.go
@@ -138,7 +138,7 @@ func TestComplianceAwsGetReportTypeAWS_SOC_Rev2(t *testing.T) {
 
 func TestComplianceAwsGetReportByName(t *testing.T) {
 	account := os.Getenv("LW_INT_TEST_AWS_ACC")
-	out, err, exitcode := LaceworkCLIWithTOMLConfig("compliance", "aws", "get-report", account, "--report_name", "'AWS CSA CCM 4.0.5'")
+	out, err, exitcode := LaceworkCLIWithTOMLConfig("compliance", "aws", "get-report", account, "--report_name", "AWS CSA CCM 4.0.5")
 	assert.Empty(t, err.String(), "STDERR should be empty")
 	assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
 	assert.Contains(t, out.String(), "AWS Cloud Security Alliance",

--- a/integration/compliance_aws_test.go
+++ b/integration/compliance_aws_test.go
@@ -136,6 +136,19 @@ func TestComplianceAwsGetReportTypeAWS_SOC_Rev2(t *testing.T) {
 		"Account ID in compliance report is not correct")
 }
 
+func TestComplianceAwsGetReportByName(t *testing.T) {
+	account := os.Getenv("LW_INT_TEST_AWS_ACC")
+	out, err, exitcode := LaceworkCLIWithTOMLConfig("compliance", "aws", "get-report", account, "--report_name", "'AWS CSA CCM 4.0.5'")
+	assert.Empty(t, err.String(), "STDERR should be empty")
+	assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
+	assert.Contains(t, out.String(), "AWS Cloud Security Alliance",
+		"STDOUT report type missing or something else is going on, please check")
+	assert.Contains(t, out.String(), "Report Title",
+		"STDOUT table headers changed, please check")
+	assert.Contains(t, out.String(), account,
+		"Account ID in compliance report is not correct")
+}
+
 func TestComplianceAwsGetAllReportType(t *testing.T) {
 	account := os.Getenv("LW_INT_TEST_AWS_ACC")
 	for _, reportType := range api.AwsReportTypes() {

--- a/integration/test_resources/help/compliance_aws_get-report
+++ b/integration/test_resources/help/compliance_aws_get-report
@@ -10,6 +10,10 @@ To show recommendation details and affected resources for a recommendation id:
 
     lacework compliance aws get-report <account_id> [recommendation_id]
 
+To retrieve a specific report by its report name:
+
+    lacework compliance aws get-report <account_id> --report_name 'AWS CSA CCM 4.0.5'
+
 Usage:
   lacework compliance aws get-report <account_id> [recommendation_id] [flags]
 
@@ -17,21 +21,22 @@ Aliases:
   get-report, get, show
 
 Flags:
-      --category strings   filter report details by category (identity-and-access-management, s3, logging...)
-      --csv                output report in CSV format
-      --details            increase details about the compliance report
-  -h, --help               help for get-report
-      --pdf                download report in PDF format
-      --service strings    filter report details by service (aws:s3, aws:iam, aws:cloudtrail, ...)
-      --severity string    filter report details by severity threshold (critical, high, medium, low, info)
-      --status string      filter report details by status (non-compliant, requires-manual-assessment, suppressed, compliant, could-not-assess)
-      --type string        report type to display, run 'lacework report-definitions list' for more information.
-                           valid types:
-                           'AWS_CIS_14','AWS_CIS_1_4_ISO_IEC_27002_2022','AWS_CIS_S3','AWS_CMMC_1.02','AWS_CSA_CCM_4_0_5',
-                           'AWS_Cyber_Essentials_2_2','AWS_HIPAA','AWS_ISO_27001:2013','AWS_NIST_800-171_rev2','AWS_NIST_800-53_rev5',
-                           'AWS_NIST_CSF','AWS_PCI_DSS_3.2.1','AWS_SOC_2','AWS_SOC_Rev2','HIPAA',
-                           'ISO_2700','LW_AWS_SEC_ADD_1_0','NIST_800-171_Rev2','NIST_800-53_Rev4','PCI',
-                           'SOC', (default "AWS_CIS_14")
+      --category strings     filter report details by category (identity-and-access-management, s3, logging...)
+      --csv                  output report in CSV format
+      --details              increase details about the compliance report
+  -h, --help                 help for get-report
+      --pdf                  download report in PDF format
+      --report_name string   report name to display, run 'lacework report-definitions list' for more information.
+      --service strings      filter report details by service (aws:s3, aws:iam, aws:cloudtrail, ...)
+      --severity string      filter report details by severity threshold (critical, high, medium, low, info)
+      --status string        filter report details by status (non-compliant, requires-manual-assessment, suppressed, compliant, could-not-assess)
+      --type string          report type to display, run 'lacework report-definitions list' for more information.
+                             valid types:
+                             'AWS_CIS_14','AWS_CIS_1_4_ISO_IEC_27002_2022','AWS_CIS_S3','AWS_CMMC_1.02','AWS_CSA_CCM_4_0_5',
+                             'AWS_Cyber_Essentials_2_2','AWS_HIPAA','AWS_ISO_27001:2013','AWS_NIST_800-171_rev2','AWS_NIST_800-53_rev5',
+                             'AWS_NIST_CSF','AWS_PCI_DSS_3.2.1','AWS_SOC_2','AWS_SOC_Rev2','HIPAA',
+                             'ISO_2700','LW_AWS_SEC_ADD_1_0','NIST_800-171_Rev2','NIST_800-53_Rev4','PCI',
+                             'SOC', (default "AWS_CIS_14")
 
 Global Flags:
   -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)

--- a/integration/test_resources/help/compliance_azure_get-report
+++ b/integration/test_resources/help/compliance_azure_get-report
@@ -9,6 +9,10 @@ To show recommendation details and affected resources for a recommendation id:
 
     lacework compliance azure get-report <tenant_id> <subscriptions_id> [recommendation_id]
 
+To retrieve a specific report by its report name:
+
+    lacework compliance azure get-report <tenant_id> <subscriptions_id> --report_name 'Azure CIS 1.3.1 Report'
+
 Usage:
   lacework compliance azure get-report <tenant_id> <subscriptions_id> [flags]
 
@@ -16,19 +20,20 @@ Aliases:
   get-report, get, show
 
 Flags:
-      --category strings   filter report details by category (networking, storage, ...)
-      --csv                output report in CSV format
-      --details            increase details about the compliance report
-  -h, --help               help for get-report
-      --pdf                download report in PDF format
-      --service strings    filter report details by service (azure:ms:storage, azure:ms:sql, azure:ms:network, ...)
-      --severity string    filter report details by severity threshold (critical, high, medium, low, info)
-      --status string      filter report details by status (non-compliant, requires-manual-assessment, suppressed, compliant, could-not-assess)
-      --type string        report type to display, run 'lacework report-definitions list' for more information.
-                           valid types:
-                           'AZURE_CIS','AZURE_CIS_131','AZURE_HIPAA','AZURE_ISO_27001','AZURE_NIST_800_171_REV2',
-                           'AZURE_NIST_800_53_REV5','AZURE_NIST_CSF','AZURE_PCI','AZURE_PCI_Rev2','AZURE_SOC',
-                           'AZURE_SOC_Rev2', (default "AZURE_CIS_131")
+      --category strings     filter report details by category (networking, storage, ...)
+      --csv                  output report in CSV format
+      --details              increase details about the compliance report
+  -h, --help                 help for get-report
+      --pdf                  download report in PDF format
+      --report_name string   report name to display, run 'lacework report-definitions list' for more information.
+      --service strings      filter report details by service (azure:ms:storage, azure:ms:sql, azure:ms:network, ...)
+      --severity string      filter report details by severity threshold (critical, high, medium, low, info)
+      --status string        filter report details by status (non-compliant, requires-manual-assessment, suppressed, compliant, could-not-assess)
+      --type string          report type to display, run 'lacework report-definitions list' for more information.
+                             valid types:
+                             'AZURE_CIS','AZURE_CIS_131','AZURE_HIPAA','AZURE_ISO_27001','AZURE_NIST_800_171_REV2',
+                             'AZURE_NIST_800_53_REV5','AZURE_NIST_CSF','AZURE_PCI','AZURE_PCI_Rev2','AZURE_SOC',
+                             'AZURE_SOC_Rev2', (default "AZURE_CIS_131")
 
 Global Flags:
   -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)

--- a/integration/test_resources/help/compliance_google_get-report
+++ b/integration/test_resources/help/compliance_google_get-report
@@ -9,6 +9,10 @@ To show recommendation details and affected resources for a recommendation id:
 
     lacework compliance gcp get-report <organization_id> <project_id> [recommendation_id]
 
+To retrieve a specific report by its report name:
+
+    lacework compliance gcp get-report <organization_id> <project_id> --report_name 'GCP Cybersecurity Maturity'
+
 Usage:
   lacework compliance google get-report <organization_id> <project_id> [flags]
 
@@ -16,21 +20,22 @@ Aliases:
   get-report, get, show
 
 Flags:
-      --category strings   filter report details by category (storage, networking, identity-and-access-management, ...)
-      --csv                output report in CSV format
-      --details            increase details about the compliance report
-  -h, --help               help for get-report
-      --pdf                download report in PDF format
-      --service strings    filter report details by service (gcp:storage:bucket, gcp:kms:cryptoKey, gcp:project, ...)
-      --severity string    filter report details by severity threshold (critical, high, medium, low, info)
-      --status string      filter report details by status (non-compliant, requires-manual-assessment, suppressed, compliant, could-not-assess)
-      --type string        report type to display, run 'lacework report-definitions list' for more information.
-                           valid types:
-                           'GCP_CIS','GCP_CIS12','GCP_CIS13','GCP_CIS_1_3_0_NIST_800_171_rev2','GCP_CIS_1_3_0_NIST_800_53_rev5',
-                           'GCP_CIS_1_3_0_NIST_CSF','GCP_CMMC_1_02','GCP_HIPAA','GCP_HIPAA_2013','GCP_HIPAA_Rev2',
-                           'GCP_ISO_27001','GCP_ISO_27001_2013','GCP_K8S','GCP_NIST_800_171_REV2','GCP_NIST_800_53_REV4',
-                           'GCP_NIST_CSF','GCP_PCI','GCP_PCI_DSS_3_2_1','GCP_PCI_Rev2','GCP_SOC',
-                           'GCP_SOC_2','GCP_SOC_Rev2', (default "GCP_CIS13")
+      --category strings     filter report details by category (storage, networking, identity-and-access-management, ...)
+      --csv                  output report in CSV format
+      --details              increase details about the compliance report
+  -h, --help                 help for get-report
+      --pdf                  download report in PDF format
+      --report_name string   report name to display, run 'lacework report-definitions list' for more information.
+      --service strings      filter report details by service (gcp:storage:bucket, gcp:kms:cryptoKey, gcp:project, ...)
+      --severity string      filter report details by severity threshold (critical, high, medium, low, info)
+      --status string        filter report details by status (non-compliant, requires-manual-assessment, suppressed, compliant, could-not-assess)
+      --type string          report type to display, run 'lacework report-definitions list' for more information.
+                             valid types:
+                             'GCP_CIS','GCP_CIS12','GCP_CIS13','GCP_CIS_1_3_0_NIST_800_171_rev2','GCP_CIS_1_3_0_NIST_800_53_rev5',
+                             'GCP_CIS_1_3_0_NIST_CSF','GCP_CMMC_1_02','GCP_HIPAA','GCP_HIPAA_2013','GCP_HIPAA_Rev2',
+                             'GCP_ISO_27001','GCP_ISO_27001_2013','GCP_K8S','GCP_NIST_800_171_REV2','GCP_NIST_800_53_REV4',
+                             'GCP_NIST_CSF','GCP_PCI','GCP_PCI_DSS_3_2_1','GCP_PCI_Rev2','GCP_SOC',
+                             'GCP_SOC_2','GCP_SOC_Rev2', (default "GCP_CIS13")
 
 Global Flags:
   -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/lacework/go-sdk) and create your branch from `main`
  2. Run `make prepare` in the repository root
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`make test`)
  5. Format your code (`make fmt`)
  6. Make sure your code lints (`make lint`)
  7. If you are updating the Lacework CLI, make sure it compiles (`make build-cli-cross-platform`)
  8. Follow the commit message standard (`type(scope): subject`) documented in [DEVELOPER_GUIDELINES.md](https://github.com/lacework/go-sdk/blob/main/DEVELOPER_GUIDELINES.md#commit-message-standard)
  9. If you haven't already, configure signed commits by [telling git about your signing key](https://docs.github.com/en/github/authenticating-to-github/managing-commit-signature-verification/telling-git-about-your-signing-key) and [signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)

  Learn more about contributing: https://github.com/lacework/go-sdk/blob/main/CONTRIBUTING.md
-->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

This change adds a new flag to `lacework compliance <cloud>` cmd to allow fetching reports by report name instead of report type.

Usage:

`lacework compliance aws get-report <account_id>  --report_name 'AWS CSA CCM 4.0.5' `

`--report_name` cannot be used with `--type` flag.
Attempting to use both flags will return 
`ERROR '--type' and '--report_name' flags cannot be used together`

The default behaviour when neither `--report_name` or `--type` is specified will remain the same i.e the type parameter is used to fetch reports.

TODO:
- [x] `compliance aws `
- [x]  `compliance gcp `
- [x]  `compliance azure `


## How did you test this change?

<!--
  How exactly did you verify that your PR solves the issue you wanted to solve?
  Include any other relevant information such as how to use the new functionality, screenshots, etc.
-->

TODO:
- [x] integration tests

## Issue

<!--
  Include the link to a Jira/Github issue
-->

https://lacework.atlassian.net/browse/GROW-1404
