### PR TITLE
feat(cli): new report-definitions revert command

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -95,8 +95,8 @@ const (
 
 	apiV2ReportDefinitions         = "v2/ReportDefinitions"
 	apiV2ReportDefinitionsFromGUID = "v2/ReportDefinitions/%s"
-	// To be re-added in GROW-1487
-	// apiV2ReportDefinitionsRevert   = "v2/ReportDefinitions/%s/RevertTo/%d"
+	apiV2ReportDefinitionsRevert   = "v2/ReportDefinitions/%s?revertTo=%d"
+	apiV2ReportDefinitionsVersions = "v2/ReportDefinitions/%s?allVersions=true"
 
 	apiV2ReportRules        = "v2/ReportRules"
 	apiV2ReportRuleFromGUID = "v2/ReportRules/%s"

--- a/api/report_definitions_test.go
+++ b/api/report_definitions_test.go
@@ -265,7 +265,7 @@ func TestReportDefinitionUpdate(t *testing.T) {
 func TestReportDefinitionRevert(t *testing.T) {
 	var (
 		intgGUID   = intgguid.New()
-		apiPath    = fmt.Sprintf("ReportDefinitions/%s/RevertTo/%d", intgGUID, 1)
+		apiPath    = fmt.Sprintf("ReportDefinitions/%s", intgGUID)
 		fakeServer = lacework.MockServer()
 	)
 	fakeServer.UseApiV2()
@@ -273,7 +273,7 @@ func TestReportDefinitionRevert(t *testing.T) {
 	defer fakeServer.Close()
 
 	fakeServer.MockAPI(apiPath, func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "PATCH", r.Method, "RevertTo() should be a PATCH method")
+		assert.Equal(t, "PATCH", r.Method, "Revert() should be a PATCH method")
 
 		if assert.NotNil(t, r.Body) {
 			body := httpBodySniffer(r)

--- a/api/report_definitions_test.go
+++ b/api/report_definitions_test.go
@@ -262,6 +262,46 @@ func TestReportDefinitionUpdate(t *testing.T) {
 	}
 }
 
+func TestReportDefinitionRevert(t *testing.T) {
+	var (
+		intgGUID   = intgguid.New()
+		apiPath    = fmt.Sprintf("ReportDefinitions/%s/RevertTo/%d", intgGUID, 1)
+		fakeServer = lacework.MockServer()
+	)
+	fakeServer.UseApiV2()
+	fakeServer.MockToken("TOKEN")
+	defer fakeServer.Close()
+
+	fakeServer.MockAPI(apiPath, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "PATCH", r.Method, "RevertTo() should be a PATCH method")
+
+		if assert.NotNil(t, r.Body) {
+			body := httpBodySniffer(r)
+			assert.Contains(t, body, "", "report definition revert should contain no message body")
+		}
+		fmt.Fprintf(w, generateReportDefinitionResponse(singleMockReportDefinition(intgGUID)))
+	})
+
+	c, err := api.NewClient("test",
+		api.WithApiV2(),
+		api.WithToken("TOKEN"),
+		api.WithURL(fakeServer.URL()),
+	)
+	assert.Nil(t, err)
+
+	response, err := c.V2.ReportDefinitions.Revert(intgGUID, 1)
+	if assert.NoError(t, err) {
+		assert.NotNil(t, response)
+		assert.Equal(t, intgGUID, response.Data.ReportDefinitionGuid)
+		assert.Equal(t, "mockReportDefinition", response.Data.ReportName)
+		assert.Equal(t, "mockReportDefinition Display", response.Data.DisplayName)
+		assert.Equal(t, "COMPLIANCE", response.Data.ReportType)
+		assert.Equal(t, "AWS", response.Data.SubReportType)
+		assert.Equal(t, "Test Section", response.Data.ReportDefinitionDetails.Sections[0].Title)
+		assert.Equal(t, []string{"lacework-global-1"}, response.Data.ReportDefinitionDetails.Sections[0].Policies)
+	}
+}
+
 func generateReportDefinitions(guids []string) string {
 	reportDefinitions := make([]string, len(guids))
 	for i, guid := range guids {

--- a/api/reports_definitions.go
+++ b/api/reports_definitions.go
@@ -88,6 +88,16 @@ func (svc *ReportDefinitionsService) Get(reportDefinitionGuid string) (response 
 	return
 }
 
+// GetVersions returns a list of all versions of a reportDefinition
+func (svc *ReportDefinitionsService) GetVersions(reportDefinitionGuid string) (response ReportDefinitionsResponse, err error) {
+	if reportDefinitionGuid == "" {
+		return ReportDefinitionsResponse{}, errors.New("specify a report definition guid")
+	}
+	apiPath := fmt.Sprintf(apiV2ReportDefinitionsVersions, reportDefinitionGuid)
+	err = svc.client.RequestDecoder("GET", apiPath, nil, &response)
+	return
+}
+
 // Delete a ReportDefinition
 func (svc *ReportDefinitionsService) Delete(guid string) error {
 	if guid == "" {
@@ -111,15 +121,14 @@ func (svc *ReportDefinitionsService) Update(guid string, report ReportDefinition
 	return
 }
 
-// To be re-added in GROW-1487
-//func (svc *ReportDefinitionsService) Revert(guid string, version int) (response ReportDefinitionResponse, err error) {
-//	if guid == "" {
-//		return response, errors.New("specify a report definition guid")
-//	}
-//
-//	err = svc.client.RequestEncoderDecoder("PATCH", fmt.Sprintf(apiV2ReportDefinitionsRevert, guid, version), "", &response)
-//	return
-//}
+func (svc *ReportDefinitionsService) Revert(guid string, version int) (response ReportDefinitionResponse, err error) {
+	if guid == "" {
+		return response, errors.New("specify a report definition guid")
+	}
+
+	err = svc.client.RequestEncoderDecoder("PATCH", fmt.Sprintf(apiV2ReportDefinitionsRevert, guid, version), "", &response)
+	return
+}
 
 // NewReportDefinition creates a new report definition for Create function
 func NewReportDefinition(cfg ReportDefinitionConfig) ReportDefinition {

--- a/api/reports_definitions.go
+++ b/api/reports_definitions.go
@@ -126,7 +126,8 @@ func (svc *ReportDefinitionsService) Revert(guid string, version int) (response 
 		return response, errors.New("specify a report definition guid")
 	}
 
-	err = svc.client.RequestEncoderDecoder("PATCH", fmt.Sprintf(apiV2ReportDefinitionsRevert, guid, version), "", &response)
+	apiPath := fmt.Sprintf(apiV2ReportDefinitionsRevert, guid, version)
+	err = svc.client.RequestEncoderDecoder("PATCH", apiPath, "", &response)
 	return
 }
 
@@ -227,7 +228,7 @@ type ReportDefinitionSection struct {
 
 type ReportDefinitionProps struct {
 	Engine         string   `json:"engine,omitempty" yaml:"engine,omitempty"`
-	ReleaseLabel   string   `json:"releaseLabel,omitempty" yaml:"engine,omitempty"`
-	ResourceGroups []string `json:"resourceGroups,omitempty" yaml:"engine,omitempty"`
-	Integrations   []string `json:"integrations,omitempty" yaml:"engine,omitempty"`
+	ReleaseLabel   string   `json:"releaseLabel,omitempty" yaml:"releaseLabel,omitempty"`
+	ResourceGroups []string `json:"resourceGroups,omitempty" yaml:"resourceGroups,omitempty"`
+	Integrations   []string `json:"integrations,omitempty" yaml:"integrations,omitempty"`
 }

--- a/api/reports_definitions.go
+++ b/api/reports_definitions.go
@@ -79,21 +79,21 @@ func (svc *ReportDefinitionsService) List() (response ReportDefinitionsResponse,
 }
 
 // Get returns a ReportDefinitionResponse
-func (svc *ReportDefinitionsService) Get(reportDefinitionGuid string) (response ReportDefinitionResponse, err error) {
-	if reportDefinitionGuid == "" {
+func (svc *ReportDefinitionsService) Get(guid string) (response ReportDefinitionResponse, err error) {
+	if guid == "" {
 		return ReportDefinitionResponse{}, errors.New("specify a report definition guid")
 	}
-	apiPath := fmt.Sprintf(apiV2ReportDefinitionsFromGUID, reportDefinitionGuid)
+	apiPath := fmt.Sprintf(apiV2ReportDefinitionsFromGUID, guid)
 	err = svc.client.RequestDecoder("GET", apiPath, nil, &response)
 	return
 }
 
 // GetVersions returns a list of all versions of a reportDefinition
-func (svc *ReportDefinitionsService) GetVersions(reportDefinitionGuid string) (response ReportDefinitionsResponse, err error) {
-	if reportDefinitionGuid == "" {
+func (svc *ReportDefinitionsService) GetVersions(guid string) (response ReportDefinitionsResponse, err error) {
+	if guid == "" {
 		return ReportDefinitionsResponse{}, errors.New("specify a report definition guid")
 	}
-	apiPath := fmt.Sprintf(apiV2ReportDefinitionsVersions, reportDefinitionGuid)
+	apiPath := fmt.Sprintf(apiV2ReportDefinitionsVersions, guid)
 	err = svc.client.RequestDecoder("GET", apiPath, nil, &response)
 	return
 }

--- a/cli/cmd/report_definitions.go
+++ b/cli/cmd/report_definitions.go
@@ -246,6 +246,7 @@ func init() {
 	reportDefinitionsCommand.AddCommand(reportDefinitionsDeleteCommand)
 	reportDefinitionsCommand.AddCommand(reportDefinitionsUpdateCommand)
 	reportDefinitionsCommand.AddCommand(reportDefinitionsRevertCommand)
+	reportDefinitionsCommand.AddCommand(reportDefinitionsDiffCommand)
 
 	// add flags to report-definition commands
 	reportDefinitionsShowCommand.Flags().StringVar(&reportDefinitionsCmdState.Version,

--- a/cli/cmd/report_definitions.go
+++ b/cli/cmd/report_definitions.go
@@ -220,7 +220,10 @@ func fetchReportDefinitionVersion(id string) error {
 		}
 
 		if cli.JSONOutput() {
-			cli.OutputJSON(response)
+			err := cli.OutputJSON(response)
+			if err != nil {
+				return err
+			}
 		}
 
 		for _, reportVersion := range response.Data {

--- a/cli/cmd/report_definitions_diff.go
+++ b/cli/cmd/report_definitions_diff.go
@@ -33,10 +33,10 @@ import (
 // reportDefinitionsDiffCommand command is used to compare 2 lacework report definition versions
 var reportDefinitionsDiffCommand = &cobra.Command{
 	Use:   "diff <report_definition_id> <version> <version>",
-	Short: "Compare 2 versions of a report definition",
-	Long: `Compare 2 versions of a report definition.
+	Short: "Compare two versions of a report definition",
+	Long: `Compare two versions of a report definition.
 
-To see a diff of 2 report definition versions:
+To see a diff of two report definition versions:
 
     lacework report-definition diff <report_definition_id> <current_version> <new_version>
 `,

--- a/cli/cmd/report_definitions_diff.go
+++ b/cli/cmd/report_definitions_diff.go
@@ -1,0 +1,166 @@
+//
+// Author:: Darren Murray(<darren.murray@lacework.net>)
+// Copyright:: Copyright 2023, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cmd
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/fatih/color"
+	"github.com/pkg/errors"
+	"github.com/pmezard/go-difflib/difflib"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+)
+
+// reportDefinitionsDiffCommand command is used to compare 2 lacework report definition versions
+var reportDefinitionsDiffCommand = &cobra.Command{
+	Use:   "diff <report_definition_id> <version> <version>",
+	Short: "Compare 2 versions of a report definition",
+	Long: `Compare 2 versions of a report definition.
+
+To see a diff of 2 report definition versions:
+
+    lacework report-definition diff <report_definition_id> <current_version> <new_version>
+`,
+	Args: cobra.ExactArgs(3),
+	RunE: diffReportDefinition,
+}
+
+func diffReportDefinition(_ *cobra.Command, args []string) error {
+	var (
+		err        error
+		versionOne int
+		versionTwo int
+		reportOne  *diffCfg
+		reportTwo  *diffCfg
+	)
+
+	if versionOne, err = strconv.Atoi(args[1]); err != nil {
+		return errors.Wrap(err, "unable to parse version")
+	}
+
+	if versionTwo, err = strconv.Atoi(args[2]); err != nil {
+		return errors.Wrap(err, "unable to parse version")
+	}
+
+	cli.StartProgress("Fetching all report definition versions...")
+	response, err := cli.LwApi.V2.ReportDefinitions.GetVersions(args[0])
+	cli.StopProgress()
+
+	if err != nil {
+		return err
+	}
+
+	for _, r := range response.Data {
+		if r.Version == versionOne {
+			reportOne = &diffCfg{
+				name:   fmt.Sprintf("Version-%d", r.Version),
+				object: r,
+			}
+		}
+		if r.Version == versionTwo {
+			reportTwo = &diffCfg{
+				name:   fmt.Sprintf("Version-%d", r.Version),
+				object: r,
+			}
+		}
+	}
+
+	if reportOne == nil || reportTwo == nil {
+		return errors.New("unable to find report definition versions")
+	}
+
+	diff, err := diffAsYamlString(*reportOne, *reportTwo)
+	if err != nil {
+		return err
+	}
+
+	cli.OutputHuman(diff)
+	return nil
+}
+
+type diffCfg struct {
+	name   string
+	object any
+}
+
+func diffAsYamlString(objectOne, objectTwo diffCfg) (string, error) {
+	yamlBytesOne, err := yaml.Marshal(objectOne.object)
+	if err != nil {
+		return "", err
+	}
+
+	yamlBytesTwo, err := yaml.Marshal(objectTwo.object)
+	if err != nil {
+		return "", err
+	}
+
+	diff := difflib.UnifiedDiff{
+		A:        difflib.SplitLines(string(yamlBytesOne)),
+		B:        difflib.SplitLines(string(yamlBytesTwo)),
+		FromFile: objectOne.name,
+		ToFile:   objectTwo.name,
+		Context:  3,
+	}
+
+	diffText, err := difflib.GetUnifiedDiffString(diff)
+	if err != nil {
+		return "", err
+	}
+
+	output := prettyPrintDiff(diffText)
+	return output, nil
+}
+
+func prettyPrintDiff(diff string) string {
+	if diff == "" {
+		return ""
+	}
+
+	var sb = &strings.Builder{}
+	lines := strings.Split(diff, "\n")
+
+	//colourize lines in diff
+	for _, s := range lines {
+		if strings.HasPrefix(s, "+") {
+			addition := color.HiGreenString(fmt.Sprintf("%s\n", s))
+			sb.WriteString(addition)
+			continue
+		}
+
+		if strings.HasPrefix(s, "-") {
+			subtraction := color.HiRedString(fmt.Sprintf("%s\n", s))
+			sb.WriteString(subtraction)
+			continue
+		}
+
+		if strings.HasPrefix(s, "@@") {
+			lineDiff := color.HiBlueString(fmt.Sprintf("%s\n", s))
+			sb.WriteString(lineDiff)
+			continue
+		}
+
+		sb.WriteString(fmt.Sprintf("%s\n", s))
+
+	}
+
+	return sb.String()
+}

--- a/cli/cmd/report_definitions_revert.go
+++ b/cli/cmd/report_definitions_revert.go
@@ -36,7 +36,7 @@ To revert a report definition:
 
     lacework report-definition revert <report_definition_id> <version>
 
-To compare 2 report definition versions before a revert:
+To compare two report definition versions before a revert:
 
     lacework report-definition diff <report_definition_id> <current_version> <new_version>
 `,

--- a/cli/cmd/report_definitions_revert.go
+++ b/cli/cmd/report_definitions_revert.go
@@ -27,13 +27,18 @@ import (
 
 // revert command is used to rollback lacework report definition to a previous version
 var reportDefinitionsRevertCommand = &cobra.Command{
-	Use:   "revert <report_definition_id> <version>",
-	Short: "Update a report definition",
+	Use:     "revert <report_definition_id> <version>",
+	Aliases: []string{"restore"},
+	Short:   "Update a report definition",
 	Long: `Update an existing custom report definition.
 
 To revert a report definition:
 
     lacework report-definition revert <report_definition_id> <version>
+
+To compare 2 report definition versions before a revert:
+
+    lacework report-definition diff <report_definition_id> <current_version> <new_version>
 `,
 	Args: cobra.ExactArgs(2),
 	RunE: revertReportDefinition,

--- a/cli/cmd/report_definitions_revert.go
+++ b/cli/cmd/report_definitions_revert.go
@@ -1,0 +1,62 @@
+//
+// Author:: Darren Murray(<darren.murray@lacework.net>)
+// Copyright:: Copyright 2023, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cmd
+
+import (
+	"strconv"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+// revert command is used to rollback lacework report definition to a previous version
+var reportDefinitionsRevertCommand = &cobra.Command{
+	Use:   "revert <report_definition_id> <version>",
+	Short: "Update a report definition",
+	Long: `Update an existing custom report definition.
+
+To revert a report definition:
+
+    lacework report-definition revert <report_definition_id> <version>
+`,
+	Args: cobra.ExactArgs(2),
+	RunE: revertReportDefinition,
+}
+
+func revertReportDefinition(_ *cobra.Command, args []string) error {
+	var (
+		err     error
+		version int
+	)
+
+	if version, err = strconv.Atoi(args[1]); err != nil {
+		return errors.Wrap(err, "unable to parse version")
+	}
+
+	cli.StartProgress("Reverting report definition...")
+	resp, err := cli.LwApi.V2.ReportDefinitions.Revert(args[0], version)
+	cli.StopProgress()
+
+	if err != nil {
+		return err
+	}
+
+	cli.OutputHuman("The report definition %s was reverted to version %d \n", resp.Data.ReportDefinitionGuid, version)
+	return nil
+}

--- a/cli/cmd/report_definitions_test.go
+++ b/cli/cmd/report_definitions_test.go
@@ -70,7 +70,48 @@ func TestFilterReportDefinitionsWithSubType(t *testing.T) {
 			assert.Equal(t, rdtt.Input.Data, rdtt.Expected)
 		})
 	}
+}
 
+func TestReportDiff(t *testing.T) {
+	reportDiffTableTest := []struct {
+		Name     string
+		InputOne diffCfg
+		InputTwo diffCfg
+		Expected string
+	}{
+		{
+			Name:     "diff valid report definitions",
+			InputOne: diffCfg{name: "mock-1", object: mockReportDefinition},
+			InputTwo: diffCfg{name: "mock-2", object: mockReportDefinitionGCP},
+			Expected: mockReportDefinitionDiff,
+		},
+		{
+			Name:     "diff empty report definitions",
+			InputOne: diffCfg{name: "mock-1", object: ""},
+			InputTwo: diffCfg{name: "mock-2", object: ""},
+			Expected: "",
+		},
+		{
+			Name:     "diff single word",
+			InputOne: diffCfg{name: "mock-1", object: "testOne"},
+			InputTwo: diffCfg{name: "mock-2", object: "testTwo"},
+			Expected: mockDiffSingleWord,
+		},
+		{
+			Name:     "diff no change",
+			InputOne: diffCfg{name: "mock-1", object: mockReportDefinition},
+			InputTwo: diffCfg{name: "mock-1", object: mockReportDefinition},
+			Expected: "",
+		},
+	}
+
+	for _, test := range reportDiffTableTest {
+		t.Run(test.Name, func(t *testing.T) {
+			diff, err := diffAsYamlString(test.InputOne, test.InputTwo)
+			assert.NoError(t, err)
+			assert.Equal(t, diff, test.Expected)
+		})
+	}
 }
 
 var created, _ = time.Parse(time.RFC3339, "2022-09-09T10:35:16Z")
@@ -163,5 +204,27 @@ var (
                       lacework-global-78                
                                                         
                                                         
+`
+	mockReportDefinitionDiff = `--- mock-1
++++ mock-2
+@@ -2,7 +2,7 @@
+ reportName: My Custom Report
+ displayName: My Custom Report Display
+ reportType: Compliance
+-subReportType: AWS
++subReportType: GCP
+ reportDefinition:
+     sections:
+         - category: 1.0.0
+
+`
+
+	mockDiffSingleWord = `--- mock-1
++++ mock-2
+@@ -1,2 +1,2 @@
+-testOne
++testTwo
+ 
+
 `
 )

--- a/integration/report_definitions_test.go
+++ b/integration/report_definitions_test.go
@@ -2,8 +2,11 @@ package integration
 
 import (
 	"fmt"
+	"log"
+	"os"
 	"testing"
 
+	"github.com/lacework/go-sdk/api"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -110,6 +113,48 @@ func TestReportDefintionsShowJson(t *testing.T) {
 	assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
 }
 
+func TestReportDefinitionsDiff(t *testing.T) {
+	versions := fetchVersionedCustomReportDefinition()
+
+	if len(versions.Data) == 0 {
+		t.Skip("skipping test. No versions for custom report definition found")
+	}
+	id := versions.Data[0].ReportDefinitionGuid
+
+	currentVersion := "2"
+	lastVersion := "1"
+
+	out, err, exitcode := LaceworkCLIWithTOMLConfig("report-definitions", "diff", id, currentVersion, lastVersion)
+
+	assert.Contains(t, out.String(), reportDefinitionDiff)
+	fmt.Println(out.String())
+	assert.Empty(t, err.String(), "STDERR should be empty")
+	assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
+
+	deleteErr := deleteCustomReportDefinition(id)
+	assert.NoError(t, deleteErr)
+}
+
+func TestReportDefinitionsRevert(t *testing.T) {
+	versions := fetchVersionedCustomReportDefinition()
+
+	if len(versions.Data) == 0 {
+		t.Skip("skipping test. No versions for custom report definition found")
+	}
+	id := versions.Data[0].ReportDefinitionGuid
+	lastVersion := "1"
+
+	out, err, exitcode := LaceworkCLIWithTOMLConfig("report-definitions", "revert", id, lastVersion)
+
+	assert.Contains(t, out.String(), fmt.Sprintf("The report definition %s was reverted to version %s", id, lastVersion))
+	fmt.Println(out.String())
+	assert.Empty(t, err.String(), "STDERR should be empty")
+	assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
+
+	deleteErr := deleteCustomReportDefinition(id)
+	assert.NoError(t, deleteErr)
+}
+
 var reportDefinitionDetailsOutput = `              REPORT DEFINITION DETAILS              
 -----------------------------------------------------
     ENGINE          lpp                              
@@ -133,3 +178,71 @@ var reportDefinitionDetailsJson = `  "data": {
     "props": {
       "engine": "lpp"
     },`
+
+var reportDefinitionDiff = `-reportName: Diff Test Versioning Updated
++reportName: Diff Test Versioning
+ displayName: Diff Test Versioning
+ reportType: COMPLIANCE
+ subReportType: AWS
+@@ -9,7 +9,7 @@
+           title: Diff Test Report
+           policies:
+             - lacework-global-1
+-version: 2
++version: 1`
+
+func fetchVersionedCustomReportDefinition() api.ReportDefinitionsResponse {
+	lacework, err := api.NewClient(os.Getenv("CI_ACCOUNT"),
+		api.WithSubaccount(os.Getenv("CI_SUBACCOUNT")),
+		api.WithApiKeys(os.Getenv("CI_API_KEY"), os.Getenv("CI_API_SECRET")),
+		api.WithApiV2(),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	rptCfg := api.ReportDefinitionConfig{
+		ReportName:    "Diff Test Versioning",
+		DisplayName:   "Diff Test Versioning",
+		ReportType:    api.ReportDefinitionTypeCompliance.String(),
+		SubReportType: api.ReportDefinitionSubTypeAws.String(),
+		Sections: []api.ReportDefinitionSection{{
+			Title:    "Diff Test Report",
+			Policies: []string{"lacework-global-1"},
+		}},
+	}
+
+	customReport := api.NewReportDefinition(rptCfg)
+
+	report, err := lacework.V2.ReportDefinitions.Create(customReport)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	rptCfg.ReportName = "Diff Test Versioning Updated"
+
+	report, err = lacework.V2.ReportDefinitions.Update(report.Data.ReportDefinitionGuid, api.NewReportDefinitionUpdate(rptCfg))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	reports, err := lacework.V2.ReportDefinitions.GetVersions(report.Data.ReportDefinitionGuid)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	return reports
+}
+
+func deleteCustomReportDefinition(id string) error {
+	lacework, err := api.NewClient(os.Getenv("CI_ACCOUNT"),
+		api.WithSubaccount(os.Getenv("CI_SUBACCOUNT")),
+		api.WithApiKeys(os.Getenv("CI_API_KEY"), os.Getenv("CI_API_SECRET")),
+		api.WithApiV2(),
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	return lacework.V2.ReportDefinitions.Delete(id)
+}

--- a/integration/test_resources/help/report-definition
+++ b/integration/test_resources/help/report-definition
@@ -9,7 +9,9 @@ Aliases:
 Available Commands:
   create      Create a report definition
   delete      Delete a report definition
+  diff        Compare 2 versions of a report definition
   list        List all report definitions
+  revert      Update a report definition
   show        Show a report definition by ID
   update      Update a report definition
 

--- a/integration/test_resources/help/report-definition
+++ b/integration/test_resources/help/report-definition
@@ -9,7 +9,7 @@ Aliases:
 Available Commands:
   create      Create a report definition
   delete      Delete a report definition
-  diff        Compare 2 versions of a report definition
+  diff        Compare two versions of a report definition
   list        List all report definitions
   revert      Update a report definition
   show        Show a report definition by ID

--- a/integration/test_resources/help/report-definition_diff
+++ b/integration/test_resources/help/report-definition_diff
@@ -1,18 +1,14 @@
-Show a single report definition by it's ID.
-To show specific report definition version:
+Compare 2 versions of a report definition.
 
-    lacework report-definition show <report_definition_id> --version <version>
+To see a diff of 2 report definition versions:
 
-To show all versions of a report definition:
-
-    lacework report-definition show <report_definition_id> --version all
+    lacework report-definition diff <report_definition_id> <current_version> <new_version>
 
 Usage:
-  lacework report-definition show <report_definition_id> [flags]
+  lacework report-definition diff <report_definition_id> <version> <version> [flags]
 
 Flags:
-  -h, --help             help for show
-      --version string   show a version of a report definition
+  -h, --help   help for diff
 
 Global Flags:
   -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)

--- a/integration/test_resources/help/report-definition_diff
+++ b/integration/test_resources/help/report-definition_diff
@@ -1,6 +1,6 @@
-Compare 2 versions of a report definition.
+Compare two versions of a report definition.
 
-To see a diff of 2 report definition versions:
+To see a diff of two report definition versions:
 
     lacework report-definition diff <report_definition_id> <current_version> <new_version>
 

--- a/integration/test_resources/help/report-definition_revert
+++ b/integration/test_resources/help/report-definition_revert
@@ -1,18 +1,21 @@
-Show a single report definition by it's ID.
-To show specific report definition version:
+Update an existing custom report definition.
 
-    lacework report-definition show <report_definition_id> --version <version>
+To revert a report definition:
 
-To show all versions of a report definition:
+    lacework report-definition revert <report_definition_id> <version>
 
-    lacework report-definition show <report_definition_id> --version all
+To compare 2 report definition versions before a revert:
+
+    lacework report-definition diff <report_definition_id> <current_version> <new_version>
 
 Usage:
-  lacework report-definition show <report_definition_id> [flags]
+  lacework report-definition revert <report_definition_id> <version> [flags]
+
+Aliases:
+  revert, restore
 
 Flags:
-  -h, --help             help for show
-      --version string   show a version of a report definition
+  -h, --help   help for revert
 
 Global Flags:
   -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)

--- a/integration/test_resources/help/report-definition_revert
+++ b/integration/test_resources/help/report-definition_revert
@@ -4,7 +4,7 @@ To revert a report definition:
 
     lacework report-definition revert <report_definition_id> <version>
 
-To compare 2 report definition versions before a revert:
+To compare two report definition versions before a revert:
 
     lacework report-definition diff <report_definition_id> <current_version> <new_version>
 


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/lacework/go-sdk) and create your branch from `main`
  2. Run `make prepare` in the repository root
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`make test`)
  5. Format your code (`make fmt`)
  6. Make sure your code lints (`make lint`)
  7. If you are updating the Lacework CLI, make sure it compiles (`make build-cli-cross-platform`)
  8. Follow the commit message standard (`type(scope): subject`) documented in [DEVELOPER_GUIDELINES.md](https://github.com/lacework/go-sdk/blob/main/DEVELOPER_GUIDELINES.md#commit-message-standard)
  9. If you haven't already, configure signed commits by [telling git about your signing key](https://docs.github.com/en/github/authenticating-to-github/managing-commit-signature-verification/telling-git-about-your-signing-key) and [signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)

  Learn more about contributing: https://github.com/lacework/go-sdk/blob/main/CONTRIBUTING.md
-->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

Changes in this PR:
Support new cmd `lacework report-definitions revert <id> <version>`
Support new cmd `lacework report-definitions diff <id> <version> <version>`

Add new `--version` flag to `lacework report-definitions show` cmd: 

  `lacework report-definitions show <id> --version <version>`
  `lacework report-definitions show <id> --version all`


## How did you test this change?
Manual
- [x] run `lacework report-definitions revert <id> <version>`
- [x] run `lacework report-definitions show <id> --version <version>`
- [x] run `lacework report-definitions show <id> --version all`
- [x] run `lacework report-definitions diff <id> <version> <version>`

Tests
- [x] `TestReportDefinitionsRevert`
- [x] `TestReportDefinitionsDiff`
- [x] `TestReportDiff`

<!--
  How exactly did you verify that your PR solves the issue you wanted to solve?
  Include any other relevant information such as how to use the new functionality, screenshots, etc.
-->

## Issue

<!--
  Include the link to a Jira/Github issue
-->

https://lacework.atlassian.net/browse/GROW-1487
