### PR TITLE
feat(cli): new report-definitions update command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,7 @@ integration-only: install-tools ## Run integration tests
 		compliance \
 		team_member \
 		vulnerability \
+		report_definitions \
 		component" -run=$(regex)
 
 .PHONY: integration-lql

--- a/api/api.go
+++ b/api/api.go
@@ -95,6 +95,8 @@ const (
 
 	apiV2ReportDefinitions         = "v2/ReportDefinitions"
 	apiV2ReportDefinitionsFromGUID = "v2/ReportDefinitions/%s"
+	// To be re-added in GROW-1487
+	// apiV2ReportDefinitionsRevert   = "v2/ReportDefinitions/%s/RevertTo/%d"
 
 	apiV2ReportRules        = "v2/ReportRules"
 	apiV2ReportRuleFromGUID = "v2/ReportRules/%s"

--- a/api/report_definitions_test.go
+++ b/api/report_definitions_test.go
@@ -1,0 +1,312 @@
+//
+// Author:: Darren Murray (<darren.murray@lacework.net>)
+// Copyright:: Copyright 2023, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package api_test
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/lacework/go-sdk/api"
+	"github.com/lacework/go-sdk/internal/intgguid"
+	"github.com/lacework/go-sdk/internal/lacework"
+)
+
+func TestReportDefinitionsGet(t *testing.T) {
+	var (
+		intgGUID         = intgguid.New()
+		apiPath          = fmt.Sprintf("ReportDefinitions/%s", intgGUID)
+		reportDefinition = singleMockReportDefinition(intgGUID)
+		fakeServer       = lacework.MockServer()
+	)
+	fakeServer.UseApiV2()
+	fakeServer.MockToken("TOKEN")
+	defer fakeServer.Close()
+
+	fakeServer.MockAPI(apiPath,
+		func(w http.ResponseWriter, r *http.Request) {
+			if assert.Equal(t, "GET", r.Method, "Get() should be a GET method") {
+				fmt.Fprintf(w, generateReportDefinitionResponse(reportDefinition))
+			}
+		},
+	)
+
+	fakeServer.MockAPI("ReportDefinitions/UNKNOWN_INTG_GUID",
+		func(w http.ResponseWriter, r *http.Request) {
+			if assert.Equal(t, "GET", r.Method, "Get() should be a GET method") {
+				http.Error(w, "{ \"message\": \"Not Found\"}", 404)
+			}
+		},
+	)
+
+	c, err := api.NewClient("test",
+		api.WithApiV2(),
+		api.WithToken("TOKEN"),
+		api.WithURL(fakeServer.URL()),
+	)
+	assert.Nil(t, err)
+
+	t.Run("when report definition exists", func(t *testing.T) {
+		var response api.ReportDefinitionResponse
+		response, err := c.V2.ReportDefinitions.Get(intgGUID)
+		assert.Nil(t, err)
+		if assert.NotNil(t, response) {
+			assert.Equal(t, intgGUID, response.Data.ReportDefinitionGuid)
+			assert.Equal(t, "mockReportDefinition", response.Data.ReportName)
+			assert.Equal(t, "mockReportDefinition Display", response.Data.DisplayName)
+			assert.Equal(t, "COMPLIANCE", response.Data.ReportType)
+			assert.Equal(t, "AWS", response.Data.SubReportType)
+			assert.Equal(t, "Test Section", response.Data.ReportDefinitionDetails.Sections[0].Title)
+			assert.Equal(t, []string{"lacework-global-1"}, response.Data.ReportDefinitionDetails.Sections[0].Policies)
+		}
+	})
+
+	t.Run("when report definition does NOT exist", func(t *testing.T) {
+		var response api.ReportDefinitionResponse
+		response, err := c.V2.ReportDefinitions.Get("UNKNOWN_INTG_GUID")
+		assert.Empty(t, response)
+		if assert.NotNil(t, err) {
+			assert.Contains(t, err.Error(), "api/v2/ReportDefinitions/UNKNOWN_INTG_GUID")
+			assert.Contains(t, err.Error(), "[404] Not Found")
+		}
+	})
+}
+
+func TestReportDefinitionsDelete(t *testing.T) {
+	var (
+		intgGUID         = intgguid.New()
+		apiPath          = fmt.Sprintf("ReportDefinitions/%s", intgGUID)
+		reportDefinition = singleMockReportDefinition(intgGUID)
+		getResponse      = generateReportDefinitionResponse(reportDefinition)
+		fakeServer       = lacework.MockServer()
+	)
+	fakeServer.UseApiV2()
+	fakeServer.MockToken("TOKEN")
+	defer fakeServer.Close()
+
+	fakeServer.MockAPI(apiPath,
+		func(w http.ResponseWriter, r *http.Request) {
+			if getResponse != "" {
+				switch r.Method {
+				case "GET":
+					fmt.Fprintf(w, getResponse)
+				case "DELETE":
+					// once deleted, empty the getResponse so that
+					// further GET requests return 404s
+					getResponse = ""
+				}
+			} else {
+				http.Error(w, "{ \"message\": \"Not Found\"}", 404)
+			}
+		},
+	)
+
+	fakeServer.MockAPI("ReportDefinitions/UNKNOWN_INTG_GUID",
+		func(w http.ResponseWriter, r *http.Request) {
+			if assert.Equal(t, "GET", r.Method, "Get() should be a GET method") {
+				http.Error(w, "{ \"message\": \"Not Found\"}", 404)
+			}
+		},
+	)
+
+	c, err := api.NewClient("test",
+		api.WithApiV2(),
+		api.WithToken("TOKEN"),
+		api.WithURL(fakeServer.URL()),
+	)
+	assert.Nil(t, err)
+
+	t.Run("verify report definition exists", func(t *testing.T) {
+		var response api.ReportDefinitionResponse
+		response, err := c.V2.ReportDefinitions.Get(intgGUID)
+		assert.Nil(t, err)
+		if assert.NotNil(t, response) {
+			assert.Equal(t, intgGUID, response.Data.ReportDefinitionGuid)
+			assert.Equal(t, "mockReportDefinition", response.Data.ReportName)
+			assert.Equal(t, "mockReportDefinition Display", response.Data.DisplayName)
+			assert.Equal(t, "COMPLIANCE", response.Data.ReportType)
+			assert.Equal(t, "AWS", response.Data.SubReportType)
+			assert.Equal(t, "Test Section", response.Data.ReportDefinitionDetails.Sections[0].Title)
+			assert.Equal(t, []string{"lacework-global-1"}, response.Data.ReportDefinitionDetails.Sections[0].Policies)
+		}
+	})
+
+	t.Run("when report definition has been deleted", func(t *testing.T) {
+		err := c.V2.ReportDefinitions.Delete(intgGUID)
+		assert.Nil(t, err)
+
+		var response api.ReportDefinitionResponse
+		response, err = c.V2.ReportDefinitions.Get(intgGUID)
+		assert.Empty(t, response)
+		if assert.NotNil(t, err) {
+			assert.Contains(t, err.Error(), "api/v2/ReportDefinitions/MOCK_")
+			assert.Contains(t, err.Error(), "[404] Not Found")
+		}
+	})
+}
+
+func TestReportDefinitionsList(t *testing.T) {
+	var (
+		allGUIDs          []string
+		reportDefinitions = generateGuids(&allGUIDs, 3)
+		expectedLen       = len(allGUIDs)
+		fakeServer        = lacework.MockServer()
+	)
+
+	fakeServer.UseApiV2()
+	fakeServer.MockToken("TOKEN")
+	fakeServer.MockAPI("ReportDefinitions",
+		func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "GET", r.Method, "List() should be a GET method")
+			reportDefinitions := []string{
+				generateReportDefinitions(reportDefinitions),
+			}
+			fmt.Fprintf(w,
+				generateReportDefinitionsResponse(
+					strings.Join(reportDefinitions, ", "),
+				),
+			)
+		},
+	)
+	defer fakeServer.Close()
+
+	c, err := api.NewClient("test",
+		api.WithApiV2(),
+		api.WithToken("TOKEN"),
+		api.WithURL(fakeServer.URL()),
+	)
+	assert.Nil(t, err)
+
+	response, err := c.V2.ReportDefinitions.List()
+	assert.Nil(t, err)
+	assert.NotNil(t, response)
+	assert.Equal(t, expectedLen, len(response.Data))
+	for _, d := range response.Data {
+		assert.Contains(t, allGUIDs, d.ReportDefinitionGuid)
+	}
+}
+
+func TestReportDefinitionUpdate(t *testing.T) {
+	var (
+		intgGUID   = intgguid.New()
+		apiPath    = fmt.Sprintf("ReportDefinitions/%s", intgGUID)
+		fakeServer = lacework.MockServer()
+	)
+	fakeServer.UseApiV2()
+	fakeServer.MockToken("TOKEN")
+	defer fakeServer.Close()
+
+	fakeServer.MockAPI(apiPath, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "PATCH", r.Method, "Update() should be a PATCH method")
+
+		if assert.NotNil(t, r.Body) {
+			body := httpBodySniffer(r)
+			assert.Contains(t, body, "mockReportDefinitionUpdate", "report definition name is missing")
+			assert.Contains(t, body, "mockReportDefinitionUpdate Display", "report definition name is missing")
+			assert.Contains(t, body, "lacework-global-1", "missing policies")
+		}
+
+		fmt.Fprintf(w, generateReportDefinitionResponse(singleMockReportDefinition(intgGUID)))
+	})
+
+	c, err := api.NewClient("test",
+		api.WithApiV2(),
+		api.WithToken("TOKEN"),
+		api.WithURL(fakeServer.URL()),
+	)
+	assert.Nil(t, err)
+
+	reportDefinition := api.ReportDefinitionUpdate{
+		ReportName:  "mockReportDefinitionUpdate",
+		DisplayName: "mockReportDefinitionUpdate Display",
+		ReportDefinitionDetails: &api.ReportDefinitionDetails{
+			Sections: []api.ReportDefinitionSection{{
+				Title:    "Test Section",
+				Policies: []string{"lacework-global-1"},
+			}},
+		},
+	}
+	assert.Equal(t, "mockReportDefinitionUpdate", reportDefinition.ReportName, "report definition name mismatch")
+	assert.Equal(t, "mockReportDefinitionUpdate Display", reportDefinition.DisplayName, "a new report definition should match its type")
+	assert.Equal(t, 1, len(reportDefinition.ReportDefinitionDetails.Sections), "a new report definition should be enabled")
+
+	response, err := c.V2.ReportDefinitions.Update(intgGUID, reportDefinition)
+	if assert.NoError(t, err) {
+		assert.NotNil(t, response)
+		assert.Equal(t, intgGUID, response.Data.ReportDefinitionGuid)
+		assert.Equal(t, "mockReportDefinition", response.Data.ReportName)
+		assert.Equal(t, "mockReportDefinition Display", response.Data.DisplayName)
+		assert.Equal(t, "COMPLIANCE", response.Data.ReportType)
+		assert.Equal(t, "AWS", response.Data.SubReportType)
+		assert.Equal(t, "Test Section", response.Data.ReportDefinitionDetails.Sections[0].Title)
+		assert.Equal(t, []string{"lacework-global-1"}, response.Data.ReportDefinitionDetails.Sections[0].Policies)
+	}
+}
+
+func generateReportDefinitions(guids []string) string {
+	reportDefinitions := make([]string, len(guids))
+	for i, guid := range guids {
+		reportDefinitions[i] = singleMockReportDefinition(guid)
+	}
+	return strings.Join(reportDefinitions, ", ")
+}
+
+func generateReportDefinitionsResponse(data string) string {
+	return `
+		{
+			"data": [` + data + `]
+		}
+	`
+}
+
+func generateReportDefinitionResponse(data string) string {
+	return `
+		{
+			"data": ` + data + `
+		}
+	`
+}
+
+func singleMockReportDefinition(id string) string {
+	return fmt.Sprintf(`{
+    "createdBy": "test.user@lacework.net",
+    "createdTime": "2023-03-16T14:10:24Z",
+    "displayName": "mockReportDefinition Display",
+    "reportDefinition": {
+      "sections": [
+        {
+          "category": "",
+          "policies": [
+            "lacework-global-1"
+          ],
+          "title": "Test Section"
+        }
+      ]
+    },
+    "reportDefinitionGuid": "%s",
+    "reportName": "mockReportDefinition",
+    "reportType": "COMPLIANCE",
+    "subReportType": "AWS",
+    "version": 1
+}
+`, id)
+}

--- a/cli/cmd/report_definitions.go
+++ b/cli/cmd/report_definitions.go
@@ -19,6 +19,7 @@
 package cmd
 
 import (
+	"strconv"
 	"strings"
 
 	"github.com/lacework/go-sdk/api"
@@ -36,8 +37,15 @@ var (
 	CreateReportDefinitionAddSectionQuestion    = "Add another policy section?"
 	CreateReportDefinitionSectionTitleQuestion  = "Section Title: "
 	CreateReportDefinitionPoliciesQuestion      = "Select Policies in this Section: "
+	SelectReportDefinitionQuestion              = "Select an existing report definition as a template?"
 
-	SelectReportDefinitionQuestion = "Select an existing report definition as a template?"
+	UpdateReportDefinitionQuestion                   = "Update report definition in editor?"
+	UpdateReportDefinitionReportNameQuestion         = "Report Name: "
+	UpdateReportDefinitionDisplayNameQuestion        = "Display Name: "
+	UpdateReportDefinitionEditSectionQuestion        = "Update an existing policy section?"
+	UpdateReportDefinitionEditAnotherSectionQuestion = "Update another existing policy section?"
+	UpdateReportDefinitionAddSectionQuestion         = "Add a new policy section?"
+	UpdateReportDefinitionSelectSectionQuestion      = "Select a section to edit"
 
 	reportDefinitionsCmdState = struct {
 		// filter report definitions by subtype. 'AWS', 'GCP' or 'Azure'
@@ -171,6 +179,7 @@ func init() {
 	reportDefinitionsCommand.AddCommand(reportDefinitionsListCommand)
 	reportDefinitionsCommand.AddCommand(reportDefinitionsShowCommand)
 	reportDefinitionsCommand.AddCommand(reportDefinitionsDeleteCommand)
+	reportDefinitionsCommand.AddCommand(reportDefinitionsUpdateCommand)
 
 	// add flags to report-definition commands
 	reportDefinitionsListCommand.Flags().StringVar(&reportDefinitionsCmdState.SubType,
@@ -178,6 +187,9 @@ func init() {
 	)
 	reportDefinitionsCreateCommand.Flags().StringVar(&reportDefinitionsCmdState.File,
 		"file", "", "create a report definition from an existing definition file",
+	)
+	reportDefinitionsUpdateCommand.Flags().StringVar(&reportDefinitionsCmdState.File,
+		"file", "", "update a report definition from an existing definition file",
 	)
 }
 
@@ -198,6 +210,7 @@ func buildReportDefinitionDetailsTable(definition api.ReportDefinition) string {
 	details = append(details, []string{"RELEASE LABEL", releaseLabel})
 	details = append(details, []string{"UPDATED BY", definition.CreatedBy})
 	details = append(details, []string{"LAST UPDATED", definition.CreatedTime.String()})
+	details = append(details, []string{"VERSION", strconv.Itoa(definition.Version)})
 
 	detailsTable := &strings.Builder{}
 	detailsTable.WriteString(renderOneLineCustomTable("REPORT DEFINITION DETAILS",

--- a/cli/cmd/report_definitions_test.go
+++ b/cli/cmd/report_definitions_test.go
@@ -153,6 +153,7 @@ var (
     RELEASE LABEL                                    
     UPDATED BY      SYSTEM                           
     LAST UPDATED    2022-09-09 10:35:16 +0000 UTC    
+    VERSION         2                                
                                                      
                         POLICIES                        
 --------------------------------------------------------

--- a/cli/cmd/report_definitions_update.go
+++ b/cli/cmd/report_definitions_update.go
@@ -1,0 +1,332 @@
+//
+// Author:: Darren Murray(<darren.murray@lacework.net>)
+// Copyright:: Copyright 2023, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/AlecAivazis/survey/v2"
+	"github.com/lacework/go-sdk/api"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"golang.org/x/exp/slices"
+	"gopkg.in/yaml.v3"
+)
+
+// update command is used to update a new lacework report definition
+var reportDefinitionsUpdateCommand = &cobra.Command{
+	Use:   "update <report_definition_id>",
+	Short: "Update a report definition",
+	Long: `Update an existing custom report definition.
+
+To update an existing report definition:
+
+    lacework report-definition update <report_definition_id>
+
+To update a new report definition from an existing file:
+
+    lacework report-definition update <report_definition_id> --file custom-report.json
+`,
+	Args: cobra.ExactArgs(1),
+	RunE: updateReportDefinition,
+}
+
+func updateReportDefinition(_ *cobra.Command, args []string) error {
+	var (
+		reportDefinition api.ReportDefinitionUpdate
+		err              error
+	)
+
+	cli.StartProgress("Fetching report definition...")
+	existingReport, err := cli.LwApi.V2.ReportDefinitions.Get(args[0])
+	cli.StopProgress()
+
+	if err != nil {
+		return err
+	}
+
+	if existingReport.Data.CreatedBy == "SYSTEM" {
+		return errors.New("only user created report definitions can be modified")
+	}
+
+	if reportDefinitionsCmdState.File != "" {
+		fileInput, err := inputReportDefinitionFromFile(reportDefinitionsCmdState.File)
+		if err != nil {
+			return err
+		}
+
+		cfg, err := parseNewReportDefinition(fileInput)
+		if err != nil {
+			return err
+		}
+		reportDefinition = api.NewReportDefinitionUpdate(cfg)
+	} else {
+		reportDefinition, err = promptUpdateReportDefinition(existingReport.Data)
+		if err != nil {
+			return err
+		}
+	}
+
+	cli.StartProgress("Updating report definition...")
+	resp, err := cli.LwApi.V2.ReportDefinitions.Update(args[0], reportDefinition)
+	cli.StopProgress()
+	if err != nil {
+		return errors.Wrap(err, "unable to update report definition")
+	}
+
+	cli.OutputHuman("The report definition %s was updated. \n", resp.Data.ReportDefinitionGuid)
+	return nil
+}
+
+func promptUpdateReportDefinition(existingReport api.ReportDefinition) (api.ReportDefinitionUpdate, error) {
+	var useEditor bool
+
+	if err := survey.AskOne(&survey.Confirm{Message: UpdateReportDefinitionQuestion}, &useEditor); err != nil {
+		return api.ReportDefinitionUpdate{}, err
+	}
+
+	if useEditor {
+		return promptUpdateReportDefinitionFromEditor(existingReport)
+	}
+
+	return promptUpdateReportDefinitionQuestions(existingReport)
+}
+
+func promptUpdateReportDefinitionQuestions(existingReport api.ReportDefinition) (reportDefinition api.ReportDefinitionUpdate, err error) {
+	questions := []*survey.Question{
+		{
+			Name:     "name",
+			Prompt:   &survey.Input{Message: UpdateReportDefinitionReportNameQuestion, Default: existingReport.ReportName},
+			Validate: survey.Required,
+		},
+		{
+			Name:     "display",
+			Prompt:   &survey.Input{Message: UpdateReportDefinitionDisplayNameQuestion, Default: existingReport.DisplayName},
+			Validate: survey.Required,
+		},
+	}
+
+	answers := struct {
+		Name        string `survey:"name"`
+		DisplayName string `survey:"display"`
+	}{}
+
+	if err = survey.Ask(questions, &answers, survey.WithIcons(promptIconsFunc)); err != nil {
+		return
+	}
+
+	reportDefinition = api.ReportDefinitionUpdate{
+		ReportName:  answers.Name,
+		DisplayName: answers.DisplayName,
+	}
+
+	sections, err := promptUpdateReportDefinitionSections(existingReport)
+	if err != nil {
+		return
+	}
+
+	reportDefinition.ReportDefinitionDetails = &api.ReportDefinitionDetails{Sections: sections}
+
+	return
+}
+
+func promptUpdateReportDefinitionSections(report api.ReportDefinition) ([]api.ReportDefinitionSection, error) {
+	var (
+		sections    = report.ReportDefinitionDetails.Sections
+		newSections []api.ReportDefinitionSection
+		err         error
+	)
+
+	cli.StartProgress("Fetching list of policy ids...")
+	resp, err := cli.LwApi.V2.Policy.List()
+	cli.StopProgress()
+
+	if err != nil {
+		return nil, err
+	}
+
+	//filter the policies not in current report's domain
+	var policies []api.Policy
+	for _, p := range resp.Data {
+		domain := strings.ToUpper(report.SubReportType)
+		if slices.Contains(p.Tags, fmt.Sprintf("domain:%s", domain)) {
+			policies = append(policies, p)
+		}
+	}
+
+	if len(policies) == 0 {
+		return nil, errors.New("unable to find policies")
+	}
+
+	// edit existing sections
+	editSection := false
+	if err := survey.AskOne(&survey.Confirm{
+		Message: UpdateReportDefinitionEditSectionQuestion,
+	}, &editSection); err != nil {
+		return nil, err
+	}
+
+	if editSection {
+		if sections, err = promptUpdateReportDefinitionSection(&sections, policies); err != nil {
+			return nil, err
+		}
+
+		editAnotherSection := false
+		for {
+			if err := survey.AskOne(&survey.Confirm{
+				Message: UpdateReportDefinitionEditAnotherSectionQuestion,
+			}, &editAnotherSection); err != nil {
+				return nil, err
+			}
+
+			if editAnotherSection {
+				if sections, err = promptUpdateReportDefinitionSection(&newSections, policies); err != nil {
+					return nil, err
+				}
+			} else {
+				break
+			}
+		}
+	}
+
+	// add new sections
+	addSection := false
+	if err := survey.AskOne(&survey.Confirm{
+		Message: UpdateReportDefinitionAddSectionQuestion,
+	}, &addSection); err != nil {
+		return nil, err
+	}
+
+	if addSection {
+		if err := promptAddReportDefinitionSection(&newSections, policies); err != nil {
+			return nil, err
+		}
+
+		addAnotherSection := false
+		for {
+			if err := survey.AskOne(&survey.Confirm{
+				Message: CreateReportDefinitionAddSectionQuestion,
+			}, &addAnotherSection); err != nil {
+				return nil, err
+			}
+
+			if addAnotherSection {
+				if err := promptAddReportDefinitionSection(&newSections, policies); err != nil {
+					return nil, err
+				}
+			} else {
+				break
+			}
+		}
+	}
+
+	sections = append(sections, newSections...)
+
+	return sections, nil
+
+}
+
+func promptUpdateReportDefinitionFromEditor(existingReport api.ReportDefinition) (reportDefinition api.ReportDefinitionUpdate, err error) {
+	var reportDefinitionConfig api.ReportDefinitionConfig
+
+	if err != nil {
+		return
+	}
+
+	updateCfg := api.NewReportDefinitionUpdate(existingReport.Config())
+	reportTemplateYaml, err := yaml.Marshal(updateCfg)
+	if err != nil {
+		return
+	}
+
+	// open editor with report yaml
+	report, err := inputReportDefinitionFromEditor("update", string(reportTemplateYaml))
+	if err != nil {
+		return
+	}
+	err = yaml.Unmarshal([]byte(report), &reportDefinitionConfig)
+
+	reportDefinition = api.NewReportDefinitionUpdate(reportDefinitionConfig)
+
+	return
+}
+
+func promptUpdateReportDefinitionSection(currentSections *[]api.ReportDefinitionSection, policies []api.Policy) ([]api.ReportDefinitionSection, error) {
+	type sectionMapping struct {
+		section  api.ReportDefinitionSection
+		position int
+	}
+
+	var (
+		policyIDs        []string
+		selectedSections = make(map[string]sectionMapping)
+		sectionTitles    []string
+		sections         = *currentSections
+	)
+
+	for _, policy := range policies {
+		policyIDs = append(policyIDs, policy.PolicyID)
+	}
+
+	for i, section := range sections {
+		sectionTitles = append(sectionTitles, section.Title)
+		selectedSections[section.Title] = sectionMapping{section: section, position: i}
+	}
+
+	var selectedTitle string
+	if err := survey.AskOne(&survey.Select{
+		Message: UpdateReportDefinitionSelectSectionQuestion,
+		Options: sectionTitles,
+	}, &selectedTitle); err != nil {
+		return nil, err
+	}
+
+	selectedSection := selectedSections[selectedTitle]
+
+	questions := []*survey.Question{
+		{
+			Name:     "title",
+			Prompt:   &survey.Input{Message: CreateReportDefinitionSectionTitleQuestion, Default: selectedSection.section.Title},
+			Validate: survey.Required,
+		},
+		{
+			Name:     "policies",
+			Prompt:   &survey.MultiSelect{Message: CreateReportDefinitionPoliciesQuestion, Options: policyIDs, Default: selectedSection.section.Policies},
+			Validate: survey.MinItems(1),
+		},
+	}
+
+	answers := struct {
+		Title    string   `survey:"title"`
+		Policies []string `survey:"policies"`
+	}{}
+
+	if err := survey.Ask(questions, &answers, survey.WithIcons(promptIconsFunc)); err != nil {
+		return nil, err
+	}
+
+	updatedSection := api.ReportDefinitionSection{
+		Title:    answers.Title,
+		Policies: answers.Policies,
+	}
+
+	sections[selectedSection.position] = updatedSection
+	return sections, nil
+}

--- a/integration/report_definitions_update_test.go
+++ b/integration/report_definitions_update_test.go
@@ -1,0 +1,140 @@
+//go:build report_definitions && !windows
+
+// Author:: Darren Murray (<dmurray-lacework@lacework.net>)
+// Copyright:: Copyright 2023, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package integration
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Netflix/go-expect"
+	"github.com/lacework/go-sdk/api"
+	"github.com/lacework/go-sdk/cli/cmd"
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v2"
+)
+
+func TestReportDefinitionsPromptUpdate(t *testing.T) {
+	report := fetchCustomReportDefinition()
+
+	if report == nil {
+		t.Skip("skipping report definitions update. No custom reports found.")
+	}
+
+	os.Setenv("LW_NOCACHE", "true")
+	defer os.Setenv("LW_NOCACHE", "")
+	var final string
+
+	dir := createTOMLConfigFromCIvars()
+	defer os.RemoveAll(dir)
+
+	suffix := time.Now().UnixMilli()
+	runFakeTerminalTestFromDir(t, dir,
+		func(c *expect.Console) {
+			expectsCliOutput(t, c, []MsgRspHandler{
+				MsgRsp{cmd.UpdateReportDefinitionQuestion, "n"},
+				MsgRsp{cmd.UpdateReportDefinitionReportNameQuestion, "CLI Test Updated"},
+				MsgRsp{cmd.UpdateReportDefinitionDisplayNameQuestion, fmt.Sprintf("Test CLI Update-%d", suffix)},
+				MsgRsp{cmd.UpdateReportDefinitionEditSectionQuestion, "n"},
+				MsgRsp{cmd.UpdateReportDefinitionAddSectionQuestion, "n"},
+			})
+			final, _ = c.ExpectEOF()
+		},
+		"report-definition",
+		"update",
+		report.ReportDefinitionGuid,
+	)
+
+	assert.Contains(t, final, "Report definition updated")
+}
+
+func TestReportDefinitionsUpdateFromFile(t *testing.T) {
+	report := fetchCustomReportDefinition()
+
+	if report == nil {
+		t.Skip("skipping report definitions update. No custom reports found.")
+	}
+
+	customReportYaml, err := yaml.Marshal(report.Config())
+	if err != nil {
+		assert.FailNow(t, err.Error())
+	}
+
+	file, err := createTemporaryFile("TestReportDefinitionUpdateFile", string(customReportYaml))
+	if err != nil {
+		t.FailNow()
+	}
+	defer os.Remove(file.Name())
+
+	out, stderr, exitcode := LaceworkCLIWithTOMLConfig(
+		"rd", "update", report.ReportDefinitionGuid, "--file", file.Name())
+
+	assert.Empty(t, stderr.String(), "STDERR should be empty")
+	assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
+	assert.Contains(t, out.String(), "Report definition updated")
+}
+
+func fetchCustomReportDefinition() *api.ReportDefinition {
+	lacework, err := api.NewClient(os.Getenv("CI_ACCOUNT"),
+		api.WithSubaccount(os.Getenv("CI_SUBACCOUNT")),
+		api.WithApiKeys(os.Getenv("CI_API_KEY"), os.Getenv("CI_API_SECRET")),
+		api.WithApiV2(),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// List all report definitions
+	reports, err := lacework.V2.ReportDefinitions.List()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Select custom report
+	for _, r := range reports.Data {
+		if r.IsCustom() && strings.Contains(r.ReportName, "CLI Test") {
+			return &r
+		}
+	}
+
+	// if test custom report doesn't exist create one
+	rptCfg := api.ReportDefinitionConfig{
+		ReportName:    "CLI Test",
+		DisplayName:   "CLI Test",
+		ReportType:    api.ReportDefinitionTypeCompliance.String(),
+		SubReportType: api.ReportDefinitionSubTypeAws.String(),
+		Sections: []api.ReportDefinitionSection{{
+			Title:    "CLI Test Report",
+			Policies: []string{"lacework-global-1"},
+		}},
+	}
+
+	customReport := api.NewReportDefinition(rptCfg)
+
+	report, err := lacework.V2.ReportDefinitions.Create(customReport)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	return &report.Data
+}

--- a/integration/report_definitions_update_test.go
+++ b/integration/report_definitions_update_test.go
@@ -65,7 +65,7 @@ func TestReportDefinitionsPromptUpdate(t *testing.T) {
 		report.ReportDefinitionGuid,
 	)
 
-	assert.Contains(t, final, "Report definition updated")
+	assert.Contains(t, final, "updated")
 }
 
 func TestReportDefinitionsUpdateFromFile(t *testing.T) {
@@ -91,7 +91,7 @@ func TestReportDefinitionsUpdateFromFile(t *testing.T) {
 
 	assert.Empty(t, stderr.String(), "STDERR should be empty")
 	assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
-	assert.Contains(t, out.String(), "Report definition updated")
+	assert.Contains(t, out.String(), "updated")
 }
 
 func fetchCustomReportDefinition() *api.ReportDefinition {

--- a/integration/test_resources/help/report-definition_update
+++ b/integration/test_resources/help/report-definition_update
@@ -1,20 +1,19 @@
-Manage report definitions to configure the data retrieval and layout information for a report.
+Update an existing custom report definition.
+
+To update an existing report definition:
+
+    lacework report-definition update <report_definition_id>
+
+To update a new report definition from an existing file:
+
+    lacework report-definition update <report_definition_id> --file custom-report.json
 
 Usage:
-  lacework report-definition [command]
-
-Aliases:
-  report-definition, report-definitions, rd
-
-Available Commands:
-  create      Create a report definition
-  delete      Delete a report definition
-  list        List all report definitions
-  show        Show a report definition by ID
-  update      Update a report definition
+  lacework report-definition update <report_definition_id> [flags]
 
 Flags:
-  -h, --help   help for report-definition
+      --file string   update a report definition from an existing definition file
+  -h, --help          help for update
 
 Global Flags:
   -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
@@ -29,5 +28,3 @@ Global Flags:
       --organization        access organization level data sets (org admins only)
   -p, --profile string      switch between profiles configured at ~/.lacework.toml
       --subaccount string   sub-account name inside your organization (org admins only)
-
-Use "lacework report-definition [command] --help" for more information about a command.


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/lacework/go-sdk) and create your branch from `main`
  2. Run `make prepare` in the repository root
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`make test`)
  5. Format your code (`make fmt`)
  6. Make sure your code lints (`make lint`)
  7. If you are updating the Lacework CLI, make sure it compiles (`make build-cli-cross-platform`)
  8. Follow the commit message standard (`type(scope): subject`) documented in [DEVELOPER_GUIDELINES.md](https://github.com/lacework/go-sdk/blob/main/DEVELOPER_GUIDELINES.md#commit-message-standard)
  9. If you haven't already, configure signed commits by [telling git about your signing key](https://docs.github.com/en/github/authenticating-to-github/managing-commit-signature-verification/telling-git-about-your-signing-key) and [signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)

  Learn more about contributing: https://github.com/lacework/go-sdk/blob/main/CONTRIBUTING.md
-->

## Summary

Support updating existing custom report definition from the CLI with the new command:

`lacework report-definitions update`


<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## How did you test this change?

<!--
  How exactly did you verify that your PR solves the issue you wanted to solve?
  Include any other relevant information such as how to use the new functionality, screenshots, etc.
-->

Testing Prereq:
Only custom report definitions can be updated. System created definitions cannot.
Either create a new custom report definition or use `F5B4F0B0124F4C9E3547DCC6E62A8C6D774E45E9610999FE5FA517EF` on tech-ally

Manual
- [x] `lacework rd update <id>` -> update from editor -> Y
- [x] `lacework rd update <id>` -> update from editor -> N
- [x] `lacework rd update <id> --file customReport.json`
- [x] `lacework rd update <id> --file customReport.yaml`


Tests
- [x]  `TestReportDefinitionsPromptUpdate`
- [x]  `TestReportDefinitionsUpdateFromFile`

## Issue

<!--
  Include the link to a Jira/Github issue
-->

https://lacework.atlassian.net/browse/GROW-1475
