### PR TITLE
feat (RAIN-54797) Add account mapping for aws and gcp sidekick in api

### DIFF
--- a/api/cloud_accounts_aws_sidekick_org.go
+++ b/api/cloud_accounts_aws_sidekick_org.go
@@ -18,6 +18,12 @@
 
 package api
 
+import (
+	"encoding/base64"
+	"fmt"
+	"strings"
+)
+
 // GetAwsSidekickOrg gets a single AwsSidekickOrg integration matching the provided integration guid
 func (svc *CloudAccountsService) GetAwsSidekickOrg(guid string) (
 	response AwsSidekickOrgResponse,
@@ -70,7 +76,29 @@ type AwsSidekickOrgData struct {
 	ManagementAccount string `json:"managementAccount,omitempty"`
 	MonitoredAccounts string `json:"monitoredAccounts"`
 
-	AccountID         string                             `json:"awsAccountId,omitempty"`
-	BucketArn         string                             `json:"bucketArn,omitempty"`
-	CrossAccountCreds AwsSidekickCrossAccountCredentials `json:"crossAccountCredentials"`
+	AccountID          string                             `json:"awsAccountId,omitempty"`
+	BucketArn          string                             `json:"bucketArn,omitempty"`
+	CrossAccountCreds  AwsSidekickCrossAccountCredentials `json:"crossAccountCredentials"`
+	AccountMappingFile string                             `json:"accountMappingFile,omitempty"`
+}
+
+func (aws *AwsSidekickOrgData) EncodeAccountMappingFile(mapping []byte) {
+	encodedMappings := base64.StdEncoding.EncodeToString(mapping)
+	aws.AccountMappingFile = fmt.Sprintf("data:application/json;name=i.json;base64,%s", encodedMappings)
+}
+
+func (aws *AwsSidekickOrgData) DecodeAccountMappingFile() ([]byte, error) {
+	if len(aws.AccountMappingFile) == 0 {
+		return []byte{}, nil
+	}
+
+	var (
+		b64      = strings.Split(aws.AccountMappingFile, ",")
+		raw, err = base64.StdEncoding.DecodeString(b64[1])
+	)
+	if err != nil {
+		return []byte{}, err
+	}
+
+	return raw, nil
 }

--- a/api/cloud_accounts_aws_sidekick_org_test.go
+++ b/api/cloud_accounts_aws_sidekick_org_test.go
@@ -30,13 +30,30 @@ import (
 )
 
 func TestCloudAccountsNewAwsSidekickOrgWithCustomTemplateFile(t *testing.T) {
+	accountMappingJSON := []byte(`{
+		"defaultLaceworkAccountAws": "lw_account_1",
+		"integration_mappings": {
+		  "lw_account_2": {
+			"aws_accounts": [
+			  "234556677",
+			  "774564564"
+			]
+		  },
+		  "lw_account_3": {
+			"aws_accounts": [
+			  "553453453",
+			  "934534535"
+			]
+		  }
+		}
+	  }`)
 	awsSidekickOrgData := api.AwsSidekickOrgData{
 		CrossAccountCreds: api.AwsSidekickCrossAccountCredentials{
 			RoleArn:    "arn:foo:bar",
 			ExternalID: "0123456789",
 		},
 	}
-
+	awsSidekickOrgData.EncodeAccountMappingFile(accountMappingJSON)
 	subject := api.NewCloudAccount("integration_name", api.AwsSidekickOrgCloudAccount, awsSidekickOrgData)
 	assert.Equal(t, api.AwsSidekickOrgCloudAccount.String(), subject.Type)
 
@@ -45,6 +62,21 @@ func TestCloudAccountsNewAwsSidekickOrgWithCustomTemplateFile(t *testing.T) {
 
 	assert.Equal(t, subjectData.CrossAccountCreds.RoleArn, "arn:foo:bar")
 	assert.Equal(t, subjectData.CrossAccountCreds.ExternalID, "0123456789")
+	assert.Contains(t,
+		subjectData.AccountMappingFile,
+		"data:application/json;name=i.json;base64,",
+		"check the custom_template_file encoder",
+	)
+	accountMapping, err := subjectData.DecodeAccountMappingFile()
+	assert.Nil(t, err)
+	assert.Equal(t, accountMappingJSON, accountMapping)
+
+	// When there is no custom account mapping file, this function should
+	// return an empty string to match the pattern
+	subjectData.AccountMappingFile = ""
+	accountMapping, err = subjectData.DecodeAccountMappingFile()
+	assert.Nil(t, err)
+	assert.Empty(t, accountMapping)
 }
 
 func TestCloudAccountsAwsSidekickOrgGet(t *testing.T) {


### PR DESCRIPTION
# Summary
This is part of a new feature that will allow Agentless Workload Scanning customers take advantage of Lacework Organizations. This enables customers with an organization deployment (on either GCP or AWS) to add an optional account mapping file which we handle on the back end to direct data to specific Lacework sub-accounts in accordance with the file.

# How did you test this change?
I verified this via unit testing (see added tests)

# Issue
https://lacework.atlassian.net/browse/RAIN-54797