### PR TITLE
docs: update install methods on Readme with chocolatey cmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 <img src="https://techally-content.s3-us-west-1.amazonaws.com/public-content/lacework_logo_full.png" width="600">
 
 # Lacework Go SDK
@@ -38,7 +39,14 @@ brew install lacework/tap/lacework-cli
 ```
 For more details, see [Lacework Homebrew Tap](https://github.com/lacework/homebrew-tap).
 
+#### Chocolatey:
+```
+choco install lacework-cli
+```
+For more details, see [Lacework CLI Chocolatey](https://community.chocolatey.org/packages/lacework-cli).
+
 Look at the [cli/](cli/) folder for more information.
+
 
 ## Lacework API Client ([`api`](api/))
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ For more details, see [Lacework Homebrew Tap](https://github.com/lacework/homebr
 ```
 choco install lacework-cli
 ```
-For more details, see [Lacework CLI Chocolatey](https://community.chocolatey.org/packages/lacework-cli).
+For more details, see [Lacework CLI Chocolatey](https://community.chocolatey.org/packages/lacework-cli#install).
 
 Look at the [cli/](cli/) folder for more information.
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -27,6 +27,11 @@ iex ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercon
 ```
 brew install lacework/tap/lacework-cli
 ```
+
+### Chocolatey:
+```
+choco install lacework-cli
+```
 ## Quick Configuration
 
 The `lacework configure` command is the fastest way to set up your Lacework


### PR DESCRIPTION
Add chocolatey install cmd to readme

`choco install lacework-cli`

https://community.chocolatey.org/packages/lacework-cli#install