### PR TITLE
fix(api): fix overly narrow type in withTransport argument

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -203,9 +203,9 @@ func WithRetries(retries *backoff.ExponentialBackOff) Option {
 }
 
 // WithTransport changes the default transport to increase TLSHandshakeTimeout
-func WithTransport(transport *http.RoundTripper) Option {
+func WithTransport(transport http.RoundTripper) Option {
 	return clientFunc(func(c *Client) error {
-		c.c.Transport = *transport
+		c.c.Transport = transport
 		return nil
 	})
 }

--- a/api/client.go
+++ b/api/client.go
@@ -203,9 +203,9 @@ func WithRetries(retries *backoff.ExponentialBackOff) Option {
 }
 
 // WithTransport changes the default transport to increase TLSHandshakeTimeout
-func WithTransport(transport *http.Transport) Option {
+func WithTransport(transport *http.RoundTripper) Option {
 	return clientFunc(func(c *Client) error {
-		c.c.Transport = transport
+		c.c.Transport = *transport
 		return nil
 	})
 }


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/lacework/go-sdk) and create your branch from `main`
  2. Run `make prepare` in the repository root
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`make test`)
  5. Format your code (`make fmt`)
  6. Make sure your code lints (`make lint`)
  7. If you are updating the Lacework CLI, make sure it compiles (`make build-cli-cross-platform`)
  8. Follow the commit message standard (`type(scope): subject`) documented in [DEVELOPER_GUIDELINES.md](https://github.com/lacework/go-sdk/blob/main/DEVELOPER_GUIDELINES.md#commit-message-standard)
  9. If you haven't already, configure signed commits by [telling git about your signing key](https://docs.github.com/en/github/authenticating-to-github/managing-commit-signature-verification/telling-git-about-your-signing-key) and [signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)

  Learn more about contributing: https://github.com/lacework/go-sdk/blob/main/CONTRIBUTING.md
-->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

The newClient option `withTransport`, which allows you to specify a custom http client transport argument, has an overly strict type definition ([`http.Transport`](https://pkg.go.dev/net/http#Transport)). It uses the argument to set the `transport` field of the [`http.Client`](https://pkg.go.dev/net/http#Client) owned by `api.Client`. But the http.Client.transport field actually has a type of [`http.RoundTripper`](https://pkg.go.dev/net/http#RoundTripper) (an interface) and not `http.Transport` (a struct type that implements the RoundTripper interface). The naming does seem a bit misleading.

The result is that you can only pass a very limited set of arguments to `withTransport`. In my case, I'd like to be able to pass an instance of `httpmock.MockTransport` to use in automated tests. But alas, I cannot, because `httpmock.MockTransport` implements `http.RoundTripper` and not `http.Transport`.

## How did you test this change?

This is just a type change and I'm broadening the type. This means that all arguments that were accepted before will still be accepted now. So just running the automated tests should be enough to verify that this didn't break anything.

## Issue

N/A
