### PR TITLE
feat(cli): Components daily version check

### DIFF
--- a/cli/cmd/component.go
+++ b/cli/cmd/component.go
@@ -216,6 +216,10 @@ func (c *cliState) LoadComponents() {
 							"cli_flags", c.componentParser.cliArgs)
 						f, ok := c.LwComponents.GetComponent(cmd.Use)
 						if ok {
+							if f.Status() == lwcomponent.UpdateAvailable {
+								format := "%s v%s available: to update, run `lacework component update %s`\n"
+								cli.OutputHuman(fmt.Sprintf(format, cmd.Use, f.LatestVersion.String(), cmd.Use))
+							}
 							envs := []string{
 								fmt.Sprintf("LW_COMPONENT_NAME=%s", cmd.Use),
 							}


### PR DESCRIPTION
## Summary
When a component is run, check whether an available is available, and if yes report it.

## How did you test this change?

Manually, e.g.
```
(⎈|lacework.teleport.sh-lacework-devtest-dev5:N/A)➜  cli git:(GROW-2470) ✗ go build . && ./cli sca 
sca v0.0.74 available: to update, run `lacework component install sca`
Lacework SCA (Software Component Analysis)
...
```
