### PR TITLE
fix: CDK bugs

### DIFF
--- a/lwcomponent/catalog.go
+++ b/lwcomponent/catalog.go
@@ -36,7 +36,15 @@ func CatalogCacheDir() (string, error) {
 		return "", errors.Wrap(err, "unable to locate components directory")
 	}
 
-	return filepath.Join(cacheDir, componentCacheDir), nil
+	path := filepath.Join(cacheDir, componentCacheDir)
+
+	if _, err = os.Stat(path); err != nil {
+		if err = os.MkdirAll(path, os.ModePerm); err != nil {
+			return "", err
+		}
+	}
+
+	return path, nil
 }
 
 type Catalog struct {
@@ -243,7 +251,11 @@ func NewCatalog(client *api.Client, stageConstructor StageConstructor) (*Catalog
 		return nil, err
 	}
 
-	rawComponents := response.Data[0].Components
+	var rawComponents []api.LatestComponentVersion
+
+	if len(response.Data) > 0 {
+		rawComponents = response.Data[0].Components
+	}
 
 	cdkComponents := make(map[string]CDKComponent, len(rawComponents)+len(localComponents))
 


### PR DESCRIPTION
## Summary

1) No components returned from the API would lead to a panic.
Fix:  safe array access

2) No `~/.config/lacework/components` directory would lead to an error
Fix: create the dir if it doesn't exist

## How did you test this change?

Local manual testing