### PR TITLE
fix(cli): allow multiple recommendation ID types

### DIFF
--- a/api/reports.go
+++ b/api/reports.go
@@ -110,7 +110,7 @@ func (r *RecommendationV2) SeverityString() string {
 }
 
 type CloudComplianceReportV2 interface {
-	GetComplianceRecommendation(recommendationID string) RecommendationV2
+	GetComplianceRecommendation(recommendationID string) (*RecommendationV2, bool)
 }
 
 // ValidComplianceStatus is a list of all valid compliance status

--- a/api/reports_aws.go
+++ b/api/reports_aws.go
@@ -146,13 +146,13 @@ func (svc *awsReportsService) DownloadPDF(filepath string, config AwsReportConfi
 	return err
 }
 
-func (aws AwsReport) GetComplianceRecommendation(recommendationID string) RecommendationV2 {
+func (aws AwsReport) GetComplianceRecommendation(recommendationID string) (*RecommendationV2, bool) {
 	for _, r := range aws.Recommendations {
 		if r.RecID == recommendationID {
-			return r
+			return &r, true
 		}
 	}
-	return RecommendationV2{}
+	return nil, false
 }
 
 type AwsReportResponse struct {

--- a/api/reports_azure.go
+++ b/api/reports_azure.go
@@ -132,13 +132,13 @@ func (svc *azureReportsService) DownloadPDF(filepath string, config AzureReportC
 	return err
 }
 
-func (azure AzureReport) GetComplianceRecommendation(recommendationID string) RecommendationV2 {
+func (azure AzureReport) GetComplianceRecommendation(recommendationID string) (*RecommendationV2, bool) {
 	for _, r := range azure.Recommendations {
 		if r.RecID == recommendationID {
-			return r
+			return &r, true
 		}
 	}
-	return RecommendationV2{}
+	return nil, false
 }
 
 type AzureReportResponse struct {

--- a/api/reports_gcp.go
+++ b/api/reports_gcp.go
@@ -144,13 +144,13 @@ func (svc *gcpReportsService) DownloadPDF(filepath string, config GcpReportConfi
 	return err
 }
 
-func (gcp GcpReport) GetComplianceRecommendation(recommendationID string) RecommendationV2 {
+func (gcp GcpReport) GetComplianceRecommendation(recommendationID string) (*RecommendationV2, bool) {
 	for _, r := range gcp.Recommendations {
 		if r.RecID == recommendationID {
-			return r
+			return &r, true
 		}
 	}
-	return RecommendationV2{}
+	return nil, false
 }
 
 type GcpReportResponse struct {

--- a/cli/cmd/compliance.go
+++ b/cli/cmd/compliance.go
@@ -20,7 +20,6 @@ package cmd
 
 import (
 	"fmt"
-	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -432,13 +431,11 @@ func statusToProperTypes(status string) string {
 	}
 }
 
-func validRecommendationID(s string) bool {
-	match, _ := regexp.MatchString(RecommendationIDRegex, s)
-	return match
-}
-
 func outputResourcesByRecommendationID(report api.CloudComplianceReportV2) error {
-	recommendation := report.GetComplianceRecommendation(compCmdState.RecommendationID)
+	recommendation, found := report.GetComplianceRecommendation(compCmdState.RecommendationID)
+	if !found || recommendation == nil {
+		return errors.Errorf("recommendation id '%s' not found.", compCmdState.RecommendationID)
+	}
 	violations := recommendation.Violations
 	affectedResources := len(recommendation.Violations)
 

--- a/cli/cmd/compliance.go
+++ b/cli/cmd/compliance.go
@@ -61,8 +61,6 @@ var (
 		RecommendationID string
 	}{}
 
-	RecommendationIDRegex = "^[A-Z]+[A-Z_]*[0-9]*"
-
 	// complianceCmd represents the compliance command
 	complianceCmd = &cobra.Command{
 		Use:     "compliance",

--- a/cli/cmd/compliance_aws.go
+++ b/cli/cmd/compliance_aws.go
@@ -70,9 +70,6 @@ var (
 			}
 			if len(args) > 1 {
 				compCmdState.RecommendationID = args[1]
-				if !validRecommendationID(compCmdState.RecommendationID) {
-					return errors.Errorf("\n'%s' is not a valid recommendation id\n", compCmdState.RecommendationID)
-				}
 			}
 
 			// ensure we cannot have both --type and --report_name flags

--- a/cli/cmd/compliance_azure.go
+++ b/cli/cmd/compliance_azure.go
@@ -124,9 +124,6 @@ Use the following command to list all Azure Tenants configured in your account:
 
 			if len(args) > 2 {
 				compCmdState.RecommendationID = args[2]
-				if !validRecommendationID(compCmdState.RecommendationID) {
-					return errors.Errorf("\n'%s' is not a valid recommendation id\n", compCmdState.RecommendationID)
-				}
 			}
 
 			// ensure we cannot have both --type and --report_name flags

--- a/cli/cmd/compliance_gcp.go
+++ b/cli/cmd/compliance_gcp.go
@@ -126,9 +126,6 @@ Then, select one GUID from an integration and visualize its details using the co
 
 			if len(args) > 2 {
 				compCmdState.RecommendationID = args[2]
-				if !validRecommendationID(compCmdState.RecommendationID) {
-					return errors.Errorf("\n'%s' is not a valid recommendation id\n", compCmdState.RecommendationID)
-				}
 			}
 
 			// ensure we cannot have both --type and --report_name flags

--- a/cli/cmd/compliance_test.go
+++ b/cli/cmd/compliance_test.go
@@ -19,7 +19,6 @@
 package cmd
 
 import (
-	"regexp"
 	"testing"
 	"time"
 
@@ -278,31 +277,3 @@ var (
 		Recommendations: []api.RecommendationV2{mockRecommendationOne, mockRecommendationTwo},
 	}
 )
-
-func TestRecommendationIDRegex(t *testing.T) {
-	regexTests := []struct {
-		input    string
-		message  string
-		expected bool
-	}{
-		{input: "invalid", message: "recommendation id must be uppercase", expected: false},
-		{input: "", message: "recommendation id cannot be empty string", expected: false},
-		{input: "44LW_AWS_ELASTICSEARCH_3", message: "recommendation id cannot be start with a number", expected: false},
-		{input: "_LW", message: "recommendation id cannot start with underscore", expected: false},
-		{input: "LW_AWS_ELASTICSEARCH_3", message: "recommendation id must start with uppercase letter, may contain underscores and numbers", expected: true},
-		{input: "LW_AWS_NETWORKING_46", message: "recommendation id must start with uppercase letter, may contain underscores and numbers", expected: true},
-		{input: "AWS_CIS_3_3", message: "recommendation id must start with uppercase letter, may contain underscores and numbers", expected: true},
-		{input: "LW_S3_15", message: "recommendation id must start with uppercase letter, may contain underscores and numbers", expected: true},
-		{input: "GCP_CIS12_3_1", message: "recommendation id must start with uppercase letter, may contain underscores and numbers", expected: true},
-		{input: "GCP_CIS12_6_1_1", message: "recommendation id must start with uppercase letter, may contain underscores and numbers", expected: true},
-		{input: "LW_AWS_GENERAL_SECURITY_2", message: "recommendation id must start with uppercase letter, may contain underscores and numbers", expected: true},
-		{input: "Azure_CIS_131_5_1_4", message: "recommendation id must start with uppercase letter, may contain underscores and numbers", expected: true},
-	}
-
-	for _, tests := range regexTests {
-		t.Run(tests.message, func(t *testing.T) {
-			result, _ := regexp.MatchString(RecommendationIDRegex, tests.input)
-			assert.Equal(t, tests.expected, result, tests.message)
-		})
-	}
-}

--- a/cli/cmd/compliance_test.go
+++ b/cli/cmd/compliance_test.go
@@ -178,17 +178,25 @@ func TestFiltersEnabled(t *testing.T) {
 }
 
 func TestComplianceRecommendationsRecommendationID(t *testing.T) {
-	result := mockComplianceReport.GetComplianceRecommendation("LW_S3_1")
+	result, found := mockComplianceReport.GetComplianceRecommendation("LW_S3_1")
 
-	assert.NotNil(t, result)
-	assert.Equal(t, result.Status, "NonCompliant")
-	assert.Equal(t, result.AssessedResourceCount, 1)
-	assert.Equal(t, result.ResourceCount, 1)
-	assert.Equal(t, result.Category, "S3")
-	assert.Equal(t, len(result.Violations), 1)
-	assert.Equal(t, result.Violations[0].Resource, "arn:aws:s3:::resource-name")
-	assert.Equal(t, result.Violations[0].Region, "us-east-1")
-	assert.Equal(t, result.Violations[0].Reasons[0], "violation reason")
+	if assert.True(t, found) {
+		assert.NotNil(t, result)
+		assert.Equal(t, result.Status, "NonCompliant")
+		assert.Equal(t, result.AssessedResourceCount, 1)
+		assert.Equal(t, result.ResourceCount, 1)
+		assert.Equal(t, result.Category, "S3")
+		assert.Equal(t, len(result.Violations), 1)
+		assert.Equal(t, result.Violations[0].Resource, "arn:aws:s3:::resource-name")
+		assert.Equal(t, result.Violations[0].Region, "us-east-1")
+		assert.Equal(t, result.Violations[0].Reasons[0], "violation reason")
+	}
+}
+
+func TestComplianceRecommendationsRecommendationIDNotFound(t *testing.T) {
+	result, found := mockComplianceReport.GetComplianceRecommendation("1.2.3.4.5")
+	assert.False(t, found)
+	assert.Nil(t, result)
 }
 
 func clearFilters() {

--- a/integration/compliance_aws_test.go
+++ b/integration/compliance_aws_test.go
@@ -186,12 +186,10 @@ func TestComplianceAwsGetReportRecommendationID(t *testing.T) {
 
 func TestComplianceAwsGetReportRecommendationIDNotFound(t *testing.T) {
 	account := os.Getenv("LW_INT_TEST_AWS_ACC")
-	out, err, exitcode := LaceworkCLIWithTOMLConfig("compliance", "aws", "get-report", account, "rec-not-found")
-
-	assert.Empty(t, out.String(), "STDOUT should be empty")
+	_, err, exitcode := LaceworkCLIWithTOMLConfig("compliance", "aws", "get-report", account, "rec-not-found")
 	assert.Equal(t, 1, exitcode, "EXITCODE is not the expected one")
 	assert.Contains(t, err.String(), "recommendation id 'rec-not-found' not found.",
-		"STDOUT changed?, please check")
+		"STDERR changed?, please check")
 }
 
 func TestComplianceAwsSearchEmpty(t *testing.T) {

--- a/integration/compliance_aws_test.go
+++ b/integration/compliance_aws_test.go
@@ -164,7 +164,7 @@ func TestComplianceAwsGetAllReportType(t *testing.T) {
 
 func TestComplianceAwsGetReportRecommendationID(t *testing.T) {
 	account := os.Getenv("LW_INT_TEST_AWS_ACC")
-	out, err, exitcode := LaceworkCLIWithTOMLConfig("compliance", "aws", "get-report", account, "AWS_CIS_2_5")
+	out, err, exitcode := LaceworkCLIWithTOMLConfig("compliance", "aws", "get-report", account, "2.1.2")
 
 	assert.Empty(t, err.String(), "STDERR should be empty")
 	assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
@@ -182,6 +182,16 @@ func TestComplianceAwsGetReportRecommendationID(t *testing.T) {
 		"STDOUT table headers changed, please check")
 	assert.Contains(t, out.String(), "AFFECTED RESOURCES",
 		"STDOUT table headers changed, please check")
+}
+
+func TestComplianceAwsGetReportRecommendationIDNotFound(t *testing.T) {
+	account := os.Getenv("LW_INT_TEST_AWS_ACC")
+	out, err, exitcode := LaceworkCLIWithTOMLConfig("compliance", "aws", "get-report", account, "rec-not-found")
+
+	assert.Empty(t, out.String(), "STDOUT should be empty")
+	assert.Equal(t, 1, exitcode, "EXITCODE is not the expected one")
+	assert.Contains(t, err.String(), "recommendation id 'rec-not-found' not found.",
+		"STDOUT changed?, please check")
 }
 
 func TestComplianceAwsSearchEmpty(t *testing.T) {


### PR DESCRIPTION


<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/lacework/go-sdk) and create your branch from `main`
  2. Run `make prepare` in the repository root
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`make test`)
  5. Format your code (`make fmt`)
  6. Make sure your code lints (`make lint`)
  7. If you are updating the Lacework CLI, make sure it compiles (`make build-cli-cross-platform`)
  8. Follow the commit message standard (`type(scope): subject`) documented in [DEVELOPER_GUIDELINES.md](https://github.com/lacework/go-sdk/blob/main/DEVELOPER_GUIDELINES.md#commit-message-standard)
  9. If you haven't already, configure signed commits by [telling git about your signing key](https://docs.github.com/en/github/authenticating-to-github/managing-commit-signature-verification/telling-git-about-your-signing-key) and [signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)

  Learn more about contributing: https://github.com/lacework/go-sdk/blob/main/CONTRIBUTING.md
-->

## Summary

We currently have three different formats (maybe more) of Compliance recommendation IDs.

* `"REC_ID": "AWS_CIS_1_3"`
* `"REC_ID": "1.10"`
* `"REC_ID": "lacework-global-76"`

If a user tries to access the resources of the second and third format, the CLI will show the following error:

```
$ lacework compliance aws get-report <AccountID> --details 1.10

ERROR
'1.10' is not a valid recommendation id
```

This change fixes that problem by removing the regex check.

## How did you test this change?

Added tests and ran a few commands. All worked out well.

## Issue

Jira https://lacework.atlassian.net/browse/RAIN-45227
