### PR TITLE
fix(api): avoid sending empty GCP private_key_id

### DIFF
--- a/api/cloud_accounts_gcp_at.go
+++ b/api/cloud_accounts_gcp_at.go
@@ -56,6 +56,6 @@ type GcpAtSesData struct {
 type GcpAtSesCredentials struct {
 	ClientID     string `json:"clientId"`
 	ClientEmail  string `json:"clientEmail"`
-	PrivateKeyID string `json:"privateKeyId"`
+	PrivateKeyID string `json:"privateKeyId,omitempty"`
 	PrivateKey   string `json:"privateKey,omitempty"`
 }

--- a/api/cloud_accounts_gcp_at_test.go
+++ b/api/cloud_accounts_gcp_at_test.go
@@ -67,6 +67,70 @@ func TestCloudAccountsGcpAtSesGet(t *testing.T) {
 	assert.Equal(t, "projects/test-project/subscriptions/test", response.Data.Data.SubscriptionName)
 }
 
+func TestCloudAccountsGcpAtSesUpdateEmptyPrivateKeyAndPrivateKeyID(t *testing.T) {
+	var (
+		intgGUID   = intgguid.New()
+		apiPath    = fmt.Sprintf("CloudAccounts/%s", intgGUID)
+		fakeServer = lacework.MockServer()
+	)
+	fakeServer.UseApiV2()
+	fakeServer.MockToken("TOKEN")
+	defer fakeServer.Close()
+
+	fakeServer.MockAPI(apiPath, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "PATCH", r.Method, "UpdateGcpAtSes() should be a PATCH method")
+
+		if assert.NotNil(t, r.Body) {
+			body := httpBodySniffer(r)
+			assert.Contains(t, body, intgGUID, "INTG_GUID missing")
+			assert.Contains(t, body, "integration_name", "cloud account name is missing")
+			assert.Contains(t, body, "GcpAtSes", "wrong cloud account type")
+			assert.Contains(t, body, "test@project.iam.gserviceaccount.com", "wrong client email")
+			assert.Contains(t, body, "123456789", "wrong client ID")
+			assert.Contains(t, body, "enabled\":1", "cloud account is not enabled")
+			assert.NotContains(t, body, "privateKey", "field whould not be displayed if empty")
+			assert.NotContains(t, body, "privateKeyId", "field whould not be displayed if empty")
+		}
+
+		fmt.Fprintf(w, generateCloudAccountResponse(singleGcpAtCloudAccount(intgGUID)))
+	})
+
+	c, err := api.NewClient("test",
+		api.WithApiV2(),
+		api.WithToken("TOKEN"),
+		api.WithURL(fakeServer.URL()),
+	)
+	assert.Nil(t, err)
+
+	cloudAccount := api.NewCloudAccount("integration_name",
+		api.GcpAtSesCloudAccount,
+		api.GcpAtSesData{
+			Credentials: api.GcpAtSesCredentials{
+				ClientID:     "123456789",
+				ClientEmail:  "test@project.iam.gserviceaccount.com",
+				PrivateKeyID: "", // testing empty fields for both,
+				PrivateKey:   "", // private key and private key id
+			},
+		},
+	)
+	assert.Equal(t, "integration_name", cloudAccount.Name, "GcpAtSes cloud account name mismatch")
+	assert.Equal(t, "GcpAtSes", cloudAccount.Type, "a new GcpAtSes cloud account should match its type")
+	assert.Equal(t, 1, cloudAccount.Enabled, "a new GcpAtSes cloud account should be enabled")
+	cloudAccount.IntgGuid = intgGUID
+
+	response, err := c.V2.CloudAccounts.UpdateGcpAtSes(cloudAccount)
+	assert.Nil(t, err)
+	assert.NotNil(t, response)
+	assert.Equal(t, intgGUID, response.Data.IntgGuid)
+	assert.Equal(t, "test-gcp", response.Data.Name)
+	assert.True(t, response.Data.State.Ok)
+	assert.Equal(t, "test@project.iam.gserviceaccount.com", response.Data.Data.Credentials.ClientEmail)
+	assert.Equal(t, "123456789", response.Data.Data.Credentials.ClientID)
+	assert.Equal(t, "", response.Data.Data.Credentials.PrivateKeyID)
+	assert.Equal(t, "", response.Data.Data.Credentials.PrivateKey)
+	assert.Equal(t, "GcpAtSes", response.Data.Type)
+}
+
 func singleGcpAtCloudAccount(id string) string {
 	return fmt.Sprintf(`{
         "createdOrUpdatedBy": "test@lacework.net",

--- a/api/cloud_accounts_gcp_cfg.go
+++ b/api/cloud_accounts_gcp_cfg.go
@@ -75,6 +75,6 @@ type GcpCfgData struct {
 type GcpCfgCredentials struct {
 	ClientID     string `json:"clientId"`
 	ClientEmail  string `json:"clientEmail"`
-	PrivateKeyID string `json:"privateKeyId"`
+	PrivateKeyID string `json:"privateKeyId,omitempty"`
 	PrivateKey   string `json:"privateKey,omitempty"`
 }


### PR DESCRIPTION



## Summary

When doing `PATCH` requests, we should not send empty fields for both, the private key and the private key id, if not, users will get a message similar to:
```
[400] Error validating integration. Please verify the configuration details entered.
```

This change avoids sending an empty GCP Private Key ID

<img src="https://media0.giphy.com/media/jpKbTF9D15fVZpPkkL/giphy.gif"/>

## How did you test this change?

Added unit test and run some Terraform and CLI commands to validate.

## Issue
https://lacework.zendesk.com/agent/tickets/11161

