### PR TITLE
fix(GROW-2435): change alert source Gcp to GCP

### DIFF
--- a/api/alert_rules.go
+++ b/api/alert_rules.go
@@ -32,7 +32,7 @@ type AlertRulesService struct {
 }
 
 // Valid inputs for AlertRule Source property
-var AlertRuleSources = []string{"Agent", "AWS", "Azure", "Gcp", "K8s"}
+var AlertRuleSources = []string{"Agent", "AWS", "Azure", "GCP", "K8s"}
 
 // Valid inputs for AlertRule Categories property
 var AlertRuleCategories = []string{"Anomaly", "Policy", "Composite"}


### PR DESCRIPTION
## Summary

The alert source GCP should be uppercase

## How did you test this change?

run `make test`

## Issue

https://github.com/lacework/terraform-provider-lacework/issues/554