### PR TITLE
fix(cdk): place Python component binary in component root

### DIFF
--- a/cli/cmd/component_dev.go
+++ b/cli/cmd/component_dev.go
@@ -369,13 +369,20 @@ func cdkPythonScaffolding(component *lwcomponent.Component) error {
 		return err
 	}
 
-	_, err = f.WriteString("build = \"poetry run pyinstaller src/")
+	_, err = f.WriteString("build.shell = \"poetry run pyinstaller src/")
 	if err != nil {
 		return err
 	}
 	_, err = f.WriteString(fmt.Sprintf(
-		"%s/__main__.py --collect-submodules application -D --name %s --distpath .\"\n",
+		"%s/__main__.py --collect-submodules application -D --name %s --distpath dist;",
 		component.Name, component.Name,
+	))
+	if err != nil {
+		return err
+	}
+	_, err = f.WriteString(fmt.Sprintf(
+		" mv dist/%s/* .\"\n",
+		component.Name,
 	))
 	if err != nil {
 		return err


### PR DESCRIPTION
## Summary

The python pyinstaller build command was creating the component binary in subdirectory, not the component root directory. This prevented the lacework cli from executing the component. 

## How did you test this change?

1. compiled the lacework cli
2.  tested the creation of a new python component with scaffolding 
3. tested that the cli could execute the component after build

## Issue

https://lacework.atlassian.net/browse/GROW-2491