### PR TITLE
fix: alert rules empty arrays

### DIFF
--- a/api/alert_rules.go
+++ b/api/alert_rules.go
@@ -154,26 +154,26 @@ const (
 // NewAlertRule returns an instance of the AlertRule struct
 //
 // Basic usage: Initialize a new AlertRule struct, then
-//              use the new instance to do CRUD operations
 //
-//   client, err := api.NewClient("account")
-//   if err != nil {
-//     return err
-//   }
+//	             use the new instance to do CRUD operations
 //
-//   alertRule := api.NewAlertRule(
-//		"Foo",
-//		api.AlertRuleConfig{
-//		Description: "My Alert Rule"
-//		Severities: api.AlertRuleSeverities{api.AlertRuleSeverityHigh,
-//		Channels: []string{"TECHALLY_000000000000AAAAAAAAAAAAAAAAAAAA"},
-//		ResourceGroups: []string{"TECHALLY_111111111111AAAAAAAAAAAAAAAAAAAA"}
-//       },
-//     },
-//   )
+//	  client, err := api.NewClient("account")
+//	  if err != nil {
+//	    return err
+//	  }
 //
-//   client.V2.AlertRules.Create(alertRule)
+//	  alertRule := api.NewAlertRule(
+//			"Foo",
+//			api.AlertRuleConfig{
+//			Description: "My Alert Rule"
+//			Severities: api.AlertRuleSeverities{api.AlertRuleSeverityHigh,
+//			Channels: []string{"TECHALLY_000000000000AAAAAAAAAAAAAAAAAAAA"},
+//			ResourceGroups: []string{"TECHALLY_111111111111AAAAAAAAAAAAAAAAAAAA"}
+//	      },
+//	    },
+//	  )
 //
+//	  client.V2.AlertRules.Create(alertRule)
 func NewAlertRule(name string, rule AlertRuleConfig) AlertRule {
 	return AlertRule{
 		Channels: rule.Channels,
@@ -272,10 +272,10 @@ type AlertRuleFilter struct {
 	Enabled              int      `json:"enabled"`
 	Description          string   `json:"description,omitempty"`
 	Severity             []int    `json:"severity"`
-	ResourceGroups       []string `json:"resourceGroups,omitempty"`
-	EventCategories      []string `json:"eventCategory,omitempty"`
+	ResourceGroups       []string `json:"resourceGroups"`
+	EventCategories      []string `json:"eventCategory"`
 	Sources              []string `json:"sources,omitempty"`
-	AlertCategories      []string `json:"category,omitempty"`
+	AlertCategories      []string `json:"category"`
 	CreatedOrUpdatedTime string   `json:"createdOrUpdatedTime,omitempty"`
 	CreatedOrUpdatedBy   string   `json:"createdOrUpdatedBy,omitempty"`
 }

--- a/cli/cmd/alert_rules.go
+++ b/cli/cmd/alert_rules.go
@@ -288,10 +288,12 @@ func promptCreateAlertRule() (api.AlertRuleResponse, error) {
 	}
 
 	resourceGroups, resourceGroupMap := promptAddResourceGroupsToAlertRule()
-	var groups []string
+	groups := make([]string, 0)
 	for _, group := range resourceGroups {
 		groups = append(groups, resourceGroupMap[group])
 	}
+
+	alertCategories := make([]string, 0)
 
 	alertRule := api.NewAlertRule(
 		answers.Name,
@@ -300,6 +302,7 @@ func promptCreateAlertRule() (api.AlertRuleResponse, error) {
 			Channels:        channels,
 			Severities:      api.NewAlertRuleSeverities(answers.Severities),
 			EventCategories: answers.EventCategories,
+			AlertCategories: alertCategories,
 			ResourceGroups:  groups,
 		})
 

--- a/integration/alert_rules_test.go
+++ b/integration/alert_rules_test.go
@@ -1,5 +1,3 @@
-//go:build alert_rule
-
 // Author:: Darren Murray (<darren.murray@lacework.net>)
 // Copyright:: Copyright 2021, Lacework Inc.
 // License:: Apache License, Version 2.0
@@ -114,6 +112,8 @@ func createAlertRuleWithSlackAlertChannel() (alertRule api.AlertRuleResponse, er
 		Description:     "This is a test Alert Rule",
 		Severities:      api.NewAlertRuleSeverities([]string{"Critical", "High"}),
 		EventCategories: []string{"Compliance"},
+		AlertCategories: []string{},
+		ResourceGroups:  []string{},
 	})
 
 	return lacework.V2.AlertRules.Create(rule)


### PR DESCRIPTION
## Summary

Go JSON `omitempty` drops the field if provided with an empty array `[]`.

## How did you test this change?

- unit test
- integration test
- cli command
- Terraform create+update alert_rules

## Issue

https://lacework.atlassian.net/browse/GROW-2361
