### PR TITLE
feat(api): Implement feature flagging endpoint

### DIFF
--- a/api/_examples/feature-flags/main.go
+++ b/api/_examples/feature-flags/main.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/lacework/go-sdk/api"
+)
+
+func main() {
+	lacework, err := api.NewClient(os.Getenv("LW_ACCOUNT"),
+		api.WithSubaccount(os.Getenv("LW_SUBACCOUNT")),
+		api.WithApiKeys(os.Getenv("LW_API_KEY"), os.Getenv("LW_API_SECRET")),
+		api.WithApiV2())
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	response, err := lacework.V2.FeatureFlags.GetFeatureFlagsMatchingPrefix("PUBLIC.sca")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Output: boolean flags evaluating with truthy values and starting with "PUBLIC.sca"
+	for _, flag := range response.Data.Flags {
+		fmt.Println(flag)
+	}
+}

--- a/api/api.go
+++ b/api/api.go
@@ -85,6 +85,8 @@ const (
 	apiV2ConfigsGcp                = "v2/Configs/GcpProjects"
 	apiV2ConfigsGcpProjects        = "v2/Configs/GcpProjects?orgId=%s"
 
+	apiV2FeatureFlags = "v2/FeatureFlags"
+
 	apiV2Policies        = "v2/Policies"
 	apiV2Queries         = "v2/Queries"
 	apiV2QueriesExecute  = "v2/Queries/execute"

--- a/api/feature_flags.go
+++ b/api/feature_flags.go
@@ -1,0 +1,25 @@
+package api
+
+import (
+	"fmt"
+)
+
+type FeatureFlagsService struct {
+	client *Client
+}
+
+type FeatureFlag string
+
+type FeatureFlags struct {
+	Flags []FeatureFlag `json:"flags,omitempty"`
+}
+
+type FeatureFlagsResponse struct {
+	Data FeatureFlags `json:"data"`
+}
+
+func (svc *FeatureFlagsService) GetFeatureFlagsMatchingPrefix(prefix string) (response FeatureFlagsResponse, err error) {
+	apiPath := fmt.Sprintf("%s/%s", apiV2FeatureFlags, prefix)
+	err = svc.client.RequestDecoder("GET", apiPath, nil, &response)
+	return
+}

--- a/api/feature_flags_test.go
+++ b/api/feature_flags_test.go
@@ -1,0 +1,46 @@
+package api_test
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/lacework/go-sdk/api"
+	"github.com/lacework/go-sdk/internal/lacework"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetFeatureFlagsMatchingPrefix(t *testing.T) {
+	fakeServer := lacework.MockServer()
+	fakeServer.UseApiV2()
+	fakeServer.MockToken("TOKEN")
+	defer fakeServer.Close()
+	fakeServer.MockAPI("FeatureFlags/PUBLIC.sca", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		_, err := fmt.Fprintf(w, generateResponse())
+		assert.Nil(t, err)
+	})
+	c, err := api.NewClient("test",
+		api.WithApiV2(),
+		api.WithToken("TOKEN"),
+		api.WithURL(fakeServer.URL()),
+	)
+	assert.Nil(t, err)
+	response, err := c.V2.FeatureFlags.GetFeatureFlagsMatchingPrefix("PUBLIC.sca")
+	assert.Nil(t, err)
+	assert.Equal(t, response.Data, api.FeatureFlags{Flags: []api.FeatureFlag{"flag1", "flag2", "flag3"}})
+}
+
+func generateResponse() string {
+	return `
+{
+	"data": {
+		"flags": [
+			"flag1",
+			"flag2",
+			"flag3"
+		]
+	}
+}
+`
+}

--- a/api/v2.go
+++ b/api/v2.go
@@ -41,6 +41,7 @@ type V2Endpoints struct {
 	ComponentData           *ComponentDataService
 	ContainerRegistries     *ContainerRegistriesService
 	Configs                 *v2ConfigService
+	FeatureFlags            *FeatureFlagsService
 	ResourceGroups          *ResourceGroupsService
 	AgentAccessTokens       *AgentAccessTokensService
 	AgentInfo               *AgentInfoService
@@ -74,6 +75,7 @@ func NewV2Endpoints(c *Client) *V2Endpoints {
 		&ComponentDataService{c},
 		&ContainerRegistriesService{c},
 		NewV2ConfigService(c),
+		&FeatureFlagsService{c},
 		&ResourceGroupsService{c},
 		&AgentAccessTokensService{c},
 		&AgentInfoService{c},
@@ -188,25 +190,28 @@ type Pageable interface {
 //
 // ```go
 // var (
-// 		response = api.MachineDetailEntityResponse{}
-// 		err      = client.V2.Entities.Search(&response, api.SearchFilter{})
+//
+//	response = api.MachineDetailEntityResponse{}
+//	err      = client.V2.Entities.Search(&response, api.SearchFilter{})
+//
 // )
 //
-// for {
-// 		// Use information from response.Data
-// 		fmt.Printf("Data from page: %d\n", len(response.Data))
+//	for {
+//			// Use information from response.Data
+//			fmt.Printf("Data from page: %d\n", len(response.Data))
 //
-// 		pageOk, err := client.NextPage(&response)
-// 		if err != nil {
-// 			fmt.Printf("Unable to access next page, error '%s'", err.Error())
-// 			break
-// 		}
+//			pageOk, err := client.NextPage(&response)
+//			if err != nil {
+//				fmt.Printf("Unable to access next page, error '%s'", err.Error())
+//				break
+//			}
 //
-// 		if pageOk {
-// 			continue
-// 		}
-// 		break
-// }
+//			if pageOk {
+//				continue
+//			}
+//			break
+//	}
+//
 // ```
 func (c *Client) NextPage(p Pageable) (bool, error) {
 	if p == nil {


### PR DESCRIPTION
**Summary**
This PR adds support in the Go SDK for finding enabled feature flags matching a certain prefix. This exploits the end-point described in https://lacework.atlassian.net/wiki/spaces/ENG/pages/2805563571/New+API+end-point+for+feature+flagging 

**How did you test this change?**
New unit tests that call a mock API. Also, manual end-to-end testing against one of our development instances, see below
![Screenshot 2023-03-30 at 17 13 09](https://user-images.githubusercontent.com/44171495/228899348-d9022d26-6496-4128-ae19-9afc584dec98.png)
This PR will not merged before https://github.com/lacework/rainbow/pull/11782

**Issue**
https://lacework.atlassian.net/browse/COD-518