### PR TITLE
feat(resource-groups): add per-group-type templates

### DIFF
--- a/api/_templates/resource_groups/aws.json
+++ b/api/_templates/resource_groups/aws.json
@@ -1,0 +1,40 @@
+{
+  "filters": {
+    "filter0": {
+      "field": "Account",
+      "operation": "EQUALS",
+      "values": [
+        "123456789012"
+      ]
+    },
+    "filter1": {
+      "field": "Resource Tag",
+      "operation": "INCLUDES",
+      "key": "Hostname",
+      "values": [
+        "*"
+      ]
+    },
+    "filter2": {
+      "field": "Region",
+      "operation": "STARTS_WITH",
+      "values": [
+        "ap-south"
+      ]
+    }
+  },
+  "expression": {
+    "operator": "AND",
+    "children": [
+      {
+        "filterName": "filter0"
+      },
+      {
+        "filterName": "filter1"
+      },
+      {
+        "filterName": "filter2"
+      }
+    ]
+  }
+}

--- a/api/_templates/resource_groups/azure.json
+++ b/api/_templates/resource_groups/azure.json
@@ -1,0 +1,70 @@
+{
+    "filters": {
+      "filter0": {
+        "field": "Subscription ID",
+        "operation": "EQUALS",
+        "values": [
+          "0fe75302-1906-45ec-bde1-79b76899dd74"
+        ]
+      },
+      "filter1": {
+        "field": "Subscription Name",
+        "operation": "STARTS_WITH",
+        "values": [
+          "prod"
+        ]
+      },
+      "filter2": {
+        "field": "Tenant ID",
+        "operation": "EQUALS",
+        "values": [
+          "b329d4bf-4587-4ccf-e132-84e7025fa22d"
+        ]
+      },
+      "filter3": {
+        "field": "Tenant Name",
+        "operation": "INCLUDES",
+        "values": [
+          "*"
+        ]
+      },
+      "filter4": {
+        "field": "Resource Tag",
+        "operation": "EQUALS",
+        "key": "Env",
+        "values": [
+          "dev"
+        ]
+      },
+      "filter5": {
+        "field": "Region",
+        "operation": "EQUALS",
+        "values": [
+          "westus2"
+        ]
+      }
+    },
+    "expression": {
+      "operator": "AND",
+      "children": [
+        {
+          "filterName": "filter0"
+        },
+        {
+          "filterName": "filter1"
+        },
+        {
+          "filterName": "filter2"
+        },
+        {
+          "filterName": "filter3"
+        },
+        {
+          "filterName": "filter4"
+        },
+        {
+          "filterName": "filter5"
+        }
+      ]
+    }
+  }

--- a/api/_templates/resource_groups/container.json
+++ b/api/_templates/resource_groups/container.json
@@ -1,0 +1,50 @@
+{
+    "filters": {
+      "filter0": {
+        "field": "Image Tag",
+        "operation": "EQUALS",
+        "values": [
+          "1.17.1"
+        ]
+      },
+      "filter1": {
+        "field": "Container Label",
+        "operation": "INCLUDES",
+        "key": "app",
+        "values": [
+          "*"
+        ]
+      },
+      "filter2": {
+        "field": "Image Repo",
+        "operation": "EQUALS",
+        "values": [
+          "parrotsec/core"
+        ]
+      },
+      "filter3": {
+        "field": "Image Registry",
+        "operation": "EQUALS",
+        "values": [
+          "k8s.gcr.io"
+        ]
+      }
+    },
+    "expression": {
+      "operator": "AND",
+      "children": [
+        {
+          "filterName": "filter0"
+        },
+        {
+          "filterName": "filter1"
+        },
+        {
+          "filterName": "filter2"
+        },
+        {
+          "filterName": "filter3"
+        }
+      ]
+    }
+  }

--- a/api/_templates/resource_groups/gcp.json
+++ b/api/_templates/resource_groups/gcp.json
@@ -11,7 +11,7 @@
         "field": "Organization ID",
         "operation": "EQUALS",
         "values": [
-          "121868925203"
+          "123456789012"
         ]
       },
       "filter2": {
@@ -25,7 +25,7 @@
         "field": "Folder",
         "operation": "EQUALS",
         "values": [
-          "1081568461605"
+          "1234567890123"
         ]
       },
       "filter4": {

--- a/api/_templates/resource_groups/gcp.json
+++ b/api/_templates/resource_groups/gcp.json
@@ -1,0 +1,70 @@
+{
+    "filters": {
+      "filter0": {
+        "field": "Project ID",
+        "operation": "EQUALS",
+        "values": [
+          "abc-demo-project-123"
+        ]
+      },
+      "filter1": {
+        "field": "Organization ID",
+        "operation": "EQUALS",
+        "values": [
+          "121868925203"
+        ]
+      },
+      "filter2": {
+        "field": "Organization Name",
+        "operation": "STARTS_WITH",
+        "values": [
+          "somecompany"
+        ]
+      },
+      "filter3": {
+        "field": "Folder",
+        "operation": "EQUALS",
+        "values": [
+          "1081568461605"
+        ]
+      },
+      "filter4": {
+        "field": "Resource Label",
+        "operation": "EQUALS",
+        "key": "Env",
+        "values": [
+          "dev"
+        ]
+      },
+      "filter5": {
+        "field": "Region",
+        "operation": "EQUALS",
+        "values": [
+          "australia-southeast2"
+        ]
+      }
+    },
+    "expression": {
+      "operator": "AND",
+      "children": [
+        {
+          "filterName": "filter0"
+        },
+        {
+          "filterName": "filter1"
+        },
+        {
+          "filterName": "filter2"
+        },
+        {
+          "filterName": "filter3"
+        },
+        {
+          "filterName": "filter4"
+        },
+        {
+          "filterName": "filter5"
+        }
+      ]
+    }
+  }

--- a/api/_templates/resource_groups/machine.json
+++ b/api/_templates/resource_groups/machine.json
@@ -1,0 +1,20 @@
+{
+    "filters": {
+      "filter0": {
+        "field": "Machine Tag",
+        "operation": "EQUALS",
+        "key": "cluster",
+        "values": [
+          "dev"
+        ]
+      }
+    },
+    "expression": {
+      "operator": "OR",
+      "children": [
+        {
+          "filterName": "filter0"
+        }
+      ]
+    }
+  }

--- a/api/_templates/resource_groups/oci.json
+++ b/api/_templates/resource_groups/oci.json
@@ -1,0 +1,50 @@
+{
+    "filters": {
+      "filter0": {
+        "field": "Compartment ID",
+        "operation": "EQUALS",
+        "values": [
+          "ocid1.tenancy.oc1..abaaaabaqp6mzxi6z3xouvhawvsekntanafelw5vmwdjw5vqmgvlegcs2s6q"
+        ]
+      },
+      "filter1": {
+        "field": "Compartment Name",
+        "operation": "INCLUDES",
+        "values": [
+          "prod"
+        ]
+      },
+      "filter2": {
+        "field": "Region",
+        "operation": "STARTS_WITH",
+        "values": [
+          "us-"
+        ]
+      },
+      "filter3": {
+        "field": "Resource Tag",
+        "operation": "EQUALS",
+        "key": "\"definedTags\".\"Oracle-Tags\".\"CreatedBy\"",
+        "values": [
+          "default/my.email@somecompany.net"
+        ]
+      }
+    },
+    "expression": {
+      "operator": "AND",
+      "children": [
+        {
+          "filterName": "filter0"
+        },
+        {
+          "filterName": "filter1"
+        },
+        {
+          "filterName": "filter2"
+        },
+        {
+          "filterName": "filter3"
+        }
+      ]
+    }
+  }

--- a/api/resource_groups.go
+++ b/api/resource_groups.go
@@ -89,25 +89,25 @@ var (
 )
 
 type resourceGroupContext struct {
-	typ           string
-	queryTemplate string
+	resourceGroupType string
+	queryTemplate     string
 }
 
 // ResourceGroupTypes is the list of available Resource Group types
 var ResourceGroupTypes = map[resourceGroupType]resourceGroupContext{
-	NoneResourceGroup:      {typ: "None", queryTemplate: NoneResourceGroupQueryTemplate},
-	AwsResourceGroup:       {typ: "AWS", queryTemplate: AwsResourceGroupQueryTemplate},
-	AzureResourceGroup:     {typ: "AZURE", queryTemplate: AzureResourceGroupQueryTemplate},
-	ContainerResourceGroup: {typ: "CONTAINER", queryTemplate: ContainerResourceGroupQueryTemplate},
-	GcpResourceGroup:       {typ: "GCP", queryTemplate: GcpResourceGroupQueryTemplate},
-	LwAccountResourceGroup: {typ: "LW_ACCOUNT", queryTemplate: LwAccountResourceGroupQueryTemplate},
-	MachineResourceGroup:   {typ: "MACHINE", queryTemplate: MachineResourceGroupQueryTemplate},
-	OciResourceGroup:       {typ: "OCI", queryTemplate: OciResourceGroupQueryTemplate},
+	NoneResourceGroup:      {resourceGroupType: "None", queryTemplate: NoneResourceGroupQueryTemplate},
+	AwsResourceGroup:       {resourceGroupType: "AWS", queryTemplate: AwsResourceGroupQueryTemplate},
+	AzureResourceGroup:     {resourceGroupType: "AZURE", queryTemplate: AzureResourceGroupQueryTemplate},
+	ContainerResourceGroup: {resourceGroupType: "CONTAINER", queryTemplate: ContainerResourceGroupQueryTemplate},
+	GcpResourceGroup:       {resourceGroupType: "GCP", queryTemplate: GcpResourceGroupQueryTemplate},
+	LwAccountResourceGroup: {resourceGroupType: "LW_ACCOUNT", queryTemplate: LwAccountResourceGroupQueryTemplate},
+	MachineResourceGroup:   {resourceGroupType: "MACHINE", queryTemplate: MachineResourceGroupQueryTemplate},
+	OciResourceGroup:       {resourceGroupType: "OCI", queryTemplate: OciResourceGroupQueryTemplate},
 }
 
 // String returns the string representation of a Resource Group type
 func (i resourceGroupType) String() string {
-	return ResourceGroupTypes[i].typ
+	return ResourceGroupTypes[i].resourceGroupType
 }
 
 // QueryTemplate returns the resource group type's query template
@@ -119,7 +119,7 @@ func (i resourceGroupType) QueryTemplate() string {
 // the matching type from the provided string, if none, returns NoneResourceGroup
 func FindResourceGroupType(typ string) (resourceGroupType, bool) {
 	for i, ctx := range ResourceGroupTypes {
-		if typ == ctx.typ {
+		if typ == ctx.resourceGroupType {
 			return i, true
 		}
 	}

--- a/api/resource_groups_v2.go
+++ b/api/resource_groups_v2.go
@@ -163,7 +163,7 @@ func (group ResourceGroupDataWithQuery) GetQuery() *RGQuery {
 	return group.Query
 }
 
-func (group ResourceGroupDataWithQuery) ResourceGroupType() ResourceGroupType {
+func (group ResourceGroupDataWithQuery) ResourceGroupType() resourceGroupType {
 	t, _ := FindResourceGroupType(group.Type)
 	return t
 }

--- a/api/resource_groups_version_service.go
+++ b/api/resource_groups_version_service.go
@@ -81,7 +81,7 @@ func NewResourceGroupsVersionService(c *Client) *ResourceGroupsVersionService {
 //	  )
 //
 //	  client.V2.ResourceGroups.Create(group)
-func NewResourceGroup(name string, iType ResourceGroupType, props interface{}) ResourceGroupData {
+func NewResourceGroup(name string, iType resourceGroupType, props interface{}) ResourceGroupData {
 	return ResourceGroupData{
 		Name:    name,
 		Type:    iType.String(),
@@ -91,7 +91,7 @@ func NewResourceGroup(name string, iType ResourceGroupType, props interface{}) R
 }
 
 // NewResourceGroupWithQuery Only available with RGv2 beta
-func NewResourceGroupWithQuery(name string, iType ResourceGroupType,
+func NewResourceGroupWithQuery(name string, iType resourceGroupType,
 	description string, query *RGQuery) ResourceGroupDataWithQuery {
 	return ResourceGroupDataWithQuery{
 		Name:        name,

--- a/cli/cmd/resource_group_v2.go
+++ b/cli/cmd/resource_group_v2.go
@@ -80,42 +80,14 @@ func createResourceGroupV2(resourceType string) error {
 }
 
 func inputRGQueryFromEditor(resourceType string) *survey.Editor {
+	iType, _ := api.FindResourceGroupType(resourceType)
+
 	prompt := &survey.Editor{
 		Message:  fmt.Sprintf("Type a query for the new %s Resource Group", resourceType),
 		FileName: "resourceGroupQuery*.json",
 		Help:     "Refer to https://lwdocs-rg2.netlify.app/api/api-resource-group/ for examples of a query",
 	}
-
-	prompt.Default = `{
-  "filters": {
-	"filter0": {
-	  "field": "Resource Tag",
-	  "operation": "INCLUDES",
-	  "values": [
-		"*"
-	  ],
-	  "key": "HOST"
-	},
-	"filter1": {
-	  "field": "Region",
-	  "operation": "STARTS_WITH",
-	  "values": [
-		"ap-south"
-	  ]
-	}
-  },
-  "expression": {
-	"operator": "AND",
-	"children": [
-	  {
-		"filterName": "filter0"
-	  },
-	  {
-		"filterName": "filter1"
-	  }
-	]
-  }
-}`
+	prompt.Default = iType.QueryTemplate()
 	prompt.HideDefault = true
 	prompt.AppendDefault = true
 

--- a/integration/resource_groups_test.go
+++ b/integration/resource_groups_test.go
@@ -1,5 +1,3 @@
-//go:build resource_groups
-
 // Author:: Salim Afiune Maya (<afiune@lacework.net>)
 // Copyright:: Copyright 2020, Lacework Inc.
 // License:: Apache License, Version 2.0
@@ -21,6 +19,7 @@ package integration
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -29,13 +28,24 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var testResourceGroup string = `{"name":"CLI_TestCreateResourceGroup","resourceType":"AWS","query":{"filters":{"filter0":{"field":"Resource Tag","operation":"INCLUDES","values":["*"],"key":"HOST"},"filter1":{"field":"Region","operation":"STARTS_WITH","values":["ap-south"]}},"expression":{"operator":"AND","children":[{"filterName":"filter0"},{"filterName":"filter1"}]}},"description":"Resource Group Created By CLI Integration Testing","enabled":1}`
+func createResourceGroup(typ string) (string, error) {
+	iType, _ := api.FindResourceGroupType(typ)
 
-func createResourceGroup() (string, error) {
-	var resourceGroupV2Response api.ResourceGroupV2Response
+	var testQuery api.RGQuery
+	err := json.Unmarshal([]byte(iType.QueryTemplate()), &testQuery)
+
+	var testResourceGroup api.ResourceGroupDataWithQuery = api.ResourceGroupDataWithQuery{
+		Name:        fmt.Sprintf("CLI_TestCreateResourceGroup_%s", iType.String()),
+		Type:        iType.String(),
+		Query:       &testQuery,
+		Description: "Resource Group Created By CLI Integration Testing",
+		Enabled:     1,
+	}
+
+	testResourceGroupBytes, err := json.Marshal(testResourceGroup)
 
 	out, stderr, exitcode := LaceworkCLIWithTOMLConfig(
-		"api", "post", "v2/ResourceGroups", "-d", testResourceGroup, "--json",
+		"api", "post", "v2/ResourceGroups", "-d", string(testResourceGroupBytes), "--json",
 	)
 	if stderr.String() != "" {
 		return "", errors.New(stderr.String())
@@ -44,7 +54,8 @@ func createResourceGroup() (string, error) {
 		return "", errors.New("non-zero exit code")
 	}
 
-	err := json.Unmarshal(out.Bytes(), &resourceGroupV2Response)
+	var resourceGroupV2Response api.ResourceGroupV2Response
+	err = json.Unmarshal(out.Bytes(), &resourceGroupV2Response)
 	if err != nil {
 		return "", err
 	}
@@ -145,15 +156,29 @@ func TestResourceGroupDeleteNoInput(t *testing.T) {
 }
 
 func TestResourceGroupDelete(t *testing.T) {
-	// setup resource group
-	resourceGroupID, err := createResourceGroup()
-	if err != nil && !strings.Contains(err.Error(), "already exists in the account") {
-		assert.FailNow(t, err.Error())
+
+	// test each RGv2 type against its default template
+	for i := range api.ResourceGroupTypes {
+		switch i {
+		case api.NoneResourceGroup, api.LwAccountResourceGroup:
+			// these resource groups are not applicable
+			continue
+		default:
+			// skip lw_account
+			t.Run(i.String(), func(t *testing.T) {
+				// setup resource group
+				resourceGroupID, err := createResourceGroup(i.String())
+				if err != nil && !strings.Contains(err.Error(), "already exists in the account") {
+					assert.FailNow(t, err.Error())
+				}
+
+				// delete resource group
+				out, stderr, exitcode := LaceworkCLIWithTOMLConfig("resource-group", "delete", resourceGroupID)
+				assert.Contains(t, out.String(), "The resource group was deleted.")
+				assert.Empty(t, stderr.String(), "STDERR should be empty")
+				assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
+			})
+		}
 	}
 
-	// delete resource group
-	out, stderr, exitcode := LaceworkCLIWithTOMLConfig("resource-group", "delete", resourceGroupID)
-	assert.Contains(t, out.String(), "The resource group was deleted.")
-	assert.Empty(t, stderr.String(), "STDERR should be empty")
-	assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
 }

--- a/integration/resource_groups_test.go
+++ b/integration/resource_groups_test.go
@@ -33,6 +33,9 @@ func createResourceGroup(typ string) (string, error) {
 
 	var testQuery api.RGQuery
 	err := json.Unmarshal([]byte(iType.QueryTemplate()), &testQuery)
+	if err != nil {
+		return "", errors.Wrap(err, "error serializing query template")
+	}
 
 	var testResourceGroup api.ResourceGroupDataWithQuery = api.ResourceGroupDataWithQuery{
 		Name:        fmt.Sprintf("CLI_TestCreateResourceGroup_%s", iType.String()),
@@ -43,6 +46,9 @@ func createResourceGroup(typ string) (string, error) {
 	}
 
 	testResourceGroupBytes, err := json.Marshal(testResourceGroup)
+	if err != nil {
+		return "", errors.Wrap(err, "error marshaling test resource group")
+	}
 
 	out, stderr, exitcode := LaceworkCLIWithTOMLConfig(
 		"api", "post", "v2/ResourceGroups", "-d", string(testResourceGroupBytes), "--json",


### PR DESCRIPTION
## Summary
This pull-request adds a template for each RGv2 type (i.e. `AWS`, `GCP`, `AZURE`, `OCI`, `MACHINE`, `CONTAINER`).  This makes it easier for our customers to create resource groups via the CLI+Editor

## How did you test this change?
- Manually
- Augmented delete integration test to iterate through each type

## Issue
https://lacework.atlassian.net/browse/GROW-2489
