### PR TITLE
chore(lwgenerate): bump azure modules to 2.0

### DIFF
--- a/lwgenerate/azure/azure.go
+++ b/lwgenerate/azure/azure.go
@@ -270,16 +270,6 @@ func createRequiredProviders() (*hclwrite.Block, error) {
 			lwgenerate.HclRequiredProviderWithSource(lwgenerate.LaceworkProviderSource),
 			lwgenerate.HclRequiredProviderWithVersion(lwgenerate.LaceworkProviderVersion),
 		),
-		lwgenerate.NewRequiredProvider(
-			"azuread",
-			lwgenerate.HclRequiredProviderWithSource(lwgenerate.HashAzureADProviderSource),
-			lwgenerate.HclRequiredProviderWithVersion(lwgenerate.HashAzureADProviderVersion),
-		),
-		lwgenerate.NewRequiredProvider(
-			"azurerm",
-			lwgenerate.HclRequiredProviderWithSource(lwgenerate.HashAzureRMProviderSource),
-			lwgenerate.HclRequiredProviderWithVersion(lwgenerate.HashAzureRMProviderVersion),
-		),
 	)
 }
 

--- a/lwgenerate/azure/test-data/activity-log-with-all-subscriptions.tf
+++ b/lwgenerate/azure/test-data/activity-log-with-all-subscriptions.tf
@@ -1,13 +1,5 @@
 terraform {
   required_providers {
-    azuread = {
-      source  = "hashicorp/azuread"
-      version = "~> 2.16"
-    }
-    azurerm = {
-      source  = "hashicorp/azurerm"
-      version = "~> 2.91.0"
-    }
     lacework = {
       source  = "lacework/lacework"
       version = "~> 1.0"
@@ -30,7 +22,7 @@ module "az_ad_application" {
 
 module "az_activity_log" {
   source                      = "lacework/activity-log/azure"
-  version                     = "~> 1.0"
+  version                     = "~> 2.0"
   all_subscriptions           = true
   application_id              = module.az_ad_application.application_id
   application_password        = module.az_ad_application.application_password

--- a/lwgenerate/azure/test-data/activity-log-with-existing-storage.tf
+++ b/lwgenerate/azure/test-data/activity-log-with-existing-storage.tf
@@ -1,13 +1,5 @@
 terraform {
   required_providers {
-    azuread = {
-      source  = "hashicorp/azuread"
-      version = "~> 2.16"
-    }
-    azurerm = {
-      source  = "hashicorp/azurerm"
-      version = "~> 2.91.0"
-    }
     lacework = {
       source  = "lacework/lacework"
       version = "~> 1.0"
@@ -30,7 +22,7 @@ module "az_ad_application" {
 
 module "az_activity_log" {
   source                         = "lacework/activity-log/azure"
-  version                        = "~> 1.0"
+  version                        = "~> 2.0"
   application_id                 = module.az_ad_application.application_id
   application_password           = module.az_ad_application.application_password
   service_principal_id           = module.az_ad_application.service_principal_id

--- a/lwgenerate/azure/test-data/activity-log-with-lacework-profile.tf
+++ b/lwgenerate/azure/test-data/activity-log-with-lacework-profile.tf
@@ -1,13 +1,5 @@
 terraform {
   required_providers {
-    azuread = {
-      source  = "hashicorp/azuread"
-      version = "~> 2.16"
-    }
-    azurerm = {
-      source  = "hashicorp/azurerm"
-      version = "~> 2.91.0"
-    }
     lacework = {
       source  = "lacework/lacework"
       version = "~> 1.0"
@@ -34,7 +26,7 @@ module "az_ad_application" {
 
 module "az_activity_log" {
   source                      = "lacework/activity-log/azure"
-  version                     = "~> 1.0"
+  version                     = "~> 2.0"
   application_id              = module.az_ad_application.application_id
   application_password        = module.az_ad_application.application_password
   service_principal_id        = module.az_ad_application.service_principal_id

--- a/lwgenerate/azure/test-data/activity-log-with-list-subscriptions.tf
+++ b/lwgenerate/azure/test-data/activity-log-with-list-subscriptions.tf
@@ -1,13 +1,5 @@
 terraform {
   required_providers {
-    azuread = {
-      source  = "hashicorp/azuread"
-      version = "~> 2.16"
-    }
-    azurerm = {
-      source  = "hashicorp/azurerm"
-      version = "~> 2.91.0"
-    }
     lacework = {
       source  = "lacework/lacework"
       version = "~> 1.0"
@@ -30,7 +22,7 @@ module "az_ad_application" {
 
 module "az_activity_log" {
   source                      = "lacework/activity-log/azure"
-  version                     = "~> 1.0"
+  version                     = "~> 2.0"
   application_id              = module.az_ad_application.application_id
   application_password        = module.az_ad_application.application_password
   service_principal_id        = module.az_ad_application.service_principal_id

--- a/lwgenerate/azure/test-data/activity-log-with-location.tf
+++ b/lwgenerate/azure/test-data/activity-log-with-location.tf
@@ -1,13 +1,5 @@
 terraform {
   required_providers {
-    azuread = {
-      source  = "hashicorp/azuread"
-      version = "~> 2.16"
-    }
-    azurerm = {
-      source  = "hashicorp/azurerm"
-      version = "~> 2.91.0"
-    }
     lacework = {
       source  = "lacework/lacework"
       version = "~> 1.0"
@@ -30,7 +22,7 @@ module "az_ad_application" {
 
 module "az_activity_log" {
   source                      = "lacework/activity-log/azure"
-  version                     = "~> 1.0"
+  version                     = "~> 2.0"
   application_id              = module.az_ad_application.application_id
   application_password        = module.az_ad_application.application_password
   location                    = "West US 2"

--- a/lwgenerate/azure/test-data/activity_log_with_config.tf
+++ b/lwgenerate/azure/test-data/activity_log_with_config.tf
@@ -1,13 +1,5 @@
 terraform {
   required_providers {
-    azuread = {
-      source  = "hashicorp/azuread"
-      version = "~> 2.16"
-    }
-    azurerm = {
-      source  = "hashicorp/azurerm"
-      version = "~> 2.91.0"
-    }
     lacework = {
       source  = "lacework/lacework"
       version = "~> 1.0"
@@ -30,7 +22,7 @@ module "az_ad_application" {
 
 module "az_config" {
   source                      = "lacework/config/azure"
-  version                     = "~> 1.0"
+  version                     = "~> 2.0"
   application_id              = module.az_ad_application.application_id
   application_password        = module.az_ad_application.application_password
   service_principal_id        = module.az_ad_application.service_principal_id
@@ -39,7 +31,7 @@ module "az_config" {
 
 module "az_activity_log" {
   source                      = "lacework/activity-log/azure"
-  version                     = "~> 1.0"
+  version                     = "~> 2.0"
   application_id              = module.az_ad_application.application_id
   application_password        = module.az_ad_application.application_password
   service_principal_id        = module.az_ad_application.service_principal_id

--- a/lwgenerate/azure/test-data/activity_log_without_config.tf
+++ b/lwgenerate/azure/test-data/activity_log_without_config.tf
@@ -1,13 +1,5 @@
 terraform {
   required_providers {
-    azuread = {
-      source  = "hashicorp/azuread"
-      version = "~> 2.16"
-    }
-    azurerm = {
-      source  = "hashicorp/azurerm"
-      version = "~> 2.91.0"
-    }
     lacework = {
       source  = "lacework/lacework"
       version = "~> 1.0"
@@ -30,7 +22,7 @@ module "az_ad_application" {
 
 module "az_activity_log" {
   source                      = "lacework/activity-log/azure"
-  version                     = "~> 1.0"
+  version                     = "~> 2.0"
   application_id              = module.az_ad_application.application_id
   application_password        = module.az_ad_application.application_password
   service_principal_id        = module.az_ad_application.service_principal_id

--- a/lwgenerate/azure/test-data/config-log-with-list-subscriptions.tf
+++ b/lwgenerate/azure/test-data/config-log-with-list-subscriptions.tf
@@ -1,13 +1,5 @@
 terraform {
   required_providers {
-    azuread = {
-      source  = "hashicorp/azuread"
-      version = "~> 2.16"
-    }
-    azurerm = {
-      source  = "hashicorp/azurerm"
-      version = "~> 2.91.0"
-    }
     lacework = {
       source  = "lacework/lacework"
       version = "~> 1.0"
@@ -30,7 +22,7 @@ module "az_ad_application" {
 
 module "az_config" {
   source                      = "lacework/config/azure"
-  version                     = "~> 1.0"
+  version                     = "~> 2.0"
   application_id              = module.az_ad_application.application_id
   application_password        = module.az_ad_application.application_password
   service_principal_id        = module.az_ad_application.service_principal_id

--- a/lwgenerate/azure/test-data/config-with-all-subscriptions.tf
+++ b/lwgenerate/azure/test-data/config-with-all-subscriptions.tf
@@ -1,13 +1,5 @@
 terraform {
   required_providers {
-    azuread = {
-      source  = "hashicorp/azuread"
-      version = "~> 2.16"
-    }
-    azurerm = {
-      source  = "hashicorp/azurerm"
-      version = "~> 2.91.0"
-    }
     lacework = {
       source  = "lacework/lacework"
       version = "~> 1.0"
@@ -30,7 +22,7 @@ module "az_ad_application" {
 
 module "az_config" {
   source                      = "lacework/config/azure"
-  version                     = "~> 1.0"
+  version                     = "~> 2.0"
   all_subscriptions           = true
   application_id              = module.az_ad_application.application_id
   application_password        = module.az_ad_application.application_password

--- a/lwgenerate/azure/test-data/config-with-azurerm-subscription.tf
+++ b/lwgenerate/azure/test-data/config-with-azurerm-subscription.tf
@@ -1,13 +1,5 @@
 terraform {
   required_providers {
-    azuread = {
-      source  = "hashicorp/azuread"
-      version = "~> 2.16"
-    }
-    azurerm = {
-      source  = "hashicorp/azurerm"
-      version = "~> 2.91.0"
-    }
     lacework = {
       source  = "lacework/lacework"
       version = "~> 1.0"
@@ -31,7 +23,7 @@ module "az_ad_application" {
 
 module "az_config" {
   source                      = "lacework/config/azure"
-  version                     = "~> 1.0"
+  version                     = "~> 2.0"
   application_id              = module.az_ad_application.application_id
   application_password        = module.az_ad_application.application_password
   service_principal_id        = module.az_ad_application.service_principal_id

--- a/lwgenerate/azure/test-data/config-with-management-group.tf
+++ b/lwgenerate/azure/test-data/config-with-management-group.tf
@@ -1,13 +1,5 @@
 terraform {
   required_providers {
-    azuread = {
-      source  = "hashicorp/azuread"
-      version = "~> 2.16"
-    }
-    azurerm = {
-      source  = "hashicorp/azurerm"
-      version = "~> 2.91.0"
-    }
     lacework = {
       source  = "lacework/lacework"
       version = "~> 1.0"
@@ -30,7 +22,7 @@ module "az_ad_application" {
 
 module "az_config" {
   source                      = "lacework/config/azure"
-  version                     = "~> 1.0"
+  version                     = "~> 2.0"
   application_id              = module.az_ad_application.application_id
   application_password        = module.az_ad_application.application_password
   management_group_id         = "test-management-group-1"

--- a/lwgenerate/azure/test-data/config-with-storage-account.tf
+++ b/lwgenerate/azure/test-data/config-with-storage-account.tf
@@ -1,13 +1,5 @@
 terraform {
   required_providers {
-    azuread = {
-      source  = "hashicorp/azuread"
-      version = "~> 2.16"
-    }
-    azurerm = {
-      source  = "hashicorp/azurerm"
-      version = "~> 2.91.0"
-    }
     lacework = {
       source  = "lacework/lacework"
       version = "~> 1.0"
@@ -30,7 +22,7 @@ module "az_ad_application" {
 
 module "az_config" {
   source                         = "lacework/config/azure"
-  version                        = "~> 1.0"
+  version                        = "~> 2.0"
   application_id                 = module.az_ad_application.application_id
   application_password           = module.az_ad_application.application_password
   service_principal_id           = module.az_ad_application.service_principal_id

--- a/lwgenerate/azure/test-data/config_without_activity_log.tf
+++ b/lwgenerate/azure/test-data/config_without_activity_log.tf
@@ -1,13 +1,5 @@
 terraform {
   required_providers {
-    azuread = {
-      source  = "hashicorp/azuread"
-      version = "~> 2.16"
-    }
-    azurerm = {
-      source  = "hashicorp/azurerm"
-      version = "~> 2.91.0"
-    }
     lacework = {
       source  = "lacework/lacework"
       version = "~> 1.0"
@@ -30,7 +22,7 @@ module "az_ad_application" {
 
 module "az_config" {
   source                      = "lacework/config/azure"
-  version                     = "~> 1.0"
+  version                     = "~> 2.0"
   application_id              = module.az_ad_application.application_id
   application_password        = module.az_ad_application.application_password
   service_principal_id        = module.az_ad_application.service_principal_id

--- a/lwgenerate/azure/test-data/customer-ad-details.tf
+++ b/lwgenerate/azure/test-data/customer-ad-details.tf
@@ -1,13 +1,5 @@
 terraform {
   required_providers {
-    azuread = {
-      source  = "hashicorp/azuread"
-      version = "~> 2.16"
-    }
-    azurerm = {
-      source  = "hashicorp/azurerm"
-      version = "~> 2.91.0"
-    }
     lacework = {
       source  = "lacework/lacework"
       version = "~> 1.0"
@@ -25,7 +17,7 @@ provider "azurerm" {
 
 module "az_config" {
   source                      = "lacework/config/azure"
-  version                     = "~> 1.0"
+  version                     = "~> 2.0"
   application_id              = "AD-Test-Application-ID"
   application_password        = "AD-Test-Password"
   lacework_integration_name   = "Test Config Rename"
@@ -35,7 +27,7 @@ module "az_config" {
 
 module "az_activity_log" {
   source                      = "lacework/activity-log/azure"
-  version                     = "~> 1.0"
+  version                     = "~> 2.0"
   application_id              = "AD-Test-Application-ID"
   application_password        = "AD-Test-Password"
   lacework_integration_name   = "Test Activity Log Rename"

--- a/lwgenerate/azure/test-data/renamed_activity_log.tf
+++ b/lwgenerate/azure/test-data/renamed_activity_log.tf
@@ -1,13 +1,5 @@
 terraform {
   required_providers {
-    azuread = {
-      source  = "hashicorp/azuread"
-      version = "~> 2.16"
-    }
-    azurerm = {
-      source  = "hashicorp/azurerm"
-      version = "~> 2.91.0"
-    }
     lacework = {
       source  = "lacework/lacework"
       version = "~> 1.0"
@@ -30,7 +22,7 @@ module "az_ad_application" {
 
 module "az_activity_log" {
   source                      = "lacework/activity-log/azure"
-  version                     = "~> 1.0"
+  version                     = "~> 2.0"
   application_id              = module.az_ad_application.application_id
   application_password        = module.az_ad_application.application_password
   lacework_integration_name   = "Test Activity Log Rename"

--- a/lwgenerate/azure/test-data/renamed_config.tf
+++ b/lwgenerate/azure/test-data/renamed_config.tf
@@ -1,13 +1,5 @@
 terraform {
   required_providers {
-    azuread = {
-      source  = "hashicorp/azuread"
-      version = "~> 2.16"
-    }
-    azurerm = {
-      source  = "hashicorp/azurerm"
-      version = "~> 2.91.0"
-    }
     lacework = {
       source  = "lacework/lacework"
       version = "~> 1.0"
@@ -30,7 +22,7 @@ module "az_ad_application" {
 
 module "az_config" {
   source                      = "lacework/config/azure"
-  version                     = "~> 1.0"
+  version                     = "~> 2.0"
   application_id              = module.az_ad_application.application_id
   application_password        = module.az_ad_application.application_password
   lacework_integration_name   = "Test Config Rename"

--- a/lwgenerate/azure/test-data/renamed_config_and_activity_log.tf
+++ b/lwgenerate/azure/test-data/renamed_config_and_activity_log.tf
@@ -1,13 +1,5 @@
 terraform {
   required_providers {
-    azuread = {
-      source  = "hashicorp/azuread"
-      version = "~> 2.16"
-    }
-    azurerm = {
-      source  = "hashicorp/azurerm"
-      version = "~> 2.91.0"
-    }
     lacework = {
       source  = "lacework/lacework"
       version = "~> 1.0"
@@ -30,7 +22,7 @@ module "az_ad_application" {
 
 module "az_config" {
   source                      = "lacework/config/azure"
-  version                     = "~> 1.0"
+  version                     = "~> 2.0"
   application_id              = module.az_ad_application.application_id
   application_password        = module.az_ad_application.application_password
   lacework_integration_name   = "Test Config Rename"
@@ -40,7 +32,7 @@ module "az_config" {
 
 module "az_activity_log" {
   source                      = "lacework/activity-log/azure"
-  version                     = "~> 1.0"
+  version                     = "~> 2.0"
   application_id              = module.az_ad_application.application_id
   application_password        = module.az_ad_application.application_password
   lacework_integration_name   = "Test Activity Log Rename"

--- a/lwgenerate/constants.go
+++ b/lwgenerate/constants.go
@@ -12,16 +12,11 @@ const (
 	AwsEksAuditVersion   = "~> 0.4"
 
 	LWAzureConfigSource       = "lacework/config/azure"
-	LWAzureConfigVersion      = "~> 1.0"
+	LWAzureConfigVersion      = "~> 2.0"
 	LWAzureActivityLogSource  = "lacework/activity-log/azure"
-	LWAzureActivityLogVersion = "~> 1.0"
+	LWAzureActivityLogVersion = "~> 2.0"
 	LWAzureADSource           = "lacework/ad-application/azure"
 	LWAzureADVersion          = "~> 1.0"
-
-	HashAzureADProviderSource  = "hashicorp/azuread"
-	HashAzureADProviderVersion = "~> 2.16"
-	HashAzureRMProviderSource  = "hashicorp/azurerm"
-	HashAzureRMProviderVersion = "~> 2.91.0"
 
 	GcpConfigSource          = "lacework/config/gcp"
 	GcpConfigVersion         = "~> 2.3"


### PR DESCRIPTION
## Summary

The latest version of the Lacework CLI is generating code using the Azure provider 2.x.0 which is very old.
This PR updates the generate command to use the latest versions.

## How did you test this change?

Updated tests and ran generate commands manually.

## Issue

https://lacework.atlassian.net/browse/GROW-1488
