### PR TITLE
chore(GROW-2289): Update AWS region regex

### DIFF
--- a/cli/cmd/generate_aws.go
+++ b/cli/cmd/generate_aws.go
@@ -65,7 +65,7 @@ var (
 	// AwsArnRegex original source: https://regex101.com/r/pOfxYN/1
 	AwsArnRegex = `^arn:(?P<Partition>[^:\n]*):(?P<Service>[^:\n]*):(?P<Region>[^:\n]*):(?P<AccountID>[^:\n]*):(?P<Ignore>(?P<ResourceType>[^:\/\n]*)[:\/])?(?P<Resource>.*)$` //nolint
 	// AwsRegionRegex regex used for validating region input; note intentionally does not match gov cloud
-	AwsRegionRegex  = `(us|ap|ca|eu|sa)-(central|(north|south)?(east|west)?)-\d`
+	AwsRegionRegex  = `(af|ap|ca|eu|me|sa|us)-(central|(north|south)?(east|west)?)-\d`
 	AwsProfileRegex = `([A-Za-z_0-9-]+)`
 
 	GenerateAwsCommandState      = &aws.GenerateAwsTfConfigurationArgs{}

--- a/cli/cmd/generate_aws_eks_audit.go
+++ b/cli/cmd/generate_aws_eks_audit.go
@@ -74,7 +74,7 @@ var (
 	EksAuditAdvancedOptDone            = "Done"
 
 	// AwsEksAuditRegionRegex regex used for validating region input; note intentionally does not match gov cloud
-	AwsEksAuditRegionRegex = `(us|ap|ca|eu|sa)-(central|(north|south)?(east|west)?)-\d`
+	AwsEksAuditRegionRegex = `(af|ap|ca|eu|me|sa|us)-(central|(north|south)?(east|west)?)-\d`
 
 	GenerateAwsEksAuditCommandState      = &aws_eks_audit.GenerateAwsEksAuditTfConfigurationArgs{}
 	GenerateAwsEksAuditCommandExtraState = &AwsEksAuditGenerateCommandExtraState{}


### PR DESCRIPTION
## Summary

Update the AWS region regex with the values in https://github.com/lacework/rainbow/pull/12821/files.

Excluding:

```
    'us-gov-east-1',
    'us-gov-west-1',
    'aws-global',
    'aws-us-gov-global',
```

## How did you test this change?

Manually with the `lacework generate` command.

## Issue

https://lacework.atlassian.net/browse/GROW-2289
