### PR TITLE
Support sast tables in cds

### DIFF
--- a/api/component_data_test.go
+++ b/api/component_data_test.go
@@ -42,6 +42,66 @@ func TestUploadFiles(t *testing.T) {
 	assert.Equal(t, "SOME-GUID", guid)
 }
 
+func TestDefaultUrlType(t *testing.T) {
+	fakeServer := lacework.MockServer()
+	fakeServer.MockToken("TOKEN")
+	defer fakeServer.Close()
+	fakeServer.MockAPI("ComponentData/requestUpload", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+		assert.NotNil(t, r.Body)
+		body := httpBodySniffer(r)
+		assert.Contains(t, body, api.URL_TYPE_DEFAULT)
+		_, err := fmt.Fprintf(w, generateInitialResponse())
+		assert.Nil(t, err)
+	})
+	fakeServer.MockAPI("ComponentData/completeUpload", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+		assert.NotNil(t, r.Body)
+		body := httpBodySniffer(r)
+		assert.Contains(t, body, api.URL_TYPE_DEFAULT)
+		_, err := fmt.Fprintf(w, generateCompleteResponse())
+		assert.Nil(t, err)
+	})
+	c, err := api.NewClient("test",
+		api.WithToken("TOKEN"),
+		api.WithURL(fakeServer.URL()),
+	)
+	assert.Nil(t, err)
+	guid, err := c.V2.ComponentData.UploadFiles("doc-set", []string{"sast"}, []string{})
+	assert.Nil(t, err)
+	assert.Equal(t, "SOME-GUID", guid)
+}
+
+func TestSastTablesUrlType(t *testing.T) {
+	fakeServer := lacework.MockServer()
+	fakeServer.MockToken("TOKEN")
+	defer fakeServer.Close()
+	fakeServer.MockAPI("ComponentData/requestUpload", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+		assert.NotNil(t, r.Body)
+		body := httpBodySniffer(r)
+		assert.Contains(t, body, api.URL_TYPE_SAST_TABLES)
+		_, err := fmt.Fprintf(w, generateInitialResponse())
+		assert.Nil(t, err)
+	})
+	fakeServer.MockAPI("ComponentData/completeUpload", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+		assert.NotNil(t, r.Body)
+		body := httpBodySniffer(r)
+		assert.Contains(t, body, api.URL_TYPE_SAST_TABLES)
+		_, err := fmt.Fprintf(w, generateCompleteResponse())
+		assert.Nil(t, err)
+	})
+	c, err := api.NewClient("test",
+		api.WithToken("TOKEN"),
+		api.WithURL(fakeServer.URL()),
+	)
+	assert.Nil(t, err)
+	guid, err := c.V2.ComponentData.UploadSastTables("doc-set", []string{})
+	assert.Nil(t, err)
+	assert.Equal(t, "SOME-GUID", guid)
+}
+
 func TestDoWithExponentialBackoffAlwaysFailing(t *testing.T) {
 	waited := 0
 	err := api.DoWithExponentialBackoff(func() error {


### PR DESCRIPTION
Add the parameter to specify the url type for sast tables

## Summary

We need to prepare the API for uploading sast tables.

## How did you test this change?

Unit tests

## Issue

https://lacework.atlassian.net/browse/COD-1156