### PR TITLE
fix: ctr list-assessments not fetching latest results

### DIFF
--- a/cli/cmd/vuln_container_list_assessments_test.go
+++ b/cli/cmd/vuln_container_list_assessments_test.go
@@ -21,7 +21,9 @@ package cmd
 import (
 	"fmt"
 	"testing"
+	"time"
 
+	"github.com/lacework/go-sdk/api"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -72,5 +74,55 @@ func TestGenerateContainerVulnListCacheKey(t *testing.T) {
 
 			assert.Equal(t, kase.expectedCacheKey, generateContainerVulnListCacheKey())
 		})
+	}
+}
+
+func TestTreeCtrVulnParseData(t *testing.T) {
+	oldTime := time.Now().Add(-time.Hour * 24)
+	newTime := time.Now().Add(-time.Hour * 1)
+	mockData := mockVulnCtrData(oldTime, newTime)
+
+	v := treeCtrVuln{}
+	v.ParseData(mockData)
+
+	assert.Equal(t, len(v.ListEvalGuid()), 3)
+	// ensure Parse Data returns latest
+	res, exists := v.Get("1")
+	assert.True(t, exists)
+	assert.Equal(t, res.StartTime, newTime)
+}
+
+func mockVulnCtrData(old time.Time, latest time.Time) []api.VulnerabilityContainer {
+	return []api.VulnerabilityContainer{
+		{
+			EvalGUID:  "1",
+			ImageID:   "1",
+			StartTime: old,
+		},
+		{
+			EvalGUID:  "2",
+			ImageID:   "1",
+			StartTime: latest,
+		},
+		{
+			EvalGUID:  "3",
+			ImageID:   "2",
+			StartTime: latest,
+		},
+		{
+			EvalGUID:  "4",
+			ImageID:   "2",
+			StartTime: old,
+		},
+		{
+			EvalGUID:  "5",
+			ImageID:   "2",
+			StartTime: old,
+		},
+		{
+			EvalGUID:  "6",
+			ImageID:   "3",
+			StartTime: latest,
+		},
 	}
 }


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/lacework/go-sdk) and create your branch from `main`
  2. Run `make prepare` in the repository root
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`make test`)
  5. Format your code (`make fmt`)
  6. Make sure your code lints (`make lint`)
  7. If you are updating the Lacework CLI, make sure it compiles (`make build-cli-cross-platform`)
  8. Follow the commit message standard (`type(scope): subject`) documented in [DEVELOPER_GUIDELINES.md](https://github.com/lacework/go-sdk/blob/main/DEVELOPER_GUIDELINES.md#commit-message-standard)
  9. If you haven't already, configure signed commits by [telling git about your signing key](https://docs.github.com/en/github/authenticating-to-github/managing-commit-signature-verification/telling-git-about-your-signing-key) and [signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)

  Learn more about contributing: https://github.com/lacework/go-sdk/blob/main/CONTRIBUTING.md
-->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

Issue in the `treeCtrVuln.ParseData` func, the slice of ctrVuln was not being updated by:
``` 
if ctr.StartTime.After(latestContainer.StartTime) {
  latestContainer.StartTime = ctr.StartTime
  latestContainer.EvalGUID = ctr.EvalGUID
}
```

This change adds a new func `treeCtrVuln.Replace` to correctly update the slice with new value. And ensure latest results are returned.

## How did you test this change?

Manual
- [x] Run `lacework vuln ctr list-assessments` and ensure last scan field is showing the latest result

Test
- [x] TestTreeCtrVulnParseData

<!--
  How exactly did you verify that your PR solves the issue you wanted to solve?
  Include any other relevant information such as how to use the new functionality, screenshots, etc.
-->

## Issue

<!--
  Include the link to a Jira/Github issue
-->

https://lacework.atlassian.net/browse/LINK-1614
