### PR TITLE
feat: default compliance report to use report_name

### DIFF
--- a/api/reports_aws.go
+++ b/api/reports_aws.go
@@ -33,6 +33,8 @@ type awsReportsService struct {
 	client *Client
 }
 
+const ComplianceReportDefaultAws = "CIS Amazon Web Services Foundations Benchmark v1.4.0"
+
 type AwsReportConfig struct {
 	AccountID string
 	Value     string

--- a/api/reports_azure.go
+++ b/api/reports_azure.go
@@ -33,6 +33,8 @@ type azureReportsService struct {
 	client *Client
 }
 
+const ComplianceReportDefaultAzure = "CIS Microsoft Azure Foundations Benchmark v1.5.0"
+
 type AzureReportConfig struct {
 	TenantID       string
 	SubscriptionID string

--- a/api/reports_gcp.go
+++ b/api/reports_gcp.go
@@ -33,6 +33,8 @@ type gcpReportsService struct {
 	client *Client
 }
 
+const ComplianceReportDefaultGcp = "GCP CIS Benchmark 1.3"
+
 type GcpReportConfig struct {
 	OrganizationID string
 	ProjectID      string

--- a/cli/cmd/compliance_aws.go
+++ b/cli/cmd/compliance_aws.go
@@ -21,7 +21,6 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"strconv"
 	"strings"
 	"time"
@@ -40,7 +39,7 @@ var (
 	compAwsCmdState = struct {
 		Type       string
 		ReportName string
-	}{ReportName: "CIS Amazon Web Services Foundations Benchmark v1.4.0"}
+	}{ReportName: api.ComplianceReportDefaultAws}
 
 	// complianceAwsListAccountsCmd represents the list-accounts inside the aws command
 	complianceAwsListAccountsCmd = &cobra.Command{
@@ -574,14 +573,11 @@ func init() {
 valid types:%s`, prettyPrintReportTypes(api.AwsReportTypes())))
 
 	// mark report type flag as deprecated
-	err := complianceAwsGetReportCmd.Flags().MarkDeprecated("type", "use --report_name flag instead")
-	if err != nil {
-		log.Fatal("unable to deprecate flag '--type'")
-	}
+	errcheckWARN(complianceAwsGetReportCmd.Flags().MarkDeprecated("type", "use --report_name flag instead"))
 
 	// Run 'lacework report-definition --subtype AWS' for a full list of AWS report names
 	complianceAwsGetReportCmd.Flags().StringVar(&compAwsCmdState.ReportName, "report_name",
-		"CIS Amazon Web Services Foundations Benchmark v1.4.0",
+		api.ComplianceReportDefaultAws,
 		"report name to display, run 'lacework report-definitions list' for more information.")
 
 	complianceAwsGetReportCmd.Flags().StringSliceVar(&compCmdState.Category, "category", []string{},

--- a/cli/cmd/compliance_aws.go
+++ b/cli/cmd/compliance_aws.go
@@ -581,7 +581,7 @@ valid types:%s`, prettyPrintReportTypes(api.AwsReportTypes())))
 
 	// Run 'lacework report-definition --subtype AWS' for a full list of AWS report names
 	complianceAwsGetReportCmd.Flags().StringVar(&compAwsCmdState.ReportName, "report_name",
-		"CIS Amazon Web Services",
+		"CIS Amazon Web Services Foundations Benchmark v1.4.0",
 		"report name to display, run 'lacework report-definitions list' for more information.")
 
 	complianceAwsGetReportCmd.Flags().StringSliceVar(&compCmdState.Category, "category", []string{},

--- a/cli/cmd/compliance_aws.go
+++ b/cli/cmd/compliance_aws.go
@@ -87,7 +87,7 @@ var (
 				if array.ContainsStr(api.AwsReportTypes(), compAwsCmdState.Type) {
 					return nil
 				} else {
-					return errors.Errorf(`supported report types are: %s'`, strings.Join(api.AwsReportTypes(), ", "))
+					return errors.Errorf("supported report types are: %s", strings.Join(api.AwsReportTypes(), ", "))
 				}
 			}
 

--- a/cli/cmd/compliance_azure.go
+++ b/cli/cmd/compliance_azure.go
@@ -21,7 +21,6 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"sort"
 	"strconv"
 	"strings"
@@ -41,7 +40,7 @@ var (
 	compAzCmdState = struct {
 		Type       string
 		ReportName string
-	}{ReportName: "CIS Microsoft Azure Foundations Benchmark v1.5.0"}
+	}{ReportName: api.ComplianceReportDefaultAzure}
 
 	// complianceAzureListSubsCmd represents the list-subscriptions sub-command inside the azure command
 	complianceAzureListSubsCmd = &cobra.Command{
@@ -532,14 +531,11 @@ valid types:%s`, prettyPrintReportTypes(api.AzureReportTypes())),
 	)
 
 	// mark report type flag as deprecated
-	err := complianceAzureGetReportCmd.Flags().MarkDeprecated("type", "use --report_name flag instead")
-	if err != nil {
-		log.Fatal("unable to deprecate flag '--type'")
-	}
+	errcheckWARN(complianceAzureGetReportCmd.Flags().MarkDeprecated("type", "use --report_name flag instead"))
 
 	// Run 'lacework report-definition --subtype Azure' for a full list of Azure report names
 	complianceAzureGetReportCmd.Flags().StringVar(&compAzCmdState.ReportName, "report_name",
-		"CIS Microsoft Azure Foundations Benchmark v1.5.0",
+		api.ComplianceReportDefaultAzure,
 		"report name to display, run 'lacework report-definitions list' for more information.")
 
 	complianceAzureGetReportCmd.Flags().StringSliceVar(&compCmdState.Category, "category", []string{},

--- a/cli/cmd/compliance_azure.go
+++ b/cli/cmd/compliance_azure.go
@@ -139,12 +139,9 @@ Use the following command to list all Azure Tenants configured in your account:
 				return validReportName(api.ReportDefinitionSubTypeAzure.String(), compAzCmdState.ReportName)
 			}
 
-			if cmd.Flags().Changed("type") {
-				if array.ContainsStr(api.AzureReportTypes(), compAzCmdState.Type) {
-					return nil
-				} else {
-					return errors.Errorf("supported report types are: %s", strings.Join(api.AzureReportTypes(), ", "))
-				}
+			if cmd.Flags().Changed("type") &&
+				!array.ContainsStr(api.AzureReportTypes(), compAzCmdState.Type) {
+				return errors.Errorf("supported report types are: %s", strings.Join(api.AzureReportTypes(), ", "))
 			}
 			return nil
 		},

--- a/cli/cmd/compliance_gcp.go
+++ b/cli/cmd/compliance_gcp.go
@@ -21,7 +21,6 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"regexp"
 	"sort"
 	"strconv"
@@ -43,7 +42,7 @@ var (
 	compGcpCmdState = struct {
 		Type       string
 		ReportName string
-	}{ReportName: "GCP CIS Benchmark 1.3"}
+	}{ReportName: api.ComplianceReportDefaultGcp}
 
 	// complianceGcpListCmd represents the list sub-command inside the gcp command
 	complianceGcpListCmd = &cobra.Command{
@@ -541,14 +540,11 @@ valid types:%s`, prettyPrintReportTypes(api.GcpReportTypes())),
 	)
 
 	// mark report type flag as deprecated
-	err := complianceGcpGetReportCmd.Flags().MarkDeprecated("type", "use --report_name flag instead")
-	if err != nil {
-		log.Fatal("unable to deprecate flag '--type'")
-	}
+	errcheckWARN(complianceGcpGetReportCmd.Flags().MarkDeprecated("type", "use --report_name flag instead"))
 
 	// Run 'lacework report-definition --subtype GCP' for a full list of GCP report names
 	complianceGcpGetReportCmd.Flags().StringVar(&compGcpCmdState.ReportName, "report_name",
-		"GCP CIS Benchmark 1.3",
+		api.ComplianceReportDefaultGcp,
 		"report name to display, run 'lacework report-definitions list' for more information.")
 
 	complianceGcpGetReportCmd.Flags().StringSliceVar(&compCmdState.Category, "category", []string{},

--- a/integration/compliance_aws_test.go
+++ b/integration/compliance_aws_test.go
@@ -154,7 +154,7 @@ func TestComplianceAwsGetAllReportType(t *testing.T) {
 	for _, reportType := range api.AwsReportTypes() {
 		t.Run(reportType, func(t *testing.T) {
 			out, err, exitcode := LaceworkCLIWithTOMLConfig("compliance", "aws", "get-report", account, "--type", reportType)
-			assert.Empty(t, err.String(), "STDERR should be empty")
+			assert.Contains(t, err.String(), "--type has been deprecated")
 			assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
 			assert.Contains(t, out.String(), "COMPLIANCE REPORT DETAILS",
 				"STDOUT table headers changed, please check")
@@ -164,9 +164,9 @@ func TestComplianceAwsGetAllReportType(t *testing.T) {
 
 func TestComplianceAwsGetReportRecommendationID(t *testing.T) {
 	account := os.Getenv("LW_INT_TEST_AWS_ACC")
-	out, err, exitcode := LaceworkCLIWithTOMLConfig("compliance", "aws", "get-report", account, "2.1.2")
+	out, err, exitcode := LaceworkCLIWithTOMLConfig("compliance", "aws", "get-report", account, "--type", "AWS_CIS_S3", "2.1.2")
 
-	assert.Empty(t, err.String(), "STDERR should be empty")
+	assert.Contains(t, err.String(), "--type has been deprecated,")
 	assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
 	assert.Contains(t, out.String(), "RECOMMENDATION DETAILS",
 		"STDOUT table headers changed, please check")
@@ -186,7 +186,7 @@ func TestComplianceAwsGetReportRecommendationID(t *testing.T) {
 
 func TestComplianceAwsGetReportRecommendationIDNotFound(t *testing.T) {
 	account := os.Getenv("LW_INT_TEST_AWS_ACC")
-	_, err, exitcode := LaceworkCLIWithTOMLConfig("compliance", "aws", "get-report", account, "rec-not-found")
+	_, err, exitcode := LaceworkCLIWithTOMLConfig("compliance", "aws", "get-report", account, "--type", "AWS_CIS_S3", "rec-not-found")
 	assert.Equal(t, 1, exitcode, "EXITCODE is not the expected one")
 	assert.Contains(t, err.String(), "recommendation id 'rec-not-found' not found.",
 		"STDERR changed?, please check")

--- a/integration/compliance_aws_test.go
+++ b/integration/compliance_aws_test.go
@@ -45,7 +45,7 @@ func TestComplianceAwsGetReportFilter(t *testing.T) {
 
 	assert.Contains(t, out.String(), detailsOutput, "Filtered detail output should contain filtered result")
 	assert.Contains(t, err.String(), "--type has been deprecated")
-	assert.Equal(t, 1, exitcode, "EXITCODE is not the expected one")
+	assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
 	assert.Contains(t, out.String(), "COMPLIANCE REPORT DETAILS",
 		"STDOUT table headers changed, please check")
 	assert.Contains(t, out.String(), account,
@@ -127,7 +127,7 @@ func TestComplianceAwsGetReportTypeAWS_SOC_Rev2(t *testing.T) {
 	account := os.Getenv("LW_INT_TEST_AWS_ACC")
 	out, err, exitcode := LaceworkCLIWithTOMLConfig("compliance", "aws", "get-report", account, "--type", "AWS_SOC_Rev2")
 	assert.Contains(t, err.String(), "--type has been deprecated")
-	assert.Equal(t, 1, exitcode, "EXITCODE is not the expected one")
+	assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
 	assert.Contains(t, out.String(), "AWS SOC 2 Report Rev2",
 		"STDOUT report type missing or something else is going on, please check")
 	assert.Contains(t, out.String(), "Report Type",
@@ -161,13 +161,12 @@ func TestComplianceAwsGetAllReportType(t *testing.T) {
 		})
 	}
 }
-
 func TestComplianceAwsGetReportRecommendationID(t *testing.T) {
 	account := os.Getenv("LW_INT_TEST_AWS_ACC")
-	out, err, exitcode := LaceworkCLIWithTOMLConfig("compliance", "aws", "get-report", account, "--type", "AWS_CIS_S3", "2.1.2")
+	out, err, exitcode := LaceworkCLIWithTOMLConfig("compliance", "aws", "get-report", account, "--type", "AWS_CIS_14", "2.1.2")
 
 	assert.Contains(t, err.String(), "--type has been deprecated,")
-	assert.Equal(t, 1, exitcode, "EXITCODE is not the expected one")
+	assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
 	assert.Contains(t, out.String(), "RECOMMENDATION DETAILS",
 		"STDOUT table headers changed, please check")
 	assert.Contains(t, out.String(), "SEVERITY",

--- a/integration/compliance_aws_test.go
+++ b/integration/compliance_aws_test.go
@@ -44,8 +44,8 @@ func TestComplianceAwsGetReportFilter(t *testing.T) {
 	out, err, exitcode := LaceworkCLIWithTOMLConfig("compliance", "aws", "get-report", account, "--status", "compliant", "--type", "AWS_CIS_S3")
 
 	assert.Contains(t, out.String(), detailsOutput, "Filtered detail output should contain filtered result")
-	assert.Empty(t, err.String(), "STDERR should be empty")
-	assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
+	assert.Contains(t, err.String(), "--type has been deprecated")
+	assert.Equal(t, 1, exitcode, "EXITCODE is not the expected one")
 	assert.Contains(t, out.String(), "COMPLIANCE REPORT DETAILS",
 		"STDOUT table headers changed, please check")
 	assert.Contains(t, out.String(), account,
@@ -126,8 +126,8 @@ func TestComplianceAwsGetReportAccountIDWithAlias(t *testing.T) {
 func TestComplianceAwsGetReportTypeAWS_SOC_Rev2(t *testing.T) {
 	account := os.Getenv("LW_INT_TEST_AWS_ACC")
 	out, err, exitcode := LaceworkCLIWithTOMLConfig("compliance", "aws", "get-report", account, "--type", "AWS_SOC_Rev2")
-	assert.Empty(t, err.String(), "STDERR should be empty")
-	assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
+	assert.Contains(t, err.String(), "--type has been deprecated")
+	assert.Equal(t, 1, exitcode, "EXITCODE is not the expected one")
 	assert.Contains(t, out.String(), "AWS SOC 2 Report Rev2",
 		"STDOUT report type missing or something else is going on, please check")
 	assert.Contains(t, out.String(), "Report Type",
@@ -167,7 +167,7 @@ func TestComplianceAwsGetReportRecommendationID(t *testing.T) {
 	out, err, exitcode := LaceworkCLIWithTOMLConfig("compliance", "aws", "get-report", account, "--type", "AWS_CIS_S3", "2.1.2")
 
 	assert.Contains(t, err.String(), "--type has been deprecated,")
-	assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
+	assert.Equal(t, 1, exitcode, "EXITCODE is not the expected one")
 	assert.Contains(t, out.String(), "RECOMMENDATION DETAILS",
 		"STDOUT table headers changed, please check")
 	assert.Contains(t, out.String(), "SEVERITY",

--- a/integration/compliance_azure_test.go
+++ b/integration/compliance_azure_test.go
@@ -35,7 +35,7 @@ func TestComplianceAzureListTenants(t *testing.T) {
 
 func TestComplianceAzureGetReportTenantAndSubscriptionWithAlias(t *testing.T) {
 	out, err, exitcode := LaceworkCLIWithTOMLConfig(
-		"compliance", "azure", "get-report", "tenant-id (tenant-alias)", "subscription-id (subscription-alias)",
+		"compliance", "azure", "get-report", "tenant-id (tenant-alias)", "subscription-id (subscription-alias)", "--type", "AZURE_CIS_131",
 	)
 	assert.Equal(t, 1, exitcode, "EXITCODE is not the expected one")
 	assert.Contains(t, out.String(),

--- a/integration/compliance_gcp_test.go
+++ b/integration/compliance_gcp_test.go
@@ -26,7 +26,7 @@ import (
 
 func TestComplianceGoogleGetReportOrgAndProjectWithAlias(t *testing.T) {
 	out, err, exitcode := LaceworkCLIWithTOMLConfig(
-		"compliance", "gcp", "get-report", "org-id (org-alias)", "proj-id (proj-alias)",
+		"compliance", "gcp", "get-report", "org-id (org-alias)", "proj-id (proj-alias)", "--type", "GCP_CIS13",
 	)
 	assert.Equal(t, 1, exitcode, "EXITCODE is not the expected one")
 	assert.Contains(t, out.String(),

--- a/integration/test_resources/help/compliance_aws_get-report
+++ b/integration/test_resources/help/compliance_aws_get-report
@@ -26,7 +26,7 @@ Flags:
       --details              increase details about the compliance report
   -h, --help                 help for get-report
       --pdf                  download report in PDF format
-      --report_name string   report name to display, run 'lacework report-definitions list' for more information. (default "CIS Amazon Web Services")
+      --report_name string   report name to display, run 'lacework report-definitions list' for more information. (default "CIS Amazon Web Services Foundations Benchmark v1.4.0")
       --service strings      filter report details by service (aws:s3, aws:iam, aws:cloudtrail, ...)
       --severity string      filter report details by severity threshold (critical, high, medium, low, info)
       --status string        filter report details by status (non-compliant, requires-manual-assessment, suppressed, compliant, could-not-assess)

--- a/integration/test_resources/help/compliance_aws_get-report
+++ b/integration/test_resources/help/compliance_aws_get-report
@@ -26,17 +26,10 @@ Flags:
       --details              increase details about the compliance report
   -h, --help                 help for get-report
       --pdf                  download report in PDF format
-      --report_name string   report name to display, run 'lacework report-definitions list' for more information.
+      --report_name string   report name to display, run 'lacework report-definitions list' for more information. (default "CIS Amazon Web Services")
       --service strings      filter report details by service (aws:s3, aws:iam, aws:cloudtrail, ...)
       --severity string      filter report details by severity threshold (critical, high, medium, low, info)
       --status string        filter report details by status (non-compliant, requires-manual-assessment, suppressed, compliant, could-not-assess)
-      --type string          report type to display, run 'lacework report-definitions list' for more information.
-                             valid types:
-                             'AWS_CIS_14','AWS_CIS_1_4_ISO_IEC_27002_2022','AWS_CIS_S3','AWS_CMMC_1.02','AWS_CSA_CCM_4_0_5',
-                             'AWS_Cyber_Essentials_2_2','AWS_HIPAA','AWS_ISO_27001:2013','AWS_NIST_800-171_rev2','AWS_NIST_800-53_rev5',
-                             'AWS_NIST_CSF','AWS_PCI_DSS_3.2.1','AWS_SOC_2','AWS_SOC_Rev2','HIPAA',
-                             'ISO_2700','LW_AWS_SEC_ADD_1_0','NIST_800-171_Rev2','NIST_800-53_Rev4','PCI',
-                             'SOC', (default "AWS_CIS_14")
 
 Global Flags:
   -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)

--- a/integration/test_resources/help/compliance_azure_get-report
+++ b/integration/test_resources/help/compliance_azure_get-report
@@ -25,15 +25,10 @@ Flags:
       --details              increase details about the compliance report
   -h, --help                 help for get-report
       --pdf                  download report in PDF format
-      --report_name string   report name to display, run 'lacework report-definitions list' for more information.
+      --report_name string   report name to display, run 'lacework report-definitions list' for more information. (default "CIS Microsoft Azure Foundations Benchmark v1.5.0")
       --service strings      filter report details by service (azure:ms:storage, azure:ms:sql, azure:ms:network, ...)
       --severity string      filter report details by severity threshold (critical, high, medium, low, info)
       --status string        filter report details by status (non-compliant, requires-manual-assessment, suppressed, compliant, could-not-assess)
-      --type string          report type to display, run 'lacework report-definitions list' for more information.
-                             valid types:
-                             'AZURE_CIS','AZURE_CIS_131','AZURE_HIPAA','AZURE_ISO_27001','AZURE_NIST_800_171_REV2',
-                             'AZURE_NIST_800_53_REV5','AZURE_NIST_CSF','AZURE_PCI','AZURE_PCI_Rev2','AZURE_SOC',
-                             'AZURE_SOC_Rev2', (default "AZURE_CIS_131")
 
 Global Flags:
   -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)

--- a/integration/test_resources/help/compliance_google_get-report
+++ b/integration/test_resources/help/compliance_google_get-report
@@ -25,17 +25,10 @@ Flags:
       --details              increase details about the compliance report
   -h, --help                 help for get-report
       --pdf                  download report in PDF format
-      --report_name string   report name to display, run 'lacework report-definitions list' for more information.
+      --report_name string   report name to display, run 'lacework report-definitions list' for more information. (default "GCP CIS Benchmark 1.3")
       --service strings      filter report details by service (gcp:storage:bucket, gcp:kms:cryptoKey, gcp:project, ...)
       --severity string      filter report details by severity threshold (critical, high, medium, low, info)
       --status string        filter report details by status (non-compliant, requires-manual-assessment, suppressed, compliant, could-not-assess)
-      --type string          report type to display, run 'lacework report-definitions list' for more information.
-                             valid types:
-                             'GCP_CIS','GCP_CIS12','GCP_CIS13','GCP_CIS_1_3_0_NIST_800_171_rev2','GCP_CIS_1_3_0_NIST_800_53_rev5',
-                             'GCP_CIS_1_3_0_NIST_CSF','GCP_CMMC_1_02','GCP_HIPAA','GCP_HIPAA_2013','GCP_HIPAA_Rev2',
-                             'GCP_ISO_27001','GCP_ISO_27001_2013','GCP_K8S','GCP_NIST_800_171_REV2','GCP_NIST_800_53_REV4',
-                             'GCP_NIST_CSF','GCP_PCI','GCP_PCI_DSS_3_2_1','GCP_PCI_Rev2','GCP_SOC',
-                             'GCP_SOC_2','GCP_SOC_Rev2', (default "GCP_CIS13")
 
 Global Flags:
   -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/lacework/go-sdk) and create your branch from `main`
  2. Run `make prepare` in the repository root
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`make test`)
  5. Format your code (`make fmt`)
  6. Make sure your code lints (`make lint`)
  7. If you are updating the Lacework CLI, make sure it compiles (`make build-cli-cross-platform`)
  8. Follow the commit message standard (`type(scope): subject`) documented in [DEVELOPER_GUIDELINES.md](https://github.com/lacework/go-sdk/blob/main/DEVELOPER_GUIDELINES.md#commit-message-standard)
  9. If you haven't already, configure signed commits by [telling git about your signing key](https://docs.github.com/en/github/authenticating-to-github/managing-commit-signature-verification/telling-git-about-your-signing-key) and [signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)

  Learn more about contributing: https://github.com/lacework/go-sdk/blob/main/CONTRIBUTING.md
-->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

This change
- Changes the default parameters for `compliance aws|az|gcp get-report` to use `report_name` over `type`
- Fix report type not being updated in --csv output
- Mark the `--type` flag as deprecated

Report names are discoverable via `lacework report-definitions list` but types are not. This makes fetching reports by name preferable. Validation can be performed by fetching a valid list of reports from the api.  New and custom reports can be discovered.

## How did you test this change?

<!--
  How exactly did you verify that your PR solves the issue you wanted to solve?
  Include any other relevant information such as how to use the new functionality, screenshots, etc.
-->

- [x] run `compliance aws|az|gcp get-report`  without any flags
- [x] run `compliance aws|az|gcp get-report`  with --report_name flag
- [x] run `compliance aws|az|gcp get-report`  with --type flag
- [x] update compliance tests 

## Issue

<!--
  Include the link to a Jira/Github issue
-->

https://lacework.atlassian.net/browse/LINK-1816
