### PR TITLE
feat(RAIN-70441): add CLI command to support migration

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -127,6 +127,8 @@ const (
 	apiSuppressions = "v2/suppressions/%s/allExceptions"
 
 	apiRecommendations = "v2/recommendations/%s"
+
+	apiV2MigrateGcpAtSes = "v2/migrateGcpAtSes"
 )
 
 // WithApiV2 configures the client to use the API version 2 (/api/v2)

--- a/api/cloud_accounts.go
+++ b/api/cloud_accounts.go
@@ -20,6 +20,7 @@ package api
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/pkg/errors"
 
@@ -168,6 +169,30 @@ func (svc *CloudAccountsService) Delete(guid string) error {
 		"DELETE",
 		fmt.Sprintf(apiV2CloudAccountsWithParam, guid),
 		nil,
+		nil,
+	)
+}
+
+// Migrate marks a Cloud Account integration that matches the provided guid for migration
+func (svc *CloudAccountsService) Migrate(guid string) error {
+	if guid == "" {
+		return errors.New("specify an intgGuid")
+	}
+
+	data := MigrateRequestData{
+		MigrateData{
+			IntgGuid: guid,
+			Props: Props{
+				Migrate:            true,
+				MigrationTimestamp: time.Now(),
+			},
+		},
+	}
+
+	return svc.client.RequestEncoderDecoder(
+		"PATCH",
+		apiV2MigrateGcpAtSes,
+		data,
 		nil,
 	)
 }

--- a/api/cloud_accounts_gcp_at.go
+++ b/api/cloud_accounts_gcp_at.go
@@ -18,6 +18,8 @@
 
 package api
 
+import "time"
+
 // GetGcpAtSes gets a single GcpAtSes integration matching the provided integration guid
 func (svc *CloudAccountsService) GetGcpAtSes(guid string) (
 	response GcpAtSesIntegrationResponse,
@@ -58,4 +60,18 @@ type GcpAtSesCredentials struct {
 	ClientEmail  string `json:"clientEmail"`
 	PrivateKeyID string `json:"privateKeyId,omitempty"`
 	PrivateKey   string `json:"privateKey,omitempty"`
+}
+
+type Props struct {
+	Migrate            bool      `json:"migrate"`
+	MigrationTimestamp time.Time `json:"migrationTimestamp"`
+}
+
+type MigrateData struct {
+	IntgGuid string `json:"intgGuid"`
+	Props    Props  `json:"props"`
+}
+
+type MigrateRequestData struct {
+	Data MigrateData `json:"data"`
 }

--- a/cli/cmd/cloud_account.go
+++ b/cli/cmd/cloud_account.go
@@ -62,6 +62,14 @@ var (
 		Args:    cobra.ExactArgs(1),
 		RunE:    cloudAccountDelete,
 	}
+
+	// cloudAccountMigrateCmd represents the migrate sub-command inside the cloud accounts command
+	cloudAccountMigrateCmd = &cobra.Command{
+		Use:   "migrate",
+		Short: "Mark a cloud account integration for migration",
+		Args:  cobra.ExactArgs(1),
+		RunE:  cloudAccountMigrate,
+	}
 )
 
 func init() {
@@ -71,6 +79,7 @@ func init() {
 	cloudAccountCommand.AddCommand(cloudAccountShowCmd)
 	cloudAccountCommand.AddCommand(cloudAccountDeleteCmd)
 	cloudAccountCommand.AddCommand(cloudAccountCreateCmd)
+	cloudAccountCommand.AddCommand(cloudAccountMigrateCmd)
 
 	// add type flag to cloud accounts list command
 	cloudAccountListCmd.Flags().StringVarP(&cloudAccountType,
@@ -137,6 +146,17 @@ func cloudAccountDelete(_ *cobra.Command, args []string) error {
 		return errors.Wrap(err, "unable to delete cloud account")
 	}
 	cli.OutputHuman("The cloud account %s was deleted.\n", args[0])
+	return nil
+}
+
+func cloudAccountMigrate(_ *cobra.Command, args []string) error {
+	cli.StartProgress(" Initiating migration for cloud account...")
+	err := cli.LwApi.V2.CloudAccounts.Migrate(args[0])
+	cli.StopProgress()
+	if err != nil {
+		return errors.Wrap(err, "unable to initiate migration for cloud-account.")
+	}
+	cli.OutputHuman("The cloud account %s was marked for migration.\n", args[0])
 	return nil
 }
 

--- a/integration/test_resources/help/cloud-account
+++ b/integration/test_resources/help/cloud-account
@@ -10,6 +10,7 @@ Available Commands:
   create       Create a new cloud account integration
   delete       Delete a cloud account integration
   list         List all available cloud account integrations
+  migrate      Mark a cloud account integration for migration
   show         Show a single cloud account integration
 
 Flags:

--- a/integration/test_resources/help/cloud-account_migrate
+++ b/integration/test_resources/help/cloud-account_migrate
@@ -1,0 +1,21 @@
+Mark a cloud account integration for migration
+
+Usage:
+  lacework cloud-account migrate [flags]
+
+Flags:
+  -h, --help   help for migrate
+
+Global Flags:
+  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -k, --api_key string      access key id
+  -s, --api_secret string   secret access key
+      --api_token string    access token (replaces the use of api_key and api_secret)
+      --debug               turn on debug logging
+      --json                switch commands output from human-readable to json format
+      --nocache             turn off caching
+      --nocolor             turn off colors
+      --noninteractive      turn off interactive mode (disable spinners, prompts, etc.)
+      --organization        access organization level data sets (org admins only)
+  -p, --profile string      switch between profiles configured at ~/.lacework.toml
+      --subaccount string   sub-account name inside your organization (org admins only)


### PR DESCRIPTION
## Summary

This PR adds a new command `cloud-account migrate <INTG_GUID>` that will be used for the GPCv2 migration process when we go GA. Customers will use this command to mark the provided integration for migration. The CLI will call a [new api server endpoint](https://github.com/lacework/rainbow/pull/13814) which will handle the backend. 

## How did you test this change?

- Added unit test.
- Tested end to end with the new API-server endpoint in `dev3`.

## Issue

[RAIN-70441](https://lacework.atlassian.net/browse/RAIN-70441)


[RAIN-70441]: https://lacework.atlassian.net/browse/RAIN-70441?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ