### PR TITLE
feat: add oci package to lwgenerate

### DIFF
--- a/lwgenerate/constants.go
+++ b/lwgenerate/constants.go
@@ -29,4 +29,7 @@ const (
 	GcpGKEAuditLogVersion    = "~> 0.3"
 	GcpPubSubAuditLog        = "lacework/pub-sub-audit-log/gcp"
 	GcpPubSubAuditLogVersion = "~> 0.2"
+
+	OciConfigSource  = "lacework/config/oci"
+	OciConfigVersion = "~> 0.2"
 )

--- a/lwgenerate/oci/oci.go
+++ b/lwgenerate/oci/oci.go
@@ -1,0 +1,182 @@
+package oci
+
+import (
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/lacework/go-sdk/lwgenerate"
+	"github.com/pkg/errors"
+)
+
+type GenerateOciTfConfigurationArgs struct {
+	// Should we configure CSPM integration in LW?
+	Config bool
+
+	// Should we configure Audit Log integration in LW?
+	AuditLog bool // Not yet supported
+
+	// Optional name for config
+	ConfigName string
+
+	// Lacework profile to use
+	LaceworkProfile string
+
+	// Tenant OCID
+	TenantOcid string
+
+	// OCI user email
+	OciUserEmail string
+}
+
+type OciTerraformModifier func(c *GenerateOciTfConfigurationArgs)
+
+const (
+	LaceworkProviderVersion = ">= 1.9.0"
+)
+
+// Set the Lacework profile to use for integration
+func WithLaceworkProfile(name string) OciTerraformModifier {
+	return func(c *GenerateOciTfConfigurationArgs) {
+		c.LaceworkProfile = name
+	}
+}
+
+// Set the name Lacework will use for the name
+func WithConfigName(name string) OciTerraformModifier {
+	return func(c *GenerateOciTfConfigurationArgs) {
+		c.ConfigName = name
+	}
+}
+
+// Set the OCID of the tenant to be integrated
+func WithTenantOcid(ocid string) OciTerraformModifier {
+	return func(c *GenerateOciTfConfigurationArgs) {
+		c.TenantOcid = ocid
+	}
+}
+
+// Set the email for the OCI user created for the integration
+func WithUserEmail(email string) OciTerraformModifier {
+	return func(c *GenerateOciTfConfigurationArgs) {
+		c.OciUserEmail = email
+	}
+}
+
+// NewTerraform returns an instance of the GenerateOciTfConfigurationArgs struct
+//
+// Note: Additional configuration details may be set using modifiers of the OciTerraformModifier type
+//
+// Basic usage:
+// Initialize a new OciTerraformModifier struct then use generate to
+// create a string output of the required HCL.
+//
+//	hcl, err := aws.NewTerraform("us-east-1", true, true,
+//	  aws.WithAwsProfile("mycorp-profile")).Generate()
+func NewTerraform(enableConfig bool, enableAuditLog bool, mods ...OciTerraformModifier,
+) *GenerateOciTfConfigurationArgs {
+	config := &GenerateOciTfConfigurationArgs{AuditLog: enableAuditLog, Config: enableConfig}
+	for _, m := range mods {
+		m(config)
+	}
+	return config
+}
+
+// Generate new Terraform code based on the supplied args.
+func (args *GenerateOciTfConfigurationArgs) Generate() (string, error) {
+	// Validate inputs
+	if err := args.validate(); err != nil {
+		return "", errors.Wrap(err, "invalid inputs")
+	}
+
+	// Required providers block
+	requiredProviders, err := createRequiredProviders()
+	if err != nil {
+		return "", errors.Wrap(err, "failed to generate required providers")
+	}
+
+	// provider lacework block
+	laceworkProvider, err := createLaceworkProvider(args)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to generate lacework provider")
+	}
+
+	configModule, err := createConfig(args)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to generate oci config module")
+	}
+
+	// render HCL
+	hclBlocks := lwgenerate.CreateHclStringOutput(
+		lwgenerate.CombineHclBlocks(
+			requiredProviders,
+			laceworkProvider,
+			configModule,
+		),
+	)
+	return hclBlocks, nil
+}
+
+// Ensure all combinations of inputs our valid for supported spec
+func (args *GenerateOciTfConfigurationArgs) validate() error {
+	// Audit Log integration currently not supported
+	if args.AuditLog {
+		return errors.New("audit log integration not yet supported")
+	}
+
+	if !args.Config {
+		return errors.New("config integration must be enabled to continue")
+	}
+
+	if args.TenantOcid == "" {
+		return errors.New("tenant OCID must be set")
+	}
+
+	if args.OciUserEmail == "" {
+		return errors.New("OCI user email must be set")
+	}
+
+	return nil
+}
+
+func createRequiredProviders() (*hclwrite.Block, error) {
+	return lwgenerate.CreateRequiredProviders(
+		lwgenerate.NewRequiredProvider("lacework",
+			lwgenerate.HclRequiredProviderWithSource(lwgenerate.LaceworkProviderSource),
+			lwgenerate.HclRequiredProviderWithVersion(LaceworkProviderVersion),
+		),
+	)
+}
+
+func createLaceworkProvider(args *GenerateOciTfConfigurationArgs) (*hclwrite.Block, error) {
+	if args.LaceworkProfile != "" {
+		return lwgenerate.NewProvider(
+			"lacework",
+			lwgenerate.HclProviderWithAttributes(map[string]interface{}{"profile": args.LaceworkProfile}),
+		).ToBlock()
+	}
+	return nil, nil
+}
+
+func createConfig(args *GenerateOciTfConfigurationArgs) (*hclwrite.Block, error) {
+	if !args.Config {
+		return nil, nil
+	}
+
+	attributes := map[string]interface{}{}
+
+	// Set the attributes
+	attributes["tenancy_id"] = args.TenantOcid
+	attributes["user_email"] = args.OciUserEmail
+	if args.ConfigName != "" {
+		attributes["integration_name"] = args.ConfigName
+	}
+
+	// Create and return the module
+	modDetails := []lwgenerate.HclModuleModifier{
+		lwgenerate.HclModuleWithVersion(lwgenerate.OciConfigVersion),
+		lwgenerate.HclModuleWithAttributes(attributes),
+	}
+	return lwgenerate.NewModule(
+		"oci_config",
+		lwgenerate.OciConfigSource,
+		modDetails...,
+	).ToBlock()
+}

--- a/lwgenerate/oci/oci_test.go
+++ b/lwgenerate/oci/oci_test.go
@@ -1,0 +1,65 @@
+package oci
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGenerationConfigNoArgs(t *testing.T) {
+	_, err := NewTerraform(true, false).Generate()
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "invalid inputs")
+}
+
+func TestGenerationConfig(t *testing.T) {
+	args := []OciTerraformModifier{
+		WithTenantOcid("ocid1.tenancy...a"),
+		WithUserEmail("a@b.c"),
+	}
+	hcl, err := NewTerraform(true, false, args...).Generate()
+	assert.Nil(t, err)
+	assert.NotNil(t, hcl)
+	assert.Equal(t, hcl, ConfigResultBasic)
+}
+
+var ConfigResultBasic = `terraform {
+  required_providers {
+    lacework = {
+      source  = "lacework/lacework"
+      version = ">= 1.9.0"
+    }
+  }
+}
+
+module "oci_config" {
+  source     = "lacework/config/oci"
+  version    = "~> 0.2"
+  tenancy_id = "ocid1.tenancy...a"
+  user_email = "a@b.c"
+}
+`
+
+func TestGenerationConfigCustomIntegrationName(t *testing.T) {
+	args := []OciTerraformModifier{
+		WithTenantOcid("ocid1.tenancy...a"),
+		WithUserEmail("a@b.c"),
+		WithConfigName("oci_test_config"),
+	}
+	hcl, err := NewTerraform(true, false, args...).Generate()
+	assert.Nil(t, err)
+	assert.NotNil(t, hcl)
+	assert.Contains(t, hcl, `integration_name = "oci_test_config"`)
+}
+
+func TestGenerationConfigCustomLaceworkProfile(t *testing.T) {
+	args := []OciTerraformModifier{
+		WithTenantOcid("ocid1.tenancy...a"),
+		WithUserEmail("a@b.c"),
+		WithLaceworkProfile("my_profile"),
+	}
+	hcl, err := NewTerraform(true, false, args...).Generate()
+	assert.Nil(t, err)
+	assert.NotNil(t, hcl)
+	assert.Contains(t, hcl, "provider \"lacework\" {\n  profile = \"my_profile\"\n}")
+}


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/lacework/go-sdk) and create your branch from `main`
  2. Run `make prepare` in the repository root
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`make test`)
  5. Format your code (`make fmt`)
  6. Make sure your code lints (`make lint`)
  7. If you are updating the Lacework CLI, make sure it compiles (`make build-cli-cross-platform`)
  8. Follow the commit message standard (`type(scope): subject`) documented in [DEVELOPER_GUIDELINES.md](https://github.com/lacework/go-sdk/blob/main/DEVELOPER_GUIDELINES.md#commit-message-standard)
  9. If you haven't already, configure signed commits by [telling git about your signing key](https://docs.github.com/en/github/authenticating-to-github/managing-commit-signature-verification/telling-git-about-your-signing-key) and [signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)

  Learn more about contributing: https://github.com/lacework/go-sdk/blob/main/CONTRIBUTING.md
-->

## Summary

This PR adds a package under `lwgenerate` to generate Terraform code for OCI integration. This is the first stop towards adding a `lacework generate cloud-account oci` command that can be used to generate Terraform code to integrate Lacework with OCI using the Lacework CLI.

## How did you test this change?

There are accompanying unit tests making sure that the output is as expected. I also used the output to create an actual Lacework integration to an OCI tenant.


## Issue

[SPM-902](https://lacework.atlassian.net/browse/SPM-902)

[SPM-902]: https://lacework.atlassian.net/browse/SPM-902?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ