### PR TITLE
fix(cli): vuln host scan-pkg-manifest showing results that do not hav…

### DIFF
--- a/api/v2_vulnerabilities_software_packages.go
+++ b/api/v2_vulnerabilities_software_packages.go
@@ -39,6 +39,10 @@ func (v *VulnerabilitySoftwarePackage) HasFix() bool {
 	return v.FixInfo.FixAvailable == 1
 }
 
+func (v *VulnerabilitySoftwarePackage) IsVulnerable() bool {
+	return v.FixInfo.EvalStatus == "VULNERABLE"
+}
+
 func (v *VulnerabilitySoftwarePackage) ScoreString() string {
 	if v.CveProps.Metadata.Nvd.Cvssv3.Score != 0 {
 		return fmt.Sprintf("%.1f", v.CveProps.Metadata.Nvd.Cvssv3.Score)

--- a/cli/cmd/vuln_host_scan_package_manifest.go
+++ b/cli/cmd/vuln_host_scan_package_manifest.go
@@ -201,6 +201,7 @@ func hostScanPackagesVulnToTable(scan api.VulnerabilitySoftwarePackagesResponse)
 			"Package",
 			"Version",
 			"Fix Version",
+			"Status",
 		}
 	}
 
@@ -257,19 +258,14 @@ func filterHostScanPackagesVulnDetails(vulns []api.VulnerabilitySoftwarePackage)
 func hostScanPackagesVulnDetailsTable(vulns []api.VulnerabilitySoftwarePackage) [][]string {
 	var out [][]string
 	for _, vuln := range vulns {
-
-		fixedVersion := ""
-		if vuln.HasFix() {
-			fixedVersion = vuln.FixInfo.FixedVersion
-		}
-
 		out = append(out, []string{
 			vuln.VulnID,
 			vuln.Severity,
 			vuln.ScoreString(),
 			vuln.OsPkgInfo.Pkg,
 			vuln.OsPkgInfo.PkgVer,
-			fixedVersion,
+			vuln.FixInfo.FixedVersion,
+			vuln.FixInfo.EvalStatus,
 		})
 	}
 


### PR DESCRIPTION
…e 'VULNERABLE' evalStatus

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/lacework/go-sdk) and create your branch from `main`
  2. Run `make prepare` in the repository root
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`make test`)
  5. Format your code (`make fmt`)
  6. Make sure your code lints (`make lint`)
  7. If you are updating the Lacework CLI, make sure it compiles (`make build-cli-cross-platform`)
  8. Follow the commit message standard (`type(scope): subject`) documented in [DEVELOPER_GUIDELINES.md](https://github.com/lacework/go-sdk/blob/main/DEVELOPER_GUIDELINES.md#commit-message-standard)
  9. If you haven't already, configure signed commits by [telling git about your signing key](https://docs.github.com/en/github/authenticating-to-github/managing-commit-signature-verification/telling-git-about-your-signing-key) and [signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)

  Learn more about contributing: https://github.com/lacework/go-sdk/blob/main/CONTRIBUTING.md
-->

## Summary

CLI not showing fixedVersions for “GOOD“ results

Following v2 api migration we no longer add the fixedVersion for GOOD results 

There is also some confusion as to why non vulnerable results are being show, this change also adds a Status column to distinguish between "VULNERABLE" & "GOOD" results
```
      CVE ID       SEVERITY   SCORE   PACKAGE           VERSION                    FIX VERSION             STATUS    
-----------------+----------+-------+---------+--------------------------+-----------------------------+-------------
  CVE-2020-1971    High       5.9     openssl   1.1.1-1ubuntu2.1~18.04.5   0:1.1.1-1ubuntu2.1~18.04.7    VULNERABLE  
  CVE-2016-6304    High       7.5     openssl   1.1.1-1ubuntu2.1~18.04.5   0:1.0.2g-1ubuntu9             GOOD
```
## How did you test this change?

<!--
  How exactly did you verify that your PR solves the issue you wanted to solve?
  Include any other relevant information such as how to use the new functionality, screenshots, etc.
-->

Manual:
- [x] Run `lacework vuln host scan-pkg-manifest '{ "osPkgInfoList": [{
                "os":"Ubuntu",
                "osVer":"18.04",
                "pkg": "openssl",
                "pkgVer": "1.1.1-1ubuntu2.1~18.04.5"
            }
        ]
    }'
`

## Issue

<!--
  Include the link to a Jira/Github issue
-->

https://lacework.atlassian.net/browse/GROW-1480
