### PR TITLE
fix(cli): HTML generation of vuln assessment

### DIFF
--- a/api/v2_vulnerabilities.go
+++ b/api/v2_vulnerabilities.go
@@ -217,7 +217,7 @@ func (r VulnerabilitiesContainersResponse) VulnFixableCount(severity string) int
 func (r VulnerabilitiesContainersResponse) TotalVulnerabilities() int {
 	count := 0
 	for _, vuln := range r.Data {
-		if vuln.EvalCtx.ImageInfo.Status == "VULNERABLE" {
+		if vuln.Status == "VULNERABLE" {
 			count = count + 1
 		}
 	}

--- a/cli/cmd/vuln_html.go
+++ b/cli/cmd/vuln_html.go
@@ -328,13 +328,12 @@ func vulContainerImageLayersToHTML(image []api.VulnerabilityContainer) []htmlVul
 	var vulns = []htmlVuln{}
 	for _, i := range image {
 		space := regexp.MustCompile(`\s+`)
-		// Todo(v2): CreatedBy does not exist in v2
-		layerCreatedBy := space.ReplaceAllString("", " ")
+		layerCreatedBy := space.ReplaceAllString(i.FeatureProps.IntroducedIn, " ")
 
 		newHtmlVuln := htmlVuln{
 			CVE:               i.VulnID,
 			Severity:          cases.Title(language.English).String(i.Severity),
-			SeverityHTMLClass: i.Severity,
+			SeverityHTMLClass: strings.ToLower(i.Severity),
 			PkgName:           i.FeatureKey.Name,
 			PkgVersion:        i.FeatureKey.Version,
 			PkgFixed:          i.FixInfo.FixedVersion,
@@ -342,18 +341,18 @@ func vulContainerImageLayersToHTML(image []api.VulnerabilityContainer) []htmlVul
 		}
 
 		// Todo(v2): CVSSv3Score does not exist in v2 container response
-		//if score := vul.CVSSv3Score(); score != 0 {
-		//	// CVSSv3
-		//	newHtmlVuln.V3Score = score
-		//	newHtmlVuln.UseV3Score = true
-		//} else if score = vul.CVSSv2Score(); score != 0 {
-		//	// CVSSv2
-		//	newHtmlVuln.V2Score = score
-		//	newHtmlVuln.UseV2Score = true
-		//} else {
-		//	// N/A
-		//	newHtmlVuln.UseNoScore = true
-		//}
+		// if score := vul.CVSSv3Score(); score != 0 {
+		// // CVSSv3
+		// newHtmlVuln.V3Score = score
+		// newHtmlVuln.UseV3Score = true
+		// } else if score = vul.CVSSv2Score(); score != 0 {
+		// // CVSSv2
+		// newHtmlVuln.V2Score = score
+		// newHtmlVuln.UseV2Score = true
+		// } else {
+		// // N/A
+		newHtmlVuln.UseNoScore = true
+		// }
 
 		vulns = append(vulns, newHtmlVuln)
 	}

--- a/cli/cmd/vuln_html_test.go
+++ b/cli/cmd/vuln_html_test.go
@@ -1,0 +1,41 @@
+//
+// Author:: Salim Afiune Maya (<afiune@lacework.net>)
+// Copyright:: Copyright 2023, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestVulContainerImageLayersToHTML(t *testing.T) {
+	var (
+		expectedVulnIDs = []string{"CVE-2021-24215", "CVE-2020-24215"}
+		resp            = mockVulnerabilityAssessment()
+		subject         = vulContainerImageLayersToHTML(resp.Data)
+	)
+	if assert.Equal(t, 2, len(subject), "wrong number of vulnerabilities") {
+		for _, vuln := range subject {
+			assert.NotEmpty(t, vuln.Layer, "the layer should not be empty, did response change?")
+			assert.True(t, vuln.UseNoScore, "do we have CVSS scores? update, please")
+			assert.Contains(t, expectedVulnIDs, vuln.CVE,
+				"missing CVE, check HTML output")
+		}
+	}
+}


### PR DESCRIPTION
## Summary
Since https://github.com/lacework/go-sdk/pull/1025 the generation of static HTML output has been broken, this change fixes it so that it renders like it was before.

## How did you test this change?

Executed the command manually and verified the generated HTML output.

```
lacework vulnerability ctr show sha256:4f299b4fc8f7b7daf411401140a0b15c1b29f5ddb547d21f4005093c566c8a98 --html
                                  CONTAINER IMAGE DETAILS                                          VULNERABILITIES
------------------------------------------------------------------------------------------+---------------------------------
    ID          sha256:6cf101feaea119e21c340a4984a8a710f7720280d39708a469ffd68c5b539324       SEVERITY   COUNT   FIXABLE
    Digest      sha256:4f299b4fc8f7b7daf411401140a0b15c1b29f5ddb547d21f4005093c566c8a98     -----------+-------+----------
    Registry    gcr.io                                                                        Critical      23        22
    Repository  techally-hipstershop-275821/adservice                                         High          56        46
    Size        169.0 MB                                                                      Medium        40        34
    Created At  2020-04-30T22:24:47Z                                                          Low           14         5
    Tags        v0.1.4-22-gdbde2f3                                                            Info          36         1

The container vulnerability assessment was stored at 'techally-hipstershop-275821-adservice-sha256:4f299b4fc8f7b7daf411401140a0b15c1b29f5ddb547d21f4005093c566c8a98.html'
```

### Old Output
![Screen Shot 2023-03-27 at 1 57 56 PM](https://user-images.githubusercontent.com/5712253/228065017-271dfb47-4a01-453c-85a6-f38031d793c8.png)

### New Output
![Screen Shot 2023-03-27 at 1 58 08 PM](https://user-images.githubusercontent.com/5712253/228065114-b036fced-a19f-4735-962f-da2b3b93272e.png)

## Issue
https://lacework.atlassian.net/browse/LINK-1409
