### PR TITLE
feat: host vuln time range flags

### DIFF
--- a/cli/cmd/vuln_host.go
+++ b/cli/cmd/vuln_host.go
@@ -86,6 +86,10 @@ func init() {
 		vulHostShowAssessmentCmd.Flags(),
 	)
 
+	setTimeRangeFlags(
+		vulHostListHostsCmd.Flags(),
+	)
+
 	// the package manifest file
 	vulHostScanPkgManifestCmd.Flags().StringVarP(&pkgManifestFile,
 		"file", "f", "",

--- a/cli/cmd/vuln_host_list_hosts.go
+++ b/cli/cmd/vuln_host_list_hosts.go
@@ -20,6 +20,7 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/lacework/go-sdk/lwtime"
 	"sort"
 	"strconv"
 	"strings"
@@ -48,21 +49,47 @@ To list the CVEs found in the hosts of your environment run:
 
     lacework vulnerability host list-cves`,
 		RunE: func(_ *cobra.Command, args []string) error {
-			now := time.Now().UTC()
-			start := now.AddDate(0, 0, -1)
-			filter := api.SearchFilter{
-				TimeFilter: &api.TimeFilter{
-					StartTime: &start,
-					EndTime:   &now,
-				},
-				Filters: []api.Filter{
-					{Expression: "eq",
-						Field: "vulnId",
-						Value: args[0]},
-					{Expression: "ne",
-						Field: "status",
-						Value: "Fixed"},
-				}}
+			var (
+				filter api.SearchFilter
+				start  time.Time
+				end    time.Time
+				err    error
+			)
+
+			if vulCmdState.Range != "" {
+				cli.Log.Debugw("retrieving natural time range", "range", vulCmdState.Range)
+				start, end, err = lwtime.ParseNatural(vulCmdState.Range)
+				if err != nil {
+					return errors.Wrap(err, "unable to parse natural time range")
+				}
+
+			} else {
+				cli.Log.Debugw("parsing start time", "start", vulCmdState.Start)
+				start, err = parseQueryTime(vulCmdState.Start)
+				if err != nil {
+					return errors.Wrap(err, "unable to parse start time")
+				}
+
+				cli.Log.Debugw("parsing end time", "end", vulCmdState.End)
+				end, err = parseQueryTime(vulCmdState.End)
+				if err != nil {
+					return errors.Wrap(err, "unable to parse end time")
+				}
+			}
+
+			filter.TimeFilter = &api.TimeFilter{
+				StartTime: &start,
+				EndTime:   &end,
+			}
+
+			filter.Filters = []api.Filter{
+				{Expression: "eq",
+					Field: "vulnId",
+					Value: args[0]},
+				{Expression: "ne",
+					Field: "status",
+					Value: "Fixed"},
+			}
 
 			cli.StartProgress("Fetching Hosts...")
 			response, err := cli.LwApi.V2.Vulnerabilities.Hosts.SearchAllPages(filter)

--- a/cli/cmd/vulnerability.go
+++ b/cli/cmd/vulnerability.go
@@ -231,6 +231,23 @@ func setActiveFlag(cmds ...*flag.FlagSet) {
 	}
 }
 
+func setTimeRangeFlags(cmds ...*flag.FlagSet) {
+	for _, cmd := range cmds {
+		if cmd != nil {
+
+			cmd.StringVar(&vulCmdState.Start,
+				"start", "-24h", "start of the time range",
+			)
+			cmd.StringVar(&vulCmdState.End,
+				"end", "now", "end of the time range",
+			)
+			cmd.StringVar(&vulCmdState.Range,
+				"range", "", "natural time range for query",
+			)
+		}
+	}
+}
+
 func buildVulnContainerAssessmentReportTable(summary string, details string) string {
 	report := &strings.Builder{}
 


### PR DESCRIPTION
## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## How did you test this change?

Manual testing

```
> date
Tue  9 May 2023 16:23:24 BST

> lacework vulnerability host list-hosts CVE-2021-4034 --range "last 5 days" --debug
...
.. "body":"{\"timeFilter\":{\"startTime\":\"2023-05-04T15:23:56.07582Z\",\"endTime\":\"2023-05-09T15:23:54.07582Z\"},\"filters\":[{\"expression\":\"eq\",\"field\":\"vulnId\",\"value\":\"CVE-2021-4034\"},{\"expression\":\"ne\",\"field\":\"status\",\"value\":\"Fixed\"}]}\n"}

> lacework vulnerability host list-hosts CVE-2021-4034 --start -48h --end -24h --debug
...
.. "body":"{\"timeFilter\":{\"startTime\":\"2023-05-07T15:24:28.732009Z\",\"endTime\":\"2023-05-08T15:24:28.732034Z\"},\"filters\":[{\"expression\":\"eq\",\"field\":\"vulnId\",\"value\":\"CVE-2021-4034\"},{\"expression\":\"ne\",\"field\":\"status\",\"value\":\"Fixed\"}]}\n"}

```

## Issue

https://lacework.atlassian.net/browse/GROW-1485