### PR TITLE
feat(COD-1255): Enhancements to how telemetry can be used

### DIFF
--- a/cli/cmd/honeyvent.go
+++ b/cli/cmd/honeyvent.go
@@ -115,9 +115,10 @@ type Honeyvent struct {
 
 	// tracing data for multiple events, this is useful for specific features
 	// within the Lacework CLI such as daily version check, polling mechanism, etc.
-	TraceID  string `json:"trace.trace_id,omitempty"`
-	SpanID   string `json:"trace.span_id,omitempty"`
-	ParentID string `json:"trace.parent_id,omitempty"`
+	TraceID   string `json:"trace.trace_id,omitempty"`
+	SpanID    string `json:"trace.span_id,omitempty"`
+	ParentID  string `json:"trace.parent_id,omitempty"`
+	ContextID string `json:"trace.context_id,omitempty"`
 }
 
 // InitHoneyvent initialize honeycomb library and main Honeyvent, such event
@@ -177,6 +178,10 @@ func (c *cliState) SendHoneyvent() {
 		c.Event.SpanID = newID()
 	}
 
+	if c.Event.ContextID == "" {
+		c.Event.ContextID = os.Getenv("LACEWORK_CONTEXT_ID")
+	}
+
 	// Lacework accounts are NOT case-sensitive but some users configure them
 	// in uppercase and others in lowercase, therefore we will normalize all
 	// account to be lowercase so that we don't see different accounts in
@@ -195,6 +200,7 @@ func (c *cliState) SendHoneyvent() {
 		"trace_id", c.Event.TraceID,
 		"span_id", c.Event.SpanID,
 		"parent_id", c.Event.ParentID,
+		"context_id", c.Event.ContextID,
 	)
 	honeyvent := libhoney.NewEvent()
 	_ = honeyvent.Add(c.Event)

--- a/cli/cmd/honeyvent_test.go
+++ b/cli/cmd/honeyvent_test.go
@@ -45,6 +45,7 @@ func TestSendHoneyventTracingFields(t *testing.T) {
 	// by default, the span_id must be empty
 	assert.Empty(t, cli.Event.SpanID)
 	assert.Empty(t, cli.Event.ParentID)
+	assert.Empty(t, cli.Event.ContextID)
 
 	// mocking sending first honeyvent
 	cli.SendHoneyvent()
@@ -53,15 +54,19 @@ func TestSendHoneyventTracingFields(t *testing.T) {
 	// but the parent_id must continue to be empty
 	assert.Equal(t, cli.id, cli.Event.SpanID)
 	assert.Empty(t, cli.Event.ParentID)
+	assert.Empty(t, cli.Event.ContextID)
 
-	// mocking sending second honeyvent
+	// mocking sending second honeyvent after setting a context ID
+	os.Setenv("LACEWORK_CONTEXT_ID", "test-id")
 	cli.SendHoneyvent()
 
 	// any further event should set the parent_id as the cli id
 	// and generate a new id for the span_id
+	// the context ID should also be read from the environment variable
 	assert.NotEmpty(t, cli.Event.SpanID)
 	assert.NotEqual(t, cli.id, cli.Event.SpanID)
 	assert.Equal(t, cli.id, cli.Event.ParentID)
+	assert.Equal(t, "test-id", cli.Event.ContextID)
 }
 
 func TestSendHoneyventFeatureFields(t *testing.T) {

--- a/cli/cmd/telemetry.go
+++ b/cli/cmd/telemetry.go
@@ -1,0 +1,96 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	cdk "github.com/lacework/go-sdk/cli/cdk/go/proto/v1"
+)
+
+var (
+	// telemetryUploadName is the name of the feature that telemetry is being uploaded for
+	telemetryUploadName string
+
+	// telemetryUploadFile is a path to a JSON file containing key value pairs to upload
+	telemetryUploadFile string
+
+	// telemetryCmd represents the telemetry command
+	telemetryCmd = &cobra.Command{
+		Hidden: true,
+		Use:    "telemetry",
+		Short:  "Manage telemetry sent by the Lacework CLI",
+		Args:   cobra.NoArgs,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return runConfigureSetup()
+		},
+	}
+
+	telemetryUploadCmd = &cobra.Command{
+		Use:   "upload",
+		Short: "Manually send some telemetry back to Lacework",
+		Args:  cobra.NoArgs,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			if telemetryUploadName == "" {
+				return errors.New("--name flag is required for this command")
+			}
+			if telemetryUploadFile == "" {
+				return errors.New("--data flag is required for this command")
+			}
+			return runUpload(telemetryUploadName, telemetryUploadFile)
+		},
+	}
+)
+
+func runUpload(name string, file string) error {
+	err := cli.NewClient()
+	if err != nil {
+		return err
+	}
+	request, err := prepareUpload(name, file)
+	if err != nil {
+		return err
+	}
+	_, err = cli.Honeyvent(context.Background(), request)
+	return err
+}
+
+func prepareUpload(name string, file string) (request *cdk.HoneyventRequest, err error) {
+	jsonFile, err := os.Open(file)
+	if err != nil {
+		return nil, err
+	}
+	defer func(jsonFile *os.File) {
+		err = jsonFile.Close()
+	}(jsonFile)
+	telemetryBytes, err := io.ReadAll(jsonFile)
+	if err != nil {
+		return nil, err
+	}
+	var telemetryData map[string]string
+	err = json.Unmarshal(telemetryBytes, &telemetryData)
+	if err != nil {
+		return nil, err
+	}
+	request = &cdk.HoneyventRequest{
+		Feature:     name,
+		FeatureData: telemetryData,
+	}
+	return request, nil
+}
+
+func init() {
+	rootCmd.AddCommand(telemetryCmd)
+	telemetryCmd.AddCommand(telemetryUploadCmd)
+
+	telemetryUploadCmd.Flags().StringVar(&telemetryUploadName,
+		"name", "", "Name of the feature the telemetry upload is for",
+	)
+	telemetryUploadCmd.Flags().StringVar(&telemetryUploadFile,
+		"data", "", "Path to JSON file containing key-value pairs to upload",
+	)
+}

--- a/cli/cmd/telemetry_test.go
+++ b/cli/cmd/telemetry_test.go
@@ -1,0 +1,22 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPrepareUpload(t *testing.T) {
+	dir, err := os.MkdirTemp("", "example")
+	assert.Nil(t, err)
+	defer os.RemoveAll(dir)
+	file := filepath.Join(dir, "upload.json")
+	err = os.WriteFile(file, []byte("{\"somekey\": \"somedata\"}"), 0666)
+	assert.Nil(t, err)
+	request, err := prepareUpload("somename", file)
+	assert.Nil(t, err)
+	assert.Equal(t, "somename", request.Feature)
+	assert.Equal(t, "somedata", request.FeatureData["somekey"])
+}


### PR DESCRIPTION
## Summary

Over in the Code Security team we want to add some observability in environments where we have the Lacework CLI and are running a bunch of command in sequence as well as doing some things outside of the CLI. We would like to land the two enhancements in this PR to support this:

- We now read a variable `LACEWORK_CONTEXT_ID` and report this. This will allow us to link up different invocations of the CLI into one unique context for the whole sequence of commands.
- We now support a hidden command `lacework telemetry upload` which accepts a JSON blob of telemetry to upload. We'll use this to report additional telemetry from the bits of our code running outside the CLI.

## How did you test this change?

- One automated test was modified to check the new behaviour, and a new one was also added.
- I did manual end-to-end testing locally and observed data arriving to Honeycomb ([here](https://ui.honeycomb.io/lacework/datasets/lacework-cli-dev/result/da4Kaqvoyav?tab=raw)).

## Issue

https://lacework.atlassian.net/browse/COD-1255
