### PR TITLE
fix(cli): vuln host scan-pkg-manifest only show 'VULNERABLE' results

### DIFF
--- a/cli/cmd/vuln_host_scan_package_manifest.go
+++ b/cli/cmd/vuln_host_scan_package_manifest.go
@@ -201,7 +201,6 @@ func hostScanPackagesVulnToTable(scan api.VulnerabilitySoftwarePackagesResponse)
 			"Package",
 			"Version",
 			"Fix Version",
-			"Status",
 		}
 	}
 
@@ -245,6 +244,11 @@ func filterHostScanPackagesVulnDetails(vulns []api.VulnerabilitySoftwarePackage)
 	out := make([]api.VulnerabilitySoftwarePackage, 0)
 
 	for _, vuln := range vulns {
+
+		if !vuln.IsVulnerable() {
+			continue
+		}
+
 		if vulCmdState.Fixable && !vuln.HasFix() {
 			continue
 		}
@@ -265,7 +269,6 @@ func hostScanPackagesVulnDetailsTable(vulns []api.VulnerabilitySoftwarePackage) 
 			vuln.OsPkgInfo.Pkg,
 			vuln.OsPkgInfo.PkgVer,
 			vuln.FixInfo.FixedVersion,
-			vuln.FixInfo.EvalStatus,
 		})
 	}
 

--- a/cli/cmd/vuln_host_scan_package_manifest.go
+++ b/cli/cmd/vuln_host_scan_package_manifest.go
@@ -244,7 +244,6 @@ func filterHostScanPackagesVulnDetails(vulns []api.VulnerabilitySoftwarePackage)
 	out := make([]api.VulnerabilitySoftwarePackage, 0)
 
 	for _, vuln := range vulns {
-
 		if !vuln.IsVulnerable() {
 			continue
 		}

--- a/cli/cmd/vuln_host_scan_package_manifest_test.go
+++ b/cli/cmd/vuln_host_scan_package_manifest_test.go
@@ -1,0 +1,55 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/lacework/go-sdk/api"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFilterHostScanPackagesVulnDetails(t *testing.T) {
+	res := filterHostScanPackagesVulnDetails(mockVulnPackages)
+
+	assert.Equal(t, len(res), 1)
+	assert.Equal(t, res[0].FixInfo.EvalStatus, "VULNERABLE")
+}
+
+func TestFilterHostScanPackagesVulnDetailsFixable(t *testing.T) {
+	vulCmdState.Fixable = true
+	res := filterHostScanPackagesVulnDetails(mockVulnPackages)
+
+	assert.Equal(t, len(res), 1)
+	assert.Equal(t, res[0].FixInfo.EvalStatus, "VULNERABLE")
+}
+
+var mockVulnPackages = []api.VulnerabilitySoftwarePackage{{FixInfo: fixInfo{
+	EvalStatus:       "VULNERABLE",
+	FixAvailable:     1,
+	FixedVersion:     "test-fix-1",
+	VersionInstalled: "current-version-1",
+}}, {FixInfo: fixInfo{
+	EvalStatus:       "GOOD",
+	FixAvailable:     0,
+	FixedVersion:     "test-fix-2",
+	VersionInstalled: "current-version-2",
+}}, {FixInfo: fixInfo{
+	EvalStatus:       "GOOD",
+	FixAvailable:     1,
+	FixedVersion:     "test-fix-3",
+	VersionInstalled: "current-version-3",
+}}}
+
+type fixInfo struct {
+	CompareResult               int    `json:"compareResult"`
+	EvalStatus                  string `json:"evalStatus"`
+	FixAvailable                int    `json:"fixAvailable"`
+	FixedVersion                string `json:"fixedVersion"`
+	FixedVersionComparisonInfos []struct {
+		CurrFixVer                         string `json:"currFixVer"`
+		IsCurrFixVerGreaterThanOtherFixVer string `json:"isCurrFixVerGreaterThanOtherFixVer"`
+		OtherFixVer                        string `json:"otherFixVer"`
+	} `json:"fixedVersionComparisonInfos"`
+	FixedVersionComparisonScore int    `json:"fixedVersionComparisonScore"`
+	MaxPrefixMatchingLenScore   int    `json:"maxPrefixMatchingLenScore"`
+	VersionInstalled            string `json:"versionInstalled"`
+}

--- a/cli/cmd/vuln_host_scan_package_manifest_test.go
+++ b/cli/cmd/vuln_host_scan_package_manifest_test.go
@@ -16,6 +16,9 @@ func TestFilterHostScanPackagesVulnDetails(t *testing.T) {
 
 func TestFilterHostScanPackagesVulnDetailsFixable(t *testing.T) {
 	vulCmdState.Fixable = true
+	defer func() {
+		vulCmdState.Fixable = false
+	}()
 	res := filterHostScanPackagesVulnDetails(mockVulnPackages)
 
 	assert.Equal(t, len(res), 1)


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/lacework/go-sdk) and create your branch from `main`
  2. Run `make prepare` in the repository root
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`make test`)
  5. Format your code (`make fmt`)
  6. Make sure your code lints (`make lint`)
  7. If you are updating the Lacework CLI, make sure it compiles (`make build-cli-cross-platform`)
  8. Follow the commit message standard (`type(scope): subject`) documented in [DEVELOPER_GUIDELINES.md](https://github.com/lacework/go-sdk/blob/main/DEVELOPER_GUIDELINES.md#commit-message-standard)
  9. If you haven't already, configure signed commits by [telling git about your signing key](https://docs.github.com/en/github/authenticating-to-github/managing-commit-signature-verification/telling-git-about-your-signing-key) and [signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)

  Learn more about contributing: https://github.com/lacework/go-sdk/blob/main/CONTRIBUTING.md
-->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

This change removes "GOOD" results from `lacework vuln host scan-pkg-manifest` and only shows "VULNERABLE"


## How did you test this change?

<!--
  How exactly did you verify that your PR solves the issue you wanted to solve?
  Include any other relevant information such as how to use the new functionality, screenshots, etc.
-->

Tests:
- [x] `TestFilterHostScanPackagesVulnDetails`
- [x] `TestFilterHostScanPackagesVulnDetailsFixable`

