### PR TITLE
feat(alerts): alert open to use new UI 

### DIFF
--- a/cli/cmd/alert.go
+++ b/cli/cmd/alert.go
@@ -104,15 +104,8 @@ func init() {
 
 // Generates a URL similar to:
 //
-//	=> https://account.lacework.net/ui/investigate/recents/EventDossier-123
-func eventLinkBuilder(id string) string {
-	return fmt.Sprintf("https://%s.lacework.net/ui/investigation/recents/EventDossier-%s", cli.Account, id)
-}
-
-// Generates a URL similar to:
-//
 //	=> https://account.lacework.net/ui/investigation/monitor/AlertInbox/123/details?accountName=subaccount
-func alertLinkBuilder(id int) string { // nolint
+func alertLinkBuilder(id int) string {
 	u, err := url.Parse(
 		fmt.Sprintf(
 			"https://%s.lacework.net/ui/investigation/monitor/AlertInbox/%d/details",
@@ -137,14 +130,13 @@ func alertLinkBuilder(id int) string { // nolint
 func openAlert(_ *cobra.Command, args []string) error {
 	cli.Log.Debugw("opening alert", "alert", args[0])
 
-	_, err := strconv.Atoi(args[0])
+	id, err := strconv.Atoi(args[0])
 	if err != nil {
 		return errors.New("alert ID must be a number")
 	}
 
 	// ALLY-1233: Need to switch to alertLinkBuilder when new Alerting UI becomes generally available
-	//url := alertLinkBuilder(id)
-	url := eventLinkBuilder(args[0])
+	url := alertLinkBuilder(id)
 
 	switch runtime.GOOS {
 	case "linux":

--- a/cli/cmd/alert_show.go
+++ b/cli/cmd/alert_show.go
@@ -98,7 +98,7 @@ func showAlert(_ *cobra.Command, args []string) error {
 	// breadcrumb
 	// ALLY-1233: Need to switch to alertLinkBuilder when new Alerting UI becomes generally available
 	if !cli.JSONOutput() {
-		url := eventLinkBuilder(args[0])
+		url := alertLinkBuilder(id)
 		cli.OutputHuman(
 			fmt.Sprintf(
 				"\nFor further investigation of this alert navigate to %s\n",


### PR DESCRIPTION
## Summary
`lacework alert open` and the breadcrumb for `lacework alert show` should be using the generally available Alerts UI.

- From a code standpoint we will now use `alertLinkBuilder` in favor of `eventLinkBuilder`.
- The alertLinkBuilder properly supports sub-accounts by passing the `accountName` query argument.

## How did you test this change?
Existing automated testing
Manual testing:
- [ ] UI Logged into Org Account and `lacework open` on Sub Account
- [ ] UI Logged into Sub Account and `lacework open` on Org Account
- [ ] UI Logged into Sub Account 1 and `lacework open` on Sub Account 2

## Issue
https://lacework.atlassian.net/browse/GROW-1233
