### PR TITLE
fix(cli): avoid auth for completion cmds

### DIFF
--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -88,9 +88,13 @@ func cliPersistentPreRun(cmd *cobra.Command, args []string) error {
 	case "help [command]", "configure", "version", "docs <directory>", "generate-pkg-manifest":
 		return nil
 	default:
-		// @afiune no need to create a client for any configure command
-		if cmd.HasParent() && cmd.Parent().Use == "configure" {
-			return nil
+		if cmd.HasParent() {
+			switch cmd.Parent().Use {
+			case "configure", "completion":
+				// @afiune no need to create a client for any configure
+				// command or any completion command
+				return nil
+			}
 		}
 		if err := cli.NewClient(); err != nil {
 			if !strings.Contains(err.Error(), "Invalid Account") {

--- a/integration/completion_unix_test.go
+++ b/integration/completion_unix_test.go
@@ -1,0 +1,34 @@
+//go:build !windows
+
+//
+// Author:: Salim Afiune Maya (<afiune@lacework.net>)
+// Copyright:: Copyright 2023, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package integration
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCompletionCommandNoAuth(t *testing.T) {
+	// running the Lacework CLI without toml config, which means no auth
+	_, err, exitcode := LaceworkCLI("completion", "bash")
+	assert.Empty(t, err.String(), "STDERR should be empty")
+	assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
+}

--- a/integration/completion_windows_test.go
+++ b/integration/completion_windows_test.go
@@ -1,0 +1,34 @@
+//go:build windows
+
+//
+// Author:: Salim Afiune Maya (<afiune@lacework.net>)
+// Copyright:: Copyright 2023, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package integration
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCompletionCommandNoAuth(t *testing.T) {
+	// running the Lacework CLI without toml config, which means no auth
+	_, err, exitcode := LaceworkCLI("completion", "powershell")
+	assert.Empty(t, err.String(), "STDERR should be empty")
+	assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
+}


### PR DESCRIPTION

## Summary

We don't need to have authentication for any `lacework completion` command.

<img src="https://media2.giphy.com/media/d1E1msx7Yw5Ne1Fe/giphy.gif"/>

## How did you test this change?

Ran this and it worked.
```
HOME=/tmp lacework completion bash
```

Also, added integration tests.
## Issue

Closes https://github.com/lacework/go-sdk/issues/1182

