### PR TITLE
fix(scaffolding): Python components can't have '-'

### DIFF
--- a/cli/cmd/component_dev.go
+++ b/cli/cmd/component_dev.go
@@ -346,6 +346,8 @@ func cdkPythonScaffolding(component *lwcomponent.Component) error {
 		"poetry",
 		"init",
 		"--no-interaction",
+		// Because of https://github.com/python-poetry/poetry/issues/5975
+		fmt.Sprintf("--name=%s", strings.ReplaceAll(component.Name, "-", "")),
 		"--python=^3.11,<3.12",
 		"--dev-dependency=pyinstaller",
 		"--dev-dependency=poethepoet")


### PR DESCRIPTION
## Summary

Apparently, Python doesn't allow `-` in library names. https://github.com/python-poetry/poetry/issues/5975

This fixes the problem by removing the hyphens, not that, we are not changing the name of the CDK component since that is packaged with `pyinstall` via the `tool.poe.tasks`

## How did you test this change?

Created a component with `-`
```
➜  ~ lacework component list
       STATUS                 NAME              VERSION                                   DESCRIPTION
-------------------+-------------------------+-----------+-----------------------------------------------------------------------------
  Update Available   sca                       0.0.73      Software Component Analysis
  Installed          remediate                 0.5.0       A tool to isolate and remediate resources
  Not Installed      chronicle-alert-channel   0.0.2       Send Alerts to Google Chronicle
  Update Available   iac                       0.6.10      Infrastructure as Code (IaC) scanner
  Update Available   sast                      0.0.55      Static Application Security Testing
  Installed          chat                      0.0.0-dev   (dev-mode) A tool which uses OpenAI to interact with Lacework
  Installed          cloud-hunter              0.0.0
  Installed          vuln-scanner              0.0.0

Components version: 0.3.0
➜  ~ lacework component dev a-b
Component 'a-b' not found. Defining a new component.
? Select the type of component you are developing: CLI_COMMAND
? What is this component about? (component description): A Python component with hyphens
Component 'a-b' in now in development mode.
? Would you like to initialize your component with scaffolding?  Python

Deploying Python scaffolding:
 [✓] File /Users/afiune/.config/lacework/components/a-b/src/package/__init__.py deployed
 [✓] File /Users/afiune/.config/lacework/components/a-b/src/package/__main__.py deployed
 [✓] File /Users/afiune/.config/lacework/components/a-b/README.md deployed
 [✓] Git repository initialized
> Command: poetry [init --no-interaction --name=ab --python=^3.11,<3.12 --dev-dependency=pyinstaller --dev-dependency=poethepoet]
> Using version ^6.0.0 for pyinstaller
> Using version ^0.23.0 for poethepoet
> Poetry init...
 [✓] Poetry init
> Command: poetry [install]
> Updating dependencies
> Resolving dependencies...
>
> Writing lock file
>
> No dependencies to install or update
> Poetry install...
 [✓] Poetry install
> 6776 INFO: Building EXE because EXE-00.toc is non existent
> 6777 INFO: Building EXE from EXE-00.toc
> 6777 INFO: Copying bootloader EXE to /Users/afiune/.config/lacework/components/a-b/a-b
> 6778 INFO: Converting EXE to target arch (x86_64)
> 6805 INFO: Removing signature(s) from EXE
> 6829 INFO: Appending PKG archive to EXE
> 6834 INFO: Fixing EXE headers for code signing
> 6842 INFO: Re-signing the EXE
> 6902 INFO: Building EXE from EXE-00.toc completed successfully.
>
 [✓] Dev component built at /Users/afiune/.config/lacework/components/a-b/a-b

Deployment completed! Time for 🍕

Root path: /Users/afiune/.config/lacework/components/a-b
Dev specs: /Users/afiune/.config/lacework/components/a-b/.dev
➜  ~ lacework component list
       STATUS                 NAME              VERSION                                   DESCRIPTION
-------------------+-------------------------+-----------+-----------------------------------------------------------------------------
  Update Available   sca                       0.0.73      Software Component Analysis
  Installed          remediate                 0.5.0       A tool to isolate and remediate resources
  Not Installed      chronicle-alert-channel   0.0.2       Send Alerts to Google Chronicle
  Update Available   iac                       0.6.10      Infrastructure as Code (IaC) scanner
  Update Available   sast                      0.0.55      Static Application Security Testing
  Installed          a-b                       0.0.0-dev   (dev-mode) A Python component with hyphens
  Installed          chat                      0.0.0-dev   (dev-mode) A tool which uses OpenAI to interact with Lacework
  Installed          cloud-hunter              0.0.0
  Installed          vuln-scanner              0.0.0

Components version: 0.3.0
➜  ~ lacework a-b
Hello python component
➜  ~
```

## Issue
N/A
