### PR TITLE
fix: vuln host scan-pkg-manifest fail_on_severity

### DIFF
--- a/cli/cmd/vuln_host_scan_package_manifest.go
+++ b/cli/cmd/vuln_host_scan_package_manifest.go
@@ -134,7 +134,7 @@ To generate a package-manifest from the local host and scan it automatically:
 				return errors.Wrap(err, "unable to request an on-demand host vulnerability scan")
 			}
 
-			if err := buildVulnHostScanPkgManifestReports(response); err != nil {
+			if err := buildVulnHostScanPkgManifestReports(&response); err != nil {
 				return err
 			}
 
@@ -160,7 +160,7 @@ To generate a package-manifest from the local host and scan it automatically:
 )
 
 // Build the cli output for vuln host scan-package-manifest
-func buildVulnHostScanPkgManifestReports(response api.VulnerabilitySoftwarePackagesResponse) error {
+func buildVulnHostScanPkgManifestReports(response *api.VulnerabilitySoftwarePackagesResponse) error {
 	response.Data = filterHostScanPackagesVulnDetails(response.Data)
 
 	if cli.JSONOutput() {
@@ -176,7 +176,7 @@ func buildVulnHostScanPkgManifestReports(response api.VulnerabilitySoftwarePacka
 	return nil
 }
 
-func hostScanPackagesVulnToTable(scan api.VulnerabilitySoftwarePackagesResponse) string {
+func hostScanPackagesVulnToTable(scan *api.VulnerabilitySoftwarePackagesResponse) string {
 	var (
 		mainBldr = &strings.Builder{}
 		rows     [][]string

--- a/cli/cmd/vuln_host_scan_package_manifest_test.go
+++ b/cli/cmd/vuln_host_scan_package_manifest_test.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"encoding/json"
+	"log"
 	"testing"
 
 	"github.com/lacework/go-sdk/api"
@@ -23,6 +25,39 @@ func TestFilterHostScanPackagesVulnDetailsFixable(t *testing.T) {
 
 	assert.Equal(t, len(res), 1)
 	assert.Equal(t, res[0].FixInfo.EvalStatus, "VULNERABLE")
+}
+
+func TestHostScanPackagesFailOnSeverity(t *testing.T) {
+	vulCmdState.FailOnSeverity = "critical"
+	defer func() {
+		vulCmdState.FailOnSeverity = ""
+	}()
+	response, err := mockVulnSoftwarePackagesResponse()
+	if err != nil {
+		log.Fatal("unable to unmarshall VulnerabilitySoftwarePackagesResponse")
+	}
+	var expectedCount int32 = 1
+	var expectedTotal int32 = 3
+
+	err = buildVulnHostScanPkgManifestReports(&response)
+	assessmentCounts := response.VulnerabilityCounts()
+	vulnPolicy := NewVulnerabilityPolicyError(
+		&assessmentCounts,
+		vulCmdState.FailOnSeverity,
+		vulCmdState.FailOnFixable,
+	)
+	nonCompliant := vulnPolicy.NonCompliant()
+
+	assert.NoError(t, err)
+	assert.Equal(t, assessmentCounts.Critical, expectedCount)
+	assert.Equal(t, assessmentCounts.Total, expectedTotal)
+	assert.True(t, nonCompliant)
+}
+
+func mockVulnSoftwarePackagesResponse() (api.VulnerabilitySoftwarePackagesResponse, error) {
+	var mock api.VulnerabilitySoftwarePackagesResponse
+	err := json.Unmarshal([]byte(mockVulnSoftwareResponse), &mock)
+	return mock, err
 }
 
 var mockVulnPackages = []api.VulnerabilitySoftwarePackage{{FixInfo: fixInfo{
@@ -56,3 +91,64 @@ type fixInfo struct {
 	MaxPrefixMatchingLenScore   int    `json:"maxPrefixMatchingLenScore"`
 	VersionInstalled            string `json:"versionInstalled"`
 }
+
+var mockVulnSoftwareResponse = `
+{"data":[
+{"osPkgInfo": {"namespace":"amzn:2","os":"amzn","osVer":"2","pkg":"python-babel","pkgVer":"0:0.9.6-8.amzn2.0.1","versionFormat":"rpm"},
+	"vulnId":"ALAS2-2023-2010","severity":"Critical","featureKey":
+		{"affectedRange": {"end":{"inclusive":false,"value":"0.9.6-8.amzn2.0.2"},"fixVersion":"0.9.6-8.amzn2.0.2",
+			"start":{"inclusive":false,"value":"#MINV#"}},
+			"name":"python-babel","namespace":"amzn:2"},
+			"cveProps":{
+				"cveBatchId":"E61EE2ABF4A948E6A4E236F243B016DE",
+				"description":"Example Description",
+				"link":"https://alas.aws.amazon.com/AL2/ALAS-2023-2010.html",
+				"metadata":{"nvd":{"cvssv2":{"publisheddatetime":"","score":0,"vectors":""},
+				"cvssv3":{"exploitabilityscore":0,"impactscore":0,"score":0,"vectors":""}}}},
+				"fixInfo":{"compareResult":1,"evalStatus":"VULNERABLE","fixAvailable":1,"fixedVersion":"0:0.9.6-8.amzn2.0.2",
+				"fixedVersionComparisonInfos":[{"currFixVer":"0.9.6-8.amzn2.0.2","isCurrFixVerGreaterThanOtherFixVer":"0","otherFixVer":"0.9.6-8.amzn2.0.2"}],
+				"fixedVersionComparisonScore":0,"maxPrefixMatchingLenScore":18,"versionInstalled":"0:0.9.6-8.amzn2.0.1"},
+				"summary":{"evalCreatedTime":"Thu, 20 Apr 2023 06:33:25 -0700","evalStatus":"MATCH_VULN","numFixableVuln":1,
+				"numFixableVulnBySeverity":{"1":0,"2":0,"3":0,"4":1,"5":0},"numTotal":1,"numVuln":1,"numVulnBySeverity":{"1":0,"2":0,"3":0,"4":1,"5":0}},
+				"props":{"evalAlgo":"1001"}},
+{"osPkgInfo":{"namespace":"amzn:2","os":"amzn","osVer":"2","pkg":"dbus","pkgVer":"1:1.10.24-7.amzn2.0.2","versionFormat":"rpm"},
+	"vulnId":"ALAS2-2023-2006","severity":"High","featureKey":
+		{"affectedRange":{"end":{"inclusive":false,"value":"1:1.10.24-7.amzn2.0.3"},
+				"fixVersion":"1:1.10.24-7.amzn2.0.3","start":{"inclusive":false,"value":"#MINV#"}},"name":"dbus","namespace":"amzn:2"},
+				"cveProps":{"cveBatchId":"E61EE2ABF4A948E6A4E236F243B016DE","description":"Example Description",
+				"link":"https://alas.aws.amazon.com/AL2/ALAS-2023-2006.html","metadata":{"nvd":{"cvssv2":{"publisheddatetime":"","score":0,"vectors":""},"cvssv3":{"exploitabilityscore":0,"impactscore":0,"score":0,"vectors":""}}}},
+				"fixInfo":{"compareResult":1,"evalStatus":"VULNERABLE","fixAvailable":1,"fixedVersion":"1:1.10.24-7.amzn2.0.3",
+				"fixedVersionComparisonInfos":[{"currFixVer":"1:1.10.24-7.amzn2.0.3","isCurrFixVerGreaterThanOtherFixVer":"0","otherFixVer":"1:1.10.24-7.amzn2.0.3"}],
+				"fixedVersionComparisonScore":0,"maxPrefixMatchingLenScore":20,"versionInstalled":"1:1.10.24-7.amzn2.0.2"},
+				"summary":{"evalCreatedTime":"Thu, 20 Apr 2023 06:33:25 -0700","evalStatus":"MATCH_VULN","numFixableVuln":1,
+				"numFixableVulnBySeverity":{"1":0,"2":0,"3":0,"4":1,"5":0},"numTotal":2,"numVuln":1,
+				"numVulnBySeverity":{"1":0,"2":0,"3":0,"4":1,"5":0}},
+				"props":{"evalAlgo":"1001"}},
+{"osPkgInfo":{"namespace":"amzn:2","os":"amzn","osVer":"2","pkg":"dbus","pkgVer":"1:1.10.24-7.amzn2.0.2","versionFormat":"rpm"},
+	"vulnId":"ALAS2-2023-2006","severity":"Critical","featureKey":
+		{"affectedRange":{"end":{"inclusive":false,"value":"1:1.10.24-7.amzn2.0.3"},
+				"fixVersion":"1:1.10.24-7.amzn2.0.3","start":{"inclusive":false,"value":"#MINV#"}},"name":"dbus","namespace":"amzn:2"},
+				"cveProps":{"cveBatchId":"E61EE2ABF4A948E6A4E236F243B016DE","description":"Example Description",
+				"link":"https://alas.aws.amazon.com/AL2/ALAS-2023-2006.html","metadata":{"nvd":{"cvssv2":{"publisheddatetime":"","score":0,"vectors":""},"cvssv3":{"exploitabilityscore":0,"impactscore":0,"score":0,"vectors":""}}}},
+				"fixInfo":{"compareResult":1,"evalStatus":"GOOD","fixAvailable":1,"fixedVersion":"1:1.10.24-7.amzn2.0.3",
+				"fixedVersionComparisonInfos":[{"currFixVer":"1:1.10.24-7.amzn2.0.3","isCurrFixVerGreaterThanOtherFixVer":"0","otherFixVer":"1:1.10.24-7.amzn2.0.3"}],
+				"fixedVersionComparisonScore":0,"maxPrefixMatchingLenScore":20,"versionInstalled":"1:1.10.24-7.amzn2.0.2"},
+				"summary":{"evalCreatedTime":"Thu, 20 Apr 2023 06:33:25 -0700","evalStatus":"MATCH_VULN","numFixableVuln":1,
+				"numFixableVulnBySeverity":{"1":0,"2":0,"3":0,"4":1,"5":0},"numTotal":2,"numVuln":1,
+				"numVulnBySeverity":{"1":0,"2":0,"3":0,"4":1,"5":0}},
+				"props":{"evalAlgo":"1001"}},
+{"osPkgInfo":{"namespace":"amzn:2","os":"amzn","osVer":"2","pkg":"vim-data","pkgVer":"2:9.0.1367-1.amzn2.0.1","versionFormat":"rpm"},
+	"vulnId":"ALAS2-2023-2005","severity":"Medium","featureKey":
+		{"affectedRange":{"end":{"inclusive":false,"value":"2:9.0.1403-1.amzn2.0.1"},
+				"fixVersion":"2:9.0.1403-1.amzn2.0.1","start":{"inclusive":false,"value":"#MINV#"}},
+				"name":"vim-data","namespace":"amzn:2"},"cveProps":{"cveBatchId":"E61EE2ABF4A948E6A4E236F243B016DE",
+				"description":"Example Description.","link":"https://alas.aws.amazon.com/AL2/ALAS-2023-2005.html",
+				"metadata":{"nvd":{"cvssv2":{"publisheddatetime":"","score":0,"vectors":""},"cvssv3":{"exploitabilityscore":0,"impactscore":0,"score":0,"vectors":""}}}},
+				"fixInfo":{"compareResult":1,"evalStatus":"VULNERABLE","fixAvailable":1,"fixedVersion":"2:9.0.1403-1.amzn2.0.1",
+				"fixedVersionComparisonInfos":[{"currFixVer":"2:9.0.1403-1.amzn2.0.1","isCurrFixVerGreaterThanOtherFixVer":"0","otherFixVer":"2:9.0.1403-1.amzn2.0.1"}],
+				"fixedVersionComparisonScore":0,"maxPrefixMatchingLenScore":7,"versionInstalled":"2:9.0.1367-1.amzn2.0.1"},
+				"summary":{"evalCreatedTime":"Thu, 20 Apr 2023 06:33:25 -0700","evalStatus":"MATCH_VULN","numFixableVuln":1,
+				"numFixableVulnBySeverity":{"1":0,"2":0,"3":0,"4":1,"5":0},"numTotal":12,"numVuln":1,
+				"numVulnBySeverity":{"1":0,"2":0,"3":0,"4":1,"5":0}},
+				"props":{"evalAlgo":"1001"}}]}
+`


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/lacework/go-sdk) and create your branch from `main`
  2. Run `make prepare` in the repository root
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`make test`)
  5. Format your code (`make fmt`)
  6. Make sure your code lints (`make lint`)
  7. If you are updating the Lacework CLI, make sure it compiles (`make build-cli-cross-platform`)
  8. Follow the commit message standard (`type(scope): subject`) documented in [DEVELOPER_GUIDELINES.md](https://github.com/lacework/go-sdk/blob/main/DEVELOPER_GUIDELINES.md#commit-message-standard)
  9. If you haven't already, configure signed commits by [telling git about your signing key](https://docs.github.com/en/github/authenticating-to-github/managing-commit-signature-verification/telling-git-about-your-signing-key) and [signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)

  Learn more about contributing: https://github.com/lacework/go-sdk/blob/main/CONTRIBUTING.md
-->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

The `VulnerabilityCounts()` used in the fail_on_severity evaluation are using the unfiltered results, eg. when vuln status is 'GOOD'. This change passes the response as a pointer so results are filtered when VulnerabilityCounts() is called.


## How did you test this change?

<!--
  How exactly did you verify that your PR solves the issue you wanted to solve?
  Include any other relevant information such as how to use the new functionality, screenshots, etc.
-->
Tests
- [x] `TestHostScanPackagesFailOnSeverity`

Manual
Run `lacework vuln host scan-pkg-manifest` against manifest from amzn2-ami-hvm-2.0.20230320.0-x86_64-gp2 
* see manifest.json on LINK-1587 attachments

## Issue

<!--
  Include the link to a Jira/Github issue
-->
https://lacework.atlassian.net/browse/LINK-1587
