### PR TITLE
refactor: show valid versions when invalid report definition version …

### DIFF
--- a/cli/cmd/report_definitions.go
+++ b/cli/cmd/report_definitions.go
@@ -246,14 +246,20 @@ func fetchReportDefinitionVersion(id string) error {
 		return err
 	}
 
-	for _, r := range response.Data {
-		if r.Version == version {
-			reportDefinition = r
+	for _, reportVersion := range response.Data {
+		versions = append(versions, strconv.Itoa(reportVersion.Version))
+		if reportVersion.Version == version {
+			reportDefinition = reportVersion
 		}
 	}
 
 	if cli.JSONOutput() {
 		return cli.OutputJSON(reportDefinition)
+	}
+
+	if reportDefinition.ReportDefinitionGuid == "" {
+		cli.OutputHuman("version %d not found\nvalid versions are: %s\n", version, strings.Join(versions, ", "))
+		return nil
 	}
 
 	outputReportDefinitionTable(reportDefinition)


### PR DESCRIPTION
…is given

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/lacework/go-sdk) and create your branch from `main`
  2. Run `make prepare` in the repository root
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`make test`)
  5. Format your code (`make fmt`)
  6. Make sure your code lints (`make lint`)
  7. If you are updating the Lacework CLI, make sure it compiles (`make build-cli-cross-platform`)
  8. Follow the commit message standard (`type(scope): subject`) documented in [DEVELOPER_GUIDELINES.md](https://github.com/lacework/go-sdk/blob/main/DEVELOPER_GUIDELINES.md#commit-message-standard)
  9. If you haven't already, configure signed commits by [telling git about your signing key](https://docs.github.com/en/github/authenticating-to-github/managing-commit-signature-verification/telling-git-about-your-signing-key) and [signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)

  Learn more about contributing: https://github.com/lacework/go-sdk/blob/main/CONTRIBUTING.md
-->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

Improve report definition show version cmd to show valid versions when an invalid version is given.


