### PR TITLE
fix(api): change alert_source Aws to AWS

### DIFF
--- a/api/_examples/alert-rules/main.go
+++ b/api/_examples/alert-rules/main.go
@@ -40,7 +40,7 @@ func main() {
 		ResourceGroups:  []string{"TECHALLY_000000000000AAAAAAAAAAAAAAAAAAAA"},
 		EventCategories: []string{"Compliance"},
 		AlertCategories: []string{"Policy"},
-		AlertSources:    []string{"Aws"},
+		AlertSources:    []string{"AWS"},
 	}
 
 	myAlertRule := api.NewAlertRule("MyTestAlertRule",

--- a/api/alert_rules.go
+++ b/api/alert_rules.go
@@ -32,7 +32,7 @@ type AlertRulesService struct {
 }
 
 // Valid inputs for AlertRule Source property
-var AlertRuleSources = []string{"Agent", "Aws", "Azure", "Gcp", "K8s"}
+var AlertRuleSources = []string{"Agent", "AWS", "Azure", "Gcp", "K8s"}
 
 // Valid inputs for AlertRule Categories property
 var AlertRuleCategories = []string{"Anomaly", "Policy", "Composite"}

--- a/api/alert_rules_test.go
+++ b/api/alert_rules_test.go
@@ -227,7 +227,7 @@ func TestAlertRuleUpdate(t *testing.T) {
 			Severities:      api.AlertRuleSeverities{api.AlertRuleSeverityHigh},
 			ResourceGroups:  []string{"TECHALLY_100000000000AAAAAAAAAAAAAAAAAAAB"},
 			EventCategories: []string{"Compliance", "SystemCall"},
-			AlertSources:    []string{"Aws", "Agent", "K8s"},
+			AlertSources:    []string{"AWS", "Agent", "K8s"},
 			AlertCategories: []string{"Policy", "Anomaly"},
 		},
 	)
@@ -242,7 +242,7 @@ func TestAlertRuleUpdate(t *testing.T) {
 		assert.Equal(t, intgGUID, response.Data.Guid)
 		assert.Contains(t, response.Data.Filter.EventCategories, "Compliance", "SystemCall")
 		assert.Contains(t, response.Data.Filter.AlertCategories, "Policy", "Anomaly")
-		assert.Contains(t, response.Data.Filter.AlertSources, "Aws", "Agent", "K8s")
+		assert.Contains(t, response.Data.Filter.AlertSources, "AWS", "Agent", "K8s")
 		assert.Contains(t, response.Data.Filter.ResourceGroups, "TECHALLY_100000000000AAAAAAAAAAAAAAAAAAAB")
 		assert.Contains(t, response.Data.Channels, "TECHALLY_000000000000AAAAAAAAAAAAAAAAAAAA")
 	}
@@ -316,7 +316,7 @@ func singleMockAlertRule(id string) string {
                 "Anomaly"
             ],
             "source": [
-                "Aws",
+                "AWS",
                 "Agent",
                 "K8s"
             ]


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/lacework/go-sdk) and create your branch from `main`
  2. Run `make prepare` in the repository root
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`make test`)
  5. Format your code (`make fmt`)
  6. Make sure your code lints (`make lint`)
  7. If you are updating the Lacework CLI, make sure it compiles (`make build-cli-cross-platform`)
  8. Follow the commit message standard (`type(scope): subject`) documented in [DEVELOPER_GUIDELINES.md](https://github.com/lacework/go-sdk/blob/main/DEVELOPER_GUIDELINES.md#commit-message-standard)
  9. If you haven't already, configure signed commits by [telling git about your signing key](https://docs.github.com/en/github/authenticating-to-github/managing-commit-signature-verification/telling-git-about-your-signing-key) and [signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)

  Learn more about contributing: https://github.com/lacework/go-sdk/blob/main/CONTRIBUTING.md
-->

## Summary

The alert source AWS should be all uppercase 

## How did you test this change?

run `make test`

## Issue
https://github.com/lacework/terraform-provider-lacework/issues/554
