### PR TITLE
fix(cli): Inconsistent results from host vuln show

### DIFF
--- a/api/v2_vulnerabilities.go
+++ b/api/v2_vulnerabilities.go
@@ -631,7 +631,7 @@ func (hosts *VulnerabilitiesHostResponse) VulnerabilityCounts() HostVulnCounts {
 
 	for _, h := range hosts.Data {
 		// avoid counting duplicates
-		if h.VulnID == "" || array.ContainsStr(cves, h.VulnID) {
+		if h.VulnID != "" && array.ContainsStr(cves, h.VulnID) {
 			continue
 		}
 		cves = append(cves, h.VulnID)

--- a/api/v2_vulnerabilities.go
+++ b/api/v2_vulnerabilities.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/lacework/go-sdk/internal/array"
 	"github.com/lacework/go-sdk/lwseverity"
 )
 
@@ -456,7 +457,6 @@ type VulnerabilityHost struct {
 		Link        string                     `json:"link"`
 		Metadata    *VulnerabilityHostMetadata `json:"metadata,omitempty"`
 	} `json:"cveProps"`
-	EndTime time.Time `json:"endTime"`
 	EvalCtx struct {
 		ExceptionProps []interface{} `json:"exception_props"`
 		Hostname       string        `json:"hostname"`
@@ -486,6 +486,8 @@ type VulnerabilityHost struct {
 	Mid         int                    `json:"mid"`
 	Severity    string                 `json:"severity"`
 	StartTime   time.Time              `json:"startTime"`
+	EndTime     time.Time              `json:"endTime"`
+	EvalGUID    string                 `json:"evalGuid"`
 	Status      string                 `json:"status"`
 	VulnID      string                 `json:"vulnId"`
 }
@@ -622,10 +624,18 @@ func (v *VulnerabilityHost) HasFix() bool {
 }
 
 func (hosts *VulnerabilitiesHostResponse) VulnerabilityCounts() HostVulnCounts {
-	var hostCounts = HostVulnCounts{}
+	var (
+		hostCounts = HostVulnCounts{}
+		cves       []string
+	)
 
-	// remove duplicates before count.
 	for _, h := range hosts.Data {
+		// avoid counting duplicates
+		if h.VulnID == "" || array.ContainsStr(cves, h.VulnID) {
+			continue
+		}
+		cves = append(cves, h.VulnID)
+
 		switch h.Severity {
 		case "Critical":
 			hostCounts.Critical++

--- a/cli/cmd/vuln_host_show_assessment.go
+++ b/cli/cmd/vuln_host_show_assessment.go
@@ -118,7 +118,7 @@ Grab a CVE id and feed it to the command:
 				filter.Filters = append(filter.Filters, api.Filter{
 					Expression: "eq",
 					Field:      "evalGuid",
-					Value:      "c147082bf2b571841a0a24c4d7efff92",
+					Value:      evalGUID,
 				})
 
 				cli.StartProgress(

--- a/cli/cmd/vuln_host_show_assessment_test.go
+++ b/cli/cmd/vuln_host_show_assessment_test.go
@@ -1,0 +1,42 @@
+package cmd
+
+import (
+	"github.com/lacework/go-sdk/api"
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+func TestGetUniqueHostEvalGUID(t *testing.T) {
+	expectedEvalGUID := "12345"
+	actualEvalGUID := getUniqueHostEvalGUID(mockVulnerabilitiesHostResponse(expectedEvalGUID))
+
+	assert.Equal(t, expectedEvalGUID, actualEvalGUID)
+}
+
+func mockVulnerabilitiesHostResponse(evalGUID string) api.VulnerabilitiesHostResponse {
+	return api.VulnerabilitiesHostResponse{
+		Data: []api.VulnerabilityHost{
+			{
+				EvalGUID:  "54321",
+				StartTime: time.Now().AddDate(0, 0, -2),
+			},
+			{
+				EvalGUID:  "54321",
+				StartTime: time.Now().AddDate(0, 0, -2),
+			},
+			{
+				EvalGUID:  evalGUID,
+				StartTime: time.Now(),
+			},
+			{
+				EvalGUID:  "98765",
+				StartTime: time.Now().AddDate(0, 0, -1),
+			},
+			{
+				EvalGUID:  evalGUID,
+				StartTime: time.Now(),
+			},
+		},
+	}
+}

--- a/cli/cmd/vuln_host_show_assessment_test.go
+++ b/cli/cmd/vuln_host_show_assessment_test.go
@@ -1,10 +1,11 @@
 package cmd
 
 import (
-	"github.com/lacework/go-sdk/api"
-	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"
+
+	"github.com/lacework/go-sdk/api"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGetUniqueHostEvalGUID(t *testing.T) {

--- a/cli/cmd/vuln_host_test.go
+++ b/cli/cmd/vuln_host_test.go
@@ -387,7 +387,6 @@ func mockHostVulnerabilityAssessment() api.VulnerabilitiesHostResponse {
     },
     "data": [
         {
-						"vulnId": "CVE-1",
             "cveProps": {
                 "metadata": {}
             },
@@ -428,7 +427,6 @@ func mockHostVulnerabilityAssessment() api.VulnerabilitiesHostResponse {
             "startTime": "2022-09-23T03:00:00.000Z"
         },
         {
-						"vulnId": "CVE-2",
             "cveProps": {
                 "metadata": {}
             },
@@ -469,7 +467,6 @@ func mockHostVulnerabilityAssessment() api.VulnerabilitiesHostResponse {
             "startTime": "2022-09-23T03:00:00.000Z"
         },
         {
-						"vulnId": "CVE-3",
             "cveProps": {
                 "metadata": {}
             },
@@ -510,7 +507,6 @@ func mockHostVulnerabilityAssessment() api.VulnerabilitiesHostResponse {
             "startTime": "2022-09-23T03:00:00.000Z"
         },
         {
-						"vulnId": "CVE-4",
             "cveProps": {
                 "metadata": {}
             },
@@ -813,7 +809,6 @@ func mockHostVulnerabilityAssessment() api.VulnerabilitiesHostResponse {
             "vulnId": "CVE-2022-0351"
         },
         {
-						"vulnId": "CVE-5",
             "cveProps": {
                 "metadata": {}
             },
@@ -854,7 +849,6 @@ func mockHostVulnerabilityAssessment() api.VulnerabilitiesHostResponse {
             "startTime": "2022-09-23T03:00:00.000Z"
         },
         {
-						"vulnId": "CVE-6",
             "cveProps": {
                 "metadata": {}
             },
@@ -895,7 +889,6 @@ func mockHostVulnerabilityAssessment() api.VulnerabilitiesHostResponse {
             "startTime": "2022-09-23T03:00:00.000Z"
         },
         {
-						"vulnId": "CVE-7",
             "cveProps": {
                 "metadata": {}
             },
@@ -1001,7 +994,6 @@ func mockHostVulnerabilityAssessment() api.VulnerabilitiesHostResponse {
             "vulnId": "CVE-2022-2129"
         },
         {
-						"vulnId": "CVE-8",
             "cveProps": {
                 "metadata": {}
             },
@@ -1042,7 +1034,6 @@ func mockHostVulnerabilityAssessment() api.VulnerabilitiesHostResponse {
             "startTime": "2022-09-23T03:00:00.000Z"
         },
         {
-						"vulnId": "CVE-9",
             "cveProps": {
                 "metadata": {}
             },
@@ -1083,7 +1074,6 @@ func mockHostVulnerabilityAssessment() api.VulnerabilitiesHostResponse {
             "startTime": "2022-09-23T03:00:00.000Z"
         },
         {
-						"vulnId": "CVE-10",
             "cveProps": {
                 "metadata": {}
             },
@@ -1124,7 +1114,6 @@ func mockHostVulnerabilityAssessment() api.VulnerabilitiesHostResponse {
             "startTime": "2022-09-23T03:00:00.000Z"
         },
         {
-						"vulnId": "CVE-11",
             "cveProps": {
                 "metadata": {}
             },
@@ -1296,7 +1285,6 @@ func mockHostVulnerabilityAssessment() api.VulnerabilitiesHostResponse {
             "vulnId": "CVE-2020-13988"
         },
         {
-						"vulnId": "CVE-12",
             "cveProps": {
                 "metadata": {}
             },
@@ -1337,7 +1325,6 @@ func mockHostVulnerabilityAssessment() api.VulnerabilitiesHostResponse {
             "startTime": "2022-09-23T03:00:00.000Z"
         },
         {
-						"vulnId": "CVE-13",
             "cveProps": {
                 "metadata": {}
             },
@@ -1378,7 +1365,6 @@ func mockHostVulnerabilityAssessment() api.VulnerabilitiesHostResponse {
             "startTime": "2022-09-23T03:00:00.000Z"
         },
         {
-						"vulnId": "CVE-14",
             "cveProps": {
                 "metadata": {}
             },

--- a/cli/cmd/vuln_host_test.go
+++ b/cli/cmd/vuln_host_test.go
@@ -387,6 +387,7 @@ func mockHostVulnerabilityAssessment() api.VulnerabilitiesHostResponse {
     },
     "data": [
         {
+						"vulnId": "CVE-1",
             "cveProps": {
                 "metadata": {}
             },
@@ -427,6 +428,7 @@ func mockHostVulnerabilityAssessment() api.VulnerabilitiesHostResponse {
             "startTime": "2022-09-23T03:00:00.000Z"
         },
         {
+						"vulnId": "CVE-2",
             "cveProps": {
                 "metadata": {}
             },
@@ -467,6 +469,7 @@ func mockHostVulnerabilityAssessment() api.VulnerabilitiesHostResponse {
             "startTime": "2022-09-23T03:00:00.000Z"
         },
         {
+						"vulnId": "CVE-3",
             "cveProps": {
                 "metadata": {}
             },
@@ -507,6 +510,7 @@ func mockHostVulnerabilityAssessment() api.VulnerabilitiesHostResponse {
             "startTime": "2022-09-23T03:00:00.000Z"
         },
         {
+						"vulnId": "CVE-4",
             "cveProps": {
                 "metadata": {}
             },
@@ -809,6 +813,7 @@ func mockHostVulnerabilityAssessment() api.VulnerabilitiesHostResponse {
             "vulnId": "CVE-2022-0351"
         },
         {
+						"vulnId": "CVE-5",
             "cveProps": {
                 "metadata": {}
             },
@@ -849,6 +854,7 @@ func mockHostVulnerabilityAssessment() api.VulnerabilitiesHostResponse {
             "startTime": "2022-09-23T03:00:00.000Z"
         },
         {
+						"vulnId": "CVE-6",
             "cveProps": {
                 "metadata": {}
             },
@@ -889,6 +895,7 @@ func mockHostVulnerabilityAssessment() api.VulnerabilitiesHostResponse {
             "startTime": "2022-09-23T03:00:00.000Z"
         },
         {
+						"vulnId": "CVE-7",
             "cveProps": {
                 "metadata": {}
             },
@@ -994,6 +1001,7 @@ func mockHostVulnerabilityAssessment() api.VulnerabilitiesHostResponse {
             "vulnId": "CVE-2022-2129"
         },
         {
+						"vulnId": "CVE-8",
             "cveProps": {
                 "metadata": {}
             },
@@ -1034,6 +1042,7 @@ func mockHostVulnerabilityAssessment() api.VulnerabilitiesHostResponse {
             "startTime": "2022-09-23T03:00:00.000Z"
         },
         {
+						"vulnId": "CVE-9",
             "cveProps": {
                 "metadata": {}
             },
@@ -1074,6 +1083,7 @@ func mockHostVulnerabilityAssessment() api.VulnerabilitiesHostResponse {
             "startTime": "2022-09-23T03:00:00.000Z"
         },
         {
+						"vulnId": "CVE-10",
             "cveProps": {
                 "metadata": {}
             },
@@ -1114,6 +1124,7 @@ func mockHostVulnerabilityAssessment() api.VulnerabilitiesHostResponse {
             "startTime": "2022-09-23T03:00:00.000Z"
         },
         {
+						"vulnId": "CVE-11",
             "cveProps": {
                 "metadata": {}
             },
@@ -1285,6 +1296,7 @@ func mockHostVulnerabilityAssessment() api.VulnerabilitiesHostResponse {
             "vulnId": "CVE-2020-13988"
         },
         {
+						"vulnId": "CVE-12",
             "cveProps": {
                 "metadata": {}
             },
@@ -1325,6 +1337,7 @@ func mockHostVulnerabilityAssessment() api.VulnerabilitiesHostResponse {
             "startTime": "2022-09-23T03:00:00.000Z"
         },
         {
+						"vulnId": "CVE-13",
             "cveProps": {
                 "metadata": {}
             },
@@ -1365,6 +1378,7 @@ func mockHostVulnerabilityAssessment() api.VulnerabilitiesHostResponse {
             "startTime": "2022-09-23T03:00:00.000Z"
         },
         {
+						"vulnId": "CVE-14",
             "cveProps": {
                 "metadata": {}
             },


### PR DESCRIPTION
## Summary

The new APIv2 for host vulnerabilities introduced the concept (exposed) of evaluation GUIDs,
this id is used to group all vulnerabilities from a single evaluation (assessment).

Before this change, we were ignoring this field and therefore, we could end up with two problems:
1. Display more vulnerabilities from other evaluations
2. Display less vulnerabilities since we were NOT reading all pages and, we were looking only to a
single day (`-24h`) of data

This PR fixes a number of issues by:
* It now parses the `EvalGUID` in the `VulnerabilityHost` struct
* The `VulnerabilityCounts()` func now removes duplicates before counting
* The CLI cmd now searching for latest host evaluation first
* Then, using the `EvalGUID` the CLI fetches vulnerabilities that match
* Finally, we look at the past 7 days instead of last 24 hours

## How did you test this change?

A bunch of manual tests.

## Issue
https://lacework.atlassian.net/browse/GROW-1624
