### PR TITLE
feat(lql): add option to generate empty lql file

### DIFF
--- a/cli/cmd/lql.go
+++ b/cli/cmd/lql.go
@@ -302,7 +302,7 @@ func inputQueryFromEditor(action string) (query string, err error) {
 		FileName: "query*.yaml",
 	}
 
-	if (action == "create" || action == "run") && queryCmdState.EmptyTemplate == false {
+	if (action == "create" || action == "run") && !queryCmdState.EmptyTemplate {
 		prompt.Default = `queryId: YourQueryID
 queryText: |-
     {
@@ -318,7 +318,7 @@ queryText: |-
     }`
 		prompt.HideDefault = true
 		prompt.AppendDefault = true
-    } else if (action == "create" || action == "run") && queryCmdState.EmptyTemplate == true {
+    } else if (action == "create" || action == "run") && queryCmdState.EmptyTemplate {
 		prompt.Default = ``
 		prompt.HideDefault = true
 		prompt.AppendDefault = true

--- a/cli/cmd/lql.go
+++ b/cli/cmd/lql.go
@@ -38,15 +38,15 @@ import (
 
 var (
 	queryCmdState = struct {
-		End          string
-		File         string
-		Limit        int
-		Range        string
-		Start        string
-		URL          string
-		ValidateOnly bool
-		FailOnCount  string
-        EmptyTemplate   bool
+		End           string
+		File          string
+		Limit         int
+		Range         string
+		Start         string
+		URL           string
+		ValidateOnly  bool
+		FailOnCount   string
+		EmptyTemplate bool
 		// create, update validate from library
 		CURVFromLibrary string
 	}{}
@@ -192,12 +192,12 @@ func init() {
 		"fail_on_count", "",
 		"fail if the results from a query match the provided expression (e.g. '>0')",
 	)
-    // empty template flag
-    queryRunCmd.Flags().BoolVar(
-        &queryCmdState.EmptyTemplate,
-        "empty", false,
-        "start $EDITOR with empty file",
-    )
+	// empty template flag
+	queryRunCmd.Flags().BoolVar(
+		&queryCmdState.EmptyTemplate,
+		"empty", false,
+		"start $EDITOR with empty file",
+	)
 }
 
 func setQuerySourceFlags(cmds ...*cobra.Command) {
@@ -318,11 +318,11 @@ queryText: |-
     }`
 		prompt.HideDefault = true
 		prompt.AppendDefault = true
-    } else if (action == "create" || action == "run") && queryCmdState.EmptyTemplate {
+	} else if (action == "create" || action == "run") && queryCmdState.EmptyTemplate {
 		prompt.Default = ``
 		prompt.HideDefault = true
 		prompt.AppendDefault = true
-    }
+	}
 
 	err = survey.AskOne(prompt, &query)
 	return
@@ -413,9 +413,9 @@ func runQuery(cmd *cobra.Command, args []string) error {
 		if queryCmdState.ValidateOnly {
 			naFlag = "validate_only"
 		}
-        if queryCmdState.EmptyTemplate {
-            naFlag = "empty"
-        }
+		if queryCmdState.EmptyTemplate {
+			naFlag = "empty"
+		}
 		if naFlag != "" {
 			return errors.New(
 				fmt.Sprintf(

--- a/cli/cmd/lql.go
+++ b/cli/cmd/lql.go
@@ -46,6 +46,7 @@ var (
 		URL          string
 		ValidateOnly bool
 		FailOnCount  string
+        EmptyTemplate   bool
 		// create, update validate from library
 		CURVFromLibrary string
 	}{}
@@ -191,6 +192,12 @@ func init() {
 		"fail_on_count", "",
 		"fail if the results from a query match the provided expression (e.g. '>0')",
 	)
+    // empty template flag
+    queryRunCmd.Flags().BoolVar(
+        &queryCmdState.EmptyTemplate,
+        "empty", false,
+        "start $EDITOR with empty file",
+    )
 }
 
 func setQuerySourceFlags(cmds ...*cobra.Command) {
@@ -295,7 +302,7 @@ func inputQueryFromEditor(action string) (query string, err error) {
 		FileName: "query*.yaml",
 	}
 
-	if action == "create" || action == "run" {
+	if (action == "create" || action == "run") && queryCmdState.EmptyTemplate == false {
 		prompt.Default = `queryId: YourQueryID
 queryText: |-
     {
@@ -311,7 +318,11 @@ queryText: |-
     }`
 		prompt.HideDefault = true
 		prompt.AppendDefault = true
-	}
+    } else if (action == "create" || action == "run") && queryCmdState.EmptyTemplate == true {
+		prompt.Default = ``
+		prompt.HideDefault = true
+		prompt.AppendDefault = true
+    }
 
 	err = survey.AskOne(prompt, &query)
 	return
@@ -402,6 +413,9 @@ func runQuery(cmd *cobra.Command, args []string) error {
 		if queryCmdState.ValidateOnly {
 			naFlag = "validate_only"
 		}
+        if queryCmdState.EmptyTemplate {
+            naFlag = "empty"
+        }
 		if naFlag != "" {
 			return errors.New(
 				fmt.Sprintf(

--- a/integration/test_resources/help/query_run
+++ b/integration/test_resources/help/query_run
@@ -31,6 +31,7 @@ Aliases:
   run, execute
 
 Flags:
+      --empty                  start $EDITOR with empty file
       --end string             end time for query (default "now")
       --fail_on_count string   fail if the results from a query match the provided expression (e.g. '>0')
   -f, --file string            path to a query to run


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/lacework/go-sdk) and create your branch from `main`
  2. Run `make prepare` in the repository root
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`make test`)
  5. Format your code (`make fmt`)
  6. Make sure your code lints (`make lint`)
  7. If you are updating the Lacework CLI, make sure it compiles (`make build-cli-cross-platform`)
  8. Follow the commit message standard (`type(scope): subject`) documented in [DEVELOPER_GUIDELINES.md](https://github.com/lacework/go-sdk/blob/main/DEVELOPER_GUIDELINES.md#commit-message-standard)
  9. If you haven't already, configure signed commits by [telling git about your signing key](https://docs.github.com/en/github/authenticating-to-github/managing-commit-signature-verification/telling-git-about-your-signing-key) and [signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)

  Learn more about contributing: https://github.com/lacework/go-sdk/blob/main/CONTRIBUTING.md
-->

## Summary
Adds a flag when running `lacework query run` to create an empty file in `$EDITOR`, rather than using the default template.

This is a useful feature for policy engineering work, as when we have a draft query already created, that we want to quickly test, it allows to just paste into an empty file and run the query.
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## How did you test this change?

<!--
  How exactly did you verify that your PR solves the issue you wanted to solve?
  Include any other relevant information such as how to use the new functionality, screenshots, etc.
-->

All changes tested locally using the testing procedure defined via the `make` rules.
Also verified that the resulting `lacework` binary behaves correctly using the new flag.

## Issue

N/A
