### PR TITLE
fix(CAD-125): Fix broken update api in RGv2

### DIFF
--- a/api/resource_groups_v2.go
+++ b/api/resource_groups_v2.go
@@ -162,3 +162,24 @@ func (group ResourceGroupDataWithQuery) GetProps() interface{} {
 func (group ResourceGroupDataWithQuery) GetQuery() *RGQuery {
 	return group.Query
 }
+
+func (group ResourceGroupDataWithQuery) ResourceGroupType() ResourceGroupType {
+	t, _ := FindResourceGroupType(group.Type)
+	return t
+}
+
+func (group ResourceGroupDataWithQuery) ID() string {
+	return group.ResourceGroupGuid
+}
+
+func (group *ResourceGroupDataWithQuery) ResetRGV2Fields() {
+	// no-op
+}
+
+func (group *ResourceGroupDataWithQuery) ResetResourceGUID() {
+	group.ResourceGroupGuid = ""
+}
+
+func (group ResourceGroupDataWithQuery) IsV2Group() bool {
+	return true
+}

--- a/api/resource_groups_version_service.go
+++ b/api/resource_groups_version_service.go
@@ -169,13 +169,13 @@ func (svc *ResourceGroupsVersionService) Update(group ResourceGroupsInterfaceDat
 	isV2FlagEnabled := isRGV2FlagEnabled(svc.featureFlagService)
 
 	if isV2FlagEnabled {
-		createResponse, createErr := svc.v2ResourceGroupService.Update(group.(ResourceGroup))
-		if createErr != nil {
-			err = createErr
+		updateResponse, updateErr := svc.v2ResourceGroupService.Update(group.(ResourceGroup))
+		if updateErr != nil {
+			err = updateErr
 			return
 		}
 
-		err = castResourceGroupV2Response(createResponse, &response)
+		err = castResourceGroupV2Response(updateResponse, &response)
 		return
 	}
 


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/lacework/go-sdk) and create your branch from `main`
  2. Run `make prepare` in the repository root
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`make test`)
  5. Format your code (`make fmt`)
  6. Make sure your code lints (`make lint`)
  7. If you are updating the Lacework CLI, make sure it compiles (`make build-cli-cross-platform`)
  8. Follow the commit message standard (`type(scope): subject`) documented in [DEVELOPER_GUIDELINES.md](https://github.com/lacework/go-sdk/blob/main/DEVELOPER_GUIDELINES.md#commit-message-standard)
  9. If you haven't already, configure signed commits by [telling git about your signing key](https://docs.github.com/en/github/authenticating-to-github/managing-commit-signature-verification/telling-git-about-your-signing-key) and [signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)

  Learn more about contributing: https://github.com/lacework/go-sdk/blob/main/CONTRIBUTING.md
-->

## Summary

The Update API is not called from the CLI, I found an issue due to forgetting to implement an interface for `ResourceGroupWithQuery` causing the Update conversion of the object to `ResourceGroup` interface to fail. This was caught during development of the terraform provider

## How did you test this change?

Made these exact same changes in the terraform provider locally and was able to run an integration test that creates, updates, deletes a resource group successfully.

<img width="1202" alt="Screenshot 2023-08-23 at 3 54 22 PM" src="https://github.com/lacework/go-sdk/assets/9832640/8f02f933-f79b-4320-8ec2-f0c2797d12d7">


## Issue

https://lacework.atlassian.net/browse/CAD-125
