### PR TITLE
fix: adjust endtime for natural time

### DIFF
--- a/integration/alert_list_test.go
+++ b/integration/alert_list_test.go
@@ -90,7 +90,7 @@ func TestAlertListJSON(t *testing.T) {
 }
 
 func TestAlertListNone(t *testing.T) {
-	out, err, exitcode := LaceworkCLIWithTOMLConfig("alert", "list", "--start", "-1s", "--end", "now")
+	out, err, exitcode := LaceworkCLIWithTOMLConfig("alert", "list", "--start", "-1m", "--end", "now")
 	assert.Contains(t, out.String(), "There are no alerts in the specified time range.")
 	assert.Empty(t, err.String(), "STDERR should be empty")
 	assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")

--- a/integration/alert_list_test.go
+++ b/integration/alert_list_test.go
@@ -90,7 +90,7 @@ func TestAlertListJSON(t *testing.T) {
 }
 
 func TestAlertListNone(t *testing.T) {
-	out, err, exitcode := LaceworkCLIWithTOMLConfig("alert", "list", "--start", "-1m", "--end", "now")
+	out, err, exitcode := LaceworkCLIWithTOMLConfig("alert", "list", "--start", "-10s", "--end", "now")
 	assert.Contains(t, out.String(), "There are no alerts in the specified time range.")
 	assert.Empty(t, err.String(), "STDERR should be empty")
 	assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")

--- a/lwtime/nattime.go
+++ b/lwtime/nattime.go
@@ -188,7 +188,7 @@ func ParseNatural(n string) (time.Time, time.Time, error) {
 	// time.Now() is intentional here such that snaps work properly
 	// For instance snapping to @d should snap to the start of the local day
 	startLocal, endLocal, err := parseNaturalFromTime(n, time.Now())
-	return startLocal.UTC(), endLocal.UTC(), err
+	return startLocal.UTC(), endLocal.UTC().Add(-time.Minute), err
 }
 
 func parseNaturalFromTime(n string, fromTime time.Time) (time.Time, time.Time, error) {

--- a/lwtime/nattime.go
+++ b/lwtime/nattime.go
@@ -181,14 +181,15 @@ func (nt natural) getRelativeRange() (relStart string, relEnd string, err error)
 // Start and End time objects are returned in UTC
 //
 // start, end, err := lwtime.ParseNatural("this year")
-// if err != nil {
-// 	...
-// }
+//
+//	if err != nil {
+//		...
+//	}
 func ParseNatural(n string) (time.Time, time.Time, error) {
 	// time.Now() is intentional here such that snaps work properly
 	// For instance snapping to @d should snap to the start of the local day
 	startLocal, endLocal, err := parseNaturalFromTime(n, time.Now())
-	return startLocal.UTC(), endLocal.UTC().Add(-time.Minute), err
+	return startLocal.UTC(), endLocal.UTC(), err
 }
 
 func parseNaturalFromTime(n string, fromTime time.Time) (time.Time, time.Time, error) {

--- a/lwtime/nattime.go
+++ b/lwtime/nattime.go
@@ -181,10 +181,9 @@ func (nt natural) getRelativeRange() (relStart string, relEnd string, err error)
 // Start and End time objects are returned in UTC
 //
 // start, end, err := lwtime.ParseNatural("this year")
-//
-//	if err != nil {
-//		...
-//	}
+// if err != nil {
+// 	...
+// }
 func ParseNatural(n string) (time.Time, time.Time, error) {
 	// time.Now() is intentional here such that snaps work properly
 	// For instance snapping to @d should snap to the start of the local day

--- a/lwtime/nattime_internal_test.go
+++ b/lwtime/nattime_internal_test.go
@@ -294,7 +294,7 @@ var NaturalFromTimeTests = []NaturalFromTimeTest{
 		"2021-01-01T00:00:01Z",
 		time.RFC3339,
 		"today",
-		1,
+		-29,
 		nil,
 	},
 	NaturalFromTimeTest{
@@ -310,7 +310,7 @@ var NaturalFromTimeTests = []NaturalFromTimeTest{
 		"2021-01-01T23:59:59Z",
 		time.RFC3339,
 		"this day",
-		86399,
+		86369,
 		nil,
 	},
 	NaturalFromTimeTest{
@@ -318,7 +318,7 @@ var NaturalFromTimeTests = []NaturalFromTimeTest{
 		"2021-01-01T23:59:59Z",
 		time.RFC3339,
 		"current month",
-		86399,
+		86369,
 		nil,
 	},
 	NaturalFromTimeTest{

--- a/lwtime/nattime_internal_test.go
+++ b/lwtime/nattime_internal_test.go
@@ -294,7 +294,7 @@ var NaturalFromTimeTests = []NaturalFromTimeTest{
 		"2021-01-01T00:00:01Z",
 		time.RFC3339,
 		"today",
-		-29,
+		-1,
 		nil,
 	},
 	NaturalFromTimeTest{
@@ -310,7 +310,7 @@ var NaturalFromTimeTests = []NaturalFromTimeTest{
 		"2021-01-01T23:59:59Z",
 		time.RFC3339,
 		"this day",
-		86369,
+		86397,
 		nil,
 	},
 	NaturalFromTimeTest{
@@ -318,7 +318,7 @@ var NaturalFromTimeTests = []NaturalFromTimeTest{
 		"2021-01-01T23:59:59Z",
 		time.RFC3339,
 		"current month",
-		86369,
+		86397,
 		nil,
 	},
 	NaturalFromTimeTest{

--- a/lwtime/reltime.go
+++ b/lwtime/reltime.go
@@ -221,9 +221,9 @@ func (rel relative) time(inTime time.Time) (outTime time.Time, err error) {
 //
 // t, err := lwtime.ParseRelative("-1y@y")
 //
-//	if err != nil {
-//		...
-//	}
+// if err != nil {
+//	...
+// }
 func ParseRelative(s string) (time.Time, error) {
 	// time.Now() is intentional here such that snaps work properly
 	// For instance snapping to @d should snap to the start of the local day

--- a/lwtime/reltime.go
+++ b/lwtime/reltime.go
@@ -134,10 +134,10 @@ func newRelative(s string) (relative, error) {
 	var rel relative
 	var rel_parts []string
 
-	// now is equivelant to -30s
+	// now is equivelant to -10s
 	// prevent corner conditions with Lacework's API server
 	if s == "now" {
-		s = "-30s"
+		s = "-10s"
 	}
 	// regex
 	re := regexp.MustCompile(relativeRE)
@@ -221,9 +221,9 @@ func (rel relative) time(inTime time.Time) (outTime time.Time, err error) {
 //
 // t, err := lwtime.ParseRelative("-1y@y")
 //
-// if err != nil {
-//	...
-// }
+//	if err != nil {
+//		...
+//	}
 func ParseRelative(s string) (time.Time, error) {
 	// time.Now() is intentional here such that snaps work properly
 	// For instance snapping to @d should snap to the start of the local day

--- a/lwtime/reltime.go
+++ b/lwtime/reltime.go
@@ -134,9 +134,10 @@ func newRelative(s string) (relative, error) {
 	var rel relative
 	var rel_parts []string
 
-	// now is equivelant to +0s
+	// now is equivelant to -30s
+	// prevent corner conditions with Lacework's API server
 	if s == "now" {
-		s = "+0s"
+		s = "-30s"
 	}
 	// regex
 	re := regexp.MustCompile(relativeRE)
@@ -219,9 +220,10 @@ func (rel relative) time(inTime time.Time) (outTime time.Time, err error) {
 // Time object is returned in UTC
 //
 // t, err := lwtime.ParseRelative("-1y@y")
-// if err != nil {
-// 	...
-// }
+//
+//	if err != nil {
+//		...
+//	}
 func ParseRelative(s string) (time.Time, error) {
 	// time.Now() is intentional here such that snaps work properly
 	// For instance snapping to @d should snap to the start of the local day

--- a/lwtime/reltime.go
+++ b/lwtime/reltime.go
@@ -21,6 +21,7 @@ package lwtime
 
 import (
 	"fmt"
+	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -33,6 +34,18 @@ type relativeDate struct {
 	year  int
 	month time.Month
 	day   int
+}
+
+// The potential difference between the clocks on the client
+// and the Lacework API server
+const clockOffset = "-2s"
+
+// Returns 'now' with the default or the provided clock offset
+func nowClockOffset() string {
+	if os.Getenv("LW_CLOCK_OFFSET") != "" {
+		return os.Getenv("LW_CLOCK_OFFSET")
+	}
+	return clockOffset
 }
 
 func mondays(year int) (mondays []relativeDate) {
@@ -134,10 +147,10 @@ func newRelative(s string) (relative, error) {
 	var rel relative
 	var rel_parts []string
 
-	// now is equivelant to -10s
+	// now is equivelant to LW_CLOCK_OFFSET (defaults to -2s)
 	// prevent corner conditions with Lacework's API server
 	if s == "now" {
-		s = "-10s"
+		s = nowClockOffset()
 	}
 	// regex
 	re := regexp.MustCompile(relativeRE)

--- a/lwtime/reltime_internal_test.go
+++ b/lwtime/reltime_internal_test.go
@@ -162,8 +162,8 @@ var newRelativeTests = []newRelativeTest{
 		"now",
 		"now",
 		relative{
-			"-30",
-			-30,
+			"-2",
+			-2,
 			relativeUnit("s"),
 			relativeUnit(""),
 		},
@@ -302,7 +302,7 @@ var RelativeTimeTests = []RelativeTimeTest{
 		"2006-02-02T15:04:05-07:00",
 		time.RFC3339,
 		"now",
-		"2006-02-02T15:03:35-07:00",
+		"2006-02-02T15:04:03-07:00",
 		nil,
 	},
 	RelativeTimeTest{

--- a/lwtime/reltime_internal_test.go
+++ b/lwtime/reltime_internal_test.go
@@ -162,8 +162,8 @@ var newRelativeTests = []newRelativeTest{
 		"now",
 		"now",
 		relative{
-			"0",
-			0,
+			"-30",
+			-30,
 			relativeUnit("s"),
 			relativeUnit(""),
 		},
@@ -302,7 +302,7 @@ var RelativeTimeTests = []RelativeTimeTest{
 		"2006-02-02T15:04:05-07:00",
 		time.RFC3339,
 		"now",
-		"2006-02-02T15:04:05-07:00",
+		"2006-02-02T15:03:35-07:00",
 		nil,
 	},
 	RelativeTimeTest{

--- a/lwtime/reltime_test.go
+++ b/lwtime/reltime_test.go
@@ -19,6 +19,7 @@
 package lwtime_test
 
 import (
+	"os"
 	"testing"
 	"time"
 
@@ -37,4 +38,15 @@ func TestParseRelativeOK(t *testing.T) {
 func TestParseRelativeErr(t *testing.T) {
 	_, err := lwtime.ParseRelative("jackie weaver")
 	assert.NotNil(t, err)
+}
+
+func TestParseRelativeCustomClockOffset(t *testing.T) {
+	os.Setenv("LW_CLOCK_OFFSET", "+5s")
+	defer os.Setenv("LW_CLOCK_OFFSET", "")
+
+	rt, err := lwtime.ParseRelative("now")
+	assert.Nil(t, err)
+
+	dur := rt.Unix() - time.Now().Unix()
+	assert.LessOrEqual(t, dur, int64(6))
 }


### PR DESCRIPTION
## Summary

Avoid issues with `now` ahead of current time when using natural and relative language flags.

When calculating the local time `now` and submitting it to the Lacework APIs, the clock on some
computers could have an offset (they could be ahead of time) with the Lacework platform, we have
seen a max of 1-2s offset so, we have decided to default `now` to `-2s` to avoid these issues.

We have also made this clock offset configurable, users can use the environment variable `LW_CLOCK_OFFSET`
to customize this parameter or put it back to the previous default (`-0s`).

## How did you test this change?

Manual
- [x] Run `lacework alert ls --range "last 3 days" ` ensure end time is adjusted.

Plus unit and integrations tests.

## Issue

https://lacework.atlassian.net/browse/LINK-1507