### PR TITLE
feat(cli): enable default query for 'lql run' cmd

### DIFF
--- a/cli/cmd/lql.go
+++ b/cli/cmd/lql.go
@@ -295,7 +295,7 @@ func inputQueryFromEditor(action string) (query string, err error) {
 		FileName: "query*.yaml",
 	}
 
-	if action == "create" {
+	if action == "create" || action == "run" {
 		prompt.Default = `queryId: YourQueryID
 queryText: |-
   {


### PR DESCRIPTION

## Summary

When running `lacework lql run` without arguments, we open an editor for the user
to write the query live, this change is starting new queries to run with the default one
that looks similar to:
```yaml
queryId: YourQueryID
queryText: |-
  {
      source {
          --- Select a datasource. To list all available datasources, use 'lacework query sources'.
      }
      filter {
          --- Add query filter(s), if any. If not, remove this block.
      }
      return {
          --- List fields to return from the selected source. Use 'lacework query describe <datasource>'.
      }
  }

```

## How did you test this change?

This functionality is being tested with;

- https://github.com/lacework/go-sdk/blob/main/integration/lql_create_unix_test.go#L32 

We are just enabling the same functionality from `lacework lql create` to `lacework lql run`.

## Issue

N/A
