### PR TITLE
fix: component download

### DIFF
--- a/lwcomponent/component.go
+++ b/lwcomponent/component.go
@@ -257,7 +257,14 @@ func (s State) Install(component *Component, version string) error {
 		return err
 	}
 
-	err = DownloadFile(path, artifact.URL, 5*time.Minute)
+	// Slow S3 downloads
+	downloadTimeout := 0 * time.Minute
+	switch component.Name {
+	case "sast":
+		downloadTimeout = 5 * time.Minute
+	}
+
+	err = DownloadFile(path, artifact.URL, time.Duration(downloadTimeout))
 	if err != nil {
 		return errors.Wrap(err, "unable to download component artifact")
 	}

--- a/lwcomponent/http.go
+++ b/lwcomponent/http.go
@@ -46,7 +46,10 @@ func DownloadFile(filepath string, url string, timeout time.Duration) (err error
 	err = downloadFile(client, url, file)
 
 	for retry := 0; retry < defaultMaxRetry && os.IsTimeout(err); retry++ {
-		file.Seek(0, io.SeekStart)
+		_, err = file.Seek(0, io.SeekStart)
+		if err != nil {
+			return err
+		}
 
 		err = downloadFile(client, url, file)
 	}


### PR DESCRIPTION
## Summary

The line `io.Copy(file, resp.Body)` streams HTTP response data to the file, at this stage we have an active HTTP connection and a timeout will interrupt us there.

This change groups the `client.Get` with the `io.Copy`.  Hardcoding component timeout values.

## How did you test this change?

local unit testing
