### PR TITLE
fix(api): avoid round numbers in responses

### DIFF
--- a/api/alerts_details_integrations_test.go
+++ b/api/alerts_details_integrations_test.go
@@ -55,8 +55,7 @@ var alertIntegrationsJSON = `{
                 },
                 "IS_ORG": 0,
                 "DATA": {
-                    "WEBHOOK_URL": "https://lars.run/alerts",
-                    "MIN_ALERT_SEVERITY": 3
+                    "WEBHOOK_URL": "https://lars.run/alerts"
                 }
             },
             "alertIntegrationId": "d7b76b0a-a9d6-e953-3asdf-53595515953f",

--- a/api/http.go
+++ b/api/http.go
@@ -129,7 +129,9 @@ func (c *Client) DoDecoder(req *http.Request, v interface{}) (*http.Response, er
 			_, err = io.Copy(w, resTee)
 			return res, err
 		}
-		err = json.NewDecoder(resTee).Decode(v)
+		dcoder := json.NewDecoder(resTee)
+		dcoder.UseNumber()
+		err = dcoder.Decode(v)
 	}
 
 	return res, err


### PR DESCRIPTION

## Summary

By using the `UseNumber()` function of the decoder https://pkg.go.dev/encoding/json#Decoder.UseNumber we are causing the Decoder to unmarshal a number into an interface{} as a Number instead of as a float64.

This fixes the problem when the CLI returns the raw response of long numbers like the `mid`.

## How did you test this change?

Ran `lacework api post /api/v2/Entities/Machines/search -d '{}'` and verified that the `mid` is returning
without rounding it. 
## Issue


https://lacework.atlassian.net/browse/GROW-2459
