### PR TITLE
fix: component download timeout retry

### DIFF
--- a/lwcomponent/component.go
+++ b/lwcomponent/component.go
@@ -257,7 +257,7 @@ func (s State) Install(component *Component, version string) error {
 		return err
 	}
 
-	err = downloadFile(path, artifact.URL)
+	err = DownloadFile(path, artifact.URL, 0)
 	if err != nil {
 		return errors.Wrap(err, "unable to download component artifact")
 	}

--- a/lwcomponent/component_internal_test.go
+++ b/lwcomponent/component_internal_test.go
@@ -125,7 +125,7 @@ type pathTest struct {
 }
 
 var pathTests = []pathTest{
-	pathTest{
+	{
 		"NotExists",
 		Component{
 			Name: "no-such-component",
@@ -133,7 +133,7 @@ var pathTests = []pathTest{
 		},
 		errors.New("component not found on disk"),
 	},
-	pathTest{
+	{
 		"Exists",
 		mockComponent,
 		nil,
@@ -176,7 +176,7 @@ type isVerifiedTest struct {
 }
 
 var isVerifiedTests = []isVerifiedTest{
-	isVerifiedTest{
+	{
 		Name: "NoSignature",
 		Component: Component{
 			Name: "lacework-mock-component",
@@ -184,7 +184,7 @@ var isVerifiedTests = []isVerifiedTest{
 		Version: "0.1.0",
 		Error:   errors.New("component signature file does not exist"),
 	},
-	isVerifiedTest{
+	{
 		Name: "Mismatch",
 		Component: Component{
 			Name: "lacework-mock-component",
@@ -193,7 +193,7 @@ var isVerifiedTests = []isVerifiedTest{
 		Signature: base64.StdEncoding.EncodeToString([]byte("blah blah blah")),
 		Error:     errors.New("unable to parse signature"),
 	},
-	isVerifiedTest{
+	{
 		Name:      "Verified",
 		Component: mockComponent,
 		Version:   "0.1.0\n",
@@ -231,26 +231,26 @@ type runTest struct {
 }
 
 var runTests = []runTest{
-	runTest{
+	{
 		Name:      "IsNotBinary",
 		Component: Component{Name: "IsNotBinary"},
 		Version:   "0.1.0",
 		Error:     errors.New("unable to run component: component IsNotBinary is not a binary"),
 	},
-	runTest{
+	{
 		Name:      "IsNotVerified",
 		Component: Component{Name: "IsNotVerified", Type: "BINARY"},
 		Version:   "0.1.0",
 		Error:     errors.New("unable to run component: component signature file does not exist"),
 	},
-	runTest{
+	{
 		Name:      "OK",
 		Component: mockComponent,
 		Version:   "0.1.0",
 		Signature: helloWorldSig,
 		Error:     nil,
 	},
-	runTest{
+	{
 		Name:      "Error",
 		Component: mockComponent,
 		Version:   "0.1.0",

--- a/lwcomponent/http.go
+++ b/lwcomponent/http.go
@@ -31,13 +31,18 @@ const (
 )
 
 // downloadFile is an internal helper that downloads a file to the provided file path
-func downloadFile(filepath string, url string) error {
+func DownloadFile(filepath string, url string, timeout time.Duration) error {
 	var (
-		resp *http.Response
-		err  error
+		resp     *http.Response
+		err      error
+		_timeout time.Duration = timeout
 	)
 
-	client := &http.Client{Timeout: defaultTimeout}
+	if _timeout == 0 {
+		_timeout = defaultTimeout
+	}
+
+	client := &http.Client{Timeout: _timeout}
 
 	resp, err = client.Get(url)
 	if err != nil {

--- a/lwcomponent/http.go
+++ b/lwcomponent/http.go
@@ -22,13 +22,31 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"time"
+)
+
+const (
+	defaultTimeout  = 30 * time.Second
+	defaultMaxRetry = 2
 )
 
 // downloadFile is an internal helper that downloads a file to the provided file path
 func downloadFile(filepath string, url string) error {
-	resp, err := http.Get(url)
+	var (
+		resp *http.Response
+		err  error
+	)
+
+	client := &http.Client{Timeout: defaultTimeout}
+
+	resp, err = client.Get(url)
 	if err != nil {
-		return err
+		for retry := 0; retry < defaultMaxRetry && os.IsTimeout(err); retry++ {
+			resp, err = client.Get(url)
+		}
+		if err != nil {
+			return err
+		}
 	}
 	defer resp.Body.Close()
 

--- a/lwcomponent/http_test.go
+++ b/lwcomponent/http_test.go
@@ -1,0 +1,56 @@
+package lwcomponent_test
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/lacework/go-sdk/lwcomponent"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDownloadFile(t *testing.T) {
+	var (
+		urlPath string = "/lw-cdk-store/catalog/component-example/1.0.0/component-example-linux-amd64.tar.gz"
+		content string = "CDK component"
+	)
+
+	file, err := os.CreateTemp("", "lwcomponent-downloadFile")
+	assert.Nil(t, err)
+	defer file.Close()
+
+	mux := http.NewServeMux()
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	mux.HandleFunc(urlPath, func(w http.ResponseWriter, r *http.Request) {
+		if assert.Equal(t, "GET", r.Method, "Get() should be a GET method") {
+			fmt.Fprint(w, content)
+		}
+	})
+
+	t.Run("happy path", func(t *testing.T) {
+		err = lwcomponent.DownloadFile(file.Name(), fmt.Sprintf("%s%s", server.URL, urlPath), 0)
+		assert.Nil(t, err)
+
+		buf, err := os.ReadFile(file.Name())
+		assert.Nil(t, err)
+		assert.Equal(t, content, string(buf))
+	})
+
+	t.Run("timeout error", func(t *testing.T) {
+		err = lwcomponent.DownloadFile(file.Name(), fmt.Sprintf("%s%s", server.URL, urlPath), 1*time.Microsecond)
+		assert.NotNil(t, err)
+		assert.True(t, os.IsTimeout(err))
+	})
+
+	t.Run("non-timeout error", func(t *testing.T) {
+		err = lwcomponent.DownloadFile(file.Name(), "", 0)
+		assert.NotNil(t, err)
+		assert.False(t, os.IsTimeout(err))
+	})
+}

--- a/lwcomponent/minisign_internal_test.go
+++ b/lwcomponent/minisign_internal_test.go
@@ -35,11 +35,11 @@ type verifySignatureTest struct {
 }
 
 var verifySignatureTests = []verifySignatureTest{
-	verifySignatureTest{
+	{
 		Name:  "UnableToParseSignature",
 		Error: errors.New("unable to parse signature"),
 	},
-	verifySignatureTest{
+	{
 		Name: "InvalidTrustedComment",
 		Signature: []byte(`untrusted comment: 
 RWQnyHnTKz1RiRl+vm7dNpp7Jrt+qLANsu9m+TaHSgVyJO9Ldeo5ZPw/GQJu1fJZBuCrsMVW5KbuB6dEPzQvi8ct1zJfMkgVsgs=
@@ -47,7 +47,7 @@ trusted comment: RWQnyHnTKz1RidqMl45Ou5XbJCroV7zohE1jpbigTUGXyQY94AF5uo4v.1.dW50
 cJwh7XDctGR8dpc1NEJnPGU5IXNvMNXa6hdMA0BBZvvnsKQHeVVEkMc7zo72iFsHEKRxe+AmXkryNgVi7Gg0DQ==`),
 		Error: errors.New("invalid signature trusted comment"),
 	},
-	verifySignatureTest{
+	{
 		Name: "UnableToParseRootSignature",
 		Signature: []byte(`untrusted comment: 
 RWQnyHnTKz1RiRl+vm7dNpp7Jrt+qLANsu9m+TaHSgVyJO9Ldeo5ZPw/GQJu1fJZBuCrsMVW5KbuB6dEPzQvi8ct1zJfMkgVsgs=
@@ -55,7 +55,7 @@ trusted comment: 1.RWQnyHnTz1RidqMl45Ou5XbJCroV7zohE1jpbigTUGXyQY94AF5uo4v.1.W50
 cJwh7XDctGR8dpc1NEJnPGU5IXNvMNXa6hdMA0BBZvvnsKQHeVVEkMc7zo72iFsHEKRxe+AmXkryNgVi7Gg0DQ==`),
 		Error: errors.New("unable to parse root signature from trusted comment: illegal base64 data at input byte 303"),
 	},
-	verifySignatureTest{
+	{
 		Name: "InvalidRootSignatureOverSigningKey",
 		Signature: []byte(`untrusted comment: 
 RWQnyHnTKz1RiRl+vm7dNpp7Jrt+qLANsu9m+TaHSgVyJO9Ldeo5ZPw/GQJu1fJZBuCrsMVW5KbuB6dEPzQvi8ct1zJfMkgVsgs=
@@ -63,7 +63,7 @@ trusted comment: 1.RWQnyHnTz1RidqMl45Ou5XbJCroV7zohE1jpbigTUGXyQY94AF5uo4v.1.dW5
 cJwh7XDctGR8dpc1NEJnPGU5IXNvMNXa6hdMA0BBZvvnsKQHeVVEkMc7zo72iFsHEKRxe+AmXkryNgVi7Gg0DQ==`),
 		Error: errors.New("invalid root signature over signing key"),
 	},
-	verifySignatureTest{
+	{
 		Name: "InvalidSignatureOverComponent",
 		Signature: []byte(`untrusted comment: 
 RWQnyHnTKz1RiRl+vm7dNpp7Jrt+qLANsu9m+TaHSgVyJO9Ldeo5ZPw/GQJu1fJZBuCrsMVW5KbuB6dEPzQvi8ct1zJfMkgVsgs=
@@ -71,7 +71,7 @@ trusted comment: 1.RWQnyHnTKz1RidqMl45Ou5XbJCroV7zohE1jpbigTUGXyQY94AF5uo4v.1.dW
 cJwh7XDctGR8dpc1NEJnPGU5IXNvMNXa6hdMA0BBZvvnsKQHeVVEkMc7zo72iFsHEKRxe+AmXkryNgVi7Gg0DQ==`),
 		Error: errors.New("invalid signature over component"),
 	},
-	verifySignatureTest{
+	{
 		Name:      "OK",
 		Message:   helloWorld,
 		Signature: helloWorldSigDecoded,


### PR DESCRIPTION
## Summary

For the download of components, use a default timeout of 30 seconds.  When timeout errors are returned, retry twice.

## How did you test this change?

Local manual testing

## Issue

https://lacework.atlassian.net/browse/GROW-2460