### PR TITLE
refactor(api): remove access to API v1 + default to v2

### DIFF
--- a/api/_examples/agent-access-token/main.go
+++ b/api/_examples/agent-access-token/main.go
@@ -9,7 +9,7 @@ import (
 )
 
 func main() {
-	lacework, err := api.NewClient(os.Getenv("LW_ACCOUNT"), api.WithApiV2(),
+	lacework, err := api.NewClient(os.Getenv("LW_ACCOUNT"),
 		api.WithApiKeys(os.Getenv("LW_API_KEY"), os.Getenv("LW_API_SECRET")),
 		api.WithSubaccount(os.Getenv("LW_SUBACCOUNT")),
 	)

--- a/api/_examples/alert-channels-v2/main.go
+++ b/api/_examples/alert-channels-v2/main.go
@@ -9,7 +9,7 @@ import (
 )
 
 func main() {
-	lacework, err := api.NewClient(os.Getenv("LW_ACCOUNT"), api.WithApiV2(),
+	lacework, err := api.NewClient(os.Getenv("LW_ACCOUNT"),
 		api.WithApiKeys(os.Getenv("LW_API_KEY"), os.Getenv("LW_API_SECRET")))
 	if err != nil {
 		log.Fatal(err)

--- a/api/_examples/alert-profiles/main.go
+++ b/api/_examples/alert-profiles/main.go
@@ -12,7 +12,6 @@ func main() {
 	lacework, err := api.NewClient(os.Getenv("LW_ACCOUNT"),
 		api.WithSubaccount(os.Getenv("LW_SUBACCOUNT")),
 		api.WithApiKeys(os.Getenv("LW_API_KEY"), os.Getenv("LW_API_SECRET")),
-		api.WithApiV2(),
 	)
 	if err != nil {
 		log.Fatal(err)

--- a/api/_examples/alert-rules/main.go
+++ b/api/_examples/alert-rules/main.go
@@ -12,7 +12,6 @@ func main() {
 	lacework, err := api.NewClient(os.Getenv("LW_ACCOUNT"),
 		api.WithSubaccount(os.Getenv("LW_SUBACCOUNT")),
 		api.WithApiKeys(os.Getenv("LW_API_KEY"), os.Getenv("LW_API_SECRET")),
-		api.WithApiV2(),
 	)
 	if err != nil {
 		log.Fatal(err)

--- a/api/_examples/aws-cloudwatch-alert-channel/main.go
+++ b/api/_examples/aws-cloudwatch-alert-channel/main.go
@@ -9,7 +9,7 @@ import (
 )
 
 func main() {
-	lacework, err := api.NewClient(os.Getenv("LW_ACCOUNT"), api.WithApiV2(),
+	lacework, err := api.NewClient(os.Getenv("LW_ACCOUNT"),
 		api.WithApiKeys(os.Getenv("LW_API_KEY"), os.Getenv("LW_API_SECRET")))
 	if err != nil {
 		log.Fatal(err)

--- a/api/_examples/aws-s3-alert-channel/main.go
+++ b/api/_examples/aws-s3-alert-channel/main.go
@@ -9,7 +9,7 @@ import (
 )
 
 func main() {
-	lacework, err := api.NewClient(os.Getenv("LW_ACCOUNT"), api.WithApiV2(),
+	lacework, err := api.NewClient(os.Getenv("LW_ACCOUNT"),
 		api.WithApiKeys(os.Getenv("LW_API_KEY"), os.Getenv("LW_API_SECRET")))
 	if err != nil {
 		log.Fatal(err)

--- a/api/_examples/cisco-webex-alert-channel/main.go
+++ b/api/_examples/cisco-webex-alert-channel/main.go
@@ -9,7 +9,7 @@ import (
 )
 
 func main() {
-	lacework, err := api.NewClient(os.Getenv("LW_ACCOUNT"), api.WithApiV2(),
+	lacework, err := api.NewClient(os.Getenv("LW_ACCOUNT"),
 		api.WithApiKeys(os.Getenv("LW_API_KEY"), os.Getenv("LW_API_SECRET")))
 	if err != nil {
 		log.Fatal(err)

--- a/api/_examples/cloud-accounts/aws-agentless-scanning-org/main.go
+++ b/api/_examples/cloud-accounts/aws-agentless-scanning-org/main.go
@@ -12,7 +12,6 @@ func main() {
 	lacework, err := api.NewClient(os.Getenv("LW_ACCOUNT"),
 		api.WithSubaccount(os.Getenv("LW_SUBACCOUNT")),
 		api.WithApiKeys(os.Getenv("LW_API_KEY"), os.Getenv("LW_API_SECRET")),
-		api.WithApiV2(),
 	)
 	if err != nil {
 		log.Fatal(err)

--- a/api/_examples/cloud-accounts/aws-agentless-scanning/main.go
+++ b/api/_examples/cloud-accounts/aws-agentless-scanning/main.go
@@ -12,7 +12,6 @@ func main() {
 	lacework, err := api.NewClient(os.Getenv("LW_ACCOUNT"),
 		api.WithSubaccount(os.Getenv("LW_SUBACCOUNT")),
 		api.WithApiKeys(os.Getenv("LW_API_KEY"), os.Getenv("LW_API_SECRET")),
-		api.WithApiV2(),
 	)
 	if err != nil {
 		log.Fatal(err)

--- a/api/_examples/cloud-accounts/aws-cfg/main.go
+++ b/api/_examples/cloud-accounts/aws-cfg/main.go
@@ -12,7 +12,6 @@ func main() {
 	lacework, err := api.NewClient(os.Getenv("LW_ACCOUNT"),
 		api.WithSubaccount(os.Getenv("LW_SUBACCOUNT")),
 		api.WithApiKeys(os.Getenv("LW_API_KEY"), os.Getenv("LW_API_SECRET")),
-		api.WithApiV2(),
 	)
 	if err != nil {
 		log.Fatal(err)

--- a/api/_examples/cloud-accounts/aws-ct-sqs/main.go
+++ b/api/_examples/cloud-accounts/aws-ct-sqs/main.go
@@ -14,7 +14,6 @@ func main() {
 	lacework, err := api.NewClient(os.Getenv("LW_ACCOUNT"),
 		api.WithSubaccount(os.Getenv("LW_SUBACCOUNT")),
 		api.WithApiKeys(os.Getenv("LW_API_KEY"), os.Getenv("LW_API_SECRET")),
-		api.WithApiV2(),
 	)
 	if err != nil {
 		log.Fatal(err)

--- a/api/_examples/cloud-accounts/aws-eks-audit/main.go
+++ b/api/_examples/cloud-accounts/aws-eks-audit/main.go
@@ -14,7 +14,6 @@ func main() {
 	lacework, err := api.NewClient(os.Getenv("LW_ACCOUNT"),
 		api.WithSubaccount(os.Getenv("LW_SUBACCOUNT")),
 		api.WithApiKeys(os.Getenv("LW_API_KEY"), os.Getenv("LW_API_SECRET")),
-		api.WithApiV2(),
 	)
 	if err != nil {
 		log.Fatal(err)

--- a/api/_examples/cloud-accounts/gcp-al-pub-sub/main.go
+++ b/api/_examples/cloud-accounts/gcp-al-pub-sub/main.go
@@ -12,7 +12,6 @@ func main() {
 	lacework, err := api.NewClient(os.Getenv("LW_ACCOUNT"),
 		api.WithSubaccount(os.Getenv("LW_SUBACCOUNT")),
 		api.WithApiKeys(os.Getenv("LW_API_KEY"), os.Getenv("LW_API_SECRET")),
-		api.WithApiV2(),
 	)
 	if err != nil {
 		log.Fatal(err)

--- a/api/_examples/cloud-accounts/gcp-gke-audit/main.go
+++ b/api/_examples/cloud-accounts/gcp-gke-audit/main.go
@@ -14,7 +14,6 @@ func main() {
 	lacework, err := api.NewClient(os.Getenv("LW_ACCOUNT"),
 		api.WithSubaccount(os.Getenv("LW_SUBACCOUNT")),
 		api.WithApiKeys(os.Getenv("LW_API_KEY"), os.Getenv("LW_API_SECRET")),
-		api.WithApiV2(),
 	)
 	if err != nil {
 		log.Fatal(err)

--- a/api/_examples/cloud-accounts/oci-cfg/main.go
+++ b/api/_examples/cloud-accounts/oci-cfg/main.go
@@ -12,7 +12,6 @@ func main() {
 	lacework, err := api.NewClient(os.Getenv("LW_ACCOUNT"),
 		api.WithSubaccount(os.Getenv("LW_SUBACCOUNT")),
 		api.WithApiKeys(os.Getenv("LW_API_KEY"), os.Getenv("LW_API_SECRET")),
-		api.WithApiV2(),
 	)
 	if err != nil {
 		log.Fatal(err)

--- a/api/_examples/container-registries/aws_ecr_access_key/main.go
+++ b/api/_examples/container-registries/aws_ecr_access_key/main.go
@@ -12,7 +12,6 @@ func main() {
 	lacework, err := api.NewClient(os.Getenv("LW_ACCOUNT"),
 		api.WithSubaccount(os.Getenv("LW_SUBACCOUNT")),
 		api.WithApiKeys(os.Getenv("LW_API_KEY"), os.Getenv("LW_API_SECRET")),
-		api.WithApiV2(),
 	)
 	if err != nil {
 		log.Fatal(err)

--- a/api/_examples/container-registries/aws_ecr_iam_role/main.go
+++ b/api/_examples/container-registries/aws_ecr_iam_role/main.go
@@ -12,7 +12,6 @@ func main() {
 	lacework, err := api.NewClient(os.Getenv("LW_ACCOUNT"),
 		api.WithSubaccount(os.Getenv("LW_SUBACCOUNT")),
 		api.WithApiKeys(os.Getenv("LW_API_KEY"), os.Getenv("LW_API_SECRET")),
-		api.WithApiV2(),
 	)
 	if err != nil {
 		log.Fatal(err)

--- a/api/_examples/container-registries/inline_scanner/main.go
+++ b/api/_examples/container-registries/inline_scanner/main.go
@@ -12,7 +12,6 @@ func main() {
 	lacework, err := api.NewClient(os.Getenv("LW_ACCOUNT"),
 		api.WithSubaccount(os.Getenv("LW_SUBACCOUNT")),
 		api.WithApiKeys(os.Getenv("LW_API_KEY"), os.Getenv("LW_API_SECRET")),
-		api.WithApiV2(),
 	)
 	if err != nil {
 		log.Fatal(err)

--- a/api/_examples/container-registries/proxy_scanner/main.go
+++ b/api/_examples/container-registries/proxy_scanner/main.go
@@ -12,7 +12,6 @@ func main() {
 	lacework, err := api.NewClient(os.Getenv("LW_ACCOUNT"),
 		api.WithSubaccount(os.Getenv("LW_SUBACCOUNT")),
 		api.WithApiKeys(os.Getenv("LW_API_KEY"), os.Getenv("LW_API_SECRET")),
-		api.WithApiV2(),
 	)
 	if err != nil {
 		log.Fatal(err)

--- a/api/_examples/container-vuln-search/main.go
+++ b/api/_examples/container-vuln-search/main.go
@@ -10,7 +10,7 @@ import (
 )
 
 func main() {
-	lacework, err := api.NewClient(os.Getenv("LW_ACCOUNT"), api.WithApiV2(),
+	lacework, err := api.NewClient(os.Getenv("LW_ACCOUNT"),
 		api.WithApiKeys(os.Getenv("LW_API_KEY"), os.Getenv("LW_API_SECRET")),
 		api.WithSubaccount(os.Getenv("LW_SUBACCOUNT")),
 	)

--- a/api/_examples/data-export-rules/main.go
+++ b/api/_examples/data-export-rules/main.go
@@ -12,7 +12,6 @@ func main() {
 	lacework, err := api.NewClient(os.Getenv("LW_ACCOUNT"),
 		api.WithSubaccount(os.Getenv("LW_SUBACCOUNT")),
 		api.WithApiKeys(os.Getenv("LW_API_KEY"), os.Getenv("LW_API_SECRET")),
-		api.WithApiV2(),
 	)
 	if err != nil {
 		log.Fatal(err)

--- a/api/_examples/datadog-alert-channel/main.go
+++ b/api/_examples/datadog-alert-channel/main.go
@@ -9,7 +9,7 @@ import (
 )
 
 func main() {
-	lacework, err := api.NewClient(os.Getenv("LW_ACCOUNT"), api.WithApiV2(),
+	lacework, err := api.NewClient(os.Getenv("LW_ACCOUNT"),
 		api.WithApiKeys(os.Getenv("LW_API_KEY"), os.Getenv("LW_API_SECRET")))
 	if err != nil {
 		log.Fatal(err)

--- a/api/_examples/feature-flags/main.go
+++ b/api/_examples/feature-flags/main.go
@@ -12,7 +12,7 @@ func main() {
 	lacework, err := api.NewClient(os.Getenv("LW_ACCOUNT"),
 		api.WithSubaccount(os.Getenv("LW_SUBACCOUNT")),
 		api.WithApiKeys(os.Getenv("LW_API_KEY"), os.Getenv("LW_API_SECRET")),
-		api.WithApiV2())
+	)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/api/_examples/gcp_pub_sub-alert-channel/main.go
+++ b/api/_examples/gcp_pub_sub-alert-channel/main.go
@@ -9,7 +9,7 @@ import (
 )
 
 func main() {
-	lacework, err := api.NewClient(os.Getenv("LW_ACCOUNT"), api.WithApiV2(),
+	lacework, err := api.NewClient(os.Getenv("LW_ACCOUNT"),
 		api.WithApiKeys(os.Getenv("LW_API_KEY"), os.Getenv("LW_API_SECRET")))
 	if err != nil {
 		log.Fatal(err)

--- a/api/_examples/jira-cloud-with-custom-template-alert-channel/main.go
+++ b/api/_examples/jira-cloud-with-custom-template-alert-channel/main.go
@@ -12,7 +12,7 @@ func main() {
 	lacework, err := api.NewClient(os.Getenv("LW_ACCOUNT"),
 		api.WithSubaccount(os.Getenv("LW_SUBACCOUNT")),
 		api.WithApiKeys(os.Getenv("LW_API_KEY"), os.Getenv("LW_API_SECRET")),
-		api.WithApiV2())
+	)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/api/_examples/microsoft-teams-alert-channel/main.go
+++ b/api/_examples/microsoft-teams-alert-channel/main.go
@@ -9,7 +9,7 @@ import (
 )
 
 func main() {
-	lacework, err := api.NewClient(os.Getenv("LW_ACCOUNT"), api.WithApiV2(),
+	lacework, err := api.NewClient(os.Getenv("LW_ACCOUNT"),
 		api.WithApiKeys(os.Getenv("LW_API_KEY"), os.Getenv("LW_API_SECRET")))
 	if err != nil {
 		log.Fatal(err)

--- a/api/_examples/new-relic-alert-channel/main.go
+++ b/api/_examples/new-relic-alert-channel/main.go
@@ -12,7 +12,7 @@ func main() {
 	lacework, err := api.NewClient(os.Getenv("LW_ACCOUNT"),
 		api.WithSubaccount(os.Getenv("LW_SUBACCOUNT")),
 		api.WithApiKeys(os.Getenv("LW_API_KEY"), os.Getenv("LW_API_SECRET")),
-		api.WithApiV2())
+	)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/api/_examples/pagerduty-alert-channel/main.go
+++ b/api/_examples/pagerduty-alert-channel/main.go
@@ -12,7 +12,7 @@ func main() {
 	lacework, err := api.NewClient(os.Getenv("LW_ACCOUNT"),
 		api.WithSubaccount(os.Getenv("LW_SUBACCOUNT")),
 		api.WithApiKeys(os.Getenv("LW_API_KEY"), os.Getenv("LW_API_SECRET")),
-		api.WithApiV2())
+	)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/api/_examples/pagination/main.go
+++ b/api/_examples/pagination/main.go
@@ -9,7 +9,7 @@ import (
 )
 
 func main() {
-	lacework, err := api.NewClient(os.Getenv("LW_ACCOUNT"), api.WithApiV2(),
+	lacework, err := api.NewClient(os.Getenv("LW_ACCOUNT"),
 		api.WithApiKeys(os.Getenv("LW_API_KEY"), os.Getenv("LW_API_SECRET")))
 	if err != nil {
 		log.Fatal(err)

--- a/api/_examples/policy-exceptions/main.go
+++ b/api/_examples/policy-exceptions/main.go
@@ -12,7 +12,6 @@ func main() {
 	lacework, err := api.NewClient(os.Getenv("LW_ACCOUNT"),
 		api.WithSubaccount(os.Getenv("LW_SUBACCOUNT")),
 		api.WithApiKeys(os.Getenv("LW_API_KEY"), os.Getenv("LW_API_SECRET")),
-		api.WithApiV2(),
 	)
 	if err != nil {
 		log.Fatal(err)

--- a/api/_examples/policy/main.go
+++ b/api/_examples/policy/main.go
@@ -13,7 +13,6 @@ func main() {
 	lacework, err := api.NewClient(os.Getenv("LW_ACCOUNT"),
 		api.WithSubaccount(os.Getenv("LW_SUBACCOUNT")),
 		api.WithApiKeys(os.Getenv("LW_API_KEY"), os.Getenv("LW_API_SECRET")),
-		api.WithApiV2(),
 	)
 	if err != nil {
 		log.Fatal(err)

--- a/api/_examples/qradar-alert-channel/main.go
+++ b/api/_examples/qradar-alert-channel/main.go
@@ -9,7 +9,7 @@ import (
 )
 
 func main() {
-	lacework, err := api.NewClient(os.Getenv("LW_ACCOUNT"), api.WithApiV2(),
+	lacework, err := api.NewClient(os.Getenv("LW_ACCOUNT"),
 		api.WithApiKeys(os.Getenv("LW_API_KEY"), os.Getenv("LW_API_SECRET")))
 	if err != nil {
 		log.Fatal(err)

--- a/api/_examples/report-definitions/main.go
+++ b/api/_examples/report-definitions/main.go
@@ -12,7 +12,6 @@ func main() {
 	lacework, err := api.NewClient(os.Getenv("LW_ACCOUNT"),
 		api.WithSubaccount(os.Getenv("LW_SUBACCOUNT")),
 		api.WithApiKeys(os.Getenv("LW_API_KEY"), os.Getenv("LW_API_SECRET")),
-		api.WithApiV2(),
 	)
 	if err != nil {
 		log.Fatal(err)

--- a/api/_examples/report-distributions/main.go
+++ b/api/_examples/report-distributions/main.go
@@ -12,7 +12,6 @@ func main() {
 	lacework, err := api.NewClient(os.Getenv("LW_ACCOUNT"),
 		api.WithSubaccount(os.Getenv("LW_SUBACCOUNT")),
 		api.WithApiKeys(os.Getenv("LW_API_KEY"), os.Getenv("LW_API_SECRET")),
-		api.WithApiV2(),
 	)
 	if err != nil {
 		log.Fatal(err)

--- a/api/_examples/report-rules/main.go
+++ b/api/_examples/report-rules/main.go
@@ -12,7 +12,6 @@ func main() {
 	lacework, err := api.NewClient(os.Getenv("LW_ACCOUNT"),
 		api.WithSubaccount(os.Getenv("LW_SUBACCOUNT")),
 		api.WithApiKeys(os.Getenv("LW_API_KEY"), os.Getenv("LW_API_SECRET")),
-		api.WithApiV2(),
 	)
 	if err != nil {
 		log.Fatal(err)

--- a/api/_examples/reports/aws/main.go
+++ b/api/_examples/reports/aws/main.go
@@ -12,7 +12,6 @@ func main() {
 	lacework, err := api.NewClient(os.Getenv("LW_ACCOUNT"),
 		api.WithSubaccount(os.Getenv("LW_SUBACCOUNT")),
 		api.WithApiKeys(os.Getenv("LW_API_KEY"), os.Getenv("LW_API_SECRET")),
-		api.WithApiV2(),
 	)
 	if err != nil {
 		log.Fatal(err)

--- a/api/_examples/reports/azure/main.go
+++ b/api/_examples/reports/azure/main.go
@@ -12,7 +12,6 @@ func main() {
 	lacework, err := api.NewClient(os.Getenv("LW_ACCOUNT"),
 		api.WithSubaccount(os.Getenv("LW_SUBACCOUNT")),
 		api.WithApiKeys(os.Getenv("LW_API_KEY"), os.Getenv("LW_API_SECRET")),
-		api.WithApiV2(),
 	)
 	if err != nil {
 		log.Fatal(err)

--- a/api/_examples/reports/gcp/main.go
+++ b/api/_examples/reports/gcp/main.go
@@ -12,7 +12,6 @@ func main() {
 	lacework, err := api.NewClient(os.Getenv("LW_ACCOUNT"),
 		api.WithSubaccount(os.Getenv("LW_SUBACCOUNT")),
 		api.WithApiKeys(os.Getenv("LW_API_KEY"), os.Getenv("LW_API_SECRET")),
-		api.WithApiV2(),
 	)
 	if err != nil {
 		log.Fatal(err)

--- a/api/_examples/resource-groups/main.go
+++ b/api/_examples/resource-groups/main.go
@@ -12,7 +12,6 @@ func main() {
 	lacework, err := api.NewClient(os.Getenv("LW_ACCOUNT"),
 		api.WithSubaccount(os.Getenv("LW_SUBACCOUNT")),
 		api.WithApiKeys(os.Getenv("LW_API_KEY"), os.Getenv("LW_API_SECRET")),
-		api.WithApiV2(),
 	)
 	if err != nil {
 		log.Fatal(err)

--- a/api/_examples/service-now-alert-channel/main.go
+++ b/api/_examples/service-now-alert-channel/main.go
@@ -9,7 +9,7 @@ import (
 )
 
 func main() {
-	lacework, err := api.NewClient(os.Getenv("LW_ACCOUNT"), api.WithApiV2(),
+	lacework, err := api.NewClient(os.Getenv("LW_ACCOUNT"),
 		api.WithApiKeys(os.Getenv("LW_API_KEY"), os.Getenv("LW_API_SECRET")))
 	if err != nil {
 		log.Fatal(err)

--- a/api/_examples/slack-alert-channel/main.go
+++ b/api/_examples/slack-alert-channel/main.go
@@ -9,7 +9,7 @@ import (
 )
 
 func main() {
-	lacework, err := api.NewClient(os.Getenv("LW_ACCOUNT"), api.WithApiV2(),
+	lacework, err := api.NewClient(os.Getenv("LW_ACCOUNT"),
 		api.WithApiKeys(os.Getenv("LW_API_KEY"), os.Getenv("LW_API_SECRET")))
 	if err != nil {
 		log.Fatal(err)

--- a/api/_examples/splunk-alert-channel/main.go
+++ b/api/_examples/splunk-alert-channel/main.go
@@ -12,7 +12,6 @@ func main() {
 	lacework, err := api.NewClient(os.Getenv("LW_ACCOUNT"),
 		api.WithSubaccount(os.Getenv("LW_SUBACCOUNT")),
 		api.WithApiKeys(os.Getenv("LW_API_KEY"), os.Getenv("LW_API_SECRET")),
-		api.WithApiV2(),
 	)
 	if err != nil {
 		log.Fatal(err)

--- a/api/_examples/team-members-org/main.go
+++ b/api/_examples/team-members-org/main.go
@@ -12,7 +12,6 @@ func main() {
 	lacework, err := api.NewClient(os.Getenv("LW_ACCOUNT"),
 		api.WithSubaccount(os.Getenv("LW_SUBACCOUNT")),
 		api.WithApiKeys(os.Getenv("LW_API_KEY"), os.Getenv("LW_API_SECRET")),
-		api.WithApiV2(),
 		api.WithOrgAccess(),
 	)
 	if err != nil {

--- a/api/_examples/team-members/main.go
+++ b/api/_examples/team-members/main.go
@@ -12,7 +12,6 @@ func main() {
 	lacework, err := api.NewClient(os.Getenv("LW_ACCOUNT"),
 		api.WithSubaccount(os.Getenv("LW_SUBACCOUNT")),
 		api.WithApiKeys(os.Getenv("LW_API_KEY"), os.Getenv("LW_API_SECRET")),
-		api.WithApiV2(),
 	)
 	if err != nil {
 		log.Fatal(err)

--- a/api/_examples/vulnerability-exceptions/main.go
+++ b/api/_examples/vulnerability-exceptions/main.go
@@ -13,7 +13,6 @@ func main() {
 	lacework, err := api.NewClient(os.Getenv("LW_ACCOUNT"),
 		api.WithSubaccount(os.Getenv("LW_SUBACCOUNT")),
 		api.WithApiKeys(os.Getenv("LW_API_KEY"), os.Getenv("LW_API_SECRET")),
-		api.WithApiV2(),
 	)
 	if err != nil {
 		log.Fatal(err)

--- a/api/_examples/webhook-alert-channel/main.go
+++ b/api/_examples/webhook-alert-channel/main.go
@@ -9,7 +9,7 @@ import (
 )
 
 func main() {
-	lacework, err := api.NewClient(os.Getenv("LW_ACCOUNT"), api.WithApiV2(),
+	lacework, err := api.NewClient(os.Getenv("LW_ACCOUNT"),
 		api.WithApiKeys(os.Getenv("LW_API_KEY"), os.Getenv("LW_API_SECRET")))
 	if err != nil {
 		log.Fatal(err)

--- a/api/agent_access_tokens_test.go
+++ b/api/agent_access_tokens_test.go
@@ -62,7 +62,6 @@ func TestAgentAccessTokenGet(t *testing.T) {
 		mockedAccessToken  = singleAgentAccessToken(expectedTokenID, expectedTokenAlias, "")
 		fakeServer         = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -83,7 +82,6 @@ func TestAgentAccessTokenGet(t *testing.T) {
 	)
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -115,7 +113,6 @@ func TestAgentAccessTokenList(t *testing.T) {
 		expectedLen            = len(expectedAgentAccTokens)
 		fakeServer             = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	fakeServer.MockAPI("AgentAccessTokens",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -130,7 +127,6 @@ func TestAgentAccessTokenList(t *testing.T) {
 	defer fakeServer.Close()
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)

--- a/api/agent_info_test.go
+++ b/api/agent_info_test.go
@@ -31,7 +31,6 @@ import (
 
 func TestAgentInfoSearch(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	fakeServer.MockAPI("AgentInfo/search",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -42,7 +41,6 @@ func TestAgentInfoSearch(t *testing.T) {
 	defer fakeServer.Close()
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)

--- a/api/alert_channel_datadog_test.go
+++ b/api/alert_channel_datadog_test.go
@@ -39,7 +39,6 @@ func TestAlertChannelsService_GetDatadog(t *testing.T) {
 		DatadogSite = api.DatadogSiteCom
 		DatadogType = api.DatadogServiceLogsDetails
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -49,7 +48,6 @@ func TestAlertChannelsService_GetDatadog(t *testing.T) {
 	})
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -76,7 +74,6 @@ func TestAlertChannelsService_UpdateDatadog(t *testing.T) {
 		DatadogSite = api.DatadogSiteCom
 		DatadogType = api.DatadogServiceLogsDetails
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -98,7 +95,6 @@ func TestAlertChannelsService_UpdateDatadog(t *testing.T) {
 	})
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)

--- a/api/alert_channels_aws_cloudwatch_test.go
+++ b/api/alert_channels_aws_cloudwatch_test.go
@@ -37,7 +37,6 @@ func TestAlertChannelsService_GetCloudwatchEb(t *testing.T) {
 		fakeServer  = lacework.MockServer()
 		eventBusArn = "arn:aws:events:YourRegion:YourAccountID:event-bus/default"
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -47,7 +46,6 @@ func TestAlertChannelsService_GetCloudwatchEb(t *testing.T) {
 	})
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -70,7 +68,6 @@ func TestAlertChannelsService_UpdateCloudwatchEb(t *testing.T) {
 		fakeServer  = lacework.MockServer()
 		eventBusArn = "arn:aws:events:YourRegion:YourAccountID:event-bus/default"
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -90,7 +87,6 @@ func TestAlertChannelsService_UpdateCloudwatchEb(t *testing.T) {
 	})
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)

--- a/api/alert_channels_aws_s3_test.go
+++ b/api/alert_channels_aws_s3_test.go
@@ -36,7 +36,6 @@ func TestAlertChannelsGetAwsS3(t *testing.T) {
 		apiPath    = fmt.Sprintf("AlertChannels/%s", intgGUID)
 		fakeServer = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -46,7 +45,6 @@ func TestAlertChannelsGetAwsS3(t *testing.T) {
 	})
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -69,7 +67,6 @@ func TestAlertChannelsAwsS3Update(t *testing.T) {
 		apiPath    = fmt.Sprintf("AlertChannels/%s", intgGUID)
 		fakeServer = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -91,7 +88,6 @@ func TestAlertChannelsAwsS3Update(t *testing.T) {
 	})
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)

--- a/api/alert_channels_cisco_spark_webhook_test.go
+++ b/api/alert_channels_cisco_spark_webhook_test.go
@@ -37,7 +37,6 @@ func TestAlertChannelsService_GetCiscoSparkWebhook(t *testing.T) {
 		fakeServer = lacework.MockServer()
 		webhook    = "https://api.ciscospark.com/v1/webhooks/incoming/api-token"
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -47,7 +46,6 @@ func TestAlertChannelsService_GetCiscoSparkWebhook(t *testing.T) {
 	})
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -69,7 +67,6 @@ func TestAlertChannelsService_UpdateCiscoSparkWebhook(t *testing.T) {
 		fakeServer = lacework.MockServer()
 		webhook    = "https://api.ciscospark.com/v1/webhooks/incoming/api-token"
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -89,7 +86,6 @@ func TestAlertChannelsService_UpdateCiscoSparkWebhook(t *testing.T) {
 	})
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)

--- a/api/alert_channels_email_user_test.go
+++ b/api/alert_channels_email_user_test.go
@@ -36,7 +36,6 @@ func TestAlertChannelsGetEmailUser(t *testing.T) {
 		apiPath    = fmt.Sprintf("AlertChannels/%s", intgGUID)
 		fakeServer = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -46,7 +45,6 @@ func TestAlertChannelsGetEmailUser(t *testing.T) {
 	})
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -68,7 +66,6 @@ func TestAlertChannelsEmailUserUpdate(t *testing.T) {
 		apiPath    = fmt.Sprintf("AlertChannels/%s", intgGUID)
 		fakeServer = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -89,7 +86,6 @@ func TestAlertChannelsEmailUserUpdate(t *testing.T) {
 	})
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -168,7 +164,6 @@ func TestAlertChannelsGetEmailUserBug(t *testing.T) {
 		apiPath    = fmt.Sprintf("AlertChannels/%s", intgGUID)
 		fakeServer = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -178,7 +173,6 @@ func TestAlertChannelsGetEmailUserBug(t *testing.T) {
 	})
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)

--- a/api/alert_channels_gcp_pub_sub_test.go
+++ b/api/alert_channels_gcp_pub_sub_test.go
@@ -36,7 +36,6 @@ func TestAlertChannelsService_GetGcpPubSub(t *testing.T) {
 		apiPath    = fmt.Sprintf("AlertChannels/%s", intgGUID)
 		fakeServer = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -46,7 +45,6 @@ func TestAlertChannelsService_GetGcpPubSub(t *testing.T) {
 	})
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -73,7 +71,6 @@ func TestAlertChannelsService_UpdateGcpPubSub(t *testing.T) {
 		apiPath    = fmt.Sprintf("AlertChannels/%s", intgGUID)
 		fakeServer = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -98,7 +95,6 @@ func TestAlertChannelsService_UpdateGcpPubSub(t *testing.T) {
 	})
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)

--- a/api/alert_channels_ibm_qradar_test.go
+++ b/api/alert_channels_ibm_qradar_test.go
@@ -36,7 +36,6 @@ func TestAlertChannelsGetIbmQRadar(t *testing.T) {
 		apiPath    = fmt.Sprintf("AlertChannels/%s", intgGUID)
 		fakeServer = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -46,7 +45,6 @@ func TestAlertChannelsGetIbmQRadar(t *testing.T) {
 	})
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -70,7 +68,6 @@ func TestAlertChannelIbmQRadarUpdate(t *testing.T) {
 		apiPath    = fmt.Sprintf("AlertChannels/%s", intgGUID)
 		fakeServer = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -91,7 +88,6 @@ func TestAlertChannelIbmQRadarUpdate(t *testing.T) {
 	})
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)

--- a/api/alert_channels_jira_cloud_server_test.go
+++ b/api/alert_channels_jira_cloud_server_test.go
@@ -38,7 +38,6 @@ func TestAlertChannelsService_GetJira(t *testing.T) {
 		apiPathServer  = fmt.Sprintf("AlertChannels/%s", intgGUIDServer)
 		fakeServer     = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -75,7 +74,6 @@ func TestAlertChannelsService_GetJira(t *testing.T) {
 			})
 
 			c, err := api.NewClient("test",
-				api.WithApiV2(),
 				api.WithToken("TOKEN"),
 				api.WithURL(fakeServer.URL()),
 			)
@@ -113,7 +111,6 @@ func TestAlertChannelsService_UpdateJira(t *testing.T) {
 		apiPathServer  = fmt.Sprintf("AlertChannels/%s", intgGUIDServer)
 		fakeServer     = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -193,7 +190,6 @@ func TestAlertChannelsService_UpdateJira(t *testing.T) {
 			})
 
 			c, err := api.NewClient("test",
-				api.WithApiV2(),
 				api.WithToken("TOKEN"),
 				api.WithURL(fakeServer.URL()),
 			)

--- a/api/alert_channels_microsoft_teams_test.go
+++ b/api/alert_channels_microsoft_teams_test.go
@@ -36,7 +36,6 @@ func TestAlertChannelsGetMicrosoftTeams(t *testing.T) {
 		apiPath    = fmt.Sprintf("AlertChannels/%s", intgGUID)
 		fakeServer = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -46,7 +45,6 @@ func TestAlertChannelsGetMicrosoftTeams(t *testing.T) {
 	})
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -67,7 +65,6 @@ func TestAlertChannelsMicrosoftTeamsUpdate(t *testing.T) {
 		apiPath    = fmt.Sprintf("AlertChannels/%s", intgGUID)
 		fakeServer = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -87,7 +84,6 @@ func TestAlertChannelsMicrosoftTeamsUpdate(t *testing.T) {
 	})
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)

--- a/api/alert_channels_new_relic_test.go
+++ b/api/alert_channels_new_relic_test.go
@@ -36,7 +36,6 @@ func TestAlertChannelsGetNewRelic(t *testing.T) {
 		apiPath    = fmt.Sprintf("AlertChannels/%s", intgGUID)
 		fakeServer = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -46,7 +45,6 @@ func TestAlertChannelsGetNewRelic(t *testing.T) {
 	})
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -69,7 +67,6 @@ func TestAlertChannelNewRelicUpdate(t *testing.T) {
 		apiPath    = fmt.Sprintf("AlertChannels/%s", intgGUID)
 		fakeServer = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -89,7 +86,6 @@ func TestAlertChannelNewRelicUpdate(t *testing.T) {
 	})
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)

--- a/api/alert_channels_pager_duty_test.go
+++ b/api/alert_channels_pager_duty_test.go
@@ -36,7 +36,6 @@ func TestAlertChannelsGetPagerDuty(t *testing.T) {
 		apiPath    = fmt.Sprintf("AlertChannels/%s", intgGUID)
 		fakeServer = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -46,7 +45,6 @@ func TestAlertChannelsGetPagerDuty(t *testing.T) {
 	})
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -68,7 +66,6 @@ func TestAlertChannelPagerDutyUpdate(t *testing.T) {
 		apiPath    = fmt.Sprintf("AlertChannels/%s", intgGUID)
 		fakeServer = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -87,7 +84,6 @@ func TestAlertChannelPagerDutyUpdate(t *testing.T) {
 	})
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)

--- a/api/alert_channels_service_now_rest_test.go
+++ b/api/alert_channels_service_now_rest_test.go
@@ -36,7 +36,6 @@ func TestAlertChannelsGetServiceNowRest(t *testing.T) {
 		apiPath    = fmt.Sprintf("AlertChannels/%s", intgGUID)
 		fakeServer = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -46,7 +45,6 @@ func TestAlertChannelsGetServiceNowRest(t *testing.T) {
 	})
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -71,7 +69,6 @@ func TestAlertChannelServiceNowRestUpdate(t *testing.T) {
 		apiPath    = fmt.Sprintf("AlertChannels/%s", intgGUID)
 		fakeServer = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -93,7 +90,6 @@ func TestAlertChannelServiceNowRestUpdate(t *testing.T) {
 	})
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)

--- a/api/alert_channels_slack_channel_test.go
+++ b/api/alert_channels_slack_channel_test.go
@@ -36,7 +36,6 @@ func TestAlertChannelsGetSlackChannel(t *testing.T) {
 		apiPath    = fmt.Sprintf("AlertChannels/%s", intgGUID)
 		fakeServer = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -46,7 +45,6 @@ func TestAlertChannelsGetSlackChannel(t *testing.T) {
 	})
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -67,7 +65,6 @@ func TestAlertChannelsSlackChannelUpdate(t *testing.T) {
 		apiPath    = fmt.Sprintf("AlertChannels/%s", intgGUID)
 		fakeServer = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -87,7 +84,6 @@ func TestAlertChannelsSlackChannelUpdate(t *testing.T) {
 	})
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)

--- a/api/alert_channels_splunk_test.go
+++ b/api/alert_channels_splunk_test.go
@@ -39,7 +39,6 @@ func TestAlertChannelsGetSplunk(t *testing.T) {
 		apiPath    = fmt.Sprintf("AlertChannels/%s", intgGUID)
 		fakeServer = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -49,7 +48,6 @@ func TestAlertChannelsGetSplunk(t *testing.T) {
 	})
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -77,7 +75,6 @@ func TestAlertChannelSplunkUpdate(t *testing.T) {
 		apiPath    = fmt.Sprintf("AlertChannels/%s", intgGUID)
 		fakeServer = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -102,7 +99,6 @@ func TestAlertChannelSplunkUpdate(t *testing.T) {
 	})
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)

--- a/api/alert_channels_test.go
+++ b/api/alert_channels_test.go
@@ -173,7 +173,6 @@ func TestAlertChannelsGet(t *testing.T) {
 		vanillaInt  = singleVanillaAlertChannel(intgGUID, vanillaType, "")
 		fakeServer  = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -194,7 +193,6 @@ func TestAlertChannelsGet(t *testing.T) {
 	)
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -231,7 +229,6 @@ func TestAlertChannelsDelete(t *testing.T) {
 		getResponse = generateAlertChannelResponse(vanillaInt)
 		fakeServer  = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -261,7 +258,6 @@ func TestAlertChannelsDelete(t *testing.T) {
 	)
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -315,7 +311,6 @@ func TestAlertChannelsList(t *testing.T) {
 		fakeServer                 = lacework.MockServer()
 	)
 
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	fakeServer.MockAPI("AlertChannels",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -348,7 +343,6 @@ func TestAlertChannelsList(t *testing.T) {
 	defer fakeServer.Close()
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -421,7 +415,6 @@ func TestAlertChannelsTest(t *testing.T) {
 		apiPath    = fmt.Sprintf("AlertChannels/%s/test", intgGUID)
 		fakeServer = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -434,7 +427,6 @@ func TestAlertChannelsTest(t *testing.T) {
 	)
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)

--- a/api/alert_channels_victorops_test.go
+++ b/api/alert_channels_victorops_test.go
@@ -36,7 +36,6 @@ func TestAlertChannelsGetVictorOps(t *testing.T) {
 		apiPath    = fmt.Sprintf("AlertChannels/%s", intgGUID)
 		fakeServer = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -46,7 +45,6 @@ func TestAlertChannelsGetVictorOps(t *testing.T) {
 	})
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -68,7 +66,6 @@ func TestAlertChannelVictorOpsUpdate(t *testing.T) {
 		apiPath    = fmt.Sprintf("AlertChannels/%s", intgGUID)
 		fakeServer = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -88,7 +85,6 @@ func TestAlertChannelVictorOpsUpdate(t *testing.T) {
 	})
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)

--- a/api/alert_channels_webhook_test.go
+++ b/api/alert_channels_webhook_test.go
@@ -36,7 +36,6 @@ func TestAlertChannelsGetWebhook(t *testing.T) {
 		apiPath    = fmt.Sprintf("AlertChannels/%s", intgGUID)
 		fakeServer = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -46,7 +45,6 @@ func TestAlertChannelsGetWebhook(t *testing.T) {
 	})
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -68,7 +66,6 @@ func TestAlertChannelWebhookUpdate(t *testing.T) {
 		apiPath    = fmt.Sprintf("AlertChannels/%s", intgGUID)
 		fakeServer = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -87,7 +84,6 @@ func TestAlertChannelWebhookUpdate(t *testing.T) {
 	})
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)

--- a/api/alert_profiles_test.go
+++ b/api/alert_profiles_test.go
@@ -37,7 +37,6 @@ func TestAlertProfilesGet(t *testing.T) {
 		alertProfile = singleMockAlertProfile(guid)
 		fakeServer   = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -58,7 +57,6 @@ func TestAlertProfilesGet(t *testing.T) {
 	)
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -96,7 +94,6 @@ func TestAlertProfilesDelete(t *testing.T) {
 		getResponse  = generateAlertProfileResponse(alertProfile)
 		fakeServer   = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -126,7 +123,6 @@ func TestAlertProfilesDelete(t *testing.T) {
 	)
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -167,7 +163,6 @@ func TestAlertProfilesList(t *testing.T) {
 		fakeServer    = lacework.MockServer()
 	)
 
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	fakeServer.MockAPI("AlertProfiles",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -185,7 +180,6 @@ func TestAlertProfilesList(t *testing.T) {
 	defer fakeServer.Close()
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -206,7 +200,6 @@ func TestAlertProfileUpdate(t *testing.T) {
 		apiPath    = fmt.Sprintf("AlertProfiles/%s", guid)
 		fakeServer = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -222,7 +215,6 @@ func TestAlertProfileUpdate(t *testing.T) {
 	})
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)

--- a/api/alert_rules_test.go
+++ b/api/alert_rules_test.go
@@ -38,7 +38,6 @@ func TestAlertRulesGet(t *testing.T) {
 		alertRule  = singleMockAlertRule(intgGUID)
 		fakeServer = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -59,7 +58,6 @@ func TestAlertRulesGet(t *testing.T) {
 	)
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -95,7 +93,6 @@ func TestAlertRulesDelete(t *testing.T) {
 		getResponse = generateAlertRuleResponse(alertRule)
 		fakeServer  = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -125,7 +122,6 @@ func TestAlertRulesDelete(t *testing.T) {
 	)
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -164,7 +160,6 @@ func TestAlertRulesList(t *testing.T) {
 		fakeServer  = lacework.MockServer()
 	)
 
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	fakeServer.MockAPI("AlertRules",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -182,7 +177,6 @@ func TestAlertRulesList(t *testing.T) {
 	defer fakeServer.Close()
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -203,7 +197,6 @@ func TestAlertRuleUpdate(t *testing.T) {
 		apiPath    = fmt.Sprintf("AlertRules/%s", intgGUID)
 		fakeServer = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -222,7 +215,6 @@ func TestAlertRuleUpdate(t *testing.T) {
 	})
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)

--- a/api/alerts_close_test.go
+++ b/api/alerts_close_test.go
@@ -39,7 +39,6 @@ var (
 
 func TestAlertsCloseMethod(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockAPI(
 		fmt.Sprintf("Alerts/%d/close", alertID),
 		func(w http.ResponseWriter, r *http.Request) {
@@ -61,7 +60,6 @@ func TestAlertsCloseMethod(t *testing.T) {
 
 func TestAlertsCloseOK(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockAPI(
 		fmt.Sprintf("Alerts/%d/close", alertID),
 		func(w http.ResponseWriter, r *http.Request) {
@@ -82,7 +80,6 @@ func TestAlertsCloseOK(t *testing.T) {
 
 func TestAlertsCloseError(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockAPI(
 		fmt.Sprintf("Alerts/%d/close", alertID),
 		func(w http.ResponseWriter, r *http.Request) {

--- a/api/alerts_comment_test.go
+++ b/api/alerts_comment_test.go
@@ -49,7 +49,6 @@ var alertCommentJSON = `{
 
 func TestAlertsCommentMethod(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockAPI(
 		fmt.Sprintf("Alerts/%d/comment", alertID),
 		func(w http.ResponseWriter, r *http.Request) {
@@ -73,7 +72,6 @@ func TestAlertsCommentOK(t *testing.T) {
 	mockResponse := alertCommentJSON
 
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockAPI(
 		fmt.Sprintf("Alerts/%d/comment", alertID),
 		func(w http.ResponseWriter, r *http.Request) {
@@ -100,7 +98,6 @@ func TestAlertsCommentOK(t *testing.T) {
 
 func TestAlertsCommentBad(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockAPI(
 		fmt.Sprintf("Alerts/%d/comment", alertID),
 		func(w http.ResponseWriter, r *http.Request) {
@@ -124,7 +121,6 @@ func TestAlertsCommentBad(t *testing.T) {
 
 func TestAlertsCommentError(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockAPI(
 		fmt.Sprintf("Alerts/%d/comment", alertID),
 		func(w http.ResponseWriter, r *http.Request) {

--- a/api/alerts_details_events_test.go
+++ b/api/alerts_details_events_test.go
@@ -47,7 +47,6 @@ var alertEventsJSON = `{
 
 func TestAlertsGetEventsMethod(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockAPI(
 		fmt.Sprintf("Alerts/%d", alertID),
 		func(w http.ResponseWriter, r *http.Request) {
@@ -71,7 +70,6 @@ func TestAlertsGetEventsOK(t *testing.T) {
 	mockResponse := alertInvestigationJSON
 
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockAPI(
 		fmt.Sprintf("Alerts/%d", alertID),
 		func(w http.ResponseWriter, r *http.Request) {
@@ -97,7 +95,6 @@ func TestAlertsGetEventsOK(t *testing.T) {
 
 func TestAlertsGetEventsError(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockAPI(
 		fmt.Sprintf("Alerts/%d", alertID),
 		func(w http.ResponseWriter, r *http.Request) {

--- a/api/alerts_details_integrations_test.go
+++ b/api/alerts_details_integrations_test.go
@@ -77,7 +77,6 @@ var alertIntegrationsJSON = `{
 
 func TestAlertsGetIntegrationsMethod(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockAPI(
 		fmt.Sprintf("Alerts/%d", alertID),
 		func(w http.ResponseWriter, r *http.Request) {
@@ -101,7 +100,6 @@ func TestAlertsGetIntegrationsOK(t *testing.T) {
 	mockResponse := alertIntegrationsJSON
 
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockAPI(
 		fmt.Sprintf("Alerts/%d", alertID),
 		func(w http.ResponseWriter, r *http.Request) {
@@ -127,7 +125,6 @@ func TestAlertsGetIntegrationsOK(t *testing.T) {
 
 func TestAlertsGetIntegrationsError(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockAPI(
 		fmt.Sprintf("Alerts/%d", alertID),
 		func(w http.ResponseWriter, r *http.Request) {

--- a/api/alerts_details_investigation_test.go
+++ b/api/alerts_details_investigation_test.go
@@ -48,7 +48,6 @@ var alertInvestigationJSON = `{
 
 func TestAlertsGetInvestigationMethod(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockAPI(
 		fmt.Sprintf("Alerts/%d", alertID),
 		func(w http.ResponseWriter, r *http.Request) {
@@ -72,7 +71,6 @@ func TestAlertsGetInvestigationOK(t *testing.T) {
 	mockResponse := alertInvestigationJSON
 
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockAPI(
 		fmt.Sprintf("Alerts/%d", alertID),
 		func(w http.ResponseWriter, r *http.Request) {
@@ -98,7 +96,6 @@ func TestAlertsGetInvestigationOK(t *testing.T) {
 
 func TestAlertsGetInvestigationError(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockAPI(
 		fmt.Sprintf("Alerts/%d", alertID),
 		func(w http.ResponseWriter, r *http.Request) {

--- a/api/alerts_details_related_test.go
+++ b/api/alerts_details_related_test.go
@@ -47,7 +47,6 @@ var alertRelatedJSON = `{
 
 func TestAlertsGetRelatedAlertsMethod(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockAPI(
 		fmt.Sprintf("Alerts/%d", alertID),
 		func(w http.ResponseWriter, r *http.Request) {
@@ -71,7 +70,6 @@ func TestAlertsGetRelatedAlertsOK(t *testing.T) {
 	mockResponse := alertInvestigationJSON
 
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockAPI(
 		fmt.Sprintf("Alerts/%d", alertID),
 		func(w http.ResponseWriter, r *http.Request) {
@@ -97,7 +95,6 @@ func TestAlertsGetRelatedAlertsOK(t *testing.T) {
 
 func TestAlertsGetRelatedAlertsError(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockAPI(
 		fmt.Sprintf("Alerts/%d", alertID),
 		func(w http.ResponseWriter, r *http.Request) {

--- a/api/alerts_details_test.go
+++ b/api/alerts_details_test.go
@@ -70,7 +70,6 @@ var alertDetailsJSON = `{
 
 func TestAlertsGetDetailsMethod(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockAPI(
 		fmt.Sprintf("Alerts/%d", alertID),
 		func(w http.ResponseWriter, r *http.Request) {
@@ -94,7 +93,6 @@ func TestAlertsGetDetailsOK(t *testing.T) {
 	mockResponse := alertDetailsJSON
 
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockAPI(
 		fmt.Sprintf("Alerts/%d", alertID),
 		func(w http.ResponseWriter, r *http.Request) {
@@ -120,7 +118,6 @@ func TestAlertsGetDetailsOK(t *testing.T) {
 
 func TestAlertsGetDetailsError(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockAPI(
 		fmt.Sprintf("Alerts/%d", alertID),
 		func(w http.ResponseWriter, r *http.Request) {

--- a/api/alerts_details_timeline_test.go
+++ b/api/alerts_details_timeline_test.go
@@ -51,7 +51,6 @@ var alertTimelineJSON = `{
 
 func TestAlertsGetTimelineMethod(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockAPI(
 		fmt.Sprintf("Alerts/%d", alertID),
 		func(w http.ResponseWriter, r *http.Request) {
@@ -75,7 +74,6 @@ func TestAlertsGetTimelineOK(t *testing.T) {
 	mockResponse := alertInvestigationJSON
 
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockAPI(
 		fmt.Sprintf("Alerts/%d", alertID),
 		func(w http.ResponseWriter, r *http.Request) {
@@ -101,7 +99,6 @@ func TestAlertsGetTimelineOK(t *testing.T) {
 
 func TestAlertsGetTimelineError(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockAPI(
 		fmt.Sprintf("Alerts/%d", alertID),
 		func(w http.ResponseWriter, r *http.Request) {

--- a/api/alerts_search_test.go
+++ b/api/alerts_search_test.go
@@ -33,7 +33,6 @@ var alertsSearchRequest api.SearchFilter
 
 func TestAlertsSearchMethod(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockAPI(
 		"Alerts/search",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -57,7 +56,6 @@ func TestAlertsSearchOK(t *testing.T) {
 	mockResponse := alertsJSON
 
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockAPI(
 		"Alerts/search",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -83,7 +81,6 @@ func TestAlertsSearchOK(t *testing.T) {
 
 func TestAlertsSearchAllOK(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 
 	nextPage := fmt.Sprintf(
 		"%s/api/v2/Alerts/search/nextPage",
@@ -120,7 +117,6 @@ func TestAlertsSearchAllOK(t *testing.T) {
 
 func TestAlertsSearchError(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockAPI(
 		"Alerts/search",
 		func(w http.ResponseWriter, r *http.Request) {

--- a/api/alerts_test.go
+++ b/api/alerts_test.go
@@ -134,7 +134,6 @@ var alertsPage2JSON = `{
 
 func TestAlertsListMethod(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockAPI(
 		"Alerts",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -158,7 +157,6 @@ func TestAlertsListOK(t *testing.T) {
 	mockResponse := alertsJSON
 
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockAPI(
 		"Alerts",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -184,7 +182,6 @@ func TestAlertsListOK(t *testing.T) {
 
 func TestAlertsListAllOK(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 
 	nextPage := fmt.Sprintf(
 		"%s/api/v2/Alerts/nextPage",
@@ -220,7 +217,6 @@ func TestAlertsListAllOK(t *testing.T) {
 
 func TestAlertsListError(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockAPI(
 		"Alerts",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -241,7 +237,6 @@ func TestAlertsListError(t *testing.T) {
 
 func TestAlertsListByTimeMethod(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockAPI(
 		"Alerts",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -265,7 +260,6 @@ func TestAlertsListByTimeOK(t *testing.T) {
 	mockResponse := alertsJSON
 
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockAPI(
 		"Alerts",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -291,7 +285,6 @@ func TestAlertsListByTimeOK(t *testing.T) {
 
 func TestAlertsListAllByTimeOK(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 
 	nextPage := fmt.Sprintf(
 		"%s/api/v2/Alerts/nextPage",
@@ -327,7 +320,6 @@ func TestAlertsListAllByTimeOK(t *testing.T) {
 
 func TestAlertsListByTimeError(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockAPI(
 		"Alerts",
 		func(w http.ResponseWriter, r *http.Request) {

--- a/api/api.go
+++ b/api/api.go
@@ -21,28 +21,12 @@ package api
 import (
 	"fmt"
 	"strings"
-
-	"go.uber.org/zap"
 )
 
 const (
-	// Common endpoints
-	//
-	// There will be times where we will have common endpoints between
-	// different versions of our APIs, by default such endpoints will
-	// be driven by the global client.apiVersion setting, when we are
-	// ready to switch over/upgrade we can do so with the option
-	// WithApiV2() at the time that the caller initializes the Go Client
-	//
-	// Example:
-	// ```go
-	//   api.NewClient("my-account", api.WithApiV2())
-	// ```
-	apiTokens = "access/tokens" // Auth
-
 	// API v2 Endpoints
-	//
-	// These endpoints only exist in APIv2 and therefore we prefix them with 'v2/'
+	apiTokens = "v2/access/tokens" // Auth
+
 	apiV2UserProfile = "v2/UserProfile"
 
 	apiV2ContainerRegistries       = "v2/ContainerRegistries"
@@ -144,16 +128,6 @@ const (
 
 	apiRecommendations = "v2/recommendations/%s"
 )
-
-// WithApiV2 configures the client to use the API version 2 (/api/v2)
-// for common API endpoints
-func WithApiV2() Option {
-	return clientFunc(func(c *Client) error {
-		c.log.Debug("setting up client", zap.String("api_version", "v2"))
-		c.apiVersion = "v2"
-		return nil
-	})
-}
 
 // ApiVersion returns the API client version
 func (c *Client) ApiVersion() string {

--- a/api/api.go
+++ b/api/api.go
@@ -129,6 +129,17 @@ const (
 	apiRecommendations = "v2/recommendations/%s"
 )
 
+// WithApiV2 configures the client to use the API version 2 (/api/v2)
+// for common API endpoints
+//
+// (no-op) DEPRECATED
+func WithApiV2() Option {
+	return clientFunc(func(c *Client) error {
+		c.log.Warn("WithApiV2() has been deprecated, all clients now default to APIv2")
+		return nil
+	})
+}
+
 // ApiVersion returns the API client version
 func (c *Client) ApiVersion() string {
 	return c.apiVersion

--- a/api/auth_internal_test.go
+++ b/api/auth_internal_test.go
@@ -25,17 +25,10 @@ import (
 )
 
 func TestApiPath(t *testing.T) {
-	c1 := &Client{apiVersion: "v1"}
-	assert.Equal(t, "/api/v1/foo", c1.apiPath("foo"), "api path mismatch")
-	assert.Equal(t,
-		"/api/v1/access/tokens",
-		c1.apiPath(apiTokens),
-		"token api path mismatch")
-
-	c2 := &Client{apiVersion: "v2"}
-	assert.Equal(t, "/api/v2/bar", c2.apiPath("bar"), "api path mismatch")
+	c := &Client{apiVersion: "v2"}
+	assert.Equal(t, "/api/v2/bar", c.apiPath("bar"), "api path mismatch")
 	assert.Equal(t,
 		"/api/v2/UserProfile",
-		c2.apiPath(apiV2UserProfile),
+		c.apiPath(apiV2UserProfile),
 		"integrations api path mismatch")
 }

--- a/api/auth_test.go
+++ b/api/auth_test.go
@@ -27,31 +27,24 @@ import (
 	"github.com/lacework/go-sdk/internal/lacework"
 )
 
-func TestWithApiV2(t *testing.T) {
-	c, err := api.NewClient("test", api.WithApiV2())
-	if assert.Nil(t, err) {
-		assert.Equal(t, "v2", c.ApiVersion(), "API version should be v2")
-	}
-}
-
 func TestWithToken(t *testing.T) {
 	c, err := api.NewClient("test", api.WithToken("TOKEN"))
 	if assert.Nil(t, err) {
-		assert.Equal(t, "v1", c.ApiVersion(), "API version should be v1")
+		assert.Equal(t, "v2", c.ApiVersion(), "API version should be v2")
 	}
 }
 
 func TestApiVersion(t *testing.T) {
 	c, err := api.NewClient("foo")
 	if assert.Nil(t, err) {
-		assert.Equal(t, "v1", c.ApiVersion(), "wrong default API version")
+		assert.Equal(t, "v2", c.ApiVersion(), "wrong default API version")
 	}
 }
 
 func TestWithApiKeys(t *testing.T) {
 	c, err := api.NewClient("foo", api.WithApiKeys("KEY", "SECRET"))
 	if assert.Nil(t, err) {
-		assert.Equal(t, "v1", c.ApiVersion(), "wrong default API version")
+		assert.Equal(t, "v2", c.ApiVersion(), "wrong default API version")
 	}
 }
 
@@ -65,24 +58,7 @@ func TestWithTokenFromKeys(t *testing.T) {
 		api.WithTokenFromKeys("KEY", "SECRET"), // this option has to be the last one
 	)
 	if assert.Nil(t, err) {
-		assert.Equal(t, "v1", c.ApiVersion(), "wrong default API version")
-	}
-}
-
-func TestGenerateTokenV2(t *testing.T) {
-	fakeServer := lacework.MockServer()
-	fakeServer.MockTokenV2("TOKEN")
-	defer fakeServer.Close()
-
-	c, err := api.NewClient("foo",
-		api.WithApiV2(),
-		api.WithURL(fakeServer.URL()),
-		api.WithApiKeys("KEY", "SECRET"),
-	)
-	if assert.Nil(t, err) {
-		response, err := c.GenerateToken()
-		assert.Nil(t, err)
-		assert.Equal(t, "TOKEN", response.Token, "token mismatch")
+		assert.Equal(t, "v2", c.ApiVersion(), "wrong default API version")
 	}
 }
 
@@ -127,23 +103,5 @@ func TestGenerateTokenErrorKeysMissing(t *testing.T) {
 				"error message mismatch",
 			)
 		}
-	}
-}
-
-func TestGenerateTokenV1(t *testing.T) {
-	fakeServer := lacework.MockServer()
-	fakeServer.MockToken("EXPECTED_TOKEN")
-	defer fakeServer.Close()
-
-	c, err := api.NewClient("t",
-		api.WithURL(fakeServer.URL()),
-		api.WithApiKeys("KEY", "SECRET"),
-	)
-
-	assert.Nil(t, err)
-
-	tokenData, err := c.GenerateToken()
-	if assert.Nil(t, err) {
-		assert.Equal(t, "EXPECTED_TOKEN", tokenData.Token)
 	}
 }

--- a/api/callbacks_test.go
+++ b/api/callbacks_test.go
@@ -30,7 +30,6 @@ import (
 
 func TestCallbacks(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	fakeServer.MockAPI(
 		"foo",
@@ -41,7 +40,6 @@ func TestCallbacks(t *testing.T) {
 	defer fakeServer.Close()
 
 	c, _ := api.NewClient("foo",
-		api.WithApiV2(),
 		api.WithURL(fakeServer.URL()),
 		api.WithToken("TOKEN"),
 		api.WithLifecycleCallbacks(api.LifecycleCallbacks{
@@ -59,7 +57,6 @@ func TestCallbacks(t *testing.T) {
 
 func TestCallbacksOnRequestError(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	fakeServer.MockAPI(
 		"foo",
@@ -70,7 +67,6 @@ func TestCallbacksOnRequestError(t *testing.T) {
 	defer fakeServer.Close()
 
 	c, _ := api.NewClient("foo",
-		api.WithApiV2(),
 		api.WithURL(fakeServer.URL()),
 		api.WithTimeout(time.Duration(1)),
 		api.WithToken("TOKEN"),

--- a/api/client.go
+++ b/api/client.go
@@ -112,7 +112,7 @@ func NewClient(account string, opts ...Option) (*Client, error) {
 		id:         newID(),
 		account:    account,
 		baseURL:    baseURL,
-		apiVersion: "v1",
+		apiVersion: "v2",
 		headers: map[string]string{
 			"User-Agent": fmt.Sprintf("Go Client/%s", Version),
 		},

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -35,7 +35,7 @@ import (
 func TestNewClient(t *testing.T) {
 	c, err := api.NewClient("test")
 	if assert.Nil(t, err) {
-		assert.Equal(t, "v1", c.ApiVersion(), "default API version should be v1")
+		assert.Equal(t, "v2", c.ApiVersion(), "default API version should be v2")
 		assert.Equal(t, "https://test.lacework.net", c.URL(), "domain does not match")
 	}
 }
@@ -79,14 +79,12 @@ func TestNewClientAccountEmptyError(t *testing.T) {
 
 func TestNewClientWithOptions(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
 	c, err := api.NewClient("test",
 		api.WithURL(fakeServer.URL()),
 		api.WithExpirationTime(1800),
-		api.WithApiV2(),
 		api.WithTimeout(time.Minute*5),
 		api.WithRetries(backoff.NewExponentialBackOff()),
 		api.WithLogLevel("DEBUG"),
@@ -129,7 +127,7 @@ func TestCopyClientWithOptions(t *testing.T) {
 		api.WithTokenFromKeys("KEY", "SECRET"), // this option has to be the last one
 	)
 	if assert.Nil(t, err) {
-		assert.Equal(t, "v1", c.ApiVersion(), "default API version should be v1")
+		assert.Equal(t, "v2", c.ApiVersion(), "default API version should be v2")
 		assert.Contains(t, c.URL(), "http://127.0.0.1:", "wrong URL")
 		assert.True(t, c.ValidAuth())
 	}
@@ -153,14 +151,12 @@ func TestCopyClientWithOptions(t *testing.T) {
 	newModifiedClient, err := api.CopyClient(c,
 		api.WithURL("https://new.lacework.net/"),
 		api.WithExpirationTime(3600),
-		api.WithApiV2(),
 		api.WithTimeout(time.Minute*60), // LOL!
 		api.WithRetries(nil),
 		api.WithLogLevel("INFO"),
 		api.WithOrgAccess(),
 	)
 	if assert.Nil(t, err) {
-		assert.NotEqual(t, c.ApiVersion(), newModifiedClient.ApiVersion(), "copy modified client mismatch")
 		assert.NotEqual(t, c.URL(), newModifiedClient.URL(), "copy modified client mismatch")
 		assert.NotEqual(t, c.Retries(), newModifiedClient.Retries(), "copy modified retrying policy")
 		assert.Equal(t, "v2", newModifiedClient.ApiVersion(), "copy modified API version should be v2")
@@ -174,7 +170,6 @@ func TestCopyClientWithOptions(t *testing.T) {
 
 func TestNewClientWithOrgAccess(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -188,7 +183,6 @@ func TestNewClientWithOrgAccess(t *testing.T) {
 
 func TestNewClientWithoutOrgAccess(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -201,7 +195,6 @@ func TestNewClientWithoutOrgAccess(t *testing.T) {
 func TestTLSHandshakeTimeout(t *testing.T) {
 	fakeServer := lacework.MockUnstartedServer()
 	fakeServer.Server.TLS = &tls.Config{InsecureSkipVerify: true}
-	fakeServer.UseApiV2()
 	apiPath := "AlertChannels"
 	fakeServer.MockToken("TOKEN")
 	fakeServer.Server.StartTLS()
@@ -216,7 +209,6 @@ func TestTLSHandshakeTimeout(t *testing.T) {
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}
 
 	client, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 		api.WithTransport(shortTimeout),
@@ -229,7 +221,6 @@ func TestTLSHandshakeTimeout(t *testing.T) {
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}
 
 	clientWithTimeout, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 		api.WithTransport(longTimeout),
@@ -241,7 +232,6 @@ func TestTLSHandshakeTimeout(t *testing.T) {
 
 func TestClientWithRetries(t *testing.T) {
 	fakeServer := lacework.MockUnstartedServer()
-	fakeServer.UseApiV2()
 	apiPath := "AlertChannels"
 	fakeServer.MockToken("TOKEN")
 	fakeServer.Server.StartTLS()
@@ -260,7 +250,6 @@ func TestClientWithRetries(t *testing.T) {
 
 	transport := &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}
 	client, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 		api.WithTransport(transport),
@@ -270,7 +259,6 @@ func TestClientWithRetries(t *testing.T) {
 	assert.Error(t, err)
 
 	clientWithRetries, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 		api.WithTransport(transport),

--- a/api/cloud_accounts_aws_cfg_test.go
+++ b/api/cloud_accounts_aws_cfg_test.go
@@ -54,7 +54,6 @@ func TestCloudAccountsAwsCfgGet(t *testing.T) {
 		apiPath    = fmt.Sprintf("CloudAccounts/%s", intgGUID)
 		fakeServer = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -64,7 +63,6 @@ func TestCloudAccountsAwsCfgGet(t *testing.T) {
 	})
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -86,7 +84,6 @@ func TestCloudAccountsAwsCfgUpdate(t *testing.T) {
 		apiPath    = fmt.Sprintf("CloudAccounts/%s", intgGUID)
 		fakeServer = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -107,7 +104,6 @@ func TestCloudAccountsAwsCfgUpdate(t *testing.T) {
 	})
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)

--- a/api/cloud_accounts_aws_ct_sqs_test.go
+++ b/api/cloud_accounts_aws_ct_sqs_test.go
@@ -86,7 +86,6 @@ func TestCloudAccountsAwsCtSqsGet(t *testing.T) {
 		apiPath    = fmt.Sprintf("CloudAccounts/%s", intgGUID)
 		fakeServer = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -96,7 +95,6 @@ func TestCloudAccountsAwsCtSqsGet(t *testing.T) {
 	})
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -119,7 +117,6 @@ func TestCloudAccountsAwsCtSqsUpdate(t *testing.T) {
 		apiPath    = fmt.Sprintf("CloudAccounts/%s", intgGUID)
 		fakeServer = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -141,7 +138,6 @@ func TestCloudAccountsAwsCtSqsUpdate(t *testing.T) {
 	})
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)

--- a/api/cloud_accounts_aws_eks_audit_test.go
+++ b/api/cloud_accounts_aws_eks_audit_test.go
@@ -36,7 +36,6 @@ func TestCloudAccountsAwsEksAuditGet(t *testing.T) {
 		apiPath    = fmt.Sprintf("CloudAccounts/%s", intgGUID)
 		fakeServer = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -46,7 +45,6 @@ func TestCloudAccountsAwsEksAuditGet(t *testing.T) {
 	})
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -74,7 +72,6 @@ func TestCloudAccountsAwsEksAuditUpdate(t *testing.T) {
 		apiPath    = fmt.Sprintf("CloudAccounts/%s", intgGUID)
 		fakeServer = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -102,7 +99,6 @@ func TestCloudAccountsAwsEksAuditUpdate(t *testing.T) {
 	})
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)

--- a/api/cloud_accounts_aws_gov_cfg_test.go
+++ b/api/cloud_accounts_aws_gov_cfg_test.go
@@ -35,7 +35,6 @@ func TestCloudAccountsAwsUsGovCfgGet(t *testing.T) {
 		apiPath    = fmt.Sprintf("CloudAccounts/%s", intgGUID)
 		fakeServer = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -45,7 +44,6 @@ func TestCloudAccountsAwsUsGovCfgGet(t *testing.T) {
 	})
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)

--- a/api/cloud_accounts_aws_gov_ct_test.go
+++ b/api/cloud_accounts_aws_gov_ct_test.go
@@ -35,7 +35,6 @@ func TestCloudAccountsAwsUsGovCtSqsGet(t *testing.T) {
 		apiPath    = fmt.Sprintf("CloudAccounts/%s", intgGUID)
 		fakeServer = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -45,7 +44,6 @@ func TestCloudAccountsAwsUsGovCtSqsGet(t *testing.T) {
 	})
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)

--- a/api/cloud_accounts_aws_sidekick_org_test.go
+++ b/api/cloud_accounts_aws_sidekick_org_test.go
@@ -85,7 +85,6 @@ func TestCloudAccountsAwsSidekickOrgGet(t *testing.T) {
 		apiPath    = fmt.Sprintf("CloudAccounts/%s", intgGUID)
 		fakeServer = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -95,7 +94,6 @@ func TestCloudAccountsAwsSidekickOrgGet(t *testing.T) {
 	})
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -124,7 +122,6 @@ func TestCloudAccountsAwsSidekickOrgUpdate(t *testing.T) {
 		apiPath    = fmt.Sprintf("CloudAccounts/%s", intgGUID)
 		fakeServer = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -145,7 +142,6 @@ func TestCloudAccountsAwsSidekickOrgUpdate(t *testing.T) {
 	})
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)

--- a/api/cloud_accounts_aws_sidekick_test.go
+++ b/api/cloud_accounts_aws_sidekick_test.go
@@ -53,7 +53,6 @@ func TestCloudAccountsAwsSidekickGet(t *testing.T) {
 		apiPath    = fmt.Sprintf("CloudAccounts/%s", intgGUID)
 		fakeServer = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -63,7 +62,6 @@ func TestCloudAccountsAwsSidekickGet(t *testing.T) {
 	})
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -88,7 +86,6 @@ func TestCloudAccountsAwsSidekickUpdate(t *testing.T) {
 		apiPath    = fmt.Sprintf("CloudAccounts/%s", intgGUID)
 		fakeServer = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -109,7 +106,6 @@ func TestCloudAccountsAwsSidekickUpdate(t *testing.T) {
 	})
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)

--- a/api/cloud_accounts_az_al_test.go
+++ b/api/cloud_accounts_az_al_test.go
@@ -35,7 +35,6 @@ func TestCloudAccountsAzAlSeqGet(t *testing.T) {
 		apiPath    = fmt.Sprintf("CloudAccounts/%s", intgGUID)
 		fakeServer = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -45,7 +44,6 @@ func TestCloudAccountsAzAlSeqGet(t *testing.T) {
 	})
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)

--- a/api/cloud_accounts_az_cfg_test.go
+++ b/api/cloud_accounts_az_cfg_test.go
@@ -35,7 +35,6 @@ func TestCloudAccountsAzCfgGet(t *testing.T) {
 		apiPath    = fmt.Sprintf("CloudAccounts/%s", intgGUID)
 		fakeServer = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -45,7 +44,6 @@ func TestCloudAccountsAzCfgGet(t *testing.T) {
 	})
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)

--- a/api/cloud_accounts_gcp_al_pubsub_test.go
+++ b/api/cloud_accounts_gcp_al_pubsub_test.go
@@ -35,7 +35,6 @@ func TestCloudAccountsGcpAlPubSubProjectGet(t *testing.T) {
 		apiPath    = fmt.Sprintf("CloudAccounts/%s", intgGUID)
 		fakeServer = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -45,7 +44,6 @@ func TestCloudAccountsGcpAlPubSubProjectGet(t *testing.T) {
 	})
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -74,7 +72,6 @@ func TestCloudAccountsGcpAlPubSubOrgGet(t *testing.T) {
 		apiPath    = fmt.Sprintf("CloudAccounts/%s", intgGUID)
 		fakeServer = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -84,7 +81,6 @@ func TestCloudAccountsGcpAlPubSubOrgGet(t *testing.T) {
 	})
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)

--- a/api/cloud_accounts_gcp_at_test.go
+++ b/api/cloud_accounts_gcp_at_test.go
@@ -35,7 +35,6 @@ func TestCloudAccountsGcpAtSesGet(t *testing.T) {
 		apiPath    = fmt.Sprintf("CloudAccounts/%s", intgGUID)
 		fakeServer = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -45,7 +44,6 @@ func TestCloudAccountsGcpAtSesGet(t *testing.T) {
 	})
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -73,7 +71,6 @@ func TestCloudAccountsGcpAtSesUpdateEmptyPrivateKeyAndPrivateKeyID(t *testing.T)
 		apiPath    = fmt.Sprintf("CloudAccounts/%s", intgGUID)
 		fakeServer = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -96,7 +93,6 @@ func TestCloudAccountsGcpAtSesUpdateEmptyPrivateKeyAndPrivateKeyID(t *testing.T)
 	})
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)

--- a/api/cloud_accounts_gcp_cfg_test.go
+++ b/api/cloud_accounts_gcp_cfg_test.go
@@ -35,7 +35,6 @@ func TestCloudAccountsGcpCfgGet(t *testing.T) {
 		apiPath    = fmt.Sprintf("CloudAccounts/%s", intgGUID)
 		fakeServer = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -45,7 +44,6 @@ func TestCloudAccountsGcpCfgGet(t *testing.T) {
 	})
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -70,7 +68,6 @@ func TestCloudAccountsGcpCfgUpdateEmptyPrivateKeyAndPrivateKeyID(t *testing.T) {
 		apiPath    = fmt.Sprintf("CloudAccounts/%s", intgGUID)
 		fakeServer = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -93,7 +90,6 @@ func TestCloudAccountsGcpCfgUpdateEmptyPrivateKeyAndPrivateKeyID(t *testing.T) {
 	})
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)

--- a/api/cloud_accounts_gcp_gke_audit_test.go
+++ b/api/cloud_accounts_gcp_gke_audit_test.go
@@ -36,7 +36,6 @@ func TestCloudAccountsGcpGkeAuditProjectLevelGet(t *testing.T) {
 		apiPath    = fmt.Sprintf("CloudAccounts/%s", intgGUID)
 		fakeServer = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -46,7 +45,6 @@ func TestCloudAccountsGcpGkeAuditProjectLevelGet(t *testing.T) {
 	})
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -77,7 +75,6 @@ func TestCloudAccountsGcpGkeAuditOrganizationLevelGet(t *testing.T) {
 		apiPath    = fmt.Sprintf("CloudAccounts/%s", intgGUID)
 		fakeServer = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -87,7 +84,6 @@ func TestCloudAccountsGcpGkeAuditOrganizationLevelGet(t *testing.T) {
 	})
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -119,7 +115,6 @@ func TestCloudAccountsGcpGkeAuditProjectLevelUpdate(t *testing.T) {
 		apiPath    = fmt.Sprintf("CloudAccounts/%s", intgGUID)
 		fakeServer = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -147,7 +142,6 @@ func TestCloudAccountsGcpGkeAuditProjectLevelUpdate(t *testing.T) {
 	})
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)

--- a/api/cloud_accounts_gcp_sidekick_test.go
+++ b/api/cloud_accounts_gcp_sidekick_test.go
@@ -131,7 +131,6 @@ func TestCloudAccountsGcpSidekickGet(t *testing.T) {
 		apiPath    = fmt.Sprintf("CloudAccounts/%s", intgGUID)
 		fakeServer = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -142,7 +141,6 @@ func TestCloudAccountsGcpSidekickGet(t *testing.T) {
 	})
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -181,7 +179,6 @@ func TestCloudAccountsGcpSidekickUpdate(t *testing.T) {
 		apiPath    = fmt.Sprintf("CloudAccounts/%s", intgGUID)
 		fakeServer = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -204,7 +201,6 @@ func TestCloudAccountsGcpSidekickUpdate(t *testing.T) {
 	})
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)

--- a/api/cloud_accounts_oci_cfg_test.go
+++ b/api/cloud_accounts_oci_cfg_test.go
@@ -35,7 +35,6 @@ func TestCloudAccountsOciCfgGet(t *testing.T) {
 		apiPath    = fmt.Sprintf("CloudAccounts/%s", intgGUID)
 		fakeServer = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -45,7 +44,6 @@ func TestCloudAccountsOciCfgGet(t *testing.T) {
 	})
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -64,7 +62,6 @@ func TestCloudAccountsOciCfgUpdate(t *testing.T) {
 		apiPath    = fmt.Sprintf("CloudAccounts/%s", intgGUID)
 		fakeServer = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -88,7 +85,6 @@ func TestCloudAccountsOciCfgUpdate(t *testing.T) {
 	})
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)

--- a/api/cloud_accounts_test.go
+++ b/api/cloud_accounts_test.go
@@ -61,7 +61,6 @@ func TestCloudAccountsGet(t *testing.T) {
 		vanillaInt  = singleVanillaCloudAccount(intgGUID, vanillaType, "")
 		fakeServer  = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -82,7 +81,6 @@ func TestCloudAccountsGet(t *testing.T) {
 	)
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -119,7 +117,6 @@ func TestCloudAccountsDelete(t *testing.T) {
 		getResponse = generateCloudAccountResponse(vanillaInt)
 		fakeServer  = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -149,7 +146,6 @@ func TestCloudAccountsDelete(t *testing.T) {
 	)
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -193,7 +189,6 @@ func TestCloudAccountsList(t *testing.T) {
 		expectedLen = len(allGUIDs)
 		fakeServer  = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	fakeServer.MockAPI("CloudAccounts",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -216,7 +211,6 @@ func TestCloudAccountsList(t *testing.T) {
 	defer fakeServer.Close()
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -237,7 +231,6 @@ func TestCloudAccountsListByType(t *testing.T) {
 		expectedLen  = len(awsIntgGUIDs)
 		fakeServer   = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	fakeServer.MockAPI("CloudAccounts/AwsCtSqs",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -255,7 +248,6 @@ func TestCloudAccountsListByType(t *testing.T) {
 	defer fakeServer.Close()
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)

--- a/api/component_data_test.go
+++ b/api/component_data_test.go
@@ -13,7 +13,6 @@ import (
 
 func TestUploadFiles(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 	fakeServer.MockAPI("ComponentData/requestUpload", func(w http.ResponseWriter, r *http.Request) {
@@ -34,7 +33,6 @@ func TestUploadFiles(t *testing.T) {
 		assert.Nil(t, err)
 	})
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)

--- a/api/container_registries_aws_ecr_access_key_test.go
+++ b/api/container_registries_aws_ecr_access_key_test.go
@@ -35,7 +35,6 @@ func TestContainerRegistriesAwsEcrAccessKeyGet(t *testing.T) {
 		apiPath    = fmt.Sprintf("ContainerRegistries/%s", intgGUID)
 		fakeServer = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -45,7 +44,6 @@ func TestContainerRegistriesAwsEcrAccessKeyGet(t *testing.T) {
 	})
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)

--- a/api/container_registries_aws_ecr_iam_role_test.go
+++ b/api/container_registries_aws_ecr_iam_role_test.go
@@ -35,7 +35,6 @@ func TestContainerRegistriesAwsEcrRoleGet(t *testing.T) {
 		apiPath    = fmt.Sprintf("ContainerRegistries/%s", intgGUID)
 		fakeServer = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -45,7 +44,6 @@ func TestContainerRegistriesAwsEcrRoleGet(t *testing.T) {
 	})
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)

--- a/api/container_registries_dockerhub_test.go
+++ b/api/container_registries_dockerhub_test.go
@@ -68,7 +68,6 @@ func TestContainerRegistriesDockerhubGet(t *testing.T) {
 		apiPath    = fmt.Sprintf("ContainerRegistries/%s", intgGUID)
 		fakeServer = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -78,7 +77,6 @@ func TestContainerRegistriesDockerhubGet(t *testing.T) {
 	})
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -101,7 +99,6 @@ func TestContainerRegistriesDockerhubUpdate(t *testing.T) {
 		apiPath    = fmt.Sprintf("ContainerRegistries/%s", intgGUID)
 		fakeServer = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -124,7 +121,6 @@ func TestContainerRegistriesDockerhubUpdate(t *testing.T) {
 	})
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)

--- a/api/container_registries_gcp_gar_test.go
+++ b/api/container_registries_gcp_gar_test.go
@@ -61,7 +61,6 @@ func TestContainerRegistriesGcpGarGet(t *testing.T) {
 		apiPath    = fmt.Sprintf("ContainerRegistries/%s", intgGUID)
 		fakeServer = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -71,7 +70,6 @@ func TestContainerRegistriesGcpGarGet(t *testing.T) {
 	})
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -95,7 +93,6 @@ func TestContainerRegistriesGcpGarUpdate(t *testing.T) {
 		apiPath    = fmt.Sprintf("ContainerRegistries/%s", intgGUID)
 		fakeServer = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -123,7 +120,6 @@ func TestContainerRegistriesGcpGarUpdate(t *testing.T) {
 	})
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)

--- a/api/container_registries_ghcr_test.go
+++ b/api/container_registries_ghcr_test.go
@@ -60,7 +60,6 @@ func TestContainerRegistriesGhcrGet(t *testing.T) {
 		apiPath    = fmt.Sprintf("ContainerRegistries/%s", intgGUID)
 		fakeServer = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -70,7 +69,6 @@ func TestContainerRegistriesGhcrGet(t *testing.T) {
 	})
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -94,7 +92,6 @@ func TestContainerRegistriesGhcrUpdate(t *testing.T) {
 		apiPath    = fmt.Sprintf("ContainerRegistries/%s", intgGUID)
 		fakeServer = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -118,7 +115,6 @@ func TestContainerRegistriesGhcrUpdate(t *testing.T) {
 	})
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)

--- a/api/container_registries_test.go
+++ b/api/container_registries_test.go
@@ -80,7 +80,6 @@ func TestContainerRegistriesGet(t *testing.T) {
 		vanillaInt  = singleVanillaContainerRegistry(intgGUID, vanillaType, "")
 		fakeServer  = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -101,7 +100,6 @@ func TestContainerRegistriesGet(t *testing.T) {
 	)
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -138,7 +136,6 @@ func TestContainerRegistriesDelete(t *testing.T) {
 		getResponse = generateContainerRegistryResponse(vanillaInt)
 		fakeServer  = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -168,7 +165,6 @@ func TestContainerRegistriesDelete(t *testing.T) {
 	)
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -210,7 +206,6 @@ func TestContainerRegistriesList(t *testing.T) {
 		expectedLen = len(allGUIDs)
 		fakeServer  = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	fakeServer.MockAPI("ContainerRegistries",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -231,7 +226,6 @@ func TestContainerRegistriesList(t *testing.T) {
 	defer fakeServer.Close()
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)

--- a/api/datasources_test.go
+++ b/api/datasources_test.go
@@ -45,7 +45,6 @@ const (
 
 func TestDatasourcesListMethod(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockAPI(
 		"Datasources",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -69,7 +68,6 @@ func TestDatasourcesListOK(t *testing.T) {
 	mockResponse := fmt.Sprintf(`{"data": [ %s ] }`, lqlDatasourceStr)
 
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockAPI(
 		"Datasources",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -95,7 +93,6 @@ func TestDatasourcesListOK(t *testing.T) {
 
 func TestDatasourcesListError(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockAPI(
 		"Datasources",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -118,7 +115,6 @@ func TestDatasourcesListError(t *testing.T) {
 
 func TestDatasourcesGetMethod(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockAPI(
 		"Datasources/CloudTrailRawEvents",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -142,7 +138,6 @@ func TestDatasourcesGetOK(t *testing.T) {
 	mockResponse := fmt.Sprintf(`{"data": %s }`, lqlDatasourceStr)
 
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockAPI(
 		"Datasources/CloudTrailRawEvents",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -170,7 +165,6 @@ func TestDatasourcesGetBadInput(t *testing.T) {
 	mockResponse := fmt.Sprintf(`{"data": %s }`, lqlDatasourceStr)
 
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockAPI(
 		"Datasources/CloudTrailRawEvents",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -193,7 +187,6 @@ func TestDatasourcesGetBadInput(t *testing.T) {
 
 func TestDatasourcesGetError(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockAPI(
 		"Datasources/CloudTrailRawEvents",
 		func(w http.ResponseWriter, r *http.Request) {

--- a/api/entities_images_test.go
+++ b/api/entities_images_test.go
@@ -32,7 +32,6 @@ import (
 
 func TestEntities_Images_Search(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	fakeServer.MockAPI("Entities/Images/search",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -43,7 +42,6 @@ func TestEntities_Images_Search(t *testing.T) {
 	defer fakeServer.Close()
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -60,7 +58,6 @@ func TestEntities_Images_Search(t *testing.T) {
 
 func TestEntities_Images_List(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	fakeServer.MockAPI("Entities/Images/search",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -71,7 +68,6 @@ func TestEntities_Images_List(t *testing.T) {
 	defer fakeServer.Close()
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -92,7 +88,6 @@ func TestEntities_Images_List(t *testing.T) {
 
 func TestEntities_Images_List_WithFilters(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	fakeServer.MockAPI("Entities/Images/search",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -103,7 +98,6 @@ func TestEntities_Images_List_WithFilters(t *testing.T) {
 	defer fakeServer.Close()
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -136,7 +130,6 @@ func TestEntities_Images_List_WithFilters(t *testing.T) {
 
 func TestEntities_Images_List_All(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	fakeServer.MockAPI("Entities/Images/search",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -147,7 +140,6 @@ func TestEntities_Images_List_All(t *testing.T) {
 	defer fakeServer.Close()
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -171,7 +163,6 @@ func TestEntities_Images_List_All(t *testing.T) {
 
 func TestEntities_Images_List_All_WithFilters(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	fakeServer.MockAPI("Entities/Images/search",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -182,7 +173,6 @@ func TestEntities_Images_List_All_WithFilters(t *testing.T) {
 	defer fakeServer.Close()
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -218,7 +208,6 @@ func TestEntities_Images_List_All_WithFilters(t *testing.T) {
 
 func TestEntities_Images_ListAll_EmptyData(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	fakeServer.MockAPI("Entities/Images/search",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -229,7 +218,6 @@ func TestEntities_Images_ListAll_EmptyData(t *testing.T) {
 	defer fakeServer.Close()
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -243,7 +231,6 @@ func TestEntities_Images_ListAll_EmptyData(t *testing.T) {
 
 func TestEntities_Images_ListAll_WithFilters_EmptyData(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	fakeServer.MockAPI("Entities/Images/search",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -254,7 +241,6 @@ func TestEntities_Images_ListAll_WithFilters_EmptyData(t *testing.T) {
 	defer fakeServer.Close()
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)

--- a/api/entities_machine_details_test.go
+++ b/api/entities_machine_details_test.go
@@ -32,7 +32,6 @@ import (
 
 func TestEntities_MachineDetails_Search(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	fakeServer.MockAPI("Entities/MachineDetails/search",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -43,7 +42,6 @@ func TestEntities_MachineDetails_Search(t *testing.T) {
 	defer fakeServer.Close()
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -60,7 +58,6 @@ func TestEntities_MachineDetails_Search(t *testing.T) {
 
 func TestEntities_MachineDetails_List(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	fakeServer.MockAPI("Entities/MachineDetails/search",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -77,7 +74,6 @@ func TestEntities_MachineDetails_List(t *testing.T) {
 	defer fakeServer.Close()
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -97,7 +93,6 @@ func TestEntities_MachineDetails_List(t *testing.T) {
 
 func TestEntities_MachineDetails_List_WithFilters(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	fakeServer.MockAPI("Entities/MachineDetails/search",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -114,7 +109,6 @@ func TestEntities_MachineDetails_List_WithFilters(t *testing.T) {
 	defer fakeServer.Close()
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -146,7 +140,6 @@ func TestEntities_MachineDetails_List_WithFilters(t *testing.T) {
 
 func TestEntities_MachineDetails_List_All(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	fakeServer.MockAPI("Entities/MachineDetails/search",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -163,7 +156,6 @@ func TestEntities_MachineDetails_List_All(t *testing.T) {
 	defer fakeServer.Close()
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -181,7 +173,6 @@ func TestEntities_MachineDetails_List_All(t *testing.T) {
 
 func TestEntities_MachineDetails_List_All_WithFilters(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	fakeServer.MockAPI("Entities/MachineDetails/search",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -198,7 +189,6 @@ func TestEntities_MachineDetails_List_All_WithFilters(t *testing.T) {
 	defer fakeServer.Close()
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -228,7 +218,6 @@ func TestEntities_MachineDetails_List_All_WithFilters(t *testing.T) {
 
 func TestEntities_MachineDetails_ListAll_EmptyData(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	fakeServer.MockAPI("Entities/MachineDetails/search",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -239,7 +228,6 @@ func TestEntities_MachineDetails_ListAll_EmptyData(t *testing.T) {
 	defer fakeServer.Close()
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -253,7 +241,6 @@ func TestEntities_MachineDetails_ListAll_EmptyData(t *testing.T) {
 
 func TestEntities_MachineDetails_ListAll_WithFilters_EmptyData(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	fakeServer.MockAPI("Entities/MachineDetails/search",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -264,7 +251,6 @@ func TestEntities_MachineDetails_ListAll_WithFilters_EmptyData(t *testing.T) {
 	defer fakeServer.Close()
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)

--- a/api/entities_test.go
+++ b/api/entities_test.go
@@ -31,7 +31,6 @@ import (
 
 func TestEntities_Search(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	fakeServer.MockAPI("Entities/MachineDetails/search",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -42,7 +41,6 @@ func TestEntities_Search(t *testing.T) {
 	defer fakeServer.Close()
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -57,7 +55,6 @@ func TestEntities_Search(t *testing.T) {
 
 func TestEntities_SearchUnknownEntity(t *testing.T) {
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 	)
 	assert.NoError(t, err)

--- a/api/entities_users_test.go
+++ b/api/entities_users_test.go
@@ -31,7 +31,6 @@ import (
 
 func TestEntities_Users_List(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	fakeServer.MockAPI("Entities/Users/search",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -42,7 +41,6 @@ func TestEntities_Users_List(t *testing.T) {
 	defer fakeServer.Close()
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -58,7 +56,6 @@ func TestEntities_Users_List(t *testing.T) {
 
 func TestEntities_Users_List_All(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	fakeServer.MockAPI("Entities/Users/search",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -69,7 +66,6 @@ func TestEntities_Users_List_All(t *testing.T) {
 	defer fakeServer.Close()
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -85,7 +81,6 @@ func TestEntities_Users_List_All(t *testing.T) {
 
 func TestEntities_Users_ListAll_EmptyData(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	fakeServer.MockAPI("Entities/Users/search",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -96,7 +91,6 @@ func TestEntities_Users_ListAll_EmptyData(t *testing.T) {
 	defer fakeServer.Close()
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)

--- a/api/errors_test.go
+++ b/api/errors_test.go
@@ -30,7 +30,6 @@ import (
 
 func TestErrorWithV2Message(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockAPI(
 		"any/endpoint",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -44,7 +43,6 @@ func TestErrorWithV2Message(t *testing.T) {
 	defer fakeServer.Close()
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)

--- a/api/feature_flags_test.go
+++ b/api/feature_flags_test.go
@@ -12,7 +12,6 @@ import (
 
 func TestGetFeatureFlagsMatchingPrefix(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 	fakeServer.MockAPI("FeatureFlags/PUBLIC.sca", func(w http.ResponseWriter, r *http.Request) {
@@ -21,7 +20,6 @@ func TestGetFeatureFlagsMatchingPrefix(t *testing.T) {
 		assert.Nil(t, err)
 	})
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)

--- a/api/inventory_aws_test.go
+++ b/api/inventory_aws_test.go
@@ -31,7 +31,6 @@ import (
 
 func TestInventoryAwsSearch(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	fakeServer.MockAPI("Inventory/search",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -42,7 +41,6 @@ func TestInventoryAwsSearch(t *testing.T) {
 	defer fakeServer.Close()
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -59,7 +57,6 @@ func TestInventoryAwsSearch(t *testing.T) {
 
 func TestInventoryAwsScan(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	fakeServer.MockAPI("Inventory/scan",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -70,7 +67,6 @@ func TestInventoryAwsScan(t *testing.T) {
 	defer fakeServer.Close()
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)

--- a/api/inventory_test.go
+++ b/api/inventory_test.go
@@ -31,7 +31,6 @@ import (
 
 func TestInventorySearch(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	fakeServer.MockAPI("Inventory/search",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -42,7 +41,6 @@ func TestInventorySearch(t *testing.T) {
 	defer fakeServer.Close()
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -57,7 +55,6 @@ func TestInventorySearch(t *testing.T) {
 
 func TestInventorySearchInvalid(t *testing.T) {
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 	)
 	assert.NoError(t, err)

--- a/api/logging_test.go
+++ b/api/logging_test.go
@@ -42,7 +42,7 @@ func TestNewClientWithLogLevel(t *testing.T) {
 			api.WithLogLevel("INFO"),
 		)
 		if assert.Nil(t, err) {
-			assert.Equal(t, "v1", c.ApiVersion(), "API version should be v1")
+			assert.Equal(t, "v2", c.ApiVersion(), "API version should be v2")
 		}
 	})
 
@@ -69,7 +69,7 @@ func TestClientWithLogLevelAndWriter(t *testing.T) {
 		api.WithLogLevelAndWriter("DEBUG", log.Writer()),
 	)
 	if assert.Nil(t, err) {
-		assert.Equal(t, "v1", c.ApiVersion(), "API version should be v1")
+		assert.Equal(t, "v2", c.ApiVersion(), "API version should be v2")
 	}
 
 	// generating a DEBUG log by creating a new request
@@ -93,7 +93,7 @@ func TestClientWithLogLevelAndWriter(t *testing.T) {
 	//   "account":"test",
 	//   "method":"GET",
 	//   "url":"http://127.0.0.1:58753",
-	//   "endpoint":"/api/v1/foo",
+	//   "endpoint":"/api/v2/foo",
 	//   "headers":{
 	//     "Accept":"application/json",
 	//     "Authorization":"TOKEN",
@@ -106,7 +106,7 @@ func TestClientWithLogLevelAndWriter(t *testing.T) {
 	assert.Contains(t, logContent, "api/client.go")
 	assert.Contains(t, logContent, "\"request\"")
 	assert.Contains(t, logContent, "\"endpoint\"")
-	assert.Contains(t, logContent, "/api/v1/foo")
+	assert.Contains(t, logContent, "/api/v2/foo")
 	assert.Contains(t, logContent, "\"method\"")
 	assert.Contains(t, logContent, "GET")
 	assert.Contains(t, logContent, "\"id\"")
@@ -130,7 +130,7 @@ func TestClientWithLogLevelAndFile(t *testing.T) {
 		api.WithLogLevelAndFile("INFO", tmpfile.Name()),
 	)
 	if assert.Nil(t, err) {
-		assert.Equal(t, "v1", c.ApiVersion(), "API version should be v1")
+		assert.Equal(t, "v2", c.ApiVersion(), "API version should be v2")
 	}
 
 	logContentB, err := ioutil.ReadFile(tmpfile.Name())
@@ -153,7 +153,7 @@ func testNewClientLogOutput(t *testing.T, out string) {
 	//   "id":        "12ba597e8b7b2379",
 	//   "account":   "test",
 	//   "url":       "http://127.0.0.1:52544",
-	//   "version":   "v1",
+	//   "version":   "v2",
 	//   "log_level": "INFO",
 	//   "timeout":   3600
 	// }
@@ -170,7 +170,7 @@ func testNewClientLogOutput(t *testing.T, out string) {
 	assert.Contains(t, out, "\"account\"")
 	assert.Contains(t, out, "test")
 	assert.Contains(t, out, "\"version\"")
-	assert.Contains(t, out, "v1")
+	assert.Contains(t, out, "v2")
 	assert.Contains(t, out, "\"log_level\"")
 	assert.Contains(t, out, "\"id\"")
 	assert.Contains(t, out, "\"ts\"")

--- a/api/lql_delete_test.go
+++ b/api/lql_delete_test.go
@@ -31,7 +31,6 @@ import (
 
 func TestQueryDeleteMethod(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockAPI(
 		"Queries/my_lql",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -54,7 +53,6 @@ func TestQueryDeleteMethod(t *testing.T) {
 
 func TestQueryDeleteBadInput(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockAPI(
 		"Queries/my_lql",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -76,7 +74,6 @@ func TestQueryDeleteBadInput(t *testing.T) {
 func TestQueryDeleteOK(t *testing.T) {
 
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockAPI(
 		"Queries/my_lql",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -104,7 +101,6 @@ func TestQueryDeleteOK(t *testing.T) {
 
 func TestQueryDeleteNotFound(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockAPI(
 		"Queries/my_lql",
 		func(w http.ResponseWriter, r *http.Request) {

--- a/api/lql_execute_test.go
+++ b/api/lql_execute_test.go
@@ -87,7 +87,6 @@ var (
 
 func TestQueryExecuteMethod(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockAPI(
 		"Queries/execute",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -111,7 +110,6 @@ func TestQueryExecuteOK(t *testing.T) {
 	mockResponse := mockQueryDataResponse(executeQueryData)
 
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockAPI(
 		"Queries/execute",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -143,7 +141,6 @@ func TestQueryExecuteBad(t *testing.T) {
 	mockResponse := mockQueryDataResponse(executeQueryData)
 
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockAPI(
 		"Queries/execute",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -167,7 +164,6 @@ func TestQueryExecuteBad(t *testing.T) {
 
 func TestQueryExecuteError(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockAPI(
 		"Queries/execute",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -188,7 +184,6 @@ func TestQueryExecuteError(t *testing.T) {
 
 func TestQueryExecuteByIDMethod(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockAPI(
 		fmt.Sprintf("Queries/%s/execute", queryID),
 		func(w http.ResponseWriter, r *http.Request) {
@@ -212,7 +207,6 @@ func TestQueryExecuteByIDOK(t *testing.T) {
 	mockResponse := mockQueryDataResponse(executeQueryData)
 
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockAPI(
 		fmt.Sprintf("Queries/%s/execute", queryID),
 		func(w http.ResponseWriter, r *http.Request) {
@@ -241,7 +235,6 @@ func TestQueryExecuteByIDBad(t *testing.T) {
 	mockResponse := mockQueryDataResponse(executeQueryData)
 
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockAPI(
 		"Queries/execute",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -265,7 +258,6 @@ func TestQueryExecuteByIDBad(t *testing.T) {
 
 func TestQueryExecuteByIDError(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockAPI(
 		fmt.Sprintf("Queries/%s/execute", queryID),
 		func(w http.ResponseWriter, r *http.Request) {

--- a/api/lql_test.go
+++ b/api/lql_test.go
@@ -110,7 +110,6 @@ func TestParseNewQuery(t *testing.T) {
 
 func TestQueryCreateMethod(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockAPI(
 		"Queries",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -134,7 +133,6 @@ func TestQueryCreateOK(t *testing.T) {
 	mockResponse := mockQueryDataResponse(newQueryJSON)
 
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockAPI(
 		"Queries",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -161,7 +159,6 @@ func TestQueryCreateOK(t *testing.T) {
 
 func TestQueryCreateError(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockAPI(
 		"Queries",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -182,7 +179,6 @@ func TestQueryCreateError(t *testing.T) {
 
 func TestQueryListMethod(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockAPI(
 		"Queries",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -206,7 +202,6 @@ func TestQueryGetQueryByIDOK(t *testing.T) {
 	mockResponse := mockQueryDataResponse(newQueryJSON)
 
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockAPI(
 		"Queries/my_lql",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -234,7 +229,6 @@ func TestQueryGetQueryByIDOK(t *testing.T) {
 
 func TestQueryGetNotFound(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockAPI(
 		"Queries",
 		func(w http.ResponseWriter, r *http.Request) {

--- a/api/lql_update_test.go
+++ b/api/lql_update_test.go
@@ -42,7 +42,6 @@ var (
 
 func TestQueryUpdateMethod(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockAPI(
 		"Queries/my_lql",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -64,7 +63,6 @@ func TestQueryUpdateMethod(t *testing.T) {
 
 func TestQueryUpdateBadInput(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockAPI(
 		"Queries/my_lql",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -87,7 +85,6 @@ func TestQueryUpdateOK(t *testing.T) {
 	mockResponse := mockQueryDataResponse(updateQueryJSON)
 
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockAPI(
 		"Queries/my_lql",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -114,7 +111,6 @@ func TestQueryUpdateOK(t *testing.T) {
 
 func TestQueryUpdateNotFound(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockAPI(
 		"Queries/my_lql",
 		func(w http.ResponseWriter, r *http.Request) {

--- a/api/lql_validate_test.go
+++ b/api/lql_validate_test.go
@@ -37,7 +37,6 @@ var (
 
 func TestQueryValidateMethod(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockAPI(
 		"Queries/validate",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -61,7 +60,6 @@ func TestQueryValidateOK(t *testing.T) {
 	mockResponse := mockQueryDataResponse(newQueryJSON)
 
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockAPI(
 		"Queries/validate",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -87,7 +85,6 @@ func TestQueryValidateOK(t *testing.T) {
 
 func TestQueryValidateError(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockAPI(
 		"Queries/validate",
 		func(w http.ResponseWriter, r *http.Request) {

--- a/api/organization_info_test.go
+++ b/api/organization_info_test.go
@@ -30,7 +30,6 @@ import (
 
 func TestOrganizationInfoGet(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	fakeServer.MockAPI("OrganizationInfo",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -41,7 +40,6 @@ func TestOrganizationInfoGet(t *testing.T) {
 	defer fakeServer.Close()
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)

--- a/api/policy_exceptions_test.go
+++ b/api/policy_exceptions_test.go
@@ -39,7 +39,6 @@ func TestPolicyExceptionsGet(t *testing.T) {
 		policyException = singleMockPolicyException(exceptionID)
 		fakeServer      = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -60,7 +59,6 @@ func TestPolicyExceptionsGet(t *testing.T) {
 	)
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -100,7 +98,6 @@ func TestPolicyExceptionsDelete(t *testing.T) {
 		getResponse     = generatePolicyExceptionResponse(policyException)
 		fakeServer      = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -130,7 +127,6 @@ func TestPolicyExceptionsDelete(t *testing.T) {
 	)
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -172,7 +168,6 @@ func TestPolicyExceptionsList(t *testing.T) {
 		fakeServer       = lacework.MockServer()
 	)
 
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	fakeServer.MockAPI("Exceptions",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -190,7 +185,6 @@ func TestPolicyExceptionsList(t *testing.T) {
 	defer fakeServer.Close()
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -211,7 +205,6 @@ func TestPolicyExceptionUpdate(t *testing.T) {
 		apiPath     = fmt.Sprintf("Exceptions/%s", exceptionID)
 		fakeServer  = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -229,7 +222,6 @@ func TestPolicyExceptionUpdate(t *testing.T) {
 	})
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)

--- a/api/policy_test.go
+++ b/api/policy_test.go
@@ -137,7 +137,6 @@ func TestPolicyHasTags(t *testing.T) {
 
 func TestPolicyCreateMethod(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockAPI(
 		policyURI,
 		func(w http.ResponseWriter, r *http.Request) {
@@ -161,7 +160,6 @@ func TestPolicyCreateOK(t *testing.T) {
 	mockResponse := mockPolicyDataResponse(policyCreateData)
 
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockAPI(
 		policyURI,
 		func(w http.ResponseWriter, r *http.Request) {
@@ -186,7 +184,6 @@ func TestPolicyCreateOK(t *testing.T) {
 
 func TestPolicyCreateError(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockAPI(
 		policyURI,
 		func(w http.ResponseWriter, r *http.Request) {
@@ -207,7 +204,6 @@ func TestPolicyCreateError(t *testing.T) {
 
 func TestPolicyGetMethod(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockAPI(
 		fmt.Sprintf("%s/%s", policyURI, policyID),
 		func(w http.ResponseWriter, r *http.Request) {
@@ -231,7 +227,6 @@ func TestPolicyGetOK(t *testing.T) {
 	mockResponse := mockPolicyDataResponse(policyCreateData)
 
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockAPI(
 		fmt.Sprintf("%s/%s", policyURI, policyID),
 		func(w http.ResponseWriter, r *http.Request) {
@@ -258,7 +253,6 @@ func TestPolicyGetOK(t *testing.T) {
 
 func TestPolicyGetNotFound(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockAPI(
 		fmt.Sprintf("%s/%s", policyURI, policyID),
 		func(w http.ResponseWriter, r *http.Request) {
@@ -279,7 +273,6 @@ func TestPolicyGetNotFound(t *testing.T) {
 
 func TestPolicyListMethod(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockAPI(
 		"Policies",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -301,7 +294,6 @@ func TestPolicyListMethod(t *testing.T) {
 
 func TestPolicyListTagsMethod(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockAPI(
 		"Policies/Tags",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -323,7 +315,6 @@ func TestPolicyListTagsMethod(t *testing.T) {
 
 func TestPolicyUpdateMethod(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockAPI(
 		fmt.Sprintf("%s/%s", policyURI, policyID),
 		func(w http.ResponseWriter, r *http.Request) {
@@ -345,7 +336,6 @@ func TestPolicyUpdateMethod(t *testing.T) {
 
 func TestPolicyUpdateManyMethod(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockAPI(
 		policyURI,
 		func(w http.ResponseWriter, r *http.Request) {
@@ -367,7 +357,6 @@ func TestPolicyUpdateManyMethod(t *testing.T) {
 
 func TestPolicyUpdateManyOK(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockAPI(
 		policyURI,
 		func(w http.ResponseWriter, r *http.Request) {
@@ -392,7 +381,6 @@ func TestPolicyUpdateManyOK(t *testing.T) {
 
 func TestPolicyUpdateBadInput(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockAPI(
 		fmt.Sprintf("%s/%s", policyURI, policyID),
 		func(w http.ResponseWriter, r *http.Request) {
@@ -416,7 +404,6 @@ func TestPolicyUpdateOK(t *testing.T) {
 	mockResponse := mockPolicyDataResponse(policyUpdateData)
 
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockAPI(
 		fmt.Sprintf("%s/%s", policyURI, policyID),
 		func(w http.ResponseWriter, r *http.Request) {
@@ -441,7 +428,6 @@ func TestPolicyUpdateOK(t *testing.T) {
 
 func TestPolicyUpdateError(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockAPI(
 		fmt.Sprintf("%s/%s", policyURI, policyID),
 		func(w http.ResponseWriter, r *http.Request) {
@@ -462,7 +448,6 @@ func TestPolicyUpdateError(t *testing.T) {
 
 func TestPolicyDeleteMethod(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockAPI(
 		fmt.Sprintf("%s/%s", policyURI, policyID),
 		func(w http.ResponseWriter, r *http.Request) {
@@ -484,7 +469,6 @@ func TestPolicyDeleteMethod(t *testing.T) {
 
 func TestPolicyDeleteBadInput(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockAPI(
 		fmt.Sprintf("%s/%s", policyURI, policyID),
 		func(w http.ResponseWriter, r *http.Request) {
@@ -505,7 +489,6 @@ func TestPolicyDeleteBadInput(t *testing.T) {
 
 func TestPolicyDeleteOK(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockAPI(
 		fmt.Sprintf("%s/%s", policyURI, policyID),
 		func(w http.ResponseWriter, r *http.Request) {
@@ -527,7 +510,6 @@ func TestPolicyDeleteOK(t *testing.T) {
 
 func TestPolicyDeleteError(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockAPI(
 		fmt.Sprintf("%s/%s", policyURI, policyID),
 		func(w http.ResponseWriter, r *http.Request) {

--- a/api/report_definitions_test.go
+++ b/api/report_definitions_test.go
@@ -38,7 +38,6 @@ func TestReportDefinitionsGet(t *testing.T) {
 		reportDefinition = singleMockReportDefinition(intgGUID)
 		fakeServer       = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -59,7 +58,6 @@ func TestReportDefinitionsGet(t *testing.T) {
 	)
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -99,7 +97,6 @@ func TestReportDefinitionsDelete(t *testing.T) {
 		getResponse      = generateReportDefinitionResponse(reportDefinition)
 		fakeServer       = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -129,7 +126,6 @@ func TestReportDefinitionsDelete(t *testing.T) {
 	)
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -172,7 +168,6 @@ func TestReportDefinitionsList(t *testing.T) {
 		fakeServer        = lacework.MockServer()
 	)
 
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	fakeServer.MockAPI("ReportDefinitions",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -190,7 +185,6 @@ func TestReportDefinitionsList(t *testing.T) {
 	defer fakeServer.Close()
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -211,7 +205,6 @@ func TestReportDefinitionUpdate(t *testing.T) {
 		apiPath    = fmt.Sprintf("ReportDefinitions/%s", intgGUID)
 		fakeServer = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -229,7 +222,6 @@ func TestReportDefinitionUpdate(t *testing.T) {
 	})
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -268,7 +260,6 @@ func TestReportDefinitionRevert(t *testing.T) {
 		apiPath    = fmt.Sprintf("ReportDefinitions/%s", intgGUID)
 		fakeServer = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -283,7 +274,6 @@ func TestReportDefinitionRevert(t *testing.T) {
 	})
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)

--- a/api/report_distributions_test.go
+++ b/api/report_distributions_test.go
@@ -38,7 +38,6 @@ func TestReportDistributionsGet(t *testing.T) {
 		reportDistribution = singleMockReportDistribution(intgGUID)
 		fakeServer         = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -59,7 +58,6 @@ func TestReportDistributionsGet(t *testing.T) {
 	)
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -96,7 +94,6 @@ func TestReportDistributionDelete(t *testing.T) {
 		getResponse        = generateReportDistributionResponse(reportDistribution)
 		fakeServer         = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -126,7 +123,6 @@ func TestReportDistributionDelete(t *testing.T) {
 	)
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -165,7 +161,6 @@ func TestReportDistributionList(t *testing.T) {
 		fakeServer          = lacework.MockServer()
 	)
 
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	fakeServer.MockAPI("ReportDistributions",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -183,7 +178,6 @@ func TestReportDistributionList(t *testing.T) {
 	defer fakeServer.Close()
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -204,7 +198,6 @@ func TestReportDistributionUpdate(t *testing.T) {
 		apiPath    = fmt.Sprintf("ReportDistributions/%s", intgGUID)
 		fakeServer = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -222,7 +215,6 @@ func TestReportDistributionUpdate(t *testing.T) {
 	})
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)

--- a/api/report_rules_test.go
+++ b/api/report_rules_test.go
@@ -38,7 +38,6 @@ func TestReportRulesGet(t *testing.T) {
 		reportRule = singleMockReportRule(intgGUID)
 		fakeServer = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -59,7 +58,6 @@ func TestReportRulesGet(t *testing.T) {
 	)
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -95,7 +93,6 @@ func TestReportRulesDelete(t *testing.T) {
 		getResponse = generateReportRuleResponse(reportRule)
 		fakeServer  = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -125,7 +122,6 @@ func TestReportRulesDelete(t *testing.T) {
 	)
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -164,7 +160,6 @@ func TestReportRulesList(t *testing.T) {
 		fakeServer  = lacework.MockServer()
 	)
 
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	fakeServer.MockAPI("ReportRules",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -182,7 +177,6 @@ func TestReportRulesList(t *testing.T) {
 	defer fakeServer.Close()
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -203,7 +197,6 @@ func TestReportRuleUpdate(t *testing.T) {
 		apiPath    = fmt.Sprintf("ReportRules/%s", intgGUID)
 		fakeServer = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -222,7 +215,6 @@ func TestReportRuleUpdate(t *testing.T) {
 	})
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)

--- a/api/reports_test.go
+++ b/api/reports_test.go
@@ -12,7 +12,6 @@ import (
 
 func TestV2ReportsAwsGet(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	fakeServer.MockAPI("Reports",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -23,7 +22,6 @@ func TestV2ReportsAwsGet(t *testing.T) {
 	defer fakeServer.Close()
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -43,7 +41,6 @@ func TestV2ReportsAwsGet(t *testing.T) {
 
 func TestV2ReportsAwsGetByName(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	fakeServer.MockAPI("Reports",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -54,7 +51,6 @@ func TestV2ReportsAwsGetByName(t *testing.T) {
 	defer fakeServer.Close()
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -74,7 +70,6 @@ func TestV2ReportsAwsGetByName(t *testing.T) {
 
 func TestV2ReportsAzureGet(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	fakeServer.MockAPI("Reports",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -85,7 +80,6 @@ func TestV2ReportsAzureGet(t *testing.T) {
 	defer fakeServer.Close()
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -105,7 +99,6 @@ func TestV2ReportsAzureGet(t *testing.T) {
 
 func TestV2ReportsAzureGetByName(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	fakeServer.MockAPI("Reports",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -116,7 +109,6 @@ func TestV2ReportsAzureGetByName(t *testing.T) {
 	defer fakeServer.Close()
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -136,7 +128,6 @@ func TestV2ReportsAzureGetByName(t *testing.T) {
 
 func TestV2ReportsGcpGet(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	fakeServer.MockAPI("Reports",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -147,7 +138,6 @@ func TestV2ReportsGcpGet(t *testing.T) {
 	defer fakeServer.Close()
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -167,7 +157,6 @@ func TestV2ReportsGcpGet(t *testing.T) {
 
 func TestV2ReportsGcpGetByName(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	fakeServer.MockAPI("Reports",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -178,7 +167,6 @@ func TestV2ReportsGcpGetByName(t *testing.T) {
 	defer fakeServer.Close()
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)

--- a/api/resource_groups_aws_test.go
+++ b/api/resource_groups_aws_test.go
@@ -39,7 +39,6 @@ func TestResourceGroupAwsGet(t *testing.T) {
 		apiPath      = fmt.Sprintf("ResourceGroups/%s", resourceGUID)
 		fakeServer   = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -49,7 +48,6 @@ func TestResourceGroupAwsGet(t *testing.T) {
 	})
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -70,7 +68,6 @@ func TestResourceGroupsAwsUpdate(t *testing.T) {
 		apiPath      = fmt.Sprintf("ResourceGroups/%s", resourceGUID)
 		fakeServer   = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -89,7 +86,6 @@ func TestResourceGroupsAwsUpdate(t *testing.T) {
 	})
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)

--- a/api/resource_groups_azure_test.go
+++ b/api/resource_groups_azure_test.go
@@ -36,7 +36,6 @@ func TestResourceGroupAzureGet(t *testing.T) {
 		apiPath      = fmt.Sprintf("ResourceGroups/%s", resourceGUID)
 		fakeServer   = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -46,7 +45,6 @@ func TestResourceGroupAzureGet(t *testing.T) {
 	})
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -68,7 +66,6 @@ func TestResourceGroupsAzureUpdate(t *testing.T) {
 		apiPath      = fmt.Sprintf("ResourceGroups/%s", resourceGUID)
 		fakeServer   = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -87,7 +84,6 @@ func TestResourceGroupsAzureUpdate(t *testing.T) {
 	})
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)

--- a/api/resource_groups_container_test.go
+++ b/api/resource_groups_container_test.go
@@ -36,7 +36,6 @@ func TestResourceGroupContainerGet(t *testing.T) {
 		apiPath      = fmt.Sprintf("ResourceGroups/%s", resourceGUID)
 		fakeServer   = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -46,7 +45,6 @@ func TestResourceGroupContainerGet(t *testing.T) {
 	})
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -68,7 +66,6 @@ func TestResourceGroupsContainerUpdate(t *testing.T) {
 		apiPath      = fmt.Sprintf("ResourceGroups/%s", resourceGUID)
 		fakeServer   = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -87,7 +84,6 @@ func TestResourceGroupsContainerUpdate(t *testing.T) {
 	})
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)

--- a/api/resource_groups_gcp_test.go
+++ b/api/resource_groups_gcp_test.go
@@ -36,7 +36,6 @@ func TestResourceGroupGcpGet(t *testing.T) {
 		apiPath      = fmt.Sprintf("ResourceGroups/%s", resourceGUID)
 		fakeServer   = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -46,7 +45,6 @@ func TestResourceGroupGcpGet(t *testing.T) {
 	})
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -68,7 +66,6 @@ func TestResourceGroupsGcpUpdate(t *testing.T) {
 		apiPath      = fmt.Sprintf("ResourceGroups/%s", resourceGUID)
 		fakeServer   = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -87,7 +84,6 @@ func TestResourceGroupsGcpUpdate(t *testing.T) {
 	})
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)

--- a/api/resource_groups_lw_account_test.go
+++ b/api/resource_groups_lw_account_test.go
@@ -36,7 +36,6 @@ func TestResourceGroupLwAccountGet(t *testing.T) {
 		apiPath      = fmt.Sprintf("ResourceGroups/%s", resourceGUID)
 		fakeServer   = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -46,7 +45,6 @@ func TestResourceGroupLwAccountGet(t *testing.T) {
 	})
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -67,7 +65,6 @@ func TestResourceGroupsLwAccountUpdate(t *testing.T) {
 		apiPath      = fmt.Sprintf("ResourceGroups/%s", resourceGUID)
 		fakeServer   = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -86,7 +83,6 @@ func TestResourceGroupsLwAccountUpdate(t *testing.T) {
 	})
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)

--- a/api/resource_groups_machine_test.go
+++ b/api/resource_groups_machine_test.go
@@ -36,7 +36,6 @@ func TestResourceGroupMachineGet(t *testing.T) {
 		apiPath      = fmt.Sprintf("ResourceGroups/%s", resourceGUID)
 		fakeServer   = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -46,7 +45,6 @@ func TestResourceGroupMachineGet(t *testing.T) {
 	})
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -67,7 +65,6 @@ func TestResourceGroupsMachineUpdate(t *testing.T) {
 		apiPath      = fmt.Sprintf("ResourceGroups/%s", resourceGUID)
 		fakeServer   = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -86,7 +83,6 @@ func TestResourceGroupsMachineUpdate(t *testing.T) {
 	})
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)

--- a/api/resource_groups_test.go
+++ b/api/resource_groups_test.go
@@ -80,7 +80,6 @@ func TestResourceGroupGet(t *testing.T) {
 		vanillaGroup = singleVanillaResourceGroup(resourceGUID, vanillaType, "")
 		fakeServer   = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -101,7 +100,6 @@ func TestResourceGroupGet(t *testing.T) {
 	)
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -138,7 +136,6 @@ func TestResourceGroupsDelete(t *testing.T) {
 		getResponse  = generateResourceGroupResponse(vanillaInt)
 		fakeServer   = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -166,7 +163,6 @@ func TestResourceGroupsDelete(t *testing.T) {
 	)
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -214,7 +210,6 @@ func TestResourceGroupsList(t *testing.T) {
 	}
 	expectedLen := len(allGuids)
 
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	fakeServer.MockAPI("ResourceGroups",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -236,7 +231,6 @@ func TestResourceGroupsList(t *testing.T) {
 	defer fakeServer.Close()
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)

--- a/api/team_members_test.go
+++ b/api/team_members_test.go
@@ -40,7 +40,6 @@ func TestTeamMembers_List(t *testing.T) {
 		fakeServer      = lacework.MockServer()
 	)
 
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	fakeServer.MockAPI("TeamMembers",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -58,7 +57,6 @@ func TestTeamMembers_List(t *testing.T) {
 	defer fakeServer.Close()
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -81,7 +79,6 @@ func TestTeamMembers_List_WithTimeFieldsAsInts(t *testing.T) {
 		fakeServer      = lacework.MockServer()
 	)
 
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	fakeServer.MockAPI("TeamMembers",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -99,7 +96,6 @@ func TestTeamMembers_List_WithTimeFieldsAsInts(t *testing.T) {
 	defer fakeServer.Close()
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -121,7 +117,6 @@ func TestTeamMembers_Get(t *testing.T) {
 		teamMember = singleMockTeamMember(intgGUID, "vatasha.white@lacework.net")
 		fakeServer = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -134,7 +129,6 @@ func TestTeamMembers_Get(t *testing.T) {
 	)
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -169,7 +163,6 @@ func TestTeamMembers_Get_WithTimeFieldsAsInts(t *testing.T) {
 		teamMember = singleMockTeamMemberWithTimeFieldsAsInts(intgGUID, "vatasha.white@lacework.net")
 		fakeServer = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -182,7 +175,6 @@ func TestTeamMembers_Get_WithTimeFieldsAsInts(t *testing.T) {
 	)
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -216,7 +208,6 @@ func TestTeamMembers_Create(t *testing.T) {
 		teamMember = singleMockTeamMember(intgGUID, "vatasha.white@lacework.net")
 		fakeServer = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -229,7 +220,6 @@ func TestTeamMembers_Create(t *testing.T) {
 	)
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -266,7 +256,6 @@ func TestTeamMembers_Create_WithTimeFieldsAsInts(t *testing.T) {
 		teamMember = singleMockTeamMemberWithTimeFieldsAsInts(intgGUID, "vatasha.white@lacework.net")
 		fakeServer = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -279,7 +268,6 @@ func TestTeamMembers_Create_WithTimeFieldsAsInts(t *testing.T) {
 	)
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -313,7 +301,6 @@ func TestTeamMembers_Create_WithTimeFieldsAsInts(t *testing.T) {
 func TestTeamMembers_CreateOrg(t *testing.T) {
 	var fakeServer = lacework.MockServer()
 
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -326,7 +313,6 @@ func TestTeamMembers_CreateOrg(t *testing.T) {
 	)
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 		api.WithOrgAccess(),
@@ -356,7 +342,6 @@ func TestTeamMember_Update(t *testing.T) {
 		fakeServer = lacework.MockServer()
 		apiPath    = fmt.Sprintf("TeamMembers/%s", intgGUID)
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -376,7 +361,6 @@ func TestTeamMember_Update(t *testing.T) {
 	)
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -413,7 +397,6 @@ func TestTeamMember_Update_WithTimeFieldsAsInts(t *testing.T) {
 		fakeServer = lacework.MockServer()
 		apiPath    = fmt.Sprintf("TeamMembers/%s", intgGUID)
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -433,7 +416,6 @@ func TestTeamMember_Update_WithTimeFieldsAsInts(t *testing.T) {
 	)
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -473,7 +455,6 @@ func TestTeamMember_UpdateOrg(t *testing.T) {
 		username   = fmt.Sprintf("vatasha.white+%s@lacework.net", teamMemberGuids[0])
 		teamMember = singleMockTeamMemberOrgUpdateResponse(teamMemberGuids[0], teamMemberGuids[1], username)
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -514,7 +495,6 @@ func TestTeamMember_UpdateOrg(t *testing.T) {
 	)
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 		api.WithOrgAccess(),
@@ -545,7 +525,6 @@ func TestTeamMember_Delete(t *testing.T) {
 		apiPath         = fmt.Sprintf("TeamMembers/%s", intgGUID)
 		responseFromGet = generateTeamMemberResponse(teamMember)
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -565,7 +544,6 @@ func TestTeamMember_Delete(t *testing.T) {
 	)
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -604,7 +582,6 @@ func TestTeamMember_Delete_WithTimeFieldsAsInts(t *testing.T) {
 		apiPath         = fmt.Sprintf("TeamMembers/%s", intgGUID)
 		responseFromGet = generateTeamMemberResponse(teamMember)
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -624,7 +601,6 @@ func TestTeamMember_Delete_WithTimeFieldsAsInts(t *testing.T) {
 	)
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -663,7 +639,6 @@ func TestTeamMember_DeleteOrg(t *testing.T) {
 		apiPath         = fmt.Sprintf("TeamMembers/%s", intgGUID)
 		responseFromGet = generateTeamMemberResponse(teamMember)
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -683,7 +658,6 @@ func TestTeamMember_DeleteOrg(t *testing.T) {
 	)
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 		api.WithOrgAccess(),
@@ -722,7 +696,6 @@ func TestTeamMembers_SearchUsername(t *testing.T) {
 		fakeServer      = lacework.MockServer()
 		username        = fmt.Sprintf("vatasha.white+%s@lacework.net", teamMemberGuids[0])
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -751,7 +724,6 @@ func TestTeamMembers_SearchUsername(t *testing.T) {
 	)
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)

--- a/api/user_profile_test.go
+++ b/api/user_profile_test.go
@@ -31,7 +31,6 @@ import (
 
 func TestV2UserProfile(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockAPI("UserProfile",
 		func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, "GET", r.Method, "UserProfile should be a GET method")

--- a/api/v2_recommendations_aws_test.go
+++ b/api/v2_recommendations_aws_test.go
@@ -35,7 +35,6 @@ func TestRecommendationsAwsGetReport(t *testing.T) {
 	)
 
 	fakeServer.MockToken("TOKEN")
-	fakeServer.UseApiV2()
 	fakeServer.MockAPI("recommendations/aws",
 		func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, "GET", r.Method, "GetReport() should be a GET method")

--- a/api/v2_recommendations_azure_test.go
+++ b/api/v2_recommendations_azure_test.go
@@ -35,7 +35,6 @@ func TestRecommendationsAzureCISGetReport(t *testing.T) {
 	)
 
 	fakeServer.MockToken("TOKEN")
-	fakeServer.UseApiV2()
 	fakeServer.MockAPI("recommendations/azure",
 		func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, "GET", r.Method, "GetReport() should be a GET method")
@@ -67,7 +66,6 @@ func TestRecommendationsAzureCIS131GetReport(t *testing.T) {
 	)
 
 	fakeServer.MockToken("TOKEN")
-	fakeServer.UseApiV2()
 	fakeServer.MockAPI("recommendations/azure",
 		func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, "GET", r.Method, "GetReport() should be a GET method")

--- a/api/v2_recommendations_gcp_test.go
+++ b/api/v2_recommendations_gcp_test.go
@@ -35,7 +35,6 @@ func TestRecommendationsGcpCISGetReport(t *testing.T) {
 	)
 
 	fakeServer.MockToken("TOKEN")
-	fakeServer.UseApiV2()
 	fakeServer.MockAPI("recommendations/gcp",
 		func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, "GET", r.Method, "GetReport() should be a GET method")
@@ -67,7 +66,6 @@ func TestRecommendationsGcpCIS12GetReport(t *testing.T) {
 	)
 
 	fakeServer.MockToken("TOKEN")
-	fakeServer.UseApiV2()
 	fakeServer.MockAPI("recommendations/gcp",
 		func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, "GET", r.Method, "GetReport() should be a GET method")

--- a/api/v2_recommendations_test.go
+++ b/api/v2_recommendations_test.go
@@ -37,7 +37,6 @@ func TestRecommendationsAwsList(t *testing.T) {
 	)
 
 	fakeServer.MockToken("TOKEN")
-	fakeServer.UseApiV2()
 	fakeServer.MockAPI("recommendations/aws",
 		func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, "GET", r.Method, "List() should be a GET method")
@@ -68,7 +67,6 @@ func TestRecommendationsAwsPatch(t *testing.T) {
 	)
 
 	fakeServer.MockToken("TOKEN")
-	fakeServer.UseApiV2()
 	fakeServer.MockAPI("recommendations/aws",
 		func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, "PATCH", r.Method, "AwsPatch() should be a PATCH method")

--- a/api/v2_suppressions_test.go
+++ b/api/v2_suppressions_test.go
@@ -33,7 +33,6 @@ import (
 
 func TestSuppressionsAwsList(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	fakeServer.MockAPI("suppressions/aws/allExceptions",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -45,7 +44,6 @@ func TestSuppressionsAwsList(t *testing.T) {
 	defer fakeServer.Close()
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)

--- a/api/v2_test.go
+++ b/api/v2_test.go
@@ -31,7 +31,6 @@ import (
 
 func TestPagination(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	fakeServer.MockAPI("Entities/MachineDetails/search",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -48,7 +47,6 @@ func TestPagination(t *testing.T) {
 	defer fakeServer.Close()
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -104,7 +102,6 @@ func TestPagination(t *testing.T) {
 
 func TestPaginationWithoutInfo(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	fakeServer.MockAPI("Entities/MachineDetails/search",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -115,7 +112,6 @@ func TestPaginationWithoutInfo(t *testing.T) {
 	defer fakeServer.Close()
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -144,7 +140,6 @@ func TestPaginationQuery(t *testing.T) {
 }`
 
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	fakeServer.MockAPI("Entities/MachineDetails/search",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -155,7 +150,6 @@ func TestPaginationQuery(t *testing.T) {
 	defer fakeServer.Close()
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)

--- a/api/v2_vulnerabilities_test.go
+++ b/api/v2_vulnerabilities_test.go
@@ -32,7 +32,6 @@ import (
 
 func TestV2Vulnerabilities_Containers_SearchAllPages_EmptyData(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	fakeServer.MockAPI("Vulnerabilities/Containers/search",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -43,7 +42,6 @@ func TestV2Vulnerabilities_Containers_SearchAllPages_EmptyData(t *testing.T) {
 	defer fakeServer.Close()
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -57,7 +55,6 @@ func TestV2Vulnerabilities_Containers_SearchAllPages_EmptyData(t *testing.T) {
 
 func TestV2Vulnerabilities_Hosts_SearchAllPages_EmptyData(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	fakeServer.MockAPI("Vulnerabilities/Hosts/search",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -68,7 +65,6 @@ func TestV2Vulnerabilities_Hosts_SearchAllPages_EmptyData(t *testing.T) {
 	defer fakeServer.Close()
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -120,7 +116,6 @@ func TestV2VulnerabilitiesFilterSingleVulnIDMultipleResults(t *testing.T) {
 }
 func TestV2Vulnerabilities_Containers_Search(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	fakeServer.MockAPI("Vulnerabilities/Containers/search",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -131,7 +126,6 @@ func TestV2Vulnerabilities_Containers_Search(t *testing.T) {
 	defer fakeServer.Close()
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -148,7 +142,6 @@ func TestV2Vulnerabilities_Containers_Search(t *testing.T) {
 
 func TestV2Vulnerabilities_Containers_SearchLastWeek(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	fakeServer.MockAPI("Vulnerabilities/Containers/search",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -159,7 +152,6 @@ func TestV2Vulnerabilities_Containers_SearchLastWeek(t *testing.T) {
 	defer fakeServer.Close()
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -178,7 +170,6 @@ func TestV2Vulnerabilities_Containers_SearchLastWeek(t *testing.T) {
 
 func TestV2Vulnerabilities_Containers_AllPages(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	fakeServer.MockAPI("Vulnerabilities/Containers/search",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -189,7 +180,6 @@ func TestV2Vulnerabilities_Containers_AllPages(t *testing.T) {
 	defer fakeServer.Close()
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -371,7 +361,6 @@ func mockVulnerabilitiesContainersResponse() string {
 
 func TestV2Vulnerabilities_Hosts_Search(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	fakeServer.MockAPI("Vulnerabilities/Hosts/search",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -382,7 +371,6 @@ func TestV2Vulnerabilities_Hosts_Search(t *testing.T) {
 	defer fakeServer.Close()
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -398,7 +386,6 @@ func TestV2Vulnerabilities_Hosts_Search(t *testing.T) {
 
 func TestV2Vulnerabilities_Hosts_SearchLastWeek(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	fakeServer.MockAPI("Vulnerabilities/Hosts/search",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -409,7 +396,6 @@ func TestV2Vulnerabilities_Hosts_SearchLastWeek(t *testing.T) {
 	defer fakeServer.Close()
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -427,7 +413,6 @@ func TestV2Vulnerabilities_Hosts_SearchLastWeek(t *testing.T) {
 
 func TestV2Vulnerabilities_Hosts_AllPages(t *testing.T) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	fakeServer.MockAPI("Vulnerabilities/Hosts/search",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -438,7 +423,6 @@ func TestV2Vulnerabilities_Hosts_AllPages(t *testing.T) {
 	defer fakeServer.Close()
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)

--- a/api/vulnerability_exceptions_test.go
+++ b/api/vulnerability_exceptions_test.go
@@ -107,7 +107,6 @@ func TestHostVulnerabilityExceptionGet(t *testing.T) {
 		vulnException = singleMockHostVulnerabilityException(intgGUID)
 		fakeServer    = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -128,7 +127,6 @@ func TestHostVulnerabilityExceptionGet(t *testing.T) {
 	)
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -163,7 +161,6 @@ func TestCtrVulnerabilityExceptionGet(t *testing.T) {
 		vulnException = singleMockCtrVulnerabilityException(intgGUID)
 		fakeServer    = lacework.MockServer()
 	)
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -184,7 +181,6 @@ func TestCtrVulnerabilityExceptionGet(t *testing.T) {
 	)
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -224,7 +220,6 @@ func TestVulnerabilityExceptionsList(t *testing.T) {
 		fakeServer              = lacework.MockServer()
 	)
 
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	fakeServer.MockAPI("VulnerabilityExceptions",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -242,7 +237,6 @@ func TestVulnerabilityExceptionsList(t *testing.T) {
 	defer fakeServer.Close()
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)
@@ -264,7 +258,6 @@ func TestVulnerabilityExceptionUpdate(t *testing.T) {
 		fakeServer = lacework.MockServer()
 	)
 	expiry, _ := time.Parse(time.RFC3339, "2021-12-31T18:47:07Z")
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	defer fakeServer.Close()
 
@@ -281,7 +274,6 @@ func TestVulnerabilityExceptionUpdate(t *testing.T) {
 	})
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)

--- a/cli/cmd/access_token.go
+++ b/cli/cmd/access_token.go
@@ -67,7 +67,6 @@ func generateAccessToken(_ *cobra.Command, args []string) error {
 		// if the duration is different from the default,
 		// regenerate the lacework api client
 		client, err := api.NewClient(cli.Account,
-			api.WithApiV2(),
 			api.WithLogLevel(cli.Log.Level().CapitalString()),
 			api.WithExpirationTime(durationSeconds),
 			api.WithHeader("User-Agent", fmt.Sprintf("Command-Line/%s", Version)),

--- a/cli/cmd/cli_state.go
+++ b/cli/cmd/cli_state.go
@@ -235,10 +235,6 @@ func (c *cliState) NewClient() error {
 		api.WithHeader("User-Agent", fmt.Sprintf("Command-Line/%s", Version)),
 	}
 
-	if c.CfgVersion == 2 {
-		apiOpts = append(apiOpts, api.WithApiV2())
-	}
-
 	if c.OrgLevel {
 		c.Log.Debug("accessing organization level data sets")
 		apiOpts = append(apiOpts, api.WithOrgAccess())

--- a/cli/cmd/compliance_azure_test.go
+++ b/cli/cmd/compliance_azure_test.go
@@ -118,7 +118,6 @@ func TestCliListAzureTenantsAndSubscriptionsWithData(t *testing.T) {
 		tenantID   = "abc123xy-1234-abcd-a1b2-09876zxy1234"
 	)
 	fakeServer.MockToken("TOKEN")
-	fakeServer.UseApiV2()
 	fakeServer.MockAPI(
 		"CloudAccounts/AzureCfg",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -133,7 +132,6 @@ func TestCliListAzureTenantsAndSubscriptionsWithData(t *testing.T) {
 
 	c, err := api.NewClient("test",
 		api.WithToken("TOKEN"),
-		api.WithApiV2(),
 		api.WithURL(fakeServer.URL()),
 	)
 

--- a/cli/cmd/suppressions_aws_test.go
+++ b/cli/cmd/suppressions_aws_test.go
@@ -34,7 +34,6 @@ func TestConvertAwsSuppressions(t *testing.T) {
 		fakeServer = lacework.MockServer()
 	)
 
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	fakeServer.MockAPI("suppressions/aws/allExceptions",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -46,7 +45,6 @@ func TestConvertAwsSuppressions(t *testing.T) {
 	defer fakeServer.Close()
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)

--- a/cli/cmd/suppressions_azure_test.go
+++ b/cli/cmd/suppressions_azure_test.go
@@ -34,7 +34,6 @@ func TestConvertAzureSuppressions(t *testing.T) {
 		fakeServer = lacework.MockServer()
 	)
 
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	fakeServer.MockAPI("suppressions/azure/allExceptions",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -46,7 +45,6 @@ func TestConvertAzureSuppressions(t *testing.T) {
 	defer fakeServer.Close()
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)

--- a/cli/cmd/suppressions_gcp_test.go
+++ b/cli/cmd/suppressions_gcp_test.go
@@ -34,7 +34,6 @@ func TestConvertGcpSuppressions(t *testing.T) {
 		fakeServer = lacework.MockServer()
 	)
 
-	fakeServer.UseApiV2()
 	fakeServer.MockToken("TOKEN")
 	fakeServer.MockAPI("suppressions/gcp/allExceptions",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -46,7 +45,6 @@ func TestConvertGcpSuppressions(t *testing.T) {
 	defer fakeServer.Close()
 
 	c, err := api.NewClient("test",
-		api.WithApiV2(),
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()),
 	)

--- a/integration/alert_rules_test.go
+++ b/integration/alert_rules_test.go
@@ -8,14 +8,13 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
 package integration
 
 import (
@@ -94,7 +93,6 @@ func createAlertRuleWithSlackAlertChannel() (alertRule api.AlertRuleResponse, er
 	lacework, err := api.NewClient(os.Getenv("CI_ACCOUNT"),
 		api.WithSubaccount(os.Getenv("CI_SUBACCOUNT")),
 		api.WithApiKeys(os.Getenv("CI_API_KEY"), os.Getenv("CI_API_SECRET")),
-		api.WithApiV2(),
 	)
 	if err != nil {
 		return

--- a/integration/framework_test.go
+++ b/integration/framework_test.go
@@ -311,7 +311,6 @@ func laceworkIntegrationTestClient() (*api.Client, error) {
 	lacework, err := api.NewClient(account,
 		api.WithApiKeys(key, secret),
 		api.WithSubaccount(subaccount),
-		api.WithApiV2(),
 	)
 	if err != nil {
 		fmt.Println(err)

--- a/integration/report_definitions_test.go
+++ b/integration/report_definitions_test.go
@@ -197,7 +197,6 @@ func fetchVersionedCustomReportDefinition() api.ReportDefinitionsResponse {
 	lacework, err := api.NewClient(os.Getenv("CI_ACCOUNT"),
 		api.WithSubaccount(os.Getenv("CI_SUBACCOUNT")),
 		api.WithApiKeys(os.Getenv("CI_API_KEY"), os.Getenv("CI_API_SECRET")),
-		api.WithApiV2(),
 	)
 	if err != nil {
 		log.Fatal(err)
@@ -240,7 +239,6 @@ func deleteCustomReportDefinition(id string) error {
 	lacework, err := api.NewClient(os.Getenv("CI_ACCOUNT"),
 		api.WithSubaccount(os.Getenv("CI_SUBACCOUNT")),
 		api.WithApiKeys(os.Getenv("CI_API_KEY"), os.Getenv("CI_API_SECRET")),
-		api.WithApiV2(),
 	)
 	if err != nil {
 		log.Fatal(err)

--- a/integration/report_definitions_update_test.go
+++ b/integration/report_definitions_update_test.go
@@ -98,7 +98,6 @@ func fetchCustomReportDefinition() *api.ReportDefinition {
 	lacework, err := api.NewClient(os.Getenv("CI_ACCOUNT"),
 		api.WithSubaccount(os.Getenv("CI_SUBACCOUNT")),
 		api.WithApiKeys(os.Getenv("CI_API_KEY"), os.Getenv("CI_API_SECRET")),
-		api.WithApiV2(),
 	)
 	if err != nil {
 		log.Fatal(err)

--- a/integration/test_resources/cdk/go-component/main.go
+++ b/integration/test_resources/cdk/go-component/main.go
@@ -58,7 +58,6 @@ func app() error {
 		api.WithSubaccount(os.Getenv("LW_SUBACCOUNT")),
 		api.WithApiKeys(os.Getenv("LW_API_KEY"), os.Getenv("LW_API_SECRET")),
 		api.WithToken(os.Getenv("LW_API_TOKEN")),
-		api.WithApiV2(),
 	)
 	if err != nil {
 		return errors.Wrap(err, "One or more missing configuration")

--- a/internal/lacework/server.go
+++ b/internal/lacework/server.go
@@ -30,17 +30,17 @@ import (
 //
 // A simple usage:
 //
-//     func TestSomethingNew(t *testing.T) {
-//         fakeServer := lacework.NewServer()
-//         fakeServer.MockToken("TOKEN")
-//         defer fakeServer.Close()
+//	func TestSomethingNew(t *testing.T) {
+//	    fakeServer := lacework.NewServer()
+//	    fakeServer.MockToken("TOKEN")
+//	    defer fakeServer.Close()
 //
-//         // Make sure to pass the fake API server URL
-//         c, err := api.NewClient("test", api.WithURL(fakeServer.URL()))
-//         if assert.Nil(t, err) {
-//         	// The client c is ready to be used
-//         }
-//     }
+//	    // Make sure to pass the fake API server URL
+//	    c, err := api.NewClient("test", api.WithURL(fakeServer.URL()))
+//	    if assert.Nil(t, err) {
+//	    	// The client c is ready to be used
+//	    }
+//	}
 type Mock struct {
 	Mux        *http.ServeMux
 	Server     *httptest.Server
@@ -53,7 +53,7 @@ func MockServer() *Mock {
 	return &Mock{
 		Mux:        mux,
 		Server:     httptest.NewServer(mux),
-		ApiVersion: "v1",
+		ApiVersion: "v2",
 	}
 }
 
@@ -66,33 +66,12 @@ func MockUnstartedServer() *Mock {
 	}
 }
 
-func (m *Mock) UseApiV2() {
-	m.ApiVersion = "v2"
-}
-
 // MockAPI will mock the api path inside the server mutex with the provided handler function
 func (m *Mock) MockAPI(p string, handler func(http.ResponseWriter, *http.Request)) {
 	m.Mux.HandleFunc(fmt.Sprintf("/api/%s/%s", m.ApiVersion, p), handler)
 }
 
 func (s *Mock) MockToken(token string) {
-	s.MockAPI("access/tokens", func(w http.ResponseWriter, r *http.Request) {
-		expiration := time.Now().AddDate(0, 0, 1)
-		fmt.Fprintf(w, `
-      {
-        "data": [{
-          "expiresAt": "`+expiration.Format("Jan 02 2006 15:04")+`",
-          "token": "`+token+`"
-        }],
-        "ok": true,
-        "message": "SUCCESS"
-      }
-    `)
-	})
-}
-
-func (s *Mock) MockTokenV2(token string) {
-	s.UseApiV2()
 	s.MockAPI("access/tokens", func(w http.ResponseWriter, r *http.Request) {
 		expiration := time.Now().AddDate(0, 0, 1)
 		fmt.Fprintf(w, `

--- a/lwcomponent/component_test.go
+++ b/lwcomponent/component_test.go
@@ -130,7 +130,6 @@ func TestLoadStateWithTwoFailures(t *testing.T) {
 
 func testLoadStateWithResponse(t *testing.T, response func(http.ResponseWriter, *http.Request)) {
 	fakeServer := lacework.MockServer()
-	fakeServer.UseApiV2()
 	fakeServer.MockAPI("Components", response)
 	defer fakeServer.Close()
 


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/lacework/go-sdk) and create your branch from `main`
  2. Run `make prepare` in the repository root
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`make test`)
  5. Format your code (`make fmt`)
  6. Make sure your code lints (`make lint`)
  7. If you are updating the Lacework CLI, make sure it compiles (`make build-cli-cross-platform`)
  8. Follow the commit message standard (`type(scope): subject`) documented in [DEVELOPER_GUIDELINES.md](https://github.com/lacework/go-sdk/blob/main/DEVELOPER_GUIDELINES.md#commit-message-standard)
  9. If you haven't already, configure signed commits by [telling git about your signing key](https://docs.github.com/en/github/authenticating-to-github/managing-commit-signature-verification/telling-git-about-your-signing-key) and [signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)

  Learn more about contributing: https://github.com/lacework/go-sdk/blob/main/CONTRIBUTING.md
-->

## Summary

We have already removed all API v1 endpoints but one, this PR is switching the auth access token
endpoint to be API v2 endpoint. Additionally, we set the API client version to `v2` and remove
completely `WithApiV2()` option function.

**BREAKING CHANGE**: Anyone using `WithApiV2()` will have to remove the function since v2
is now the default.

## How did you test this change?

Updated all tests, built and run CLI manually.

## Issue

https://lacework.atlassian.net/browse/GROW-2277
