### PR TITLE
feat(cli): add `server_url` flag for CTF commands

### DIFF
--- a/cli/cmd/agent.go
+++ b/cli/cmd/agent.go
@@ -50,6 +50,7 @@ var (
 		InstallBYORole        string
 		InstallSkipCreatInfra bool
 		InstallForceReinstall bool
+		InstallServerURL      string
 	}{}
 
 	defaultSshIdentityKey = "~/.ssh/id_rsa"

--- a/cli/cmd/agent_aws-install_ec2ic.go
+++ b/cli/cmd/agent_aws-install_ec2ic.go
@@ -57,6 +57,10 @@ select a token and pass it to the '--token' flag. This flag must be selected if 
 
     lacework agent aws-install ec2ic --token <token>
 
+To explicitly specify the server URL that the agent will connect to:
+
+    lacework agent aws-install ec2ic --server_url https://api.fra.lacework.net
+
 AWS credentials are read from the following environment variables:
 - AWS_ACCESS_KEY_ID
 - AWS_SECRET_ACCESS_KEY
@@ -98,6 +102,9 @@ func init() {
 		"n",
 		50,
 		"maximum number of workers executing AWS API calls, set if rate limits are lower or higher than normal",
+	)
+	agentInstallAWSEC2ICCmd.Flags().StringVar(&agentCmdState.InstallServerURL,
+		"server_url", "https://api.lacework.net", "server URL that agents will talk to, prefixed with `https://`",
 	)
 }
 
@@ -162,7 +169,7 @@ func installAWSEC2IC(_ *cobra.Command, _ []string) error {
 				return
 			}
 
-			cmd := fmt.Sprintf("sudo sh -c \"curl -sSL %s | sh -s -- %s\"", agentInstallDownloadURL, token)
+			cmd := fmt.Sprintf("sudo sh -c \"curl -sSL %s | sh -s -- %s -U %s\"", agentInstallDownloadURL, token, agentCmdState.InstallServerURL)
 			err = runInstallCommandOnRemoteHost(&threadRunner.Runner, cmd)
 			if err != nil {
 				cli.Log.Debugw("runInstallCommandOnRemoteHost failed", "err", err, "runner", threadRunner.InstanceID)

--- a/cli/cmd/agent_aws-install_ec2ssh.go
+++ b/cli/cmd/agent_aws-install_ec2ssh.go
@@ -51,7 +51,11 @@ To provide an existing access token, use the '--token' flag. This flag is requir
 when running non-interactively ('--noninteractive' flag). The interactive command
 'lacework agent token list' can be used to query existing tokens.
 
-    lacework agent aws-install ec2ic --token <token>
+    lacework agent aws-install ec2ssh --token <token>
+
+To explicitly specify the server URL that the agent will connect to:
+
+    lacework agent aws-install ec2ssh --server_url https://api.fra.lacework.net
 
 You will need to provide an SSH authentication method. This authentication method
 should work for all instances that your tag or region filters select. Instances must
@@ -113,6 +117,9 @@ func init() {
 		"n",
 		50,
 		"maximum number of workers executing AWS API calls, set if rate limits are lower or higher than normal",
+	)
+	agentInstallAWSSSHCmd.Flags().StringVar(&agentCmdState.InstallServerURL,
+		"server_url", "https://api.lacework.net", "server URL that agents will talk to, prefixed with `https://`",
 	)
 }
 
@@ -177,7 +184,7 @@ func installAWSSSH(_ *cobra.Command, args []string) error {
 				return
 			}
 
-			cmd := fmt.Sprintf("sudo sh -c \"curl -sSL %s | sh -s -- %s\"", agentInstallDownloadURL, token)
+			cmd := fmt.Sprintf("sudo sh -c \"curl -sSL %s | sh -s -- %s -U %s\"", agentInstallDownloadURL, token, agentCmdState.InstallServerURL)
 			err = runInstallCommandOnRemoteHost(&threadRunner.Runner, cmd)
 			if err != nil {
 				cli.Log.Debugw("runInstallCommandOnRemoteHost failed", "thread_runner", threadRunner.InstanceID)

--- a/cli/cmd/agent_aws-install_ec2ssm.go
+++ b/cli/cmd/agent_aws-install_ec2ssm.go
@@ -82,6 +82,10 @@ select a token and pass it to the '--token' flag. This flag must be selected if 
 
     lacework agent aws-install ec2ssm --token <token>
 
+To explicitly specify the server URL that the agent will connect to:
+
+    lacework agent aws-install ec2ssm --server_url https://api.fra.lacework.net
+
 AWS credentials are read from the following environment variables:
 - AWS_ACCESS_KEY_ID
 - AWS_SECRET_ACCESS_KEY
@@ -136,6 +140,9 @@ func init() {
 		"f",
 		false,
 		"set this flag to force-reinstall the agent, even if already running on the target instance",
+	)
+	agentInstallAWSSSMCmd.Flags().StringVar(&agentCmdState.InstallServerURL,
+		"server_url", "https://api.lacework.net", "server URL that agents will talk to, prefixed with `https://`",
 	)
 }
 
@@ -344,8 +351,8 @@ func installAWSSSM(_ *cobra.Command, _ []string) error {
 
 			// Install the agent on the host
 			// No need to sleep because instance profile already associated
-			const runInstallCmdTmpl = "sudo sh -c 'curl -sSL %s | sh -s -- %s'"
-			runInstallCmd := fmt.Sprintf(runInstallCmdTmpl, agentInstallDownloadURL, token)
+			const runInstallCmdTmpl = "sudo sh -c 'curl -sSL %s | sh -s -- %s -U %s'"
+			runInstallCmd := fmt.Sprintf(runInstallCmdTmpl, agentInstallDownloadURL, token, agentCmdState.InstallServerURL)
 			commandOutput, err := threadRunner.RunSSMCommandOnRemoteHost(cfg, runInstallCmd)
 			if err != nil {
 				cli.OutputHuman(

--- a/cli/cmd/agent_gcp-install-osl.go
+++ b/cli/cmd/agent_gcp-install-osl.go
@@ -61,6 +61,10 @@ select a token and pass it to the '--token' flag. This flag must be selected if 
 
     lacework agent gcp-install osl <gcp_username> --token <token>
 
+To explicitly specify the server URL that the agent will connect to:
+
+    lacework agent gcp-install osl --server_url https://api.fra.lacework.net
+
 GCP credentials are read using the following environment variables:
 - GOOGLE_APPLICATION_CREDENTIALS
 
@@ -114,6 +118,12 @@ func init() {
 		"token",
 		"",
 		"agent access token",
+	)
+	agentInstallGCPOSLCmd.Flags().StringVar(
+		&agentCmdState.InstallServerURL,
+		"server_url",
+		"https://api.lacework.net",
+		"server URL that agents will talk to, prefixed with `https://`",
 	)
 }
 
@@ -185,7 +195,7 @@ func installGCPOSL(_ *cobra.Command, args []string) error {
 				return
 			}
 
-			cmd := fmt.Sprintf("sudo sh -c \"curl -sSL %s | sh -s -- %s\"", agentInstallDownloadURL, token)
+			cmd := fmt.Sprintf("sudo sh -c \"curl -sSL %s | sh -s -- %s -U %s\"", agentInstallDownloadURL, token, agentCmdState.InstallServerURL)
 			err = runInstallCommandOnRemoteHost(&threadRunner.Runner, cmd)
 			if err != nil {
 				cli.Log.Debugw("runInstallCommandOnRemoteHost failed", "err", err, "runner", threadRunner.InstanceID)

--- a/integration/test_resources/help/agent_aws-install_ec2ic
+++ b/integration/test_resources/help/agent_aws-install_ec2ic
@@ -22,6 +22,10 @@ select a token and pass it to the '--token' flag. This flag must be selected if 
 
     lacework agent aws-install ec2ic --token <token>
 
+To explicitly specify the server URL that the agent will connect to:
+
+    lacework agent aws-install ec2ic --server_url https://api.fra.lacework.net
+
 AWS credentials are read from the following environment variables:
 - AWS_ACCESS_KEY_ID
 - AWS_SECRET_ACCESS_KEY
@@ -42,6 +46,7 @@ Flags:
   -h, --help                      help for ec2ic
   -r, --include_regions strings   list of regions to filter on
   -n, --max_parallelism int       maximum number of workers executing AWS API calls, set if rate limits are lower or higher than normal (default 50)
+      --server_url https://       server URL that agents will talk to, prefixed with https:// (default "https://api.lacework.net")
       --ssh_username string       username to login with
       --tag strings               only install agents on infra with this tag
       --tag_key string            only install agents on infra with this tag key set

--- a/integration/test_resources/help/agent_aws-install_ec2ssh
+++ b/integration/test_resources/help/agent_aws-install_ec2ssh
@@ -17,7 +17,11 @@ To provide an existing access token, use the '--token' flag. This flag is requir
 when running non-interactively ('--noninteractive' flag). The interactive command
 'lacework agent token list' can be used to query existing tokens.
 
-    lacework agent aws-install ec2ic --token <token>
+    lacework agent aws-install ec2ssh --token <token>
+
+To explicitly specify the server URL that the agent will connect to:
+
+    lacework agent aws-install ec2ssh --server_url https://api.fra.lacework.net
 
 You will need to provide an SSH authentication method. This authentication method
 should work for all instances that your tag or region filters select. Instances must
@@ -48,6 +52,7 @@ Flags:
   -i, --identity_file string      identity (private key) for public key authentication (default "~/.ssh/id_rsa")
   -r, --include_regions strings   list of regions to filter on
   -n, --max_parallelism int       maximum number of workers executing AWS API calls, set if rate limits are lower or higher than normal (default 50)
+      --server_url https://       server URL that agents will talk to, prefixed with https:// (default "https://api.lacework.net")
       --ssh_password string       password for authentication
       --ssh_port int              port to connect to on the remote host (default 22)
       --ssh_username string       username to login with

--- a/integration/test_resources/help/agent_aws-install_ec2ssm
+++ b/integration/test_resources/help/agent_aws-install_ec2ssm
@@ -38,6 +38,10 @@ select a token and pass it to the '--token' flag. This flag must be selected if 
 
     lacework agent aws-install ec2ssm --token <token>
 
+To explicitly specify the server URL that the agent will connect to:
+
+    lacework agent aws-install ec2ssm --server_url https://api.fra.lacework.net
+
 AWS credentials are read from the following environment variables:
 - AWS_ACCESS_KEY_ID
 - AWS_SECRET_ACCESS_KEY
@@ -54,6 +58,7 @@ Flags:
       --iam_role_name string      IAM role name (not ARN) with SSM policy, if not provided then an ephemeral role will be created
   -r, --include_regions strings   list of regions to filter on
   -n, --max_parallelism int       maximum number of workers executing AWS API calls, set if rate limits are lower or higher than normal (default 50)
+      --server_url https://       server URL that agents will talk to, prefixed with https:// (default "https://api.lacework.net")
       --skip_iam_role_creation    set this flag to skip creating an IAM role and instance profile and associating the instance profile. Assumes all instances are already setup for SSM
       --tag strings               only install agents on infra with this tag
       --tag_key string            only install agents on infra with this tag key set

--- a/integration/test_resources/help/agent_gcp-install_osl
+++ b/integration/test_resources/help/agent_gcp-install_osl
@@ -26,6 +26,10 @@ select a token and pass it to the '--token' flag. This flag must be selected if 
 
     lacework agent gcp-install osl <gcp_username> --token <token>
 
+To explicitly specify the server URL that the agent will connect to:
+
+    lacework agent gcp-install osl --server_url https://api.fra.lacework.net
+
 GCP credentials are read using the following environment variables:
 - GOOGLE_APPLICATION_CREDENTIALS
 
@@ -42,6 +46,7 @@ Flags:
       --metadata strings          only install agents on infra with this metadata
       --metadata_key string       only install agents on infra with this metadata key set
       --project_id string         ID of the GCP project, set if metadata server does not provide
+      --server_url https://       server URL that agents will talk to, prefixed with https:// (default "https://api.lacework.net")
       --token string              agent access token
       --trust_host_key            automatically add host keys to the ~/.ssh/known_hosts file (default true)
 


### PR DESCRIPTION
This commit adds a new CLI flag called `server_url` to:

* `aws-install ec2ic`
* `aws-install ec2ssh`
* `aws-install ec2ssm`
* `gcp-install osl`

`server_url` allows the user to set the server URL that their agents
will connect to after deployment through the CLI.

This commit also updates the integration help texts with the new flag
and instructions for use.

Fixes RAIN-53798

Signed-off-by: Nick Schmeller <nick.schmeller@lacework.net>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/lacework/go-sdk) and create your branch from `main`
  2. Run `make prepare` in the repository root
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`make test`)
  5. Format your code (`make fmt`)
  6. Make sure your code lints (`make lint`)
  7. If you are updating the Lacework CLI, make sure it compiles (`make build-cli-cross-platform`)
  8. Follow the commit message standard (`type(scope): subject`) documented in [DEVELOPER_GUIDELINES.md](https://github.com/lacework/go-sdk/blob/main/DEVELOPER_GUIDELINES.md#commit-message-standard)
  9. If you haven't already, configure signed commits by [telling git about your signing key](https://docs.github.com/en/github/authenticating-to-github/managing-commit-signature-verification/telling-git-about-your-signing-key) and [signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)

  Learn more about contributing: https://github.com/lacework/go-sdk/blob/main/CONTRIBUTING.md
-->

## How did you test this change?

<!--
  How exactly did you verify that your PR solves the issue you wanted to solve?
  Include any other relevant information such as how to use the new functionality, screenshots, etc.
-->

New integration tests for all CTF commands at https://github.com/lacework/agent/pull/2103

## Issue

<!--
  Include the link to a Jira/Github issue
-->
https://lacework.atlassian.net/browse/RAIN-53798
