### PR TITLE
feat(RAIN-68434): add support to skip LW integration creation for gcp pub/sub audit log

### DIFF
--- a/cli/docs/lacework_generate_cloud-account_gcp.md
+++ b/cli/docs/lacework_generate_cloud-account_gcp.md
@@ -64,6 +64,7 @@ lacework generate cloud-account gcp [flags]
       --project_id string                             specify the project id to be used to provision lacework resources (required)
       --projects strings                              list of project IDs to integrate with (project-level integrations)
       --service_account_credentials string            specify service account credentials JSON file path (leave blank to make use of google credential ENV vars)
+      --skip_create_lacework_integration              skip creating Lacework integration when set to true
       --use_pub_sub                                   use pub/sub for the audit log data rather than bucket
       --wait_time string                              amount of time to wait before the next resource is provisioned
 ```

--- a/integration/gcp_generation_test.go
+++ b/integration/gcp_generation_test.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/Netflix/go-expect"
 	"github.com/lacework/go-sdk/cli/cmd"
 	"github.com/lacework/go-sdk/lwgenerate/gcp"
 	"github.com/stretchr/testify/assert"
@@ -161,6 +160,7 @@ func TestGenerationPubSubAuditlogOnlyGcp(t *testing.T) {
 				MsgMenu{cmd.GcpAdvancedOptAuditLog, 0},
 				MsgRsp{cmd.QuestionUsePubSubAudit, "y"},
 				MsgRsp{cmd.QuestionGcpUseExistingSink, "n"},
+				MsgRsp{cmd.QuestionGcpSkipCreateLaceworkIntegration, "n"},
 				MsgRsp{cmd.QuestionGcpCustomFilter, ""},
 				MsgRsp{cmd.QuestionGcpAnotherAdvancedOpt, "n"},
 				MsgRsp{cmd.QuestionRunTfPlan, "n"},
@@ -177,6 +177,46 @@ func TestGenerationPubSubAuditlogOnlyGcp(t *testing.T) {
 
 	buildTf, _ := gcp.NewTerraform(false, true, true,
 		gcp.WithProjectId(projectId),
+	).Generate()
+	assert.Equal(t, buildTf, tfResult)
+}
+
+// Test pub sub audit log with skip_enable_lacework_integration flag enabled
+func TestGenerationPubSubAuditLogSkipCreateLaceworkIntegration(t *testing.T) {
+	os.Setenv("LW_NOCACHE", "true")
+	defer os.Setenv("LW_NOCACHE", "")
+	var final string
+
+	tfResult := runGcpGenerateTest(t,
+		func(c *expect.Console) {
+			expectsCliOutput(t, c, []MsgRspHandler{
+				MsgRsp{cmd.QuestionGcpEnableConfiguration, "n"},
+				MsgRsp{cmd.QuestionGcpEnableAuditLog, "y"},
+				MsgRsp{cmd.QuestionGcpProjectID, projectId},
+				MsgRsp{cmd.QuestionGcpOrganizationIntegration, "n"},
+				MsgRsp{cmd.QuestionGcpServiceAccountCredsPath, ""},
+				MsgRsp{cmd.QuestionGcpConfigureAdvanced, "y"},
+				MsgMenu{cmd.GcpAdvancedOptAuditLog, 0},
+				MsgRsp{cmd.QuestionUsePubSubAudit, "y"},
+				MsgRsp{cmd.QuestionGcpUseExistingSink, "n"},
+				MsgRsp{cmd.QuestionGcpSkipCreateLaceworkIntegration, "y"},
+				MsgRsp{cmd.QuestionGcpCustomFilter, ""},
+				MsgRsp{cmd.QuestionGcpAnotherAdvancedOpt, "n"},
+				MsgRsp{cmd.QuestionRunTfPlan, "n"},
+			})
+
+			final, _ = c.ExpectEOF()
+		},
+		"generate",
+		"cloud-account",
+		"gcp",
+	)
+
+	assertTerraformSaved(t, final)
+
+	buildTf, _ := gcp.NewTerraform(false, true, true,
+		gcp.WithProjectId(projectId),
+		gcp.WithSkipCreateLaceworkIntegration(true),
 	).Generate()
 	assert.Equal(t, buildTf, tfResult)
 }
@@ -199,6 +239,7 @@ func TestGenerationPubSubAuditlogOrgGcp(t *testing.T) {
 				MsgMenu{cmd.GcpAdvancedOptAuditLog, 0},
 				MsgRsp{cmd.QuestionUsePubSubAudit, "y"},
 				MsgRsp{cmd.QuestionGcpUseExistingSink, "n"},
+				MsgRsp{cmd.QuestionGcpSkipCreateLaceworkIntegration, "n"},
 				MsgRsp{cmd.QuestionGcpCustomFilter, ""},
 				MsgRsp{cmd.QuestionGcpAnotherAdvancedOpt, "n"},
 				MsgRsp{cmd.QuestionRunTfPlan, "n"},
@@ -692,6 +733,7 @@ func TestGenerationPubSubUseExistingSA(t *testing.T) {
 				MsgMenu{cmd.GcpAdvancedOptAuditLog, 0},
 				MsgRsp{cmd.QuestionUsePubSubAudit, "y"},
 				MsgRsp{cmd.QuestionGcpUseExistingSink, "n"},
+				MsgRsp{cmd.QuestionGcpSkipCreateLaceworkIntegration, "n"},
 				MsgRsp{cmd.QuestionGcpCustomFilter, ""},
 				MsgRsp{cmd.QuestionGcpAnotherAdvancedOpt, "y"},
 				MsgMenu{cmd.GcpAdvancedOptAuditLog, 1},

--- a/integration/test_resources/help/generate_cloud-account_gcp
+++ b/integration/test_resources/help/generate_cloud-account_gcp
@@ -48,6 +48,7 @@ Flags:
       --project_id string                             specify the project id to be used to provision lacework resources (required)
       --projects strings                              list of project IDs to integrate with (project-level integrations)
       --service_account_credentials string            specify service account credentials JSON file path (leave blank to make use of google credential ENV vars)
+      --skip_create_lacework_integration              skip creating Lacework integration when set to true
       --use_pub_sub                                   use pub/sub for the audit log data rather than bucket
       --wait_time string                              amount of time to wait before the next resource is provisioned
 

--- a/lwgenerate/_examples/gcp/main.go
+++ b/lwgenerate/_examples/gcp/main.go
@@ -55,6 +55,23 @@ func existingGcpBucketAndSink() {
 	fmt.Printf("\n-----\n%s", hcl)
 }
 
+func skipCreateLaceworkIntegration() {
+	hcl, err := gcp.NewTerraform(
+		true,
+		true,
+		gcp.WithProjectId("example_project"),
+		gcp.WithGcpServiceAccountCredentials("path/to/service/account/creds.json"),
+		gcp.WithSkipCreateLaceworkIntegration(true),
+	).Generate()
+
+	if err != nil {
+		fmt.Println(err.Error())
+		os.Exit(1)
+	}
+
+	fmt.Printf("\n-----\n%s", hcl)
+}
+
 func gcpWithLaceworkProfile() {
 	hcl, err := gcp.NewTerraform(
 		true,

--- a/lwgenerate/gcp/gcp_test.go
+++ b/lwgenerate/gcp/gcp_test.go
@@ -141,6 +141,15 @@ func TestGenerateGcpTfConfigurationArgs_Generate_AuditLog(t *testing.T) {
 			),
 			ReqProvider(projectName, moduleImportProjectLevelPubSubAuditLogExistingLogSinkName),
 		},
+		{
+			"TestGenerationProjectLevelPubSubAuditLogSkipCreateLaceworkIntegration",
+			gcp.NewTerraform(false, true, true,
+				gcp.WithGcpServiceAccountCredentials("/path/to/credentials"),
+				gcp.WithProjectId(projectName),
+				gcp.WithSkipCreateLaceworkIntegration(true),
+			),
+			ReqProvider(projectName, moduleImportProjectLevelPubSubAuditLogSkipCreateLaceworkIntegration),
+		},
 		{"TestGenerationProjectLevelAuditLogEnableUBLA",
 			gcp.NewTerraform(false, true, false,
 				gcp.WithGcpServiceAccountCredentials("/path/to/credentials"),
@@ -879,6 +888,12 @@ var moduleImportProjectLevelPubSubAuditLogExistingLogSinkName = `module "gcp_pro
   source             = "lacework/pub-sub-audit-log/gcp"
   version            = "~> 0.2"
   existing_sink_name = "foo"
+}
+`
+var moduleImportProjectLevelPubSubAuditLogSkipCreateLaceworkIntegration = `module "gcp_project_audit_log" {
+  source                           = "lacework/pub-sub-audit-log/gcp"
+  version                          = "~> 0.2"
+  skip_create_lacework_integration = true
 }
 `
 


### PR DESCRIPTION
## Summary

This PR adds an advanced configuration option to allow the user to skip creating the Lacework GCPv2 integration when using the `generate cloud-account gcp` command during migration from GCPv1 to GCPv2. This step is needed for migrating customers as there are some intermediary steps required during migration between GCP resource creation and Lacework integration creation. This way, the user can run the CLI command once with the `--skip_create_lacework_integration` flag enabled, and once without it, after some steps in between. Below is the new option added:
| Option | Type | Description |
| --- | --- | --- |
| `--skip_create_lacework_integration` | bool | Skip creating Lacework integration |

## How did you test this change?

Changes were tested by adding both, unit tests and integration test in code, as well as by building the CLI and testing end-to-end with the new terraform module that accepts this parameter.

## Issue
[RAIN-68434](https://lacework.atlassian.net/browse/RAIN-68434?atlOrigin=eyJpIjoiYWFhNjIxZjU4NTcxNDY2YmI5MDhjMTE3YzcyMDU3ZWIiLCJwIjoiaiJ9)
