### PR TITLE
refactor: do not filter csv output for vuln ctr show

### DIFF
--- a/cli/cmd/vuln_container_show_assessments.go
+++ b/cli/cmd/vuln_container_show_assessments.go
@@ -515,9 +515,9 @@ func vulContainerImageLayersToCSV(assessment []api.VulnerabilityContainer) [][]s
 		out = append(out, []string{
 			vuln.VulnID,
 			vuln.Severity,
-			strconv.Itoa(0),
-			strconv.Itoa(0),
-			vuln.FeatureKey.Namespace,
+			strconv.FormatFloat(0.0, 'f', 1, 64),
+			strconv.FormatFloat(0.0, 'f', 1, 64),
+			vuln.FeatureKey.Name,
 			vuln.FeatureKey.Version,
 			vuln.FixInfo.FixedVersion,
 			vuln.FeatureProps.IntroducedIn,

--- a/cli/cmd/vuln_container_show_assessments.go
+++ b/cli/cmd/vuln_container_show_assessments.go
@@ -256,7 +256,9 @@ func buildVulnContainerAssessmentReports(response api.VulnerabilitiesContainersR
 		}
 
 		if err := cli.OutputCSV([]string{"CVE ID", "Severity", "CVSSv2", "CVSSv3", "Package", "Current Version",
-			"Fix Version", "Introduced in Layer"}, vulContainerImageLayersToCSV(assessment)); err != nil {
+			"Fix Version", "Version Format", "Feed", "Src", "Start Time", "Status", "Namespace", "Image Digest",
+			"Image ID", "Image Repo", "Image Registry", "Image Size", "Introduced in Layer"},
+			vulContainerImageLayersToCSV(assessment)); err != nil {
 			return err
 		}
 	default:
@@ -520,6 +522,16 @@ func vulContainerImageLayersToCSV(assessment []api.VulnerabilityContainer) [][]s
 			vuln.FeatureKey.Name,
 			vuln.FeatureKey.Version,
 			vuln.FixInfo.FixedVersion,
+			vuln.FeatureProps.VersionFormat,
+			vuln.FeatureProps.Feed,
+			vuln.FeatureProps.Src,
+			vuln.StartTime.Format(time.RFC3339),
+			vuln.FeatureKey.Namespace,
+			vuln.EvalCtx.ImageInfo.ID,
+			vuln.EvalCtx.ImageInfo.Digest,
+			vuln.EvalCtx.ImageInfo.Repo,
+			vuln.EvalCtx.ImageInfo.Registry,
+			strconv.Itoa(vuln.EvalCtx.ImageInfo.Size),
 			vuln.FeatureProps.IntroducedIn,
 		})
 	}

--- a/cli/cmd/vuln_container_test.go
+++ b/cli/cmd/vuln_container_test.go
@@ -109,11 +109,10 @@ func TestBuildCSVVulnCtrReportWithVulnerabilities(t *testing.T) {
 		assert.Nil(t, buildVulnContainerAssessmentReports(response))
 	})
 
-	expected := `
-CVE ID,Severity,CVSSv2,CVSSv3,Package,Current Version,Fix Version,Introduced in Layer
-CVE-2020-12345,Critical,0.0,0.0,example-2,1.2.0,,apk add --no-cache ca-certificates
-CVE-2020-12345,High,0.0,0.0,example-4,1.0.0,1.31.1-r11,apk add --no-cache ca-certificates
-CVE-2029-21234,Medium,0.0,0.0,example-1,1.0.0,2.2.0-11+deb9u4,example introduced in layer
+	expected := `CVE ID,Severity,CVSSv2,CVSSv3,Package,Current Version,Fix Version,Version Format,Feed,Src,Start Time,Status,Namespace,Image Digest,Image ID,Image Repo,Image Registry,Image Size,Introduced in Layer
+CVE-2020-12345,Critical,0.0,0.0,example-2,1.2.0,,apk,n/a,,2022-11-21T19:21:57Z,alpine:v3.11,sha256:7652596622b05043763f962cff30edf01f6ea1ba29374f1703dda759dc9ff3a1,sha256:12b072fd2ce1732e4c2f0f601c2c12ea2ea657c9572d9ba477b1174d9159e123,techally-test-2/exservice,gcr.io,14933503,apk add --no-cache ca-certificates
+CVE-2020-12345,High,0.0,0.0,example-4,1.0.0,1.31.1-r11,apk,lacework,,2022-11-21T19:21:57Z,alpine:v3.11,sha256:1252596622b05043763f962gff30adf01f6ea1ba29374f1703dda759dc9ab3a1,sha256:15b072fd2ce1732e4c2f0f601c2c12ea2ea657c9572d9ba477b1174d9159e123,techally-test-4/exservice,gcr.io,14933503,apk add --no-cache ca-certificates
+CVE-2029-21234,Medium,0.0,0.0,example-1,1.0.0,2.2.0-11+deb9u4,dpkg,lacework,var/lib/dpkg/status,2022-11-21T18:33:28Z,debian:9,sha256:a65572164cb78c4d04f57bd66201c775e2dab08fce394806a03a933c5daf9e48,sha256:77b2d2246518044ef95e3dbd029e51dd477788e5bf8e278e418685aabc3fe28a,techally-test/test-cli,index.docker.io,360608563,example introduced in layer
 `
 	assert.Equal(t, strings.TrimPrefix(expected, "\n"), cliOutput)
 }
@@ -134,10 +133,9 @@ func TestBuildVulnCtrReportWithIntroducedInLayerCSV(t *testing.T) {
 		assert.Nil(t, buildVulnContainerAssessmentReports(response))
 	})
 
-	expected := `
-CVE ID,Severity,CVSSv2,CVSSv3,Package,Current Version,Fix Version,Introduced in Layer
-CVE-2029-21234,Medium,0.0,0.0,example-1,1.0.0,2.2.0-11+deb9u4,example introduced in layer 1
-CVE-2029-21234,Medium,0.0,0.0,example-1,1.0.0,2.2.0-11+deb9u4,example introduced in layer 2
+	expected := `CVE ID,Severity,CVSSv2,CVSSv3,Package,Current Version,Fix Version,Version Format,Feed,Src,Start Time,Status,Namespace,Image Digest,Image ID,Image Repo,Image Registry,Image Size,Introduced in Layer
+CVE-2029-21234,Medium,0.0,0.0,example-1,1.0.0,2.2.0-11+deb9u4,dpkg,lacework,var/lib/dpkg/status,2022-11-21T18:33:28Z,debian:9,sha256:a65572164cb78c4d04f57bd66201c775e2dab08fce394806a03a933c5daf9e48,sha256:77b2d2246518044ef95e3dbd029e51dd477788e5bf8e278e418685aabc3fe28a,techally-test/test-cli,index.docker.io,360608563,example introduced in layer 1
+CVE-2029-21234,Medium,0.0,0.0,example-1,1.0.0,2.2.0-11+deb9u4,dpkg,lacework,var/lib/dpkg/status,2022-11-21T18:33:28Z,debian:9,sha256:a65572164cb78c4d04f57bd66201c775e2dab08fce394806a03a933c5daf9e48,sha256:77b2d2246518044ef95e3dbd029e51dd477788e5bf8e278e418685aabc3fe28a,techally-test/test-cli,index.docker.io,360608563,example introduced in layer 2
 `
 	assert.Equal(t, strings.TrimPrefix(expected, "\n"), cliOutput)
 }


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/lacework/go-sdk) and create your branch from `main`
  2. Run `make prepare` in the repository root
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`make test`)
  5. Format your code (`make fmt`)
  6. Make sure your code lints (`make lint`)
  7. If you are updating the Lacework CLI, make sure it compiles (`make build-cli-cross-platform`)
  8. Follow the commit message standard (`type(scope): subject`) documented in [DEVELOPER_GUIDELINES.md](https://github.com/lacework/go-sdk/blob/main/DEVELOPER_GUIDELINES.md#commit-message-standard)
  9. If you haven't already, configure signed commits by [telling git about your signing key](https://docs.github.com/en/github/authenticating-to-github/managing-commit-signature-verification/telling-git-about-your-signing-key) and [signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)

  Learn more about contributing: https://github.com/lacework/go-sdk/blob/main/CONTRIBUTING.md
-->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

Remove filtering from CSV output

## How did you test this change?

<!--
  How exactly did you verify that your PR solves the issue you wanted to solve?
  Include any other relevant information such as how to use the new functionality, screenshots, etc.
-->

Tests
- [x] `TestBuildVulnCtrReportWithIntroducedInLayerCSV`
- [x] `TestBuildVulnCtrReportAndJsonCount`

## Issue

<!--
  Include the link to a Jira/Github issue
-->

https://lacework.atlassian.net/browse/GROW-1490
