### PR TITLE
style(cli): fix 'component' commands formatting

### DIFF
--- a/cli/cmd/component.go
+++ b/cli/cmd/component.go
@@ -276,10 +276,25 @@ func runComponentsShow(_ *cobra.Command, args []string) (err error) {
 	if cli.JSONOutput() {
 		return cli.OutputJSON(component)
 	}
+
+	var colorize *color.Color
+	switch component.Status() {
+	case lwcomponent.NotInstalled:
+		colorize = color.New(color.FgWhite, color.Bold)
+	case lwcomponent.Installed:
+		colorize = color.New(color.FgGreen, color.Bold)
+	case lwcomponent.UpdateAvailable:
+		colorize = color.New(color.FgYellow, color.Bold)
+	}
+
 	cli.OutputHuman(
 		renderCustomTable(
 			[]string{"Name", "Status", "Description"},
-			[][]string{{component.Name, component.Status().String(), component.Description}},
+			[][]string{{
+				component.Name,
+				colorize.Sprintf(component.Status().String()),
+				component.Description,
+			}},
 			tableFunc(func(t *tablewriter.Table) {
 				t.SetBorder(false)
 				t.SetColumnSeparator(" ")
@@ -296,6 +311,7 @@ func runComponentsShow(_ *cobra.Command, args []string) (err error) {
 		}
 		currentVersion = installed
 	}
+	cli.OutputHuman("\n")
 	cli.OutputHuman(component.ListVersions(currentVersion))
 	cli.OutputHuman("\n")
 	return
@@ -367,6 +383,7 @@ func runComponentsInstall(_ *cobra.Command, args []string) (err error) {
 	if component.Breadcrumbs.InstallationMessage != "" {
 		cli.OutputHuman("\n")
 		cli.OutputHuman(component.Breadcrumbs.InstallationMessage)
+		cli.OutputHuman("\n")
 	}
 	return
 }

--- a/lwcomponent/component.go
+++ b/lwcomponent/component.go
@@ -698,7 +698,10 @@ func (c Component) ListVersions(installed *semver.Version) string {
 		}
 	}
 	if installed != nil && !foundInstalled {
-		result += fmt.Sprintf("\nThe currently installed version %s is no longer available to install.", installed.String())
+		result += fmt.Sprintf(
+			"\n\nThe currently installed version %s is no longer available to install.",
+			installed.String(),
+		)
 	}
 	return result
 }


### PR DESCRIPTION
## Summary

Quick nitpicks for `component` commands.

<img src="https://media1.giphy.com/media/LNg3XXyiyLOgrkglD8/giphy.gif"/>

## `lacework component show <name>`

It now shows colors for the Status and has a few missing carriage returns.

![Screen Shot 2023-03-06 at 6 38 03 PM](https://user-images.githubusercontent.com/5712253/223305699-983bea3a-3da4-4dcc-b009-297c8f47c5bc.png)
