### PR TITLE
fix(api): fix alert rules source field

### DIFF
--- a/api/_examples/alert-rules/main.go
+++ b/api/_examples/alert-rules/main.go
@@ -40,7 +40,7 @@ func main() {
 		ResourceGroups:  []string{"TECHALLY_000000000000AAAAAAAAAAAAAAAAAAAA"},
 		EventCategories: []string{"Compliance"},
 		AlertCategories: []string{"Policy"},
-		Sources:         []string{"Aws"},
+		AlertSources:    []string{"Aws"},
 	}
 
 	myAlertRule := api.NewAlertRule("MyTestAlertRule",

--- a/api/alert_rules.go
+++ b/api/alert_rules.go
@@ -186,7 +186,7 @@ func NewAlertRule(name string, rule AlertRuleConfig) AlertRule {
 			ResourceGroups:  rule.ResourceGroups,
 			EventCategories: rule.EventCategories,
 			AlertCategories: rule.AlertCategories,
-			Sources:         rule.Sources,
+			AlertSources:    rule.AlertSources,
 		},
 	}
 }
@@ -256,8 +256,8 @@ type AlertRuleConfig struct {
 	Severities      AlertRuleSeverities
 	ResourceGroups  []string
 	EventCategories []string
-	Sources         []string
 	AlertCategories []string
+	AlertSources    []string
 }
 
 type AlertRule struct {
@@ -274,8 +274,8 @@ type AlertRuleFilter struct {
 	Severity             []int    `json:"severity"`
 	ResourceGroups       []string `json:"resourceGroups"`
 	EventCategories      []string `json:"eventCategory"`
-	Sources              []string `json:"sources,omitempty"`
 	AlertCategories      []string `json:"category"`
+	AlertSources         []string `json:"source,omitempty"`
 	CreatedOrUpdatedTime string   `json:"createdOrUpdatedTime,omitempty"`
 	CreatedOrUpdatedBy   string   `json:"createdOrUpdatedBy,omitempty"`
 }

--- a/api/alert_rules_test.go
+++ b/api/alert_rules_test.go
@@ -227,7 +227,7 @@ func TestAlertRuleUpdate(t *testing.T) {
 			Severities:      api.AlertRuleSeverities{api.AlertRuleSeverityHigh},
 			ResourceGroups:  []string{"TECHALLY_100000000000AAAAAAAAAAAAAAAAAAAB"},
 			EventCategories: []string{"Compliance", "SystemCall"},
-			Sources:         []string{"Aws", "Agent", "K8s"},
+			AlertSources:    []string{"Aws", "Agent", "K8s"},
 			AlertCategories: []string{"Policy", "Anomaly"},
 		},
 	)
@@ -241,8 +241,8 @@ func TestAlertRuleUpdate(t *testing.T) {
 		assert.NotNil(t, response)
 		assert.Equal(t, intgGUID, response.Data.Guid)
 		assert.Contains(t, response.Data.Filter.EventCategories, "Compliance", "SystemCall")
-		assert.Contains(t, response.Data.Filter.Sources, "Aws", "Agent", "K8s")
 		assert.Contains(t, response.Data.Filter.AlertCategories, "Policy", "Anomaly")
+		assert.Contains(t, response.Data.Filter.AlertSources, "Aws", "Agent", "K8s")
 		assert.Contains(t, response.Data.Filter.ResourceGroups, "TECHALLY_100000000000AAAAAAAAAAAAAAAAAAAB")
 		assert.Contains(t, response.Data.Channels, "TECHALLY_000000000000AAAAAAAAAAAAAAAAAAAA")
 	}
@@ -315,7 +315,7 @@ func singleMockAlertRule(id string) string {
                 "Policy",
                 "Anomaly"
             ],
-            "sources": [
+            "source": [
                 "Aws",
                 "Agent",
                 "K8s"


### PR DESCRIPTION
## Summary

The alert sources field should be `source` instead of `sources`

## How did you test this change?

Run `make test`

## Issue

https://lacework.atlassian.net/browse/GROW-2413
