### PR TITLE
fix: unsupported aws region

### DIFF
--- a/cli/cmd/generate_aws.go
+++ b/cli/cmd/generate_aws.go
@@ -65,7 +65,7 @@ var (
 	// AwsArnRegex original source: https://regex101.com/r/pOfxYN/1
 	AwsArnRegex = `^arn:(?P<Partition>[^:\n]*):(?P<Service>[^:\n]*):(?P<Region>[^:\n]*):(?P<AccountID>[^:\n]*):(?P<Ignore>(?P<ResourceType>[^:\/\n]*)[:\/])?(?P<Resource>.*)$`
 	// AwsRegionRegex regex used for validating region input; note intentionally does not match gov cloud
-	AwsRegionRegex  = `(us|ap|ca|cn|eu|sa)-(central|(north|south)?(east|west)?)-\d`
+	AwsRegionRegex  = `(us|ap|ca|eu|sa)-(central|(north|south)?(east|west)?)-\d`
 	AwsProfileRegex = `([A-Za-z_0-9-]+)`
 
 	GenerateAwsCommandState      = &aws.GenerateAwsTfConfigurationArgs{}

--- a/cli/cmd/generate_aws_eks_audit.go
+++ b/cli/cmd/generate_aws_eks_audit.go
@@ -73,7 +73,7 @@ var (
 	EksAuditAdvancedOptDone            = "Done"
 
 	// AwsEksAuditRegionRegex regex used for validating region input; note intentionally does not match gov cloud
-	AwsEksAuditRegionRegex = `(us|ap|ca|cn|eu|sa)-(central|(north|south)?(east|west)?)-\d`
+	AwsEksAuditRegionRegex = `(us|ap|ca|eu|sa)-(central|(north|south)?(east|west)?)-\d`
 
 	GenerateAwsEksAuditCommandState      = &aws_eks_audit.GenerateAwsEksAuditTfConfigurationArgs{}
 	GenerateAwsEksAuditCommandExtraState = &AwsEksAuditGenerateCommandExtraState{}


### PR DESCRIPTION
## Summary

Not all AWS region are supported.  The `cn` region is not supported by Lacework ingestion.

## Issue

https://github.com/lacework/services/pull/12158
