### PR TITLE
fix: omit private key id if empty

### DIFF
--- a/api/cloud_accounts_gcp_sidekick.go
+++ b/api/cloud_accounts_gcp_sidekick.go
@@ -88,7 +88,7 @@ type GcpSidekickData struct {
 type GcpSidekickCredentials struct {
 	ClientID     string `json:"clientId"`
 	ClientEmail  string `json:"clientEmail"`
-	PrivateKeyID string `json:"privateKeyId"`
+	PrivateKeyID string `json:"privateKeyId,omitempty"`
 	PrivateKey   string `json:"privateKey,omitempty"`
 	TokenUri     string `json:"tokenUri,omitempty"`
 }


### PR DESCRIPTION
**Summary**
Terraform update for `https://github.com/lacework/terraform-gcp-agentless-scanning` fails as the private key id is empty.
On investigating with @afiune , we found that the patch workflow sends empty key instead of omitting it from the request.

**How did you test this change?**
Update the terraform provider with the go-sdk changed and pointed terraform module to use the provider. Terraform update went through successfully,

**Issue**
https://lacework.atlassian.net/browse/LINK-1923