### PR TITLE
test: add integration tests for container scan with fail on flags

### DIFF
--- a/integration/container_vulnerability_test.go
+++ b/integration/container_vulnerability_test.go
@@ -205,6 +205,32 @@ func TestContainerVulnerabilityCommandScanErrorContainerImageNotFound(t *testing
 		"EXITCODE is not the expected one")
 }
 
+func TestContainerVulnerabilityCommandScanFailOnSeverity(t *testing.T) {
+	home := createTOMLConfigFromCIvars()
+	defer os.RemoveAll(home)
+	_, err, exitcode := LaceworkCLIWithHome(home,
+		"vulnerability", "container", "scan", registry, dirtyRepository, "latest", "--poll", "--fail_on_severity", "high")
+
+	// CLI should terminate with exit code 9
+	assert.Equal(t, 9, exitcode, "EXITCODE is not the expected one")
+	assert.Contains(t, err.String(),
+		"ERROR (FAIL-ON): vulnerabilities found with threshold 'high' (exit code: 9)",
+		"STDERR doesn't match")
+}
+
+func TestContainerVulnerabilityCommandScanFailOnFixable(t *testing.T) {
+	home := createTOMLConfigFromCIvars()
+	defer os.RemoveAll(home)
+	_, err, exitcode := LaceworkCLIWithHome(home,
+		"vulnerability", "container", "scan", registry, dirtyRepository, "latest", "--poll", "--fail_on_fixable")
+
+	// CLI should terminate with exit code 9
+	assert.Equal(t, 9, exitcode, "EXITCODE is not the expected one")
+	assert.Contains(t, err.String(),
+		"ERROR (FAIL-ON): fixable vulnerabilities found (exit code: 9)",
+		"STDERR doesn't match")
+}
+
 func TestContainerVulnerabilityCommandScanHumanReadablePollGenerateHtml(t *testing.T) {
 	// create a temporal directory to check that the HTML file is deployed
 	home := createTOMLConfigFromCIvars()


### PR DESCRIPTION
## Summary

Add integration tests to verify container scan command fails correctly with the fail_on_severity and fail_on_fixable

## How did you test this change?

run `make integration regex=TestContainerVulnerability`
