### PR TITLE
chore(GROW-1600): lacework component dev preflight check

### DIFF
--- a/cli/cmd/component_dev.go
+++ b/cli/cmd/component_dev.go
@@ -412,7 +412,7 @@ func cdkScaffoldingPreflightCheck(scaffolding string, requirements map[string]st
 		if _, err := exec.LookPath(file); err != nil {
 			errMessage += fmt.Sprintf(`
 %s is required to create the %s scaffolding. Please install it before proceeding:
-	%s: %s`, file, scaffolding, file, site)
+  %s: %s`, file, scaffolding, file, site)
 		}
 	}
 	if errMessage != "" {

--- a/cli/cmd/component_dev.go
+++ b/cli/cmd/component_dev.go
@@ -53,8 +53,8 @@ var cdkGolangScaffoldingRequirements = map[string]string{
 }
 
 var cdkPythonScaffoldingRequirements = map[string]string{
-	"python": "https://www.python.org/downloads/",
-	"poetry": "https://python-poetry.org/docs/",
+	"python3": "https://www.python.org/downloads/",
+	"poetry":  "https://python-poetry.org/docs/",
 }
 
 func init() {

--- a/cli/cmd/component_dev.go
+++ b/cli/cmd/component_dev.go
@@ -48,6 +48,16 @@ var cdkDevState = struct {
 	Description string
 }{}
 
+var cdkGolangScaffoldingRequirements = map[string]string{
+	"go": "https://go.dev/dl/",
+}
+
+var cdkPythonScaffoldingRequirements = map[string]string{
+	"python3": "https://www.python.org/downloads/",
+	"poetry":  "https://python-poetry.org/docs/",
+	"shiv":    "https://github.com/linkedin/shiv/",
+}
+
 func init() {
 	componentsDevModeCmd.Flags().StringVar(
 		&cdkDevState.Type,
@@ -173,6 +183,10 @@ func runComponentsDevMode(_ *cobra.Command, args []string) error {
 }
 
 func cdkGolangScaffolding(component *lwcomponent.Component) error {
+	if err := cdkScaffoldingPreflightCheck("Golang", cdkGolangScaffoldingRequirements); err != nil {
+		return err
+	}
+
 	cli.OutputHuman("\nDeploying %s scaffolding:\n", color.HiMagentaString("Golang"))
 	rootPath, err := component.RootPath()
 	if err != nil {
@@ -275,6 +289,10 @@ func cdkGolangScaffolding(component *lwcomponent.Component) error {
 }
 
 func cdkPythonScaffolding(component *lwcomponent.Component) error {
+	if err := cdkScaffoldingPreflightCheck("Python", cdkPythonScaffoldingRequirements); err != nil {
+		return err
+	}
+
 	cli.OutputHuman("\nDeploying %s scaffolding:\n", color.HiMagentaString("Python"))
 	rootPath, err := component.RootPath()
 	if err != nil {
@@ -386,6 +404,21 @@ func cdkPythonScaffolding(component *lwcomponent.Component) error {
 	}
 
 	cli.OutputHuman("\nDeployment completed! Time for %s\n", randomEmoji())
+	return nil
+}
+
+func cdkScaffoldingPreflightCheck(scaffolding string, requirements map[string]string) error {
+	errMessage := ""
+	for file, site := range requirements {
+		if _, err := exec.LookPath(file); err != nil {
+			errMessage += fmt.Sprintf(`
+%s is required to create the %s scaffolding. Please install it before proceeding:
+	%s: %s`, file, scaffolding, file, site)
+		}
+	}
+	if errMessage != "" {
+		return errors.New(errMessage)
+	}
 	return nil
 }
 

--- a/cli/cmd/component_dev.go
+++ b/cli/cmd/component_dev.go
@@ -53,9 +53,8 @@ var cdkGolangScaffoldingRequirements = map[string]string{
 }
 
 var cdkPythonScaffoldingRequirements = map[string]string{
-	"python3": "https://www.python.org/downloads/",
-	"poetry":  "https://python-poetry.org/docs/",
-	"shiv":    "https://github.com/linkedin/shiv/",
+	"python": "https://www.python.org/downloads/",
+	"poetry": "https://python-poetry.org/docs/",
 }
 
 func init() {


### PR DESCRIPTION
## Summary
The interactive prompt for the command lacework component dev <name> will fail for GO/Python if required tools are not installed.  We need a pre-flight check to ensure that the requirements are met.

- Use `exec.LookPath` to check if a tool is installed.
- For Go scaffolding, `go` is required
- For Python scaffolding, `python3` and `shiv` are required.

## How did you test this change?

<img width="631" alt="Screenshot 2023-06-29 at 11 06 59 AM" src="https://github.com/lacework/go-sdk/assets/7945666/c965ff71-0916-41bc-a530-34937b205f1a">

## Issue
https://lacework.atlassian.net/browse/GROW-1600
