### PR TITLE
chore(lwtime): set LW_CLOCK_OFFSET = +0s

### DIFF
--- a/lwtime/reltime.go
+++ b/lwtime/reltime.go
@@ -38,7 +38,7 @@ type relativeDate struct {
 
 // The potential difference between the clocks on the client
 // and the Lacework API server
-const clockOffset = "-2s"
+const clockOffset = "+0s"
 
 // Returns 'now' with the default or the provided clock offset
 func nowClockOffset() string {


### PR DESCRIPTION
## Summary

This PR sets the `LW_CLOCK_OFFSET` back to be the exact current time, we won't have more
problems where `endTime` is ahead of the current time since we loose the API sever itself.

## How did you test this change?

Ran a few commands with the `LW_CLOCK_OFFSET=+5s` and all commands succeeded.

## Issue
https://lacework.atlassian.net/browse/GROW-1623