### PR TITLE
feat(CAD-360): Support Resource Group v2 in CLI

### DIFF
--- a/api/_examples/resource-groups/main.go
+++ b/api/_examples/resource-groups/main.go
@@ -23,8 +23,17 @@ func main() {
 	}
 
 	for _, account := range res.Data {
+		var resourceGuid string
+		resourceType := account.Type
+
+		if account.Props != nil {
+			resourceGuid = account.ResourceGuid
+		} else {
+			resourceGuid = account.ResourceGroupGuid
+		}
+
 		support := "Unsupported"
-		switch account.Type {
+		switch resourceType {
 		case api.AwsResourceGroup.String():
 			support = "Supported"
 		case api.AzureResourceGroup.String():
@@ -40,8 +49,63 @@ func main() {
 		}
 
 		// Output: RESOURCE_GUID:RESOURCE_TYPE:[Supported|Unsupported]
-		fmt.Printf("%s:%s:%s\n", account.ResourceGuid, account.Type, support)
+		fmt.Printf("%s:%s:%s\n", resourceGuid, resourceType, support)
 	}
+
+	rgExpression := api.RGExpression{
+		Operator: "AND",
+		Children: []*api.RGChild{
+			{
+				FilterName: "filter1",
+			},
+		},
+	}
+
+	rgFilter := api.RGFilter{
+		Field:     "Region",
+		Operation: "STARTS_WITH",
+		Values:    []string{"us-"},
+	}
+
+	rgQuery := api.RGQuery{
+		Expression: &rgExpression,
+		Filters: map[string]*api.RGFilter{
+			"filter1": &rgFilter,
+		},
+	}
+
+	myResourceGroupWithQuery := api.NewResourceGroupWithQuery(
+		"resource-group-with-query-from-golang",
+		api.AwsResourceGroup,
+		"Resource groups in `us` regions",
+		&rgQuery,
+	)
+
+	println("Creating a resource group v2")
+	rgV2Resp, err := lacework.V2.ResourceGroups.Create(myResourceGroupWithQuery)
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("Succesfully created resource group \n %+v\n", rgV2Resp)
+
+	println("Updating v2 resource group name")
+	rgV2Resp.Data.NameV2 = "resource-group-with-query-from-golang-updated"
+
+	updatedResponse, err := lacework.V2.ResourceGroups.UpdateAws(&rgV2Resp.Data)
+
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("Succesfully updated resource group \n %+v\n", updatedResponse)
+
+	fmt.Printf("Deleting resource group %s\n", updatedResponse.Data.ResourceGroupGuid)
+	err = lacework.V2.ResourceGroups.Delete(updatedResponse.Data.ResourceGroupGuid)
+	if err != nil {
+		log.Fatal(err)
+	}
+	println("Successfully deleted resource group")
 
 	props := api.LwAccountResourceGroupProps{
 		Description: "All Lacework accounts",

--- a/api/feature_flags.go
+++ b/api/feature_flags.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 )
 
+const ApiV2CliFeatureFlag = "PUBLIC.rgv2.cli"
+
 type FeatureFlagsService struct {
 	client *Client
 }

--- a/api/resource_groups.go
+++ b/api/resource_groups.go
@@ -269,15 +269,7 @@ func (group ResourceGroupData) Status() string {
 }
 
 func (group ResourceGroupData) IsV2Group() bool {
-	if group.Props != nil {
-		return false
-	}
-
-	if group.Query != nil {
-		return true
-	}
-
-	return false
+	return group.Query != nil 
 }
 
 type ResourceGroupResponse struct {

--- a/api/resource_groups.go
+++ b/api/resource_groups.go
@@ -22,10 +22,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
-
-	"github.com/pkg/errors"
+	"time"
 
 	"github.com/lacework/go-sdk/lwtime"
+	"github.com/pkg/errors"
 )
 
 // ResourceGroupsService is the service that interacts with
@@ -291,16 +291,16 @@ type ResourceGroupData struct {
 	Props        interface{} `json:"props,omitempty"`
 
 	// RG v2 Fields. `Enabled` and `Type` fields are the same in RGv1 nd RGv2
-	NameV2            string        `json:"name,omitempty"`
-	Query             *RGQuery      `json:"query,omitempty"`
-	Description       string        `json:"description,omitempty"`
-	ResourceGroupGuid string        `json:"resourceGroupGuid,omitempty"`
-	CreatedTime       *lwtime.Epoch `json:"lastUpdated,omitempty"`
-	CreatedBy         string        `json:"createdBy,omitempty"`
-	UpdatedTime       *lwtime.Epoch `json:"updatedTime,omitempty"`
-	UpdatedBy         string        `json:"updatedBy,omitempty"`
-	IsDefaultBoolean  *bool         `json:"isDefaultBoolean,omitempty"`
-	IsOrg             *bool         `json:"isOrg,omitempty"`
+	NameV2            string     `json:"name,omitempty"`
+	Query             *RGQuery   `json:"query,omitempty"`
+	Description       string     `json:"description,omitempty"`
+	ResourceGroupGuid string     `json:"resourceGroupGuid,omitempty"`
+	CreatedTime       *time.Time `json:"lastUpdated,omitempty"`
+	CreatedBy         string     `json:"createdBy,omitempty"`
+	UpdatedTime       *time.Time `json:"updatedTime,omitempty"`
+	UpdatedBy         string     `json:"updatedBy,omitempty"`
+	IsDefaultBoolean  *bool      `json:"isDefaultBoolean,omitempty"`
+	IsOrg             *bool      `json:"isOrg,omitempty"`
 }
 
 // RAIN-21510 workaround
@@ -321,14 +321,14 @@ type resourceGroupWorkaroundData struct {
 	Enabled      int         `json:"enabled,omitempty"`
 	Props        interface{} `json:"props"`
 
-	NameV2            string        `json:"name,omitempty"`
-	Query             *RGQuery      `json:"query,omitempty"`
-	Description       string        `json:"description,omitempty"`
-	ResourceGroupGuid string        `json:"resourceGroupGuid,omitempty"`
-	CreatedTime       *lwtime.Epoch `json:"lastUpdated,omitempty"`
-	CreatedBy         string        `json:"createdBy,omitempty"`
-	UpdatedTime       *lwtime.Epoch `json:"updatedTime,omitempty"`
-	UpdatedBy         string        `json:"updatedBy,omitempty"`
-	IsDefaultBoolean  *bool         `json:"isDefaultBoolean,omitempty"`
-	IsOrg             *bool         `json:"isOrg,omitempty"`
+	NameV2            string     `json:"name,omitempty"`
+	Query             *RGQuery   `json:"query,omitempty"`
+	Description       string     `json:"description,omitempty"`
+	ResourceGroupGuid string     `json:"resourceGroupGuid,omitempty"`
+	CreatedTime       *time.Time `json:"lastUpdated,omitempty"`
+	CreatedBy         string     `json:"createdBy,omitempty"`
+	UpdatedTime       *time.Time `json:"updatedTime,omitempty"`
+	UpdatedBy         string     `json:"updatedBy,omitempty"`
+	IsDefaultBoolean  *bool      `json:"isDefaultBoolean,omitempty"`
+	IsOrg             *bool      `json:"isOrg,omitempty"`
 }

--- a/api/resource_groups.go
+++ b/api/resource_groups.go
@@ -269,7 +269,7 @@ func (group ResourceGroupData) Status() string {
 }
 
 func (group ResourceGroupData) IsV2Group() bool {
-	return group.Query != nil 
+	return group.Query != nil
 }
 
 type ResourceGroupResponse struct {

--- a/api/resource_groups.go
+++ b/api/resource_groups.go
@@ -48,6 +48,8 @@ type ResourceGroup interface {
 	ID() string
 	ResourceGroupType() ResourceGroupType
 	ResetResourceGUID()
+	ResetRGV2Fields()
+	IsV2Group() bool
 }
 
 type ResourceGroupType int
@@ -79,41 +81,6 @@ var ResourceGroupTypes = map[ResourceGroupType]string{
 // String returns the string representation of a Resource Group type
 func (i ResourceGroupType) String() string {
 	return ResourceGroupTypes[i]
-}
-
-// NewResourceGroup returns an instance of the ResourceGroupData struct with the
-// provided ResourceGroup type, name and the props field as an interface{}.
-//
-// NOTE: This function must be used by any ResourceGroup type.
-//
-// Basic usage: Initialize a new ContainerResourceGroup struct, then
-//
-//	             use the new instance to do CRUD operations
-//
-//	  client, err := api.NewClient("account")
-//	  if err != nil {
-//	    return err
-//	  }
-//
-//	  group := api.NewResourceGroup("container resource group",
-//	    api.ContainerResourceGroup,
-//	    api.ContainerResourceGroupData{
-//	      Props: api.ContainerResourceGroupProps{
-//				Description:     "all containers,
-//				ContainerLabels: ContainerResourceGroupAllLabels,
-//				ContainerTags:   ContainerResourceGroupAllTags,
-//			},
-//	    },
-//	  )
-//
-//	  client.V2.ResourceGroups.Create(group)
-func NewResourceGroup(name string, iType ResourceGroupType, props interface{}) ResourceGroupData {
-	return ResourceGroupData{
-		Name:    name,
-		Type:    iType.String(),
-		Enabled: 1,
-		Props:   props,
-	}
 }
 
 // FindResourceGroupType looks up inside the list of available resource group types
@@ -200,24 +167,6 @@ func castResourceGroupResponse(data resourceGroupWorkaroundData, response interf
 	return nil
 }
 
-func setResourceGroupResponse(response resourceGroupWorkaroundData) (ResourceGroupResponse, error) {
-	isDefault, err := strconv.Atoi(response.IsDefault)
-	if err != nil {
-		return ResourceGroupResponse{}, err
-	}
-	return ResourceGroupResponse{
-		Data: ResourceGroupData{
-			Guid:         response.Guid,
-			IsDefault:    isDefault,
-			ResourceGuid: response.ResourceGuid,
-			Name:         response.Name,
-			Type:         response.Type,
-			Enabled:      response.Enabled,
-			Props:        response.Props,
-		},
-	}, nil
-}
-
 func setResourceGroupsResponse(workaround resourceGroupsWorkaroundResponse) (ResourceGroupsResponse, error) {
 	var data []ResourceGroupData
 	for _, r := range workaround.Data {
@@ -250,9 +199,9 @@ func (svc *ResourceGroupsService) Delete(guid string) error {
 // To return a more specific Go struct of a Resource Group, use the proper
 // method such as GetContainerResourceGroup() where the function name is composed by:
 //
-//	Get<Type>(guid)
+//  Get<Type>(guid)
 //
-//	  Where <Type> is the Resource Group type.
+//    Where <Type> is the Resource Group type.
 func (svc *ResourceGroupsService) Get(guid string, response interface{}) error {
 	var rawResponse resourceGroupWorkaroundResponse
 	err := svc.get(guid, &rawResponse)
@@ -290,11 +239,26 @@ func (group ResourceGroupData) ResourceGroupType() ResourceGroupType {
 }
 
 func (group ResourceGroupData) ID() string {
-	return group.ResourceGuid
+	if !group.IsV2Group() {
+		return group.ResourceGuid
+	} else {
+		return group.ResourceGroupGuid
+	}
+}
+
+func (group *ResourceGroupData) ResetRGV2Fields() {
+	group.UpdatedBy = ""
+	group.UpdatedTime = nil
+	group.CreatedBy = ""
+	group.CreatedTime = nil
+	group.IsDefaultBoolean = nil
+	group.IsOrg = nil
 }
 
 func (group *ResourceGroupData) ResetResourceGUID() {
 	group.ResourceGuid = ""
+	group.ResourceGroupGuid = ""
+	group.ResetRGV2Fields()
 }
 
 func (group ResourceGroupData) Status() string {
@@ -302,6 +266,18 @@ func (group ResourceGroupData) Status() string {
 		return "Enabled"
 	}
 	return "Disabled"
+}
+
+func (group ResourceGroupData) IsV2Group() bool {
+	if group.Props != nil {
+		return false
+	}
+
+	if group.Query != nil {
+		return true
+	}
+
+	return false
 }
 
 type ResourceGroupResponse struct {
@@ -313,13 +289,26 @@ type ResourceGroupsResponse struct {
 }
 
 type ResourceGroupData struct {
+	// RGv1 Fields
 	Guid         string      `json:"guid,omitempty"`
 	IsDefault    int         `json:"isDefault,omitempty"`
 	ResourceGuid string      `json:"resourceGuid,omitempty"`
-	Name         string      `json:"resourceName"`
+	Name         string      `json:"resourceName,omitempty"`
 	Type         string      `json:"resourceType"`
-	Enabled      int         `json:"enabled,omitempty"`
-	Props        interface{} `json:"props"`
+	Enabled      int         `json:"enabled"`
+	Props        interface{} `json:"props,omitempty"`
+
+	// RG v2 Fields. `Enabled` and `Type` fields are the same in RGv1 nd RGv2
+	NameV2            string        `json:"name,omitempty"`
+	Query             *RGQuery      `json:"query,omitempty"`
+	Description       string        `json:"description,omitempty"`
+	ResourceGroupGuid string        `json:"resourceGroupGuid,omitempty"`
+	CreatedTime       *lwtime.Epoch `json:"lastUpdated,omitempty"`
+	CreatedBy         string        `json:"createdBy,omitempty"`
+	UpdatedTime       *lwtime.Epoch `json:"updatedTime,omitempty"`
+	UpdatedBy         string        `json:"updatedBy,omitempty"`
+	IsDefaultBoolean  *bool         `json:"isDefaultBoolean,omitempty"`
+	IsOrg             *bool         `json:"isOrg,omitempty"`
 }
 
 // RAIN-21510 workaround
@@ -339,4 +328,15 @@ type resourceGroupWorkaroundData struct {
 	Type         string      `json:"resourceType"`
 	Enabled      int         `json:"enabled,omitempty"`
 	Props        interface{} `json:"props"`
+
+	NameV2            string        `json:"name,omitempty"`
+	Query             *RGQuery      `json:"query,omitempty"`
+	Description       string        `json:"description,omitempty"`
+	ResourceGroupGuid string        `json:"resourceGroupGuid,omitempty"`
+	CreatedTime       *lwtime.Epoch `json:"lastUpdated,omitempty"`
+	CreatedBy         string        `json:"createdBy,omitempty"`
+	UpdatedTime       *lwtime.Epoch `json:"updatedTime,omitempty"`
+	UpdatedBy         string        `json:"updatedBy,omitempty"`
+	IsDefaultBoolean  *bool         `json:"isDefaultBoolean,omitempty"`
+	IsOrg             *bool         `json:"isOrg,omitempty"`
 }

--- a/api/resource_groups_aws.go
+++ b/api/resource_groups_aws.go
@@ -33,7 +33,7 @@ var (
 
 // GetAws gets a single Aws ResourceGroup matching the
 // provided resource guid
-func (svc *ResourceGroupsService) GetAws(guid string) (
+func (svc *ResourceGroupsVersionService) GetAws(guid string) (
 	response AwsResourceGroupResponse,
 	err error,
 ) {
@@ -47,8 +47,9 @@ func (svc *ResourceGroupsService) GetAws(guid string) (
 }
 
 // UpdateAws updates a single Aws ResourceGroup on the Lacework Server
-func (svc *ResourceGroupsService) UpdateAws(data ResourceGroup) (
+func (svc *ResourceGroupsVersionService) UpdateAws(data ResourceGroup) (
 	response AwsResourceGroupResponse, err error) {
+
 	if data == nil {
 		err = errors.New("resource group must not be empty")
 		return
@@ -65,7 +66,7 @@ func (svc *ResourceGroupsService) UpdateAws(data ResourceGroup) (
 }
 
 // CreateAws creates a single Aws ResourceGroup on the Lacework Server
-func (svc *ResourceGroupsService) CreateAws(data ResourceGroup) (
+func (svc *ResourceGroupsVersionService) CreateAws(data ResourceGroup) (
 	response AwsResourceGroupResponse,
 	err error,
 ) {
@@ -118,6 +119,17 @@ type AwsResourceGroupData struct {
 	Type         string                `json:"resourceType"`
 	Enabled      int                   `json:"enabled,omitempty"`
 	Props        AwsResourceGroupProps `json:"props"`
+
+	NameV2            string        `json:"name"`
+	Query             *RGQuery      `json:"query"`
+	Description       string        `json:"description,omitempty"`
+	ResourceGroupGuid string        `json:"resourceGroupGuid,omitempty"`
+	CreatedTime       *lwtime.Epoch `json:"lastUpdated,omitempty"`
+	CreatedBy         string        `json:"createdBy,omitempty"`
+	UpdatedTime       *lwtime.Epoch `json:"updatedTime,omitempty"`
+	UpdatedBy         string        `json:"updatedBy,omitempty"`
+	IsDefaultBoolean  *bool         `json:"isDefaultBoolean,omitempty"`
+	IsOrg             *bool         `json:"isOrg,omitempty"`
 }
 
 type AwsResourceGroupProps struct {

--- a/api/resource_groups_azure.go
+++ b/api/resource_groups_azure.go
@@ -33,7 +33,7 @@ var (
 
 // GetAzure gets a single Azure ResourceGroup matching the
 // provided resource guid
-func (svc *ResourceGroupsService) GetAzure(guid string) (
+func (svc *ResourceGroupsVersionService) GetAzure(guid string) (
 	response AzureResourceGroupResponse,
 	err error,
 ) {
@@ -47,7 +47,7 @@ func (svc *ResourceGroupsService) GetAzure(guid string) (
 }
 
 // UpdateAzure updates a single Azure ResourceGroup on the Lacework Server
-func (svc *ResourceGroupsService) UpdateAzure(data ResourceGroup) (
+func (svc *ResourceGroupsVersionService) UpdateAzure(data ResourceGroup) (
 	response AzureResourceGroupResponse,
 	err error,
 ) {
@@ -67,7 +67,7 @@ func (svc *ResourceGroupsService) UpdateAzure(data ResourceGroup) (
 }
 
 // CreateAzure creates a single Azure ResourceGroup on the Lacework Server
-func (svc *ResourceGroupsService) CreateAzure(data ResourceGroup) (
+func (svc *ResourceGroupsVersionService) CreateAzure(data ResourceGroup) (
 	response AzureResourceGroupResponse,
 	err error,
 ) {

--- a/api/resource_groups_container.go
+++ b/api/resource_groups_container.go
@@ -34,7 +34,7 @@ var (
 
 // GetContainer gets a single Container ResourceGroup matching the
 // provided resource guid
-func (svc *ResourceGroupsService) GetContainer(guid string) (
+func (svc *ResourceGroupsVersionService) GetContainer(guid string) (
 	response ContainerResourceGroupResponse,
 	err error,
 ) {
@@ -48,7 +48,7 @@ func (svc *ResourceGroupsService) GetContainer(guid string) (
 }
 
 // UpdateContainer updates a single Container ResourceGroup on the Lacework Server
-func (svc *ResourceGroupsService) UpdateContainer(data ResourceGroup) (
+func (svc *ResourceGroupsVersionService) UpdateContainer(data ResourceGroup) (
 	response ContainerResourceGroupResponse,
 	err error,
 ) {
@@ -64,7 +64,7 @@ func (svc *ResourceGroupsService) UpdateContainer(data ResourceGroup) (
 }
 
 // CreateContainer creates a single Container ResourceGroup on the Lacework Server
-func (svc *ResourceGroupsService) CreateContainer(data ResourceGroup) (
+func (svc *ResourceGroupsVersionService) CreateContainer(data ResourceGroup) (
 	response ContainerResourceGroupResponse,
 	err error,
 ) {

--- a/api/resource_groups_gcp.go
+++ b/api/resource_groups_gcp.go
@@ -33,7 +33,7 @@ var (
 
 // GetGcp gets a single Gcp ResourceGroup matching the
 // provided resource guid
-func (svc *ResourceGroupsService) GetGcp(guid string) (
+func (svc *ResourceGroupsVersionService) GetGcp(guid string) (
 	response GcpResourceGroupResponse,
 	err error,
 ) {
@@ -47,7 +47,7 @@ func (svc *ResourceGroupsService) GetGcp(guid string) (
 }
 
 // UpdateGcp updates a single Gcp ResourceGroup on the Lacework Server
-func (svc *ResourceGroupsService) UpdateGcp(data ResourceGroup) (
+func (svc *ResourceGroupsVersionService) UpdateGcp(data ResourceGroup) (
 	response GcpResourceGroupResponse,
 	err error,
 ) {
@@ -63,7 +63,7 @@ func (svc *ResourceGroupsService) UpdateGcp(data ResourceGroup) (
 }
 
 // CreateGcp creates a single Gcp ResourceGroup on the Lacework Server
-func (svc *ResourceGroupsService) CreateGcp(data ResourceGroup) (
+func (svc *ResourceGroupsVersionService) CreateGcp(data ResourceGroup) (
 	response GcpResourceGroupResponse,
 	err error,
 ) {

--- a/api/resource_groups_lw_account.go
+++ b/api/resource_groups_lw_account.go
@@ -33,7 +33,7 @@ var (
 
 // GetContainer gets a single LwAccount ResourceGroup matching the
 // provided resource guid
-func (svc *ResourceGroupsService) GetLwAccount(guid string) (
+func (svc *ResourceGroupsVersionService) GetLwAccount(guid string) (
 	response LwAccountResourceGroupResponse,
 	err error,
 ) {
@@ -47,7 +47,7 @@ func (svc *ResourceGroupsService) GetLwAccount(guid string) (
 }
 
 // UpdateLwAccount updates a single LwAccount ResourceGroup on the Lacework Server
-func (svc *ResourceGroupsService) UpdateLwAccount(data ResourceGroup) (
+func (svc *ResourceGroupsVersionService) UpdateLwAccount(data ResourceGroup) (
 	response LwAccountResourceGroupResponse,
 	err error,
 ) {
@@ -67,7 +67,7 @@ func (svc *ResourceGroupsService) UpdateLwAccount(data ResourceGroup) (
 }
 
 // CreateLwAccount creates a single LwAccount ResourceGroup on the Lacework Server
-func (svc *ResourceGroupsService) CreateLwAccount(data ResourceGroup) (
+func (svc *ResourceGroupsVersionService) CreateLwAccount(data ResourceGroup) (
 	response LwAccountResourceGroupResponse,
 	err error,
 ) {

--- a/api/resource_groups_machine.go
+++ b/api/resource_groups_machine.go
@@ -33,7 +33,7 @@ var (
 
 // GetMachine gets a single Machine ResourceGroup matching the
 // provided resource guid
-func (svc *ResourceGroupsService) GetMachine(guid string) (
+func (svc *ResourceGroupsVersionService) GetMachine(guid string) (
 	response MachineResourceGroupResponse,
 	err error,
 ) {
@@ -47,7 +47,7 @@ func (svc *ResourceGroupsService) GetMachine(guid string) (
 }
 
 // UpdateMachine updates a single Machine ResourceGroup on the Lacework Server
-func (svc *ResourceGroupsService) UpdateMachine(data ResourceGroup) (
+func (svc *ResourceGroupsVersionService) UpdateMachine(data ResourceGroup) (
 	response MachineResourceGroupResponse,
 	err error,
 ) {
@@ -67,7 +67,7 @@ func (svc *ResourceGroupsService) UpdateMachine(data ResourceGroup) (
 }
 
 // CreateMachine creates a single Machine ResourceGroup on the Lacework Server
-func (svc *ResourceGroupsService) CreateMachine(data ResourceGroup) (
+func (svc *ResourceGroupsVersionService) CreateMachine(data ResourceGroup) (
 	response MachineResourceGroupResponse,
 	err error,
 ) {

--- a/api/resource_groups_v2.go
+++ b/api/resource_groups_v2.go
@@ -20,8 +20,8 @@ package api
 
 import (
 	"fmt"
+	"time"
 
-	"github.com/lacework/go-sdk/lwtime"
 	"github.com/pkg/errors"
 )
 
@@ -141,18 +141,18 @@ type RGQuery struct {
 	Expression *RGExpression        `json:"expression"`
 }
 type ResourceGroupDataWithQuery struct {
-	Name              string        `json:"name"`
-	Type              string        `json:"resourceType"`
-	Query             *RGQuery      `json:"query"`
-	Description       string        `json:"description,omitempty"`
-	ResourceGroupGuid string        `json:"resourceGroupGuid,omitempty"`
-	CreatedTime       *lwtime.Epoch `json:"lastUpdated,omitempty"`
-	CreatedBy         string        `json:"createdBy,omitempty"`
-	UpdatedTime       *lwtime.Epoch `json:"updatedTime,omitempty"`
-	UpdatedBy         string        `json:"updatedBy,omitempty"`
-	Enabled           int           `json:"enabled,omitempty"`
-	IsDefaultBoolean  *bool         `json:"isDefaultBoolean,omitempty"`
-	IsOrg             *bool         `json:"isOrg,omitempty"`
+	Name              string     `json:"name"`
+	Type              string     `json:"resourceType"`
+	Query             *RGQuery   `json:"query"`
+	Description       string     `json:"description,omitempty"`
+	ResourceGroupGuid string     `json:"resourceGroupGuid,omitempty"`
+	CreatedTime       *time.Time `json:"lastUpdated,omitempty"`
+	CreatedBy         string     `json:"createdBy,omitempty"`
+	UpdatedTime       *time.Time `json:"updatedTime,omitempty"`
+	UpdatedBy         string     `json:"updatedBy,omitempty"`
+	Enabled           int        `json:"enabled,omitempty"`
+	IsDefaultBoolean  *bool      `json:"isDefaultBoolean,omitempty"`
+	IsOrg             *bool      `json:"isOrg,omitempty"`
 }
 
 func (group ResourceGroupDataWithQuery) GetProps() interface{} {

--- a/api/resource_groups_v2.go
+++ b/api/resource_groups_v2.go
@@ -1,0 +1,164 @@
+//
+// Author:: Zeki Sherif(<zeki.sherif@lacework.net>)
+// Copyright:: Copyright 2021, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package api
+
+import (
+	"fmt"
+
+	"github.com/lacework/go-sdk/lwtime"
+	"github.com/pkg/errors"
+)
+
+func (svc *ResourceGroupsV2Service) List() (response ResourceGroupsResponse, err error) {
+	var rawResponse ResourceGroupsV2Response
+	err = svc.client.RequestDecoder("GET", apiV2ResourceGroups, nil, &rawResponse)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+func (svc *ResourceGroupsV2Service) Create(group ResourceGroupDataWithQuery) (
+	response ResourceGroupV2Response,
+	err error,
+) {
+	err = svc.create(group, &response)
+	return
+}
+
+func (svc *ResourceGroupsV2Service) Update(data ResourceGroup) (
+	response ResourceGroupV2Response,
+	err error,
+) {
+	if data == nil {
+		err = errors.New("resource group must not be empty")
+		return
+	}
+	guid := data.ID()
+	data.ResetResourceGUID()
+
+	err = svc.update(guid, data, &response)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+func (svc *ResourceGroupsV2Service) Delete(guid string) error {
+	if guid == "" {
+		return errors.New("specify a resourceGuid")
+	}
+
+	return svc.client.RequestDecoder(
+		"DELETE",
+		fmt.Sprintf(apiV2ResourceGroupsFromGUID, guid),
+		nil,
+		nil,
+	)
+}
+
+func (svc *ResourceGroupsV2Service) Get(guid string, response interface{}) error {
+	var rawResponse resourceGroupWorkaroundResponse
+	err := svc.get(guid, &rawResponse)
+	if err != nil {
+		return err
+	}
+
+	return castResourceGroupResponse(rawResponse.Data, &response)
+}
+
+func (svc *ResourceGroupsV2Service) create(data interface{}, response interface{}) error {
+	return svc.client.RequestEncoderDecoder("POST", apiV2ResourceGroups, data, response)
+}
+
+func (svc *ResourceGroupsV2Service) get(guid string, response interface{}) error {
+	if guid == "" {
+		return errors.New("specify an resourceGuid")
+	}
+	apiPath := fmt.Sprintf(apiV2ResourceGroupsFromGUID, guid)
+	return svc.client.RequestDecoder("GET", apiPath, nil, response)
+}
+
+func (svc *ResourceGroupsV2Service) update(guid string, data interface{}, response interface{}) error {
+	if guid == "" {
+		return errors.New("specify a resource group guid")
+	}
+
+	apiPath := fmt.Sprintf(apiV2ResourceGroupsFromGUID, guid)
+	return svc.client.RequestEncoderDecoder("PATCH", apiPath, data, response)
+}
+
+type ResourceGroupV2Response struct {
+	Data ResourceGroupDataWithQuery `json:"data"`
+}
+
+type ResourceGroupsV2Response struct {
+	Data []ResourceGroupDataWithQuery `json:"data"`
+}
+
+type ResourceGroupsV2Service struct {
+	client *Client
+}
+
+type RGExpression struct {
+	Operator string     `json:"operator"`
+	Children []*RGChild `json:"children"`
+}
+
+type RGChild struct {
+	Operator   string     `json:"operator,omitempty"`
+	FilterName string     `json:"filterName,omitempty"`
+	Children   []*RGChild `json:"children,omitempty"`
+}
+
+type RGFilter struct {
+	Field     string   `json:"field"`
+	Operation string   `json:"operation"`
+	Values    []string `json:"values"`
+	Key       string   `json:"key,omitempty"`
+}
+
+type RGQuery struct {
+	Filters    map[string]*RGFilter `json:"filters"`
+	Expression *RGExpression        `json:"expression"`
+}
+type ResourceGroupDataWithQuery struct {
+	Name              string        `json:"name"`
+	Type              string        `json:"resourceType"`
+	Query             *RGQuery      `json:"query"`
+	Description       string        `json:"description,omitempty"`
+	ResourceGroupGuid string        `json:"resourceGroupGuid,omitempty"`
+	CreatedTime       *lwtime.Epoch `json:"lastUpdated,omitempty"`
+	CreatedBy         string        `json:"createdBy,omitempty"`
+	UpdatedTime       *lwtime.Epoch `json:"updatedTime,omitempty"`
+	UpdatedBy         string        `json:"updatedBy,omitempty"`
+	Enabled           int           `json:"enabled,omitempty"`
+	IsDefaultBoolean  *bool         `json:"isDefaultBoolean,omitempty"`
+	IsOrg             *bool         `json:"isOrg,omitempty"`
+}
+
+func (group ResourceGroupDataWithQuery) GetProps() interface{} {
+	return nil
+}
+
+func (group ResourceGroupDataWithQuery) GetQuery() *RGQuery {
+	return group.Query
+}

--- a/api/resource_groups_version_service.go
+++ b/api/resource_groups_version_service.go
@@ -1,0 +1,372 @@
+//
+// Author:: Zeki Sherif(<zeki.sherif@lacework.net>)
+// Copyright:: Copyright 2021, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/pkg/errors"
+	"strconv"
+)
+
+type ResourceGroupsVersionService struct {
+	client                 *Client
+	v1ResourceGroupService *ResourceGroupsService
+	v2ResourceGroupService *ResourceGroupsV2Service
+	featureFlagService     *FeatureFlagsService
+}
+
+type ResourceGroupsInterfaceData interface {
+	GetProps() interface{}
+	GetQuery() *RGQuery
+}
+
+func (group ResourceGroupData) GetProps() interface{} {
+	return group.Props
+}
+
+func (group ResourceGroupData) GetQuery() *RGQuery {
+	return nil
+}
+
+func NewResourceGroupsVersionService(c *Client) *ResourceGroupsVersionService {
+	return &ResourceGroupsVersionService{
+		c,
+		&ResourceGroupsService{c},
+		&ResourceGroupsV2Service{c},
+		&FeatureFlagsService{c},
+	}
+}
+
+// NewResourceGroup returns an instance of the ResourceGroupData struct with the
+// provided ResourceGroup type, name and the props field as an interface{}.
+//
+// NOTE: This function must be used by any ResourceGroup type.
+//
+// Basic usage: Initialize a new ContainerResourceGroup struct, then
+//              use the new instance to do CRUD operations
+//
+//   client, err := api.NewClient("account")
+//   if err != nil {
+//     return err
+//   }
+//
+//   group := api.NewResourceGroup("container resource group",
+//     api.ContainerResourceGroup,
+//     api.ContainerResourceGroupData{
+//       Props: api.ContainerResourceGroupProps{
+//			Description:     "all containers,
+//			ContainerLabels: ContainerResourceGroupAllLabels,
+//			ContainerTags:   ContainerResourceGroupAllTags,
+//		},
+//     },
+//   )
+//
+//   client.V2.ResourceGroups.Create(group)
+//
+func NewResourceGroup(name string, iType ResourceGroupType, props interface{}) ResourceGroupData {
+	return ResourceGroupData{
+		Name:    name,
+		Type:    iType.String(),
+		Enabled: 1,
+		Props:   props,
+	}
+}
+
+// NewResourceGroupWithQuery Only available with RGv2 beta
+func NewResourceGroupWithQuery(name string, iType ResourceGroupType,
+	description string, query *RGQuery) ResourceGroupDataWithQuery {
+	return ResourceGroupDataWithQuery{
+		Name:        name,
+		Type:        iType.String(),
+		Enabled:     1,
+		Query:       query,
+		Description: description,
+	}
+}
+
+func isRGV2FlagEnabled(featureFlagService *FeatureFlagsService) bool {
+	response, err := featureFlagService.GetFeatureFlagsMatchingPrefix("PUBLIC.rgv2.cli")
+
+	if err != nil {
+		return false
+	}
+
+	return len(response.Data.Flags) >= 1
+}
+
+func (svc *ResourceGroupsVersionService) Get(guid string, response interface{}) error {
+	var rawResponse resourceGroupWorkaroundResponse
+	err := svc.get(guid, &rawResponse)
+	if err != nil {
+		return err
+	}
+
+	if rawResponse.Data.Query != nil {
+		return castRGV2WorkAroundResponse(rawResponse, response)
+	} else {
+		return castRGV1WorkAroundResponse(rawResponse, response)
+	}
+}
+
+func (svc *ResourceGroupsVersionService) Create(group ResourceGroupsInterfaceData) (
+	response ResourceGroupResponse,
+	err error,
+) {
+	isV2FlagEnabled := isRGV2FlagEnabled(svc.featureFlagService)
+
+	if group.GetProps() == nil && !isV2FlagEnabled && group.GetQuery() == nil {
+		if isV2FlagEnabled {
+			err = errors.New("Invalid request. Missing `query` field.")
+		} else {
+			err = errors.New("Invalid request. Missing `props` field.")
+		}
+
+		return
+	}
+
+	if group.GetProps() != nil {
+		response, err = svc.v1ResourceGroupService.Create(group.(ResourceGroupData))
+		return
+	}
+
+	createResponse, createErr := svc.v2ResourceGroupService.Create(group.(ResourceGroupDataWithQuery))
+	if createErr != nil {
+		err = createErr
+		return
+	}
+
+	err = castResourceGroupV2Response(createResponse, &response)
+	return
+}
+
+func (svc *ResourceGroupsVersionService) Update(group ResourceGroupsInterfaceData) (
+	response ResourceGroupResponse,
+	err error,
+) {
+	if group.GetProps() != nil {
+		response, err = svc.v1ResourceGroupService.Update(group.(ResourceGroup))
+		return
+	}
+
+	isV2FlagEnabled := isRGV2FlagEnabled(svc.featureFlagService)
+
+	if isV2FlagEnabled {
+		createResponse, createErr := svc.v2ResourceGroupService.Update(group.(ResourceGroup))
+		if createErr != nil {
+			err = createErr
+			return
+		}
+
+		err = castResourceGroupV2Response(createResponse, &response)
+		return
+	}
+
+	err = errors.New("Unable to update resource group")
+	return
+}
+
+func (svc *ResourceGroupsVersionService) Delete(guid string) error {
+	// It doesn't matcher which version of service we use as api-server handles
+	// delete for both v1 and v2 resource groups
+	err := svc.v1ResourceGroupService.Delete(guid)
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (svc *ResourceGroupsVersionService) List() (response ResourceGroupsResponse, err error) {
+	var rawResponse resourceGroupsWorkaroundResponse
+	err = svc.client.RequestDecoder("GET", apiV2ResourceGroups, nil, &rawResponse)
+
+	if err != nil {
+		return
+	}
+
+	return setResourceGroupsVersionUnawareResponse(rawResponse)
+}
+
+func castRGV1WorkAroundResponse(data resourceGroupWorkaroundResponse, response interface{}) error {
+	isDefault, err := strconv.Atoi(data.Data.IsDefault)
+	if err != nil {
+		return err
+	}
+	group := ResourceGroupResponse{
+		Data: ResourceGroupData{
+			Guid:         data.Data.Guid,
+			IsDefault:    isDefault,
+			ResourceGuid: data.Data.ResourceGuid,
+			Name:         data.Data.Name,
+			Type:         data.Data.Type,
+			Enabled:      data.Data.Enabled,
+			Props:        data.Data.Props,
+		},
+	}
+
+	j, err := json.Marshal(group)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(j, &response)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func castRGV2WorkAroundResponse(data resourceGroupWorkaroundResponse, response interface{}) error {
+	group := ResourceGroupResponse{
+		Data: ResourceGroupData{
+			Type:              data.Data.Type,
+			Enabled:           data.Data.Enabled,
+			NameV2:            data.Data.NameV2,
+			Query:             data.Data.Query,
+			Description:       data.Data.Description,
+			ResourceGroupGuid: data.Data.ResourceGroupGuid,
+			CreatedTime:       data.Data.CreatedTime,
+			CreatedBy:         data.Data.CreatedBy,
+			UpdatedTime:       data.Data.UpdatedTime,
+			UpdatedBy:         data.Data.UpdatedBy,
+			IsDefaultBoolean:  data.Data.IsDefaultBoolean,
+			IsOrg:             data.Data.IsOrg,
+		},
+	}
+
+	j, err := json.Marshal(group)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(j, &response)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func castResourceGroupV2Response(data ResourceGroupV2Response, response interface{}) error {
+	group := ResourceGroupResponse{
+		Data: ResourceGroupData{
+			Type:              data.Data.Type,
+			Enabled:           data.Data.Enabled,
+			NameV2:            data.Data.Name,
+			Query:             data.Data.Query,
+			Description:       data.Data.Description,
+			ResourceGroupGuid: data.Data.ResourceGroupGuid,
+			CreatedTime:       data.Data.CreatedTime,
+			CreatedBy:         data.Data.CreatedBy,
+			UpdatedTime:       data.Data.UpdatedTime,
+			UpdatedBy:         data.Data.UpdatedBy,
+			IsDefaultBoolean:  data.Data.IsDefaultBoolean,
+			IsOrg:             data.Data.IsOrg,
+		},
+	}
+
+	j, err := json.Marshal(group)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(j, &response)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (svc *ResourceGroupsVersionService) get(guid string, response interface{}) error {
+	if guid == "" {
+		return errors.New("specify an resourceGuid")
+	}
+	apiPath := fmt.Sprintf(apiV2ResourceGroupsFromGUID, guid)
+	return svc.client.RequestDecoder("GET", apiPath, nil, response)
+}
+
+func (svc *ResourceGroupsVersionService) create(data interface{}, response interface{}) error {
+	return svc.client.RequestEncoderDecoder("POST", apiV2ResourceGroups, data, response)
+}
+
+func (svc *ResourceGroupsVersionService) update(guid string, data interface{}, response interface{}) error {
+	if guid == "" {
+		return errors.New("specify a resource group guid")
+	}
+
+	apiPath := fmt.Sprintf(apiV2ResourceGroupsFromGUID, guid)
+	return svc.client.RequestEncoderDecoder("PATCH", apiPath, data, response)
+}
+
+func setResourceGroupResponse(response resourceGroupWorkaroundData) (ResourceGroupResponse,
+	error) {
+
+	if response.Props != nil {
+		isDefault, err := strconv.Atoi(response.IsDefault)
+		if err != nil {
+			return ResourceGroupResponse{}, err
+		}
+		return ResourceGroupResponse{
+			Data: ResourceGroupData{
+				Guid:         response.Guid,
+				IsDefault:    isDefault,
+				ResourceGuid: response.ResourceGuid,
+				Name:         response.Name,
+				Type:         response.Type,
+				Enabled:      response.Enabled,
+				Props:        response.Props,
+			},
+		}, nil
+	} else {
+		return ResourceGroupResponse{
+			Data: ResourceGroupData{
+				Type:              response.Type,
+				Enabled:           response.Enabled,
+				NameV2:            response.NameV2,
+				Query:             response.Query,
+				Description:       response.Description,
+				ResourceGroupGuid: response.ResourceGroupGuid,
+				CreatedTime:       response.CreatedTime,
+				CreatedBy:         response.CreatedBy,
+				UpdatedTime:       response.UpdatedTime,
+				UpdatedBy:         response.UpdatedBy,
+				IsDefaultBoolean:  response.IsDefaultBoolean,
+				IsOrg:             response.IsOrg,
+			},
+		}, nil
+	}
+}
+
+func setResourceGroupsVersionUnawareResponse(workaround resourceGroupsWorkaroundResponse) (
+	ResourceGroupsResponse, error) {
+	var data []ResourceGroupData
+	for _, r := range workaround.Data {
+		group, err := setResourceGroupResponse(r)
+		if err != nil {
+			return ResourceGroupsResponse{}, err
+		}
+		data = append(data, group.Data)
+	}
+
+	return ResourceGroupsResponse{Data: data}, nil
+}

--- a/api/resource_groups_version_service.go
+++ b/api/resource_groups_version_service.go
@@ -103,7 +103,7 @@ func NewResourceGroupWithQuery(name string, iType ResourceGroupType,
 }
 
 func isRGV2FlagEnabled(featureFlagService *FeatureFlagsService) bool {
-	response, err := featureFlagService.GetFeatureFlagsMatchingPrefix("PUBLIC.rgv2.cli")
+	response, err := featureFlagService.GetFeatureFlagsMatchingPrefix(ApiV2CliFeatureFlag)
 
 	if err != nil {
 		return false

--- a/api/resource_groups_version_service.go
+++ b/api/resource_groups_version_service.go
@@ -21,8 +21,9 @@ package api
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/pkg/errors"
 	"strconv"
+
+	"github.com/pkg/errors"
 )
 
 type ResourceGroupsVersionService struct {

--- a/api/v2.go
+++ b/api/v2.go
@@ -42,7 +42,7 @@ type V2Endpoints struct {
 	ContainerRegistries     *ContainerRegistriesService
 	Configs                 *v2ConfigService
 	FeatureFlags            *FeatureFlagsService
-	ResourceGroups          *ResourceGroupsService
+	ResourceGroups          *ResourceGroupsVersionService
 	AgentAccessTokens       *AgentAccessTokensService
 	AgentInfo               *AgentInfoService
 	Inventory               *InventoryService
@@ -77,7 +77,7 @@ func NewV2Endpoints(c *Client) *V2Endpoints {
 		&ContainerRegistriesService{c},
 		NewV2ConfigService(c),
 		&FeatureFlagsService{c},
-		&ResourceGroupsService{c},
+		NewResourceGroupsVersionService(c),
 		&AgentAccessTokensService{c},
 		&AgentInfoService{c},
 		&InventoryService{c},

--- a/cli/cmd/resource_group_v2.go
+++ b/cli/cmd/resource_group_v2.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/lacework/go-sdk/api"
 )

--- a/cli/cmd/resource_group_v2.go
+++ b/cli/cmd/resource_group_v2.go
@@ -1,0 +1,122 @@
+//
+// Author:: Zeki Sherif(<zeki.sherif@lacework.net>)
+// Copyright:: Copyright 2021, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cmd
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"github.com/AlecAivazis/survey/v2"
+	"github.com/lacework/go-sdk/api"
+)
+
+func createResourceGroupV2(resourceType string) error {
+	questions := []*survey.Question{
+		{
+			Name:     "name",
+			Prompt:   &survey.Input{Message: "Name: "},
+			Validate: survey.Required,
+		},
+		{
+			Name:     "description",
+			Prompt:   &survey.Input{Message: "Description: "},
+			Validate: survey.Required,
+		},
+		{
+			Name:     "query",
+			Prompt:   inputRGQueryFromEditor(resourceType),
+			Validate: survey.Required,
+		},
+	}
+
+	answers := struct {
+		Name        string `survey:"name"`
+		Description string `survey:"description"`
+		Query       string `survey:"query"`
+	}{}
+
+	err := survey.Ask(questions, &answers,
+		survey.WithIcons(promptIconsFunc),
+	)
+
+	if err != nil {
+		return err
+	}
+
+	var rgQuery api.RGQuery
+	err = json.Unmarshal([]byte(answers.Query), &rgQuery)
+	if err != nil {
+		return err
+	}
+
+	groupType, isValid := api.FindResourceGroupType(resourceType)
+	if !isValid {
+		// This should never reach this. The type is controlled by us in cmd/resource_groups
+		return errors.New("internal error")
+	}
+	resourceGroup := api.NewResourceGroupWithQuery(answers.Name, groupType, answers.Description, &rgQuery)
+
+	cli.StartProgress(" Creating resource group...")
+	_, err = cli.LwApi.V2.ResourceGroups.Create(resourceGroup)
+	cli.StopProgress()
+	return err
+}
+
+func inputRGQueryFromEditor(resourceType string) *survey.Editor {
+	prompt := &survey.Editor{
+		Message:  fmt.Sprintf("Type a query for the new %s Resource Group", resourceType),
+		FileName: "resourceGroupQuery*.json",
+		Help:     "Refer to https://lwdocs-rg2.netlify.app/api/api-resource-group/ for examples of a query",
+	}
+
+	prompt.Default = `{
+  "filters": {
+	"filter0": {
+	  "field": "Resource Tag",
+	  "operation": "INCLUDES",
+	  "values": [
+		"*"
+	  ],
+	  "key": "HOST"
+	},
+	"filter1": {
+	  "field": "Region",
+	  "operation": "STARTS_WITH",
+	  "values": [
+		"ap-south"
+	  ]
+	}
+  },
+  "expression": {
+	"operator": "AND",
+	"children": [
+	  {
+		"filterName": "filter0"
+	  },
+	  {
+		"filterName": "filter1"
+	  }
+	]
+  }
+}`
+	prompt.HideDefault = true
+	prompt.AppendDefault = true
+
+	return prompt
+}

--- a/cli/cmd/resource_groups.go
+++ b/cli/cmd/resource_groups.go
@@ -270,7 +270,7 @@ func promptCreateResourceGroup() error {
 	}
 
 	isRGv2Enabled := false
-	ffResponse, _ := cli.LwApi.V2.FeatureFlags.GetFeatureFlagsMatchingPrefix("PUBLIC.rgv2.cli")
+	ffResponse, _ := cli.LwApi.V2.FeatureFlags.GetFeatureFlagsMatchingPrefix(api.ApiV2CliFeatureFlag)
 	if len(ffResponse.Data.Flags) >= 1 {
 		isRGv2Enabled = true
 	}

--- a/cli/cmd/resource_groups.go
+++ b/cli/cmd/resource_groups.go
@@ -21,9 +21,9 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
-
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/lacework/go-sdk/api"
+	"github.com/lacework/go-sdk/lwtime"
 	"github.com/olekukonko/tablewriter"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -69,16 +69,35 @@ Then navigate to Settings > Resource Groups.
 
 			groups := make([]resourceGroup, 0)
 			for _, g := range resourceGroups.Data {
-				props, _ := parsePropsType(g)
+				var props api.ResourceGroupProps
+				var resourceGroupGuid string
+				var isDefault int
+				var resourceName string
+
+				if g.GetProps() != nil {
+					props, _ = parsePropsType(g.Props, g.Type)
+					resourceGroupGuid = g.ResourceGuid
+					isDefault = g.IsDefault
+					resourceName = g.Name
+				} else {
+					resourceGroupGuid = g.ResourceGroupGuid
+					if *g.IsDefaultBoolean {
+						isDefault = 1
+					} else {
+						isDefault = 0
+					}
+					resourceName = g.NameV2
+				}
 
 				groups = append(groups, resourceGroup{
-					Id:        g.ResourceGuid,
+					Id:        resourceGroupGuid,
 					ResType:   g.Type,
-					Name:      g.Name,
+					Name:      resourceName,
 					status:    g.Status(),
-					Enabled:   g.Enabled,
-					IsDefault: g.IsDefault,
 					Props:     props,
+					Enabled:   g.Enabled,
+					IsDefault: isDefault,
+					Query:     g.Query,
 				})
 			}
 
@@ -111,16 +130,38 @@ Then navigate to Settings > Resource Groups.
 				return errors.Wrap(err, "unable to get resource group")
 			}
 
-			props, _ := parsePropsType(response.Data)
+			var props api.ResourceGroupProps
+			var resourceGroupGuid string
+			var isDefault int
+			var name string
+
+			if response.Data.Props != nil {
+				props, _ = parsePropsType(response.Data.Props, response.Data.Type)
+				resourceGroupGuid = response.Data.ResourceGuid
+				isDefault = response.Data.IsDefault
+				name = response.Data.Name
+			} else {
+				resourceGroupGuid = response.Data.ResourceGroupGuid
+				if *response.Data.IsDefaultBoolean {
+					isDefault = 1
+				} else {
+					isDefault = 0
+				}
+				name = response.Data.NameV2
+			}
 
 			group := resourceGroup{
-				Id:        response.Data.ResourceGuid,
-				ResType:   response.Data.Type,
-				Name:      response.Data.Name,
-				status:    response.Data.Status(),
-				Props:     props,
-				Enabled:   response.Data.Enabled,
-				IsDefault: response.Data.IsDefault,
+				Id:          resourceGroupGuid,
+				ResType:     response.Data.Type,
+				Name:        name,
+				status:      response.Data.Status(),
+				Props:       props,
+				Enabled:     response.Data.Enabled,
+				IsDefault:   isDefault,
+				Query:       response.Data.Query,
+				Description: response.Data.Description,
+				UpdatedBy:   response.Data.UpdatedBy,
+				UpdatedTime: response.Data.UpdatedTime,
 			}
 
 			if cli.JSONOutput() {
@@ -131,13 +172,22 @@ Then navigate to Settings > Resource Groups.
 			}
 
 			var groupCommon [][]string
-			groupCommon = append(groupCommon,
-				[]string{group.Id, group.ResType, group.Name, group.status, IsDefault(group.IsDefault)},
-			)
 
-			cli.OutputHuman(renderSimpleTable([]string{"RESOURCE ID", "TYPE", "NAME", "STATE", "DEFAULT"}, groupCommon))
-			cli.OutputHuman("\n")
-			cli.OutputHuman(buildResourceGroupPropsTable(group))
+			if group.Props != nil {
+				groupCommon = append(groupCommon,
+					[]string{group.Id, group.ResType, group.Name, group.status, IsDefault(group.IsDefault)},
+				)
+				cli.OutputHuman(renderSimpleTable([]string{"RESOURCE ID", "TYPE", "NAME", "STATE", "DEFAULT"}, groupCommon))
+				cli.OutputHuman("\n")
+				cli.OutputHuman(buildResourceGroupPropsTable(group))
+			} else {
+				groupCommon = append(groupCommon,
+					[]string{group.Id, group.ResType, group.Name, group.Description, group.status,
+						IsDefault(group.IsDefault), group.UpdatedBy, group.UpdatedTime.UTC().String()},
+				)
+				cli.OutputHuman(renderSimpleTable([]string{"RESOURCE ID", "TYPE", "NAME", "DESCRIPTION", "STATE",
+					"DEFAULT", "UPDATED BY", "UPDATED_TIME"}, groupCommon))
+			}
 
 			return nil
 		},
@@ -154,6 +204,8 @@ Then navigate to Settings > Resource Groups.
 			if err != nil {
 				return errors.Wrap(err, "unable to delete resource group")
 			}
+
+			cli.OutputHuman("The resource group was deleted.\n")
 			return nil
 		},
 	}
@@ -180,10 +232,10 @@ Then navigate to Settings > Resource Groups.
 )
 
 // parsePropsType converts props json string to interface of resource group props type
-func parsePropsType(response api.ResourceGroupData) (api.ResourceGroupProps, error) {
-	propsString := response.Props.(string)
+func parsePropsType(props interface{}, resourceType string) (api.ResourceGroupProps, error) {
+	propsString := props.(string)
 
-	switch response.Type {
+	switch resourceType {
 	case api.AwsResourceGroup.String():
 		return unmarshallAwsPropString([]byte(propsString))
 	case api.AzureResourceGroup.String():
@@ -201,18 +253,42 @@ func parsePropsType(response api.ResourceGroupData) (api.ResourceGroupProps, err
 }
 
 func promptCreateResourceGroup() error {
+
+	resourceGroupOptions := []string{
+		"AWS",
+		"AZURE",
+		"CONTAINER",
+		"GCP",
+		"LW_ACCOUNT",
+		"MACHINE",
+		"AWS(v2)",
+		"AZURE(v2)",
+		"GCP(v2)",
+		"CONTAINER(v2)",
+		"MACHINE(v2)",
+	}
+
+	isRGv2Enabled := false
+	ffResponse, _ := cli.LwApi.V2.FeatureFlags.GetFeatureFlagsMatchingPrefix("PUBLIC.rgv2.cli")
+	if len(ffResponse.Data.Flags) >= 1 {
+		isRGv2Enabled = true
+	}
+
+	if isRGv2Enabled {
+		resourceGroupOptions = append(resourceGroupOptions,
+			"AWS(v2)",
+			"AZURE(v2)",
+			"GCP(v2)",
+			"CONTAINER(v2)",
+			"MACHINE(v2)",
+		)
+	}
+
 	var (
 		group  = ""
 		prompt = &survey.Select{
 			Message: "Choose a resource group type to create: ",
-			Options: []string{
-				"AWS",
-				"AZURE",
-				"CONTAINER",
-				"GCP",
-				"LW_ACCOUNT",
-				"MACHINE",
-			},
+			Options: resourceGroupOptions,
 		}
 		err = survey.AskOne(prompt, &group)
 	)
@@ -233,6 +309,16 @@ func promptCreateResourceGroup() error {
 		return createLwAccountResourceGroup()
 	case "MACHINE":
 		return createMachineResourceGroup()
+	case "AWS(v2)":
+		return createResourceGroupV2("AWS")
+	case "AZURE(v2)":
+		return createResourceGroupV2("AZURE")
+	case "GCP(v2)":
+		return createResourceGroupV2("GCP")
+	case "CONTAINER(v2)":
+		return createResourceGroupV2("CONTAINER")
+	case "MACHINE(v2)":
+		return createResourceGroupV2("MACHINE")
 	default:
 		return errors.New("unknown resource group type")
 	}
@@ -312,11 +398,15 @@ func IsDefault(isDefault int) string {
 }
 
 type resourceGroup struct {
-	Id        string                 `json:"resource_guid"`
-	ResType   string                 `json:"type"`
-	Name      string                 `json:"name"`
-	Props     api.ResourceGroupProps `json:"props"`
-	Enabled   int                    `json:"enabled"`
-	IsDefault int                    `json:"isDefault"`
-	status    string
+	Id          string                 `json:"resource_guid"`
+	ResType     string                 `json:"type"`
+	Name        string                 `json:"name"`
+	Props       api.ResourceGroupProps `json:"props"`
+	Enabled     int                    `json:"enabled"`
+	IsDefault   int                    `json:"isDefault"`
+	Query       *api.RGQuery           `json:"query"`
+	Description string                 `json:"description,omitempty"`
+	UpdatedTime *lwtime.Epoch          `json:"updatedTime,omitempty"`
+	UpdatedBy   string                 `json:"updatedBy,omitempty"`
+	status      string
 }

--- a/cli/cmd/resource_groups.go
+++ b/cli/cmd/resource_groups.go
@@ -21,6 +21,7 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/lacework/go-sdk/api"
 	"github.com/lacework/go-sdk/lwtime"

--- a/cli/cmd/resource_groups.go
+++ b/cli/cmd/resource_groups.go
@@ -21,10 +21,10 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/lacework/go-sdk/api"
-	"github.com/lacework/go-sdk/lwtime"
 	"github.com/olekukonko/tablewriter"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -407,7 +407,7 @@ type resourceGroup struct {
 	IsDefault   int                    `json:"isDefault"`
 	Query       *api.RGQuery           `json:"query"`
 	Description string                 `json:"description,omitempty"`
-	UpdatedTime *lwtime.Epoch          `json:"updatedTime,omitempty"`
+	UpdatedTime *time.Time             `json:"updatedTime,omitempty"`
 	UpdatedBy   string                 `json:"updatedBy,omitempty"`
 	status      string
 }


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/lacework/go-sdk) and create your branch from `main`
  2. Run `make prepare` in the repository root
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`make test`)
  5. Format your code (`make fmt`)
  6. Make sure your code lints (`make lint`)
  7. If you are updating the Lacework CLI, make sure it compiles (`make build-cli-cross-platform`)
  8. Follow the commit message standard (`type(scope): subject`) documented in [DEVELOPER_GUIDELINES.md](https://github.com/lacework/go-sdk/blob/main/DEVELOPER_GUIDELINES.md#commit-message-standard)
  9. If you haven't already, configure signed commits by [telling git about your signing key](https://docs.github.com/en/github/authenticating-to-github/managing-commit-signature-verification/telling-git-about-your-signing-key) and [signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)

  Learn more about contributing: https://github.com/lacework/go-sdk/blob/main/CONTRIBUTING.md
-->

## Summary

Adds support for the CRUD operations for Resource Groups V2.

## How did you test this change?

1. Updated example code for resource groups and ensured it passed.
2. Manually ran the command line. See pictures below
3. ran all the commands listed to do before publishing a PR

List Resource Groups
<img width="1151" alt="Screenshot 2023-08-07 at 12 17 49 PM" src="https://github.com/lacework/go-sdk/assets/9832640/70d646e4-9dee-4540-9a9a-e1bce3da745d">

Create an AWS RGv2
<img width="868" alt="Screenshot 2023-08-07 at 12 18 41 PM" src="https://github.com/lacework/go-sdk/assets/9832640/6a8f54fb-197a-4a42-b2e4-fb5a41f596d8">

Create an AWS RGv1
<img width="1104" alt="Screenshot 2023-08-07 at 12 19 08 PM" src="https://github.com/lacework/go-sdk/assets/9832640/52580d6a-c685-4a3e-b95a-688ed53ea29e">

List showing the RGv2 that was created
<img width="869" alt="Screenshot 2023-08-07 at 12 19 30 PM" src="https://github.com/lacework/go-sdk/assets/9832640/6ad1860c-5557-469f-a2fb-d0472285bcaf">

Delete the RGv1 created earlier
<img width="961" alt="Screenshot 2023-08-07 at 12 22 22 PM" src="https://github.com/lacework/go-sdk/assets/9832640/2abc5c39-a3db-466e-b50f-58673926380e">

Calling GET for both an V1 and V2 resource
<img width="1281" alt="Screenshot 2023-08-07 at 12 34 41 PM" src="https://github.com/lacework/go-sdk/assets/9832640/bb634ade-adb7-46a0-90b5-2cf032311a79">



## Issue

https://lacework.atlassian.net/browse/CAD-360
