### PR TITLE
add ScanMultiVolume bool field to Agentless integrations

### DIFF
--- a/api/cloud_accounts_aws_sidekick.go
+++ b/api/cloud_accounts_aws_sidekick.go
@@ -69,6 +69,7 @@ type AwsSidekickData struct {
 
 	ScanContainers          bool `json:"scanContainers"`
 	ScanHostVulnerabilities bool `json:"scanHostVulnerabilities"`
+	ScanMultiVolume         bool `json:"scanMultiVolume"`
 
 	AccountID         string                             `json:"awsAccountId,omitempty"`
 	BucketArn         string                             `json:"bucketArn,omitempty"`

--- a/api/cloud_accounts_aws_sidekick.go
+++ b/api/cloud_accounts_aws_sidekick.go
@@ -70,6 +70,7 @@ type AwsSidekickData struct {
 	ScanContainers          bool `json:"scanContainers"`
 	ScanHostVulnerabilities bool `json:"scanHostVulnerabilities"`
 	ScanMultiVolume         bool `json:"scanMultiVolume"`
+	ScanStoppedInstances    bool `json:"scanStoppedInstances"`
 
 	AccountID         string                             `json:"awsAccountId,omitempty"`
 	BucketArn         string                             `json:"bucketArn,omitempty"`

--- a/api/cloud_accounts_aws_sidekick_org.go
+++ b/api/cloud_accounts_aws_sidekick_org.go
@@ -71,6 +71,7 @@ type AwsSidekickOrgData struct {
 	ScanContainers          bool `json:"scanContainers"`
 	ScanHostVulnerabilities bool `json:"scanHostVulnerabilities"`
 	ScanMultiVolume         bool `json:"scanMultiVolume"`
+	ScanStoppedInstances    bool `json:"scanStoppedInstances"`
 
 	//Properties specific to the AWS organization integration type
 	ScanningAccount   string `json:"scanningAccount"`

--- a/api/cloud_accounts_aws_sidekick_org.go
+++ b/api/cloud_accounts_aws_sidekick_org.go
@@ -70,6 +70,7 @@ type AwsSidekickOrgData struct {
 
 	ScanContainers          bool `json:"scanContainers"`
 	ScanHostVulnerabilities bool `json:"scanHostVulnerabilities"`
+	ScanMultiVolume         bool `json:"scanMultiVolume"`
 
 	//Properties specific to the AWS organization integration type
 	ScanningAccount   string `json:"scanningAccount"`

--- a/api/cloud_accounts_gcp_sidekick.go
+++ b/api/cloud_accounts_gcp_sidekick.go
@@ -76,11 +76,13 @@ type GcpSidekickData struct {
 	FilterList        string `json:"filterList,omitempty"`
 	QueryText         string `json:"queryText,omitempty"`
 	//ScanFrequency in hours, 24 == 24 hours
-	ScanFrequency           int    `json:"scanFrequency"`
-	ScanContainers          bool   `json:"scanContainers"`
-	ScanHostVulnerabilities bool   `json:"scanHostVulnerabilities"`
-	ScanMultiVolume         bool   `json:"scanMultiVolume"`
-	AccountMappingFile      string `json:"accountMappingFile,omitempty"`
+	ScanFrequency           int  `json:"scanFrequency"`
+	ScanContainers          bool `json:"scanContainers"`
+	ScanHostVulnerabilities bool `json:"scanHostVulnerabilities"`
+	ScanMultiVolume         bool `json:"scanMultiVolume"`
+	ScanStoppedInstances    bool `json:"scanStoppedInstances"`
+
+	AccountMappingFile string `json:"accountMappingFile,omitempty"`
 }
 
 type GcpSidekickCredentials struct {

--- a/api/cloud_accounts_gcp_sidekick.go
+++ b/api/cloud_accounts_gcp_sidekick.go
@@ -79,6 +79,7 @@ type GcpSidekickData struct {
 	ScanFrequency           int    `json:"scanFrequency"`
 	ScanContainers          bool   `json:"scanContainers"`
 	ScanHostVulnerabilities bool   `json:"scanHostVulnerabilities"`
+	ScanMultiVolume         bool   `json:"scanMultiVolume"`
 	AccountMappingFile      string `json:"accountMappingFile,omitempty"`
 }
 


### PR DESCRIPTION
## Summary
This is part of the work of multi-volume (secondary volume) and stopped instances scanning features for agentless workload scanning. We are finishing up the feature by adding a toggle / boolean for integrations to indicate if they want to turn on Multi-Volume scanning and/or Stopped Instances scanning. This is handled on the backend (in sidekick) to "turn on" the feature if the boolean is set to true. 

## How did you test this change?

Tested via unit tests

## Issue
https://lacework.atlassian.net/browse/RAIN-54831
