### PR TITLE
feat(api): Addition of S3 Bucket ARN for AWS EKS Audit log

### DIFF
--- a/api/_examples/cloud-accounts/aws-eks-audit/main.go
+++ b/api/_examples/cloud-accounts/aws-eks-audit/main.go
@@ -42,6 +42,7 @@ func main() {
 			ExternalID: "abc123",
 		},
 		SnsArn: "arn:aws:sns:us-west-2:0123456789:foo-lacework-eks:00777777-ab77-1234-a123-a12ab1d12c1d",
+		S3BucketArn: "arn:aws:s3:::example-bucket-name",
 	}
 
 	awsEksAuditCloudAccount := api.NewCloudAccount(

--- a/api/cloud_accounts_aws_eks_audit.go
+++ b/api/cloud_accounts_aws_eks_audit.go
@@ -48,6 +48,7 @@ type AwsEksAuditIntegration struct {
 type AwsEksAuditData struct {
 	Credentials AwsEksAuditCredentials `json:"crossAccountCredentials"`
 	SnsArn      string                 `json:"snsArn"`
+	S3BucketArn string                 `json:"s3BucketArn"`
 }
 
 type AwsEksAuditCredentials struct {

--- a/api/cloud_accounts_aws_eks_audit_test.go
+++ b/api/cloud_accounts_aws_eks_audit_test.go
@@ -65,6 +65,7 @@ func TestCloudAccountsAwsEksAuditGet(t *testing.T) {
 		"arn:aws:sns:us-west-2:0123456789:foo-lacework-eks:00777777-ab77-1234-a123-a12ab1d12c1d",
 		response.Data.Data.SnsArn,
 	)
+	assert.Equal(t, "arn:aws:s3:::example-bucket-name", response.Data.Data.S3BucketArn)
 }
 
 func TestCloudAccountsAwsEksAuditUpdate(t *testing.T) {
@@ -92,6 +93,8 @@ func TestCloudAccountsAwsEksAuditUpdate(t *testing.T) {
 				body,
 				"arn:aws:sns:us-west-2:0123456789:foo-lacework-eks:00777777-ab77-1234-a123-a12ab1d12c1d",
 				"wrong sns arn")
+
+			assert.Contains(t, body, "arn:aws:s3:::example-bucket-name", "wrong s3 bucket arn")
 			assert.Contains(t, body, "enabled\":1", "cloud account is not enabled")
 		}
 
@@ -108,7 +111,8 @@ func TestCloudAccountsAwsEksAuditUpdate(t *testing.T) {
 	cloudAccount := api.NewCloudAccount("integration_name",
 		api.AwsEksAuditCloudAccount,
 		api.AwsEksAuditData{
-			SnsArn: "arn:aws:sns:us-west-2:0123456789:foo-lacework-eks:00777777-ab77-1234-a123-a12ab1d12c1d",
+			SnsArn:      "arn:aws:sns:us-west-2:0123456789:foo-lacework-eks:00777777-ab77-1234-a123-a12ab1d12c1d",
+			S3BucketArn: "arn:aws:s3:::example-bucket-name",
 			Credentials: api.AwsEksAuditCredentials{
 				RoleArn:    "arn:bubu:lubu",
 				ExternalID: "abc123",
@@ -127,6 +131,7 @@ func TestCloudAccountsAwsEksAuditUpdate(t *testing.T) {
 	assert.Equal(t,
 		"arn:aws:sns:us-west-2:0123456789:foo-lacework-eks:00777777-ab77-1234-a123-a12ab1d12c1d",
 		response.Data.Data.SnsArn)
+	assert.Equal(t, "arn:aws:s3:::example-bucket-name", response.Data.Data.S3BucketArn)
 }
 
 func singleAwsEksAuditCloudAccount(id string) string {
@@ -152,6 +157,7 @@ func singleAwsEksAuditCloudAccount(id string) string {
 	"type": "AwsEksAudit",
     "data": {
       "snsArn": "arn:aws:sns:us-west-2:0123456789:foo-lacework-eks:00777777-ab77-1234-a123-a12ab1d12c1d",
+	  "s3BucketArn": "arn:aws:s3:::example-bucket-name",
       "crossAccountCredentials": {
         "externalId": "0123456789",
         "roleArn": "arn:foo:bar"


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/lacework/go-sdk) and create your branch from `main`
  2. Run `make prepare` in the repository root
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`make test`)
  5. Format your code (`make fmt`)
  6. Make sure your code lints (`make lint`)
  7. If you are updating the Lacework CLI, make sure it compiles (`make build-cli-cross-platform`)
  8. Follow the commit message standard (`type(scope): subject`) documented in [DEVELOPER_GUIDELINES.md](https://github.com/lacework/go-sdk/blob/main/DEVELOPER_GUIDELINES.md#commit-message-standard)
  9. If you haven't already, configure signed commits by [telling git about your signing key](https://docs.github.com/en/github/authenticating-to-github/managing-commit-signature-verification/telling-git-about-your-signing-key) and [signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)

  Learn more about contributing: https://github.com/lacework/go-sdk/blob/main/CONTRIBUTING.md
-->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->
AWS EKS Audit log has an additional field for a S3 Bucket ARN, this change allows the SDK to set that field when calling the API

## How did you test this change?
Added to the Unit tests
<!--
  How exactly did you verify that your PR solves the issue you wanted to solve?
  Include any other relevant information such as how to use the new functionality, screenshots, etc.
-->

## Issue

<!--
  Include the link to a Jira/Github issue
-->
https://lacework.atlassian.net/browse/GROW-1515