### PR TITLE
fix(cli): respect fail flags in vulnerability container scan

### DIFF
--- a/api/v2_vulnerabilities.go
+++ b/api/v2_vulnerabilities.go
@@ -187,7 +187,9 @@ func (r VulnerabilitiesContainersResponse) HighestSeverity() string {
 	var sevs []lwseverity.Severity
 
 	for _, vuln := range r.Data {
-		sevs = append(sevs, lwseverity.NewSeverity(vuln.Severity))
+		if lwseverity.NewSeverity(vuln.Severity) != lwseverity.Unknown {
+			sevs = append(sevs, lwseverity.NewSeverity(vuln.Severity))
+		}
 	}
 
 	if len(sevs) == 0 {

--- a/cli/cmd/vuln_container_scan.go
+++ b/cli/cmd/vuln_container_scan.go
@@ -151,8 +151,8 @@ To integrate a new container registry use the command:
 
 		msg := `container image '%s@%s' not found in registry '%s'.
 
-This error is likely due to a problem with the container registry integration 
-configured in your account. Verify that the integration was configured with 
+This error is likely due to a problem with the container registry integration
+configured in your account. Verify that the integration was configured with
 Lacework using the correct permissions, and that the repository belongs
 to the provided registry.
 
@@ -272,7 +272,26 @@ func pollScanStatus(requestID string, args []string) error {
 			)
 		}
 
-		return outputContainerVulnerabilityAssessment(assessment)
+		if err := outputContainerVulnerabilityAssessment(assessment); err != nil {
+			return err
+		}
+
+		if vulFailureFlagsEnabled() {
+			cli.Log.Infow("failure flags enabled",
+				"fail_on_severity", vulCmdState.FailOnSeverity,
+				"fail_on_fixable", vulCmdState.FailOnFixable,
+			)
+			vulnPolicy := NewVulnerabilityPolicyErrorV2(
+				assessment,
+				vulCmdState.FailOnSeverity,
+				vulCmdState.FailOnFixable,
+			)
+			if vulnPolicy.NonCompliant() {
+				return vulnPolicy
+			}
+		}
+
+		return nil
 	}
 }
 


### PR DESCRIPTION
## Summary

- For `lacework vulnerability container scan ...`, if the `fail_on_severity` or `fail_on_fixable` flag is provided, fail the CLI as expected.
- Filter out unknown severities when finding out the highest severity of a container. 

## How did you test this change?

Verify container scan:
- Run `lacework vuln container scan index.docker.io techallylw/test-cli-dirty latest --poll`
  - Should not fail
- Run `lacework vuln container scan index.docker.io techallylw/test-cli-dirty latest --poll --fail_on_severity low`
  - Should fail
<img width="984" alt="Screenshot 2023-08-24 at 6 17 30 PM" src="https://github.com/lacework/go-sdk/assets/7945666/1db52e96-262e-4fcf-b2a6-e1c3ba02d401">



Verify container show:
- Run `lacework vuln ctr show sha256:a65572164cb78c4d04f57bd66201c775e2dab08fce394806a03a933c5daf9e48`
  - Should not fail
- Run `lacework vuln ctr show sha256:a65572164cb78c4d04f57bd66201c775e2dab08fce394806a03a933c5daf9e48 --fail_on_severity low`
  - Should fail
<img width="1028" alt="Screenshot 2023-08-24 at 6 15 22 PM" src="https://github.com/lacework/go-sdk/assets/7945666/f8730489-75d8-49ee-92aa-18d08816621e">


