### PR TITLE
chore: OCI test build tag

### DIFF
--- a/integration/generate_oci_test.go
+++ b/integration/generate_oci_test.go
@@ -1,3 +1,5 @@
+//go:build !windows && generation
+
 package integration
 
 import (


### PR DESCRIPTION
## Summary

Fix for https://g.codefresh.io/build/64f84da90f189767780d7076.  Need to exclude generation tests from windows integration testing.

## Issue

https://g.codefresh.io/build/64f84da90f189767780d7076
