### PR TITLE
fix(cdk): handle -v flag for components

### DIFF
--- a/cli/cmd/component_args.go
+++ b/cli/cmd/component_args.go
@@ -143,6 +143,7 @@ func (p *componentArgParser) parseShortArg(flags *pflag.FlagSet, s string, args 
 		} else if flag.NoOptDefVal != "" {
 			// '-f' (arg was optional)
 			p.cliArgs = append(p.cliArgs, s)
+			return args
 		} else if len(shorthands) > 1 {
 			// '-farg'
 			p.cliArgs = append(p.cliArgs, s)

--- a/cli/cmd/component_args_test.go
+++ b/cli/cmd/component_args_test.go
@@ -20,13 +20,24 @@ package cmd
 import (
 	"testing"
 
+	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestComponentArgs(t *testing.T) {
 	assert := assert.New(t)
-	flags := rootCmd.PersistentFlags()
+	flags := &pflag.FlagSet{}
+	rootCmd.PersistentFlags().VisitAll(func(f *pflag.Flag) {
+		flags.AddFlag(f)
+	})
+	// cobra adds a -v flag very late in the execution flow
+	flags.BoolP("version", "v", false, "version of command")
 	for _, k := range []struct{ args, expectedComponent, expectedCLI []string }{
+		{
+			[]string{"iac", "-v", "-d", "foo"},
+			[]string{"iac", "-d", "foo"},
+			[]string{"-v"},
+		},
 		{
 			[]string{"--profile", "none", "--debug"},
 			[]string{},


### PR DESCRIPTION
## Summary

A bug in the component arg parser makes `lacework sca -v` hang.

What `lacework sca -v` is supposed to do is print the version (where "supposed to do" means what cobra is trying to do.). This isn't done correctly either.

## How did you test this change?

There's a unit test to check that -v is parsed correctly.    And run by hand to verify that `lacework sca -v` prints the version of the sca command.

## Issue

GROW-1438