### PR TITLE
fix: CDK v1 signature verify

### DIFF
--- a/cli/cmd/component.go
+++ b/cli/cmd/component.go
@@ -373,7 +373,7 @@ func installComponent(cmd *cobra.Command, args []string) (err error) {
 		err = errors.Wrap(err, "Install of component failed")
 		return
 	}
-	cli.OutputChecklist(successIcon, "Component installed\n")
+	cli.OutputChecklist(successIcon, "Component version %s installed\n", component.InstalledVersion())
 
 	// @jon-stewart: TODO: Component lifecycle `cdk-init` command
 


### PR DESCRIPTION
## Summary

Lacework minisign library signs a SHA256 hash of the data.

## How did you test this change?

manual

```
> /usr/local/bin/lacework components install component-example
 [✓] Component component-example found
 [✓] Component component-example staged
 [✓] Component signature verified
 [✓] Component version 0.7.30 installed
```

## Issue

https://lacework.atlassian.net/browse/GROW-2473
