### PR TITLE
fix: add missing subscription_id from azurerm block

### DIFF
--- a/cli/cmd/generate_azure.go
+++ b/cli/cmd/generate_azure.go
@@ -378,7 +378,7 @@ func initGenerateAzureTfCommandFlags() {
 		&GenerateAzureCommandState.SubscriptionID,
 		"subscription_id",
 		"",
-		"specify a subscription id")
+		"specify the Azure Subscription ID to be used to provision Lacework resources")
 
 	generateAzureTfCommand.PersistentFlags().BoolVar(
 		&GenerateAzureCommandState.CreateAdIntegration,
@@ -773,7 +773,6 @@ func promptAzureGenerate(config *azure.GenerateAzureTfConfigurationArgs, extraSt
 		return errors.New("must enable activity log or config")
 	}
 
-	//GROW-1444: Prompt for Azure SubscriptionID
 	if err := askAzureSubscriptionID(config); err != nil {
 		return err
 	}

--- a/integration/azure_generation_test.go
+++ b/integration/azure_generation_test.go
@@ -42,7 +42,6 @@ func TestGenerationAzureErrorOnNoSelection(t *testing.T) {
 				MsgRsp{cmd.QuestionAzureEnableConfig, "n"},
 				MsgRsp{cmd.QuestionEnableActivityLog, "n"},
 				MsgRsp{cmd.QuestionEnableAdIntegration, "n"},
-				MsgRsp{cmd.QuestionAddAzureSubscriptionID, "n"},
 				MsgOnly{"ERROR collecting/confirming parameters: must enable activity log or config"},
 			})
 		},

--- a/integration/azure_generation_test.go
+++ b/integration/azure_generation_test.go
@@ -42,6 +42,7 @@ func TestGenerationAzureErrorOnNoSelection(t *testing.T) {
 				MsgRsp{cmd.QuestionAzureEnableConfig, "n"},
 				MsgRsp{cmd.QuestionEnableActivityLog, "n"},
 				MsgRsp{cmd.QuestionEnableAdIntegration, "n"},
+				MsgRsp{cmd.QuestionAddAzureSubscriptionID, "n"},
 				MsgOnly{"ERROR collecting/confirming parameters: must enable activity log or config"},
 			})
 		},
@@ -68,6 +69,7 @@ func TestGenerationAzureSimple(t *testing.T) {
 				MsgRsp{cmd.QuestionAzureEnableConfig, "y"},
 				MsgRsp{cmd.QuestionEnableActivityLog, "y"},
 				MsgRsp{cmd.QuestionEnableAdIntegration, "y"},
+				MsgRsp{cmd.QuestionAddAzureSubscriptionID, "n"},
 				MsgRsp{cmd.QuestionAzureConfigAdvanced, "n"},
 				MsgRsp{cmd.QuestionRunTfPlan, "n"},
 			})
@@ -108,6 +110,7 @@ func TestGenerationAzureCustomizedOutputLocation(t *testing.T) {
 				MsgRsp{cmd.QuestionAzureEnableConfig, "y"},
 				MsgRsp{cmd.QuestionEnableActivityLog, "y"},
 				MsgRsp{cmd.QuestionEnableAdIntegration, "y"},
+				MsgRsp{cmd.QuestionAddAzureSubscriptionID, "n"},
 				MsgRsp{cmd.QuestionAzureConfigAdvanced, "y"},
 				MsgMenu{cmd.AzureAdvancedOptDone, 5},
 				MsgRsp{cmd.QuestionAzureCustomizeOutputLocation, dir},
@@ -146,6 +149,7 @@ func TestGenerationAzureConfigOnly(t *testing.T) {
 				MsgRsp{cmd.QuestionAzureEnableConfig, "y"},
 				MsgRsp{cmd.QuestionEnableActivityLog, "n"},
 				MsgRsp{cmd.QuestionEnableAdIntegration, "y"},
+				MsgRsp{cmd.QuestionAddAzureSubscriptionID, "n"},
 				MsgRsp{cmd.QuestionAzureConfigAdvanced, "n"},
 				MsgRsp{cmd.QuestionRunTfPlan, "n"},
 			})
@@ -179,6 +183,7 @@ func TestGenerationAzureActivityLogOnly(t *testing.T) {
 				MsgRsp{cmd.QuestionAzureEnableConfig, "n"},
 				MsgRsp{cmd.QuestionEnableActivityLog, "y"},
 				MsgRsp{cmd.QuestionEnableAdIntegration, "y"},
+				MsgRsp{cmd.QuestionAddAzureSubscriptionID, "n"},
 				MsgRsp{cmd.QuestionAzureConfigAdvanced, "n"},
 				MsgRsp{cmd.QuestionRunTfPlan, "n"},
 			})
@@ -215,6 +220,7 @@ func TestGenerationAzureNoADEnabled(t *testing.T) {
 				MsgRsp{cmd.QuestionAzureEnableConfig, "y"},
 				MsgRsp{cmd.QuestionEnableActivityLog, "y"},
 				MsgRsp{cmd.QuestionEnableAdIntegration, "n"},
+				MsgRsp{cmd.QuestionAddAzureSubscriptionID, "n"},
 				MsgRsp{cmd.QuestionAzureConfigAdvanced, "y"},
 				MsgMenu{cmd.AzureAdvancedOptLocation, 2},
 				MsgRsp{cmd.QuestionADApplicationPass, pass},
@@ -258,6 +264,7 @@ func TestGenerationAzureNamedConfig(t *testing.T) {
 				MsgRsp{cmd.QuestionAzureEnableConfig, "y"},
 				MsgRsp{cmd.QuestionEnableActivityLog, "n"},
 				MsgRsp{cmd.QuestionEnableAdIntegration, "y"},
+				MsgRsp{cmd.QuestionAddAzureSubscriptionID, "n"},
 				MsgRsp{cmd.QuestionAzureConfigAdvanced, "y"},
 
 				MsgMenu{cmd.AzureAdvancedOptDone, 0},
@@ -300,6 +307,7 @@ func TestGenerationAzureNamedActivityLog(t *testing.T) {
 				MsgRsp{cmd.QuestionAzureEnableConfig, "n"},
 				MsgRsp{cmd.QuestionEnableActivityLog, "y"},
 				MsgRsp{cmd.QuestionEnableAdIntegration, "y"},
+				MsgRsp{cmd.QuestionAddAzureSubscriptionID, "n"},
 				MsgRsp{cmd.QuestionAzureConfigAdvanced, "y"},
 
 				MsgMenu{cmd.AzureAdvancedOptDone, 0},
@@ -340,6 +348,7 @@ func TestGenerationAzureAdvancedOptsDone(t *testing.T) {
 				MsgRsp{cmd.QuestionAzureEnableConfig, "y"},
 				MsgRsp{cmd.QuestionEnableActivityLog, "y"},
 				MsgRsp{cmd.QuestionEnableAdIntegration, "y"},
+				MsgRsp{cmd.QuestionAddAzureSubscriptionID, "n"},
 				MsgRsp{cmd.QuestionAzureConfigAdvanced, "y"},
 
 				MsgMenu{cmd.AzureAdvancedOptDone, 6},
@@ -387,6 +396,7 @@ func TestGenerationAzureWithExistingTerraform(t *testing.T) {
 				MsgRsp{cmd.QuestionAzureEnableConfig, "y"},
 				MsgRsp{cmd.QuestionEnableActivityLog, "y"},
 				MsgRsp{cmd.QuestionEnableAdIntegration, "y"},
+				MsgRsp{cmd.QuestionAddAzureSubscriptionID, "n"},
 				MsgRsp{cmd.QuestionAzureConfigAdvanced, "y"},
 				MsgMenu{cmd.AzureAdvancedOptDone, 5},
 				MsgRsp{cmd.QuestionAzureCustomizeOutputLocation, dir},
@@ -425,6 +435,7 @@ func TestGenerationAzureConfigAllSubs(t *testing.T) {
 				MsgRsp{cmd.QuestionAzureEnableConfig, "y"},
 				MsgRsp{cmd.QuestionEnableActivityLog, "n"},
 				MsgRsp{cmd.QuestionEnableAdIntegration, "y"},
+				MsgRsp{cmd.QuestionAddAzureSubscriptionID, "n"},
 				MsgRsp{cmd.QuestionAzureConfigAdvanced, "y"},
 				MsgMenu{cmd.AzureAdvancedOptDone, 1},
 				MsgRsp{cmd.QuestionEnableAllSubscriptions, "y"},
@@ -465,6 +476,7 @@ func TestGenerationAzureConfigMgmntGroup(t *testing.T) {
 				MsgRsp{cmd.QuestionAzureEnableConfig, "y"},
 				MsgRsp{cmd.QuestionEnableActivityLog, "n"},
 				MsgRsp{cmd.QuestionEnableAdIntegration, "y"},
+				MsgRsp{cmd.QuestionAddAzureSubscriptionID, "n"},
 				MsgRsp{cmd.QuestionAzureConfigAdvanced, "y"},
 
 				MsgMenu{cmd.AzureAdvancedOptDone, 2},
@@ -508,6 +520,7 @@ func TestGenerationAzureConfigSubs(t *testing.T) {
 				MsgRsp{cmd.QuestionAzureEnableConfig, "y"},
 				MsgRsp{cmd.QuestionEnableActivityLog, "n"},
 				MsgRsp{cmd.QuestionEnableAdIntegration, "y"},
+				MsgRsp{cmd.QuestionAddAzureSubscriptionID, "n"},
 				MsgRsp{cmd.QuestionAzureConfigAdvanced, "y"},
 
 				MsgMenu{cmd.AzureAdvancedOptDone, 1},
@@ -551,6 +564,7 @@ func TestGenerationAzureActivityLogSubs(t *testing.T) {
 				MsgRsp{cmd.QuestionAzureEnableConfig, "n"},
 				MsgRsp{cmd.QuestionEnableActivityLog, "y"},
 				MsgRsp{cmd.QuestionEnableAdIntegration, "y"},
+				MsgRsp{cmd.QuestionAddAzureSubscriptionID, "n"},
 				MsgRsp{cmd.QuestionAzureConfigAdvanced, "y"},
 
 				MsgMenu{cmd.AzureAdvancedOptDone, 1},
@@ -595,6 +609,7 @@ func TestGenerationAzureActivityLogStorageAccount(t *testing.T) {
 				MsgRsp{cmd.QuestionAzureEnableConfig, "n"},
 				MsgRsp{cmd.QuestionEnableActivityLog, "y"},
 				MsgRsp{cmd.QuestionEnableAdIntegration, "y"},
+				MsgRsp{cmd.QuestionAddAzureSubscriptionID, "n"},
 				MsgRsp{cmd.QuestionAzureConfigAdvanced, "y"},
 
 				MsgMenu{cmd.AzureAdvancedOptDone, 3},
@@ -641,6 +656,7 @@ func TestGenerationAzureActivityLogAllSubs(t *testing.T) {
 				MsgRsp{cmd.QuestionAzureEnableConfig, "n"},
 				MsgRsp{cmd.QuestionEnableActivityLog, "y"},
 				MsgRsp{cmd.QuestionEnableAdIntegration, "y"},
+				MsgRsp{cmd.QuestionAddAzureSubscriptionID, "n"},
 				MsgRsp{cmd.QuestionAzureConfigAdvanced, "y"},
 
 				MsgMenu{cmd.AzureAdvancedOptDone, 1},
@@ -683,6 +699,7 @@ func TestGenerationAzureActivityLogLocation(t *testing.T) {
 				MsgRsp{cmd.QuestionAzureEnableConfig, "n"},
 				MsgRsp{cmd.QuestionEnableActivityLog, "y"},
 				MsgRsp{cmd.QuestionEnableAdIntegration, "y"},
+				MsgRsp{cmd.QuestionAddAzureSubscriptionID, "n"},
 				MsgRsp{cmd.QuestionAzureConfigAdvanced, "y"},
 
 				MsgMenu{cmd.AzureAdvancedOptDone, 2},
@@ -728,6 +745,7 @@ func TestGenerationAzureOverwrite(t *testing.T) {
 				MsgRsp{cmd.QuestionAzureEnableConfig, "y"},
 				MsgRsp{cmd.QuestionEnableActivityLog, "y"},
 				MsgRsp{cmd.QuestionEnableAdIntegration, "y"},
+				MsgRsp{cmd.QuestionAddAzureSubscriptionID, "n"},
 				MsgRsp{cmd.QuestionAzureConfigAdvanced, "n"},
 				MsgRsp{cmd.QuestionRunTfPlan, "n"},
 			})
@@ -746,6 +764,7 @@ func TestGenerationAzureOverwrite(t *testing.T) {
 				MsgRsp{cmd.QuestionAzureEnableConfig, "y"},
 				MsgRsp{cmd.QuestionEnableActivityLog, "y"},
 				MsgRsp{cmd.QuestionEnableAdIntegration, "y"},
+				MsgRsp{cmd.QuestionAddAzureSubscriptionID, "n"},
 				MsgRsp{cmd.QuestionAzureConfigAdvanced, "n"},
 				MsgRsp{"already exists, overwrite?", "n"},
 				MsgRsp{cmd.QuestionRunTfPlan, "n"},
@@ -781,6 +800,7 @@ func TestGenerationAzureOverwriteOutput(t *testing.T) {
 				MsgRsp{cmd.QuestionAzureEnableConfig, "y"},
 				MsgRsp{cmd.QuestionEnableActivityLog, "y"},
 				MsgRsp{cmd.QuestionEnableAdIntegration, "y"},
+				MsgRsp{cmd.QuestionAddAzureSubscriptionID, "n"},
 				MsgRsp{cmd.QuestionAzureConfigAdvanced, "n"},
 				MsgRsp{cmd.QuestionRunTfPlan, "n"},
 			})
@@ -801,6 +821,7 @@ func TestGenerationAzureOverwriteOutput(t *testing.T) {
 				MsgRsp{cmd.QuestionAzureEnableConfig, "y"},
 				MsgRsp{cmd.QuestionEnableActivityLog, "y"},
 				MsgRsp{cmd.QuestionEnableAdIntegration, "y"},
+				MsgRsp{cmd.QuestionAddAzureSubscriptionID, "n"},
 				MsgRsp{cmd.QuestionAzureConfigAdvanced, "n"},
 				MsgRsp{"already exists, overwrite?", "n"},
 				MsgRsp{cmd.QuestionRunTfPlan, "n"},
@@ -830,6 +851,7 @@ func TestGenerationAzureLaceworkProfile(t *testing.T) {
 				MsgRsp{cmd.QuestionAzureEnableConfig, "y"},
 				MsgRsp{cmd.QuestionEnableActivityLog, "y"},
 				MsgRsp{cmd.QuestionEnableAdIntegration, "y"},
+				MsgRsp{cmd.QuestionAddAzureSubscriptionID, "n"},
 				MsgRsp{cmd.QuestionAzureConfigAdvanced, "n"},
 				MsgRsp{cmd.QuestionRunTfPlan, "n"},
 			})
@@ -848,6 +870,41 @@ func TestGenerationAzureLaceworkProfile(t *testing.T) {
 	buildTf, _ := azure.NewTerraform(true, true, true,
 		azure.WithLaceworkProfile(azProfile),
 	).Generate()
+	assert.Equal(t, buildTf, tfResult)
+}
+
+func TestGenerationAzureWithSubscriptionID(t *testing.T) {
+	os.Setenv("LW_NOCACHE", "true")
+	defer os.Setenv("LW_NOCACHE", "")
+	var final string
+	var runError error
+	mockSubscriptionID := "111aaa1a-a1a1-11aa-a111-1aaaa1a11a11"
+
+	// Run CLI
+	tfResult := runGenerateAzureTest(t,
+		func(c *expect.Console) {
+			expectsCliOutput(t, c, []MsgRspHandler{
+				MsgRsp{cmd.QuestionAzureEnableConfig, "y"},
+				MsgRsp{cmd.QuestionEnableActivityLog, "y"},
+				MsgRsp{cmd.QuestionEnableAdIntegration, "y"},
+				MsgRsp{cmd.QuestionAddAzureSubscriptionID, "y"},
+				MsgRsp{cmd.QuestionAzureSubscriptionID, mockSubscriptionID},
+				MsgRsp{cmd.QuestionAzureConfigAdvanced, "n"},
+				MsgRsp{cmd.QuestionRunTfPlan, "n"},
+			})
+			final, _ = c.ExpectEOF()
+		},
+		"generate",
+		"cloud-account",
+		"az",
+	)
+
+	// Ensure CLI ran correctly
+	assert.Nil(t, runError)
+	assert.Contains(t, final, "Terraform code saved in")
+
+	// Create the TF directly with lwgenerate and validate same result via CLI
+	buildTf, _ := azure.NewTerraform(true, true, true, azure.WithSubscriptionID(mockSubscriptionID)).Generate()
 	assert.Equal(t, buildTf, tfResult)
 }
 

--- a/integration/test_resources/help/generate_cloud-account_azure
+++ b/integration/test_resources/help/generate_cloud-account_azure
@@ -35,6 +35,7 @@ Flags:
       --output string                          location to write generated content (default is ~/lacework/azure)
       --storage_account_name string            specify storage account name
       --storage_resource_group string          specify storage resource group
+      --subscription_id string                 specify a subscription id
       --subscription_ids strings               list of subscriptions to grant read access; format is id1,id2,id3
       --terraform-apply                        run terraform apply for the generated hcl
 

--- a/integration/test_resources/help/generate_cloud-account_azure
+++ b/integration/test_resources/help/generate_cloud-account_azure
@@ -35,7 +35,7 @@ Flags:
       --output string                          location to write generated content (default is ~/lacework/azure)
       --storage_account_name string            specify storage account name
       --storage_resource_group string          specify storage resource group
-      --subscription_id string                 specify a subscription id
+      --subscription_id string                 specify the Azure Subscription ID to be used to provision Lacework resources
       --subscription_ids strings               list of subscriptions to grant read access; format is id1,id2,id3
       --terraform-apply                        run terraform apply for the generated hcl
 

--- a/lwgenerate/azure/azure_test.go
+++ b/lwgenerate/azure/azure_test.go
@@ -231,3 +231,13 @@ func TestGenerationWithLaceworkProvider(t *testing.T) {
 	assert.NotNil(t, hcl)
 	assert.Equal(t, laceworkProfile, hcl)
 }
+
+func TestGenerationAzureRmProviderWithSubscriptionID(t *testing.T) {
+	configWithSubscription, fileErr := getFileContent("test-data/config-with-azurerm-subscription.tf")
+	assert.Nil(t, fileErr)
+
+	hcl, err := azure.NewTerraform(true, false, true, azure.WithSubscriptionID("test-subscription")).Generate()
+	assert.Nil(t, err)
+	assert.NotNil(t, hcl)
+	assert.Equal(t, configWithSubscription, hcl)
+}

--- a/lwgenerate/azure/test-data/config-with-azurerm-subscription.tf
+++ b/lwgenerate/azure/test-data/config-with-azurerm-subscription.tf
@@ -1,0 +1,39 @@
+terraform {
+  required_providers {
+    azuread = {
+      source  = "hashicorp/azuread"
+      version = "~> 2.16"
+    }
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 2.91.0"
+    }
+    lacework = {
+      source  = "lacework/lacework"
+      version = "~> 1.0"
+    }
+  }
+}
+
+provider "azuread" {
+}
+
+provider "azurerm" {
+  subscription_id = "test-subscription"
+  features {
+  }
+}
+
+module "az_ad_application" {
+  source  = "lacework/ad-application/azure"
+  version = "~> 1.0"
+}
+
+module "az_config" {
+  source                      = "lacework/config/azure"
+  version                     = "~> 1.0"
+  application_id              = module.az_ad_application.application_id
+  application_password        = module.az_ad_application.application_password
+  service_principal_id        = module.az_ad_application.service_principal_id
+  use_existing_ad_application = true
+}


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/lacework/go-sdk) and create your branch from `main`
  2. Run `make prepare` in the repository root
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`make test`)
  5. Format your code (`make fmt`)
  6. Make sure your code lints (`make lint`)
  7. If you are updating the Lacework CLI, make sure it compiles (`make build-cli-cross-platform`)
  8. Follow the commit message standard (`type(scope): subject`) documented in [DEVELOPER_GUIDELINES.md](https://github.com/lacework/go-sdk/blob/main/DEVELOPER_GUIDELINES.md#commit-message-standard)
  9. If you haven't already, configure signed commits by [telling git about your signing key](https://docs.github.com/en/github/authenticating-to-github/managing-commit-signature-verification/telling-git-about-your-signing-key) and [signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)

  Learn more about contributing: https://github.com/lacework/go-sdk/blob/main/CONTRIBUTING.md
-->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

`lacework generate cloud-account azure` does not currently make use of subscription_id in the azurerm provider block. The azure resources will always use the default subscription. 

This change adds a new SubscriptionID var to GenerateAzureTfConfigurationArgs. 

The subscription_id can optionally be set in the interactive prompt or with the flag `--subscription_id`. The Default behaviour is the same as current behaviour with subscription_id unset.

## How did you test this change?

<!--
  How exactly did you verify that your PR solves the issue you wanted to solve?
  Include any other relevant information such as how to use the new functionality, screenshots, etc.
-->

Manual:
- [x] Run `lacework gen ca azure` 
- [x] Run `lacework gen ca azure --subscription_id test`
- [x] Run `lacework gen ca azure --subscription_id test --noninteractive --configuration`

Tests:
- [x] `TestGenerationAzureRmProviderWithSubscriptionID`
- [x]  `TestGenerationAzureWithSubscriptionID`

## Issue

<!--
  Include the link to a Jira/Github issue
-->

https://lacework.atlassian.net/browse/GROW-1444
