### PR TITLE
fix: increase component download timeout to 5m

### DIFF
--- a/lwcomponent/component.go
+++ b/lwcomponent/component.go
@@ -257,7 +257,7 @@ func (s State) Install(component *Component, version string) error {
 		return err
 	}
 
-	err = DownloadFile(path, artifact.URL, 0)
+	err = DownloadFile(path, artifact.URL, 5*time.Minute)
 	if err != nil {
 		return errors.Wrap(err, "unable to download component artifact")
 	}


### PR DESCRIPTION
## Summary

The SAST component is over 200mb in size and requires at least 1 minute to download.  Increasing the component download timeout to 5 minutes.

## How did you test this change?

Local manual