### PR TITLE
add short lived instance field in agentless data structs

### DIFF
--- a/api/cloud_accounts_aws_sidekick.go
+++ b/api/cloud_accounts_aws_sidekick.go
@@ -71,6 +71,7 @@ type AwsSidekickData struct {
 	ScanHostVulnerabilities bool `json:"scanHostVulnerabilities"`
 	ScanMultiVolume         bool `json:"scanMultiVolume"`
 	ScanStoppedInstances    bool `json:"scanStoppedInstances"`
+	ScanShortLivedInstances bool `json:"scanShortLivedInstances"`
 
 	AccountID         string                             `json:"awsAccountId,omitempty"`
 	BucketArn         string                             `json:"bucketArn,omitempty"`

--- a/api/cloud_accounts_aws_sidekick_org.go
+++ b/api/cloud_accounts_aws_sidekick_org.go
@@ -72,6 +72,7 @@ type AwsSidekickOrgData struct {
 	ScanHostVulnerabilities bool `json:"scanHostVulnerabilities"`
 	ScanMultiVolume         bool `json:"scanMultiVolume"`
 	ScanStoppedInstances    bool `json:"scanStoppedInstances"`
+	ScanShortLivedInstances bool `json:"scanShortLivedInstances"`
 
 	//Properties specific to the AWS organization integration type
 	ScanningAccount   string `json:"scanningAccount"`

--- a/api/cloud_accounts_aws_sidekick_org_test.go
+++ b/api/cloud_accounts_aws_sidekick_org_test.go
@@ -193,6 +193,9 @@ func singleAwsSidekickOrgCloudAccount(id string) string {
 	  "scanFrequency": 24,
 	  "scanContainers": true,
 	  "scanHostVulnerabilities": true,
+	  "scanShortLivedInstances": false,
+	  "scanStoppedInstances": true,
+	  "scanMultiVolume": false,
 	  "managementAccount": "000123456789",
 	  "monitoredAccounts": "r-1234, ou-0987",
 	  "scanningAccount": "123456789000"

--- a/api/cloud_accounts_aws_sidekick_test.go
+++ b/api/cloud_accounts_aws_sidekick_test.go
@@ -150,7 +150,10 @@ func singleAwsSidekickCloudAccount(id string) string {
       },
 	  "scanFrequency": 24,
 	  "scanContainers": true,
-	  "scanHostVulnerabilities": true
+	  "scanHostVulnerabilities": true,
+	  "scanShortLivedInstances": false,
+	  "scanStoppedInstances": true,
+	  "scanMultiVolume": false
     },
     "enabled": 1,
     "intgGuid": "` + id + `",


### PR DESCRIPTION
## Summary

In order to go fully-GA on the short-lived feature for AWS for Agentless Workload scanning, we need to also update the terraform to have a field for short-lived instances. I've added the field to both AWLS and AWLS Org integration types. This feature is not currently available on GCP. 

## How did you test this change?

Tested via integration tests, added additional field in the integration tests.

## Issue

https://lacework.atlassian.net/browse/RAIN-71760
