### PR TITLE
fix(cli): filter 'Fixed' host vulnerabilities

### DIFF
--- a/cli/cmd/vuln_host_list_hosts.go
+++ b/cli/cmd/vuln_host_list_hosts.go
@@ -23,6 +23,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/lacework/go-sdk/api"
 	"github.com/pkg/errors"
@@ -47,11 +48,21 @@ To list the CVEs found in the hosts of your environment run:
 
     lacework vulnerability host list-cves`,
 		RunE: func(_ *cobra.Command, args []string) error {
-			filter := api.SearchFilter{Filters: []api.Filter{{
-				Expression: "eq",
-				Field:      "vulnId",
-				Value:      args[0],
-			}}}
+			now := time.Now()
+			start := now.AddDate(0, 0, -1)
+			filter := api.SearchFilter{
+				TimeFilter: &api.TimeFilter{
+					StartTime: &start,
+					EndTime:   &now,
+				},
+				Filters: []api.Filter{
+					{Expression: "eq",
+						Field: "vulnId",
+						Value: args[0]},
+					{Expression: "ne",
+						Field: "status",
+						Value: "Fixed"},
+				}}
 
 			cli.StartProgress("Fetching Hosts...")
 			response, err := cli.LwApi.V2.Vulnerabilities.Hosts.SearchAllPages(filter)

--- a/integration/host_vulnerability_test.go
+++ b/integration/host_vulnerability_test.go
@@ -133,6 +133,10 @@ func TestHostVulnerabilityCommandsEndToEnd(t *testing.T) {
 			assert.Contains(t, out.String(), header,
 				"STDOUT table headers changed, please check")
 		}
+
+		// LINK-1387
+		assert.NotContains(t, out.String(), "Fixed",
+			"we were not expecting 'Fixed' package status")
 	})
 
 	// Test unmarshall Epoch time for last_evaluation_time


### PR DESCRIPTION

## Summary
Showing vulnerabilities that have been 'Fixed' is confusing customers,
this change is filtering them out so we no longer show them.

We have a separate ticket to add custom time ranges https://lacework.atlassian.net/browse/GROW-1485

## How did you test this change?

Ran test manually and added a test that checks that we no longer show the `Fixed` status.

## Issue
https://lacework.atlassian.net/browse/LINK-1387

