### PR TITLE
fix: resolve inaccurate total packages count on 'vuln ctr show --deta…

### DIFF
--- a/cli/cmd/vuln_container_test.go
+++ b/cli/cmd/vuln_container_test.go
@@ -151,6 +151,19 @@ func TestVulnCtrIntroducedInRegex(t *testing.T) {
 	}
 }
 
+func TestVulnCtrCountPackages(t *testing.T) {
+	var (
+		response api.VulnerabilitiesContainersResponse
+		expected = 3
+	)
+	if err := json.Unmarshal([]byte(rawListAssessments), &response); err != nil {
+		panic(err)
+	}
+
+	totalPackages := countVulnContainerImagePackages(response.Data)
+	assert.Equal(t, totalPackages, expected)
+}
+
 var rawListAssessments = `
 {
     "paging": {

--- a/cli/cmd/vulnerability_test.go
+++ b/cli/cmd/vulnerability_test.go
@@ -98,7 +98,7 @@ func TestBuildVulnContainerAssessmentReportsWithVulnerabilitiesPackagesViewWithF
   CVE COUNT   SEVERITY    PACKAGE    CURRENT VERSION   FIX VERSION  
 ------------+----------+-----------+-----------------+--------------
   1           Critical   example-2   1.00.0-r1         1.20.00-r0   
-1 of 1 packages showing 
+1 of 2 packages showing 
 `
 	assert.Equal(t, strings.TrimPrefix(expectedTable, "\n"), cliOutput)
 


### PR DESCRIPTION
…ils' footer

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/lacework/go-sdk) and create your branch from `main`
  2. Run `make prepare` in the repository root
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`make test`)
  5. Format your code (`make fmt`)
  6. Make sure your code lints (`make lint`)
  7. If you are updating the Lacework CLI, make sure it compiles (`make build-cli-cross-platform`)
  8. Follow the commit message standard (`type(scope): subject`) documented in [DEVELOPER_GUIDELINES.md](https://github.com/lacework/go-sdk/blob/main/DEVELOPER_GUIDELINES.md#commit-message-standard)
  9. If you haven't already, configure signed commits by [telling git about your signing key](https://docs.github.com/en/github/authenticating-to-github/managing-commit-signature-verification/telling-git-about-your-signing-key) and [signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)

  Learn more about contributing: https://github.com/lacework/go-sdk/blob/main/CONTRIBUTING.md
-->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

This change moves the total packages count to use the unfiltered list of vulnCtrs. The total count was incorrect as it was using the already filtered list of vulnCtrs to do the count.

## How did you test this change?

<!--
  How exactly did you verify that your PR solves the issue you wanted to solve?
  Include any other relevant information such as how to use the new functionality, screenshots, etc.
-->

- [x] Manually run `lacework vuln ctr show <image> --packages --severity critical`
- [x] Unit test `countVulnContainerImagePackages` 

## Issue

<!--
  Include the link to a Jira/Github issue
-->

https://lacework.atlassian.net/browse/GROW-1428
