### PR TITLE
feat: Allow logging format to be chosen by caller

### DIFF
--- a/lwlogger/logger.go
+++ b/lwlogger/logger.go
@@ -51,8 +51,15 @@ var (
 
 // New initialize a new logger with the provided level and options
 func New(level string, options ...zap.Option) *zap.Logger {
+	return NewWithFormat(level, "", options...)
+}
+
+func NewWithFormat(level string, format string, options ...zap.Option) *zap.Logger {
 	if level == "" {
 		level = LogLevelFromEnvironment()
+	}
+	if format == "" {
+		format = logFormatFromEnv()
 	}
 
 	zapConfig := zap.Config{
@@ -62,7 +69,7 @@ func New(level string, options ...zap.Option) *zap.Logger {
 			Thereafter: 100,
 		},
 		Development:      inDevelopmentMode(),
-		Encoding:         logFormatFromEnv(),
+		Encoding:         format,
 		EncoderConfig:    laceworkEncoderConfig(),
 		OutputPaths:      []string{"stderr"},
 		ErrorOutputPaths: []string{"stderr"},


### PR DESCRIPTION
For SAST, we'd like to be able to select the logging format explicitly rather than have it be set from the environment.