### PR TITLE
feat(lwgenerate): support complex/nested module attribute values

### DIFF
--- a/lwgenerate/_examples/hcl/main.go
+++ b/lwgenerate/_examples/hcl/main.go
@@ -21,6 +21,35 @@ func exampleModule() {
 	fmt.Print(lwgenerate.CreateHclStringOutput(lwgenerate.CombineHclBlocks(data)))
 }
 
+func exampleModuleNestedData() {
+	data, err := lwgenerate.NewModule("foo",
+		"mycorp/mycloud",
+		lwgenerate.HclModuleWithVersion("~> 0.1"),
+		lwgenerate.HclModuleWithAttributes(map[string]interface{}{
+			"org_account_mappings": []map[string]interface{}{
+				{
+					"default_lacework_account": "main-account",
+					"mapping": []map[string]interface{}{
+						{
+							"lacework_account": "sub-account-1",
+							"aws_accounts":     []string{"123456789011"},
+						},
+						{
+							"lacework_account": "sub-account-2",
+							"aws_accounts":     []string{"123455564235"},
+						},
+					},
+				},
+			},
+		}),
+	).ToBlock()
+	if err != nil {
+		fmt.Print(err.Error())
+		os.Exit(1)
+	}
+	fmt.Print(lwgenerate.CreateHclStringOutput(lwgenerate.CombineHclBlocks(data)))
+}
+
 func exampleProvider() {
 	attrs := map[string]interface{}{"region": "us-east-2"}
 	data, err := lwgenerate.NewProvider("aws", lwgenerate.HclProviderWithAttributes(attrs)).ToBlock()
@@ -91,4 +120,5 @@ func main() {
 	exampleModule()
 	exampleSimpleTraversal()
 	exampleGenericHclBlock()
+	exampleModuleNestedData()
 }

--- a/lwgenerate/hcl_test.go
+++ b/lwgenerate/hcl_test.go
@@ -1,6 +1,7 @@
 package lwgenerate_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/hashicorp/hcl/v2"
@@ -10,45 +11,68 @@ import (
 )
 
 func TestGenericBlockCreation(t *testing.T) {
-	data, err := lwgenerate.HclCreateGenericBlock(
-		"thing",
-		[]string{"a", "b"},
-		map[string]interface{}{
-			"a": "foo",
-			"b": 1,
-			"c": false,
-			"d": map[string]interface{}{ // Order of map elements should be sorted when executed
-				"f": 1,
-				"g": "bar",
-				"e": true,
+	t.Run("should be a working generic block", func(t *testing.T) {
+		data, err := lwgenerate.HclCreateGenericBlock(
+			"thing",
+			[]string{"a", "b"},
+			map[string]interface{}{
+				"a": "foo",
+				"b": 1,
+				"c": false,
+				"d": map[string]interface{}{ // Order of map elements should be sorted when executed
+					"f": 1,
+					"g": "bar",
+					"e": true,
+				},
+				"h": hcl.Traversal{
+					hcl.TraverseRoot{
+						Name: "module",
+					},
+					hcl.TraverseAttr{
+						Name: "example",
+					},
+					hcl.TraverseAttr{
+						Name: "value",
+					},
+				},
+				"i": []string{"one", "two", "three"},
+				"j": []interface{}{"one", 2, true},
+				"k": []interface{}{
+					map[string]interface{}{"test1": []string{"f", "o", "o"}},
+					map[string]interface{}{"test2": []string{"b", "a", "r"}},
+				},
 			},
-			"h": hcl.Traversal{
-				hcl.TraverseRoot{
-					Name: "module",
-				},
-				hcl.TraverseAttr{
-					Name: "example",
-				},
-				hcl.TraverseAttr{
-					Name: "value",
-				},
-			},
-			"i": []string{"one", "two", "three"},
-			"j": []interface{}{"one", 2, true},
-		},
-	)
+		)
 
-	assert.Nil(t, err)
-	assert.Equal(t, "thing", data.Type())
-	assert.Equal(t, "a", data.Labels()[0])
-	assert.Equal(t, "b", data.Labels()[1])
-	assert.Equal(t, "a=\"foo\"\n", string(data.Body().GetAttribute("a").BuildTokens(nil).Bytes()))
-	assert.Equal(t, "b=1\n", string(data.Body().GetAttribute("b").BuildTokens(nil).Bytes()))
-	assert.Equal(t, "c=false\n", string(data.Body().GetAttribute("c").BuildTokens(nil).Bytes()))
-	assert.Equal(t, "d={\n  e = true\n  f = 1\n  g = \"bar\"\n}\n", string(data.Body().GetAttribute("d").BuildTokens(nil).Bytes()))
-	assert.Equal(t, "h=module.example.value\n", string(data.Body().GetAttribute("h").BuildTokens(nil).Bytes()))
-	assert.Equal(t, "i=[\"one\", \"two\", \"three\"]\n", string(data.Body().GetAttribute("i").BuildTokens(nil).Bytes()))
-	assert.Equal(t, "j=[\"one\", 2, true]\n", string(data.Body().GetAttribute("j").BuildTokens(nil).Bytes()))
+		assert.Nil(t, err)
+		assert.Equal(t, "thing", data.Type())
+		assert.Equal(t, "a", data.Labels()[0])
+		assert.Equal(t, "b", data.Labels()[1])
+		assert.Equal(t, "a=\"foo\"\n", string(data.Body().GetAttribute("a").BuildTokens(nil).Bytes()))
+		assert.Equal(t, "b=1\n", string(data.Body().GetAttribute("b").BuildTokens(nil).Bytes()))
+		assert.Equal(t, "c=false\n", string(data.Body().GetAttribute("c").BuildTokens(nil).Bytes()))
+		assert.Equal(t, "d={\n  e = true\n  f = 1\n  g = \"bar\"\n}\n", string(data.Body().GetAttribute("d").BuildTokens(nil).Bytes()))
+		assert.Equal(t, "h=module.example.value\n", string(data.Body().GetAttribute("h").BuildTokens(nil).Bytes()))
+		assert.Equal(t, "i=[\"one\", \"two\", \"three\"]\n", string(data.Body().GetAttribute("i").BuildTokens(nil).Bytes()))
+		assert.Equal(t, "j=[\"one\", 2, true]\n", string(data.Body().GetAttribute("j").BuildTokens(nil).Bytes()))
+		assert.Equal(t,
+			"k=[{\n  test1 = [\"f\", \"o\", \"o\"]\n  }, {\n  test2 = [\"b\", \"a\", \"r\"]\n}]\n",
+			string(data.Body().GetAttribute("k").BuildTokens(nil).Bytes()))
+	})
+	t.Run("should fail to construct generic block with mismatched list element types", func(t *testing.T) {
+		_, err := lwgenerate.HclCreateGenericBlock(
+			"thing",
+			[]string{},
+			map[string]interface{}{
+				"k": []map[string]interface{}{ // can use []interface{} here to support this sort of structure, but as-is will fail
+					{"test1": []string{"f", "o", "o"}},
+					{"test2": []string{"b", "a", "r"}},
+				},
+			},
+		)
+
+		assert.Error(t, err, "should have failed to generate block with mismatched list element types")
+	})
 }
 
 func TestModuleBlock(t *testing.T) {
@@ -125,6 +149,32 @@ func TestRequiredProvidersBlock(t *testing.T) {
 	assert.Equal(t, testRequiredProvider, lwgenerate.CreateHclStringOutput([]*hclwrite.Block{data}))
 }
 
+func TestModuleBlockWithComplexAttributes(t *testing.T) {
+	data, err := lwgenerate.NewModule("foo",
+		"mycorp/mycloud",
+		lwgenerate.HclModuleWithAttributes(map[string]interface{}{
+			"org_account_mappings": []map[string]interface{}{ // support deeply nested data types
+				{
+					"default_lacework_account": "main-account",
+					"mapping": []map[string]interface{}{
+						{
+							"lacework_account": "sub-account-1",
+							"aws_accounts":     []string{"123455555555"},
+						},
+						{
+							"lacework_account": "sub-account-2",
+							"aws_accounts":     []string{"123444444444"},
+						},
+					},
+				},
+			},
+		}),
+	).ToBlock()
+
+	assert.Equal(t, fmt.Sprintf("%s\n", testExpectedBlockWithComplexAttributes), string(data.Body().GetAttribute("org_account_mappings").BuildTokens(nil).Bytes()))
+	assert.NoError(t, err)
+}
+
 var testRequiredProvider = `terraform {
   required_providers {
     bar = {
@@ -140,3 +190,14 @@ var testRequiredProvider = `terraform {
   }
 }
 `
+
+var testExpectedBlockWithComplexAttributes = `org_account_mappings=[{
+  default_lacework_account = "main-account"
+  mapping = [{
+    aws_accounts     = ["123455555555"]
+    lacework_account = "sub-account-1"
+    }, {
+    aws_accounts     = ["123444444444"]
+    lacework_account = "sub-account-2"
+  }]
+}]`


### PR DESCRIPTION



## Summary
During HCL generation there's the need to support some more complex module attributes:


e.g.,
```
list(object({
    value1 = string
    mapping = list(object({
      thing1 = string
      thing2     = list(string)
    }))
}))
```

Prior to this commit, using nested data for a module attribute didn't work correctly. This commit adds support for `map[string]interface{}` and `[]map[string]interface{}`. Because the same set of functions are used for converting Go types to cty.Value(s), any block attribute should now be able to use these data types.


## How did you test this change?

See tests.

