### PR TITLE
test(cli): fix daily version integration test

### DIFF
--- a/integration/alert_list_test.go
+++ b/integration/alert_list_test.go
@@ -32,7 +32,9 @@ import (
 func popAlert() (string, error) {
 	var alerts api.Alerts
 
-	out, stderr, exitcode := LaceworkCLIWithTOMLConfig("alert", "list", "--status", "Open", "--json")
+	out, stderr, exitcode := LaceworkCLIWithTOMLConfig(
+		"alert", "list", "--status", "Open", "--json", "--range", "last 7 days",
+	)
 	if stderr.String() != "" {
 		return "-1", errors.New(stderr.String())
 	}
@@ -123,7 +125,7 @@ func TestAlertListStatusBad(t *testing.T) {
 }
 
 func TestAlertListStatusOpen(t *testing.T) {
-	out, err, exitcode := LaceworkCLIWithTOMLConfig("alert", "list", "--status", "Open")
+	out, err, exitcode := LaceworkCLIWithTOMLConfig("alert", "list", "--status", "Open", "--range", "last 7 days")
 	assert.Contains(t, out.String(), "Open")
 	assert.Empty(t, err.String(), "STDERR should be empty")
 	assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")

--- a/integration/version_test.go
+++ b/integration/version_test.go
@@ -49,9 +49,15 @@ func TestDailyVersionCheckEndToEnd(t *testing.T) {
 	defer os.RemoveAll(home)
 
 	out, errB, exitcode := LaceworkCLIWithHome(home, "configure", "list")
-	assert.Empty(t, errB.String())
 	assert.Equal(t, 0, exitcode)
 	assert.Contains(t, out.String(),
+		"To switch profiles use 'lacework configure switch-profile",
+	)
+
+	assert.NotContains(t, out.String(),
+		"A newer version of the Lacework CLI is available! The latest version is v",
+	)
+	assert.Contains(t, errB.String(),
 		"A newer version of the Lacework CLI is available! The latest version is v",
 		"version check message changed?",
 	)
@@ -100,11 +106,18 @@ func TestDailyVersionCheckEndToEnd(t *testing.T) {
 	assert.Nil(t, err)
 
 	out, errB, exitcode = LaceworkCLIWithHome(home, "configure", "list")
-	assert.Empty(t, errB.String())
 	assert.Equal(t, 0, exitcode)
+
 	assert.Contains(t, out.String(),
+		"To switch profiles use 'lacework configure switch-profile",
+	)
+
+	assert.NotContains(t, out.String(),
 		"A newer version of the Lacework CLI is available! The latest version is v",
-		"version check message should be there",
+	)
+	assert.Contains(t, errB.String(),
+		"A newer version of the Lacework CLI is available! The latest version is v",
+		"version check message changed?",
 	)
 
 	assert.FileExists(t, versionCacheFile, "the version_cache file is missing")


### PR DESCRIPTION

## Summary

When moving the daily version output from STDOUT to STDERR (https://github.com/lacework/go-sdk/pull/1207) we
forgot to update these tests that are blocking the release https://github.com/lacework/go-sdk/pull/1223

## How did you test this change?

Ran the integration tests with and without the suffix `-dev` in the `VERSION` file

## Issue
N/A
