### PR TITLE
feat(api): support new fields in alert_rules api

### DIFF
--- a/api/_examples/alert-rules/main.go
+++ b/api/_examples/alert-rules/main.go
@@ -39,6 +39,8 @@ func main() {
 		Severities:      api.AlertRuleSeverities{api.AlertRuleSeverityHigh},
 		ResourceGroups:  []string{"TECHALLY_000000000000AAAAAAAAAAAAAAAAAAAA"},
 		EventCategories: []string{"Compliance"},
+		AlertCategories: []string{"Policy"},
+		Sources: 		 []string{"Aws"},
 	}
 
 	myAlertRule := api.NewAlertRule("MyTestAlertRule",

--- a/api/_examples/alert-rules/main.go
+++ b/api/_examples/alert-rules/main.go
@@ -40,7 +40,7 @@ func main() {
 		ResourceGroups:  []string{"TECHALLY_000000000000AAAAAAAAAAAAAAAAAAAA"},
 		EventCategories: []string{"Compliance"},
 		AlertCategories: []string{"Policy"},
-		Sources: 		 []string{"Aws"},
+		Sources:         []string{"Aws"},
 	}
 
 	myAlertRule := api.NewAlertRule("MyTestAlertRule",

--- a/api/alert_rules.go
+++ b/api/alert_rules.go
@@ -31,6 +31,28 @@ type AlertRulesService struct {
 	client *Client
 }
 
+// Valid inputs for AlertRule Source property
+var AlertRuleSources = []string{"Agent", "Aws", "Azure", "Gcp", "K8s"}
+
+// Valid inputs for AlertRule Categories property
+var AlertRuleCategories = []string{"Anomaly", "Policy", "Composite"}
+
+// Valid inputs for AlertRule SubCategories property
+var AlertRuleSubCategories = []string{
+	"Compliance",
+	"App",
+	"Cloud",
+	"File",
+	"Machine",
+	"User",
+	"Platform",
+	"K8sActivity",
+	"Registry",
+	"SystemCall",
+	"HostVulnerability",
+	"ContainerVulnerability",
+}
+
 type alertRuleSeverity int
 
 type AlertRuleSeverities []alertRuleSeverity
@@ -165,6 +187,8 @@ func NewAlertRule(name string, rule AlertRuleConfig) AlertRule {
 			Severity:        rule.Severities.toInt(),
 			ResourceGroups:  rule.ResourceGroups,
 			EventCategories: rule.EventCategories,
+			AlertCategories: rule.AlertCategories,
+			Sources:         rule.Sources,
 		},
 	}
 }
@@ -234,6 +258,8 @@ type AlertRuleConfig struct {
 	Severities      AlertRuleSeverities
 	ResourceGroups  []string
 	EventCategories []string
+	Sources         []string
+	AlertCategories []string
 }
 
 type AlertRule struct {
@@ -250,6 +276,8 @@ type AlertRuleFilter struct {
 	Severity             []int    `json:"severity"`
 	ResourceGroups       []string `json:"resourceGroups,omitempty"`
 	EventCategories      []string `json:"eventCategory,omitempty"`
+	Sources              []string `json:"sources,omitempty"`
+	AlertCategories      []string `json:"category,omitempty"`
 	CreatedOrUpdatedTime string   `json:"createdOrUpdatedTime,omitempty"`
 	CreatedOrUpdatedBy   string   `json:"createdOrUpdatedBy,omitempty"`
 }

--- a/api/alert_rules_test.go
+++ b/api/alert_rules_test.go
@@ -310,11 +310,11 @@ func singleMockAlertRule(id string) string {
             "eventCategory": [
                 "Compliance",
                 "SystemCall"
-			]
+			],
             "category": [
                 "Policy",
                 "Anomaly"
-            ]
+            ],
             "sources": [
                 "Aws",
                 "Agent",

--- a/api/alert_rules_test.go
+++ b/api/alert_rules_test.go
@@ -226,7 +226,9 @@ func TestAlertRuleUpdate(t *testing.T) {
 			Description:     "This is a test alert rule",
 			Severities:      api.AlertRuleSeverities{api.AlertRuleSeverityHigh},
 			ResourceGroups:  []string{"TECHALLY_100000000000AAAAAAAAAAAAAAAAAAAB"},
-			EventCategories: []string{"Compliance"},
+			EventCategories: []string{"Compliance", "SystemCall"},
+			Sources:         []string{"Aws", "Agent", "K8s"},
+			AlertCategories: []string{"Policy", "Anomaly"},
 		},
 	)
 	assert.Equal(t, "rule_name", alertRule.Filter.Name, "alert rule name mismatch")
@@ -238,7 +240,9 @@ func TestAlertRuleUpdate(t *testing.T) {
 	if assert.NoError(t, err) {
 		assert.NotNil(t, response)
 		assert.Equal(t, intgGUID, response.Data.Guid)
-		assert.Contains(t, response.Data.Filter.EventCategories, "Compliance")
+		assert.Contains(t, response.Data.Filter.EventCategories, "Compliance", "SystemCall")
+		assert.Contains(t, response.Data.Filter.Sources, "Aws", "Agent", "K8s")
+		assert.Contains(t, response.Data.Filter.AlertCategories, "Policy", "Anomaly")
 		assert.Contains(t, response.Data.Filter.ResourceGroups, "TECHALLY_100000000000AAAAAAAAAAAAAAAAAAAB")
 		assert.Contains(t, response.Data.Channels, "TECHALLY_000000000000AAAAAAAAAAAAAAAAAAAA")
 	}
@@ -304,7 +308,17 @@ func singleMockAlertRule(id string) string {
                 2
             ],
             "eventCategory": [
-                "Compliance"
+                "Compliance",
+                "SystemCall"
+			]
+            "category": [
+                "Policy",
+                "Anomaly"
+            ]
+            "sources": [
+                "Aws",
+                "Agent",
+                "K8s"
             ]
 	  },
       "mcGuid": %q,


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/lacework/go-sdk) and create your branch from `main`
  2. Run `make prepare` in the repository root
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`make test`)
  5. Format your code (`make fmt`)
  6. Make sure your code lints (`make lint`)
  7. If you are updating the Lacework CLI, make sure it compiles (`make build-cli-cross-platform`)
  8. Follow the commit message standard (`type(scope): subject`) documented in [DEVELOPER_GUIDELINES.md](https://github.com/lacework/go-sdk/blob/main/DEVELOPER_GUIDELINES.md#commit-message-standard)
  9. If you haven't already, configure signed commits by [telling git about your signing key](https://docs.github.com/en/github/authenticating-to-github/managing-commit-signature-verification/telling-git-about-your-signing-key) and [signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)

  Learn more about contributing: https://github.com/lacework/go-sdk/blob/main/CONTRIBUTING.md
-->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

Add support for missing fields in the alert_rules api

In the EventCategory property the values Registry, SystemCall, HostVulnerability & ContainerVulnerability
The Sources property has been added with the values Agent, Aws, Azure, Gcp, K8s
The AlertCategory property has been added with the values Policy, Anomaly, Composite

## How did you test this change?

<!--
  How exactly did you verify that your PR solves the issue you wanted to solve?
  Include any other relevant information such as how to use the new functionality, screenshots, etc.
-->

- [x] Run example `api/_examples/alert-rules/main.go` with [api changes](https://github.com/lacework/rainbow/pull/13216)

## Issue

<!--
  Include the link to a Jira/Github issue
-->

https://lacework.atlassian.net/browse/GROW-2326
