### PR TITLE
feat: support Agentless origanization integration with auto snapshot

### DIFF
--- a/cli/cmd/generate_aws.go
+++ b/cli/cmd/generate_aws.go
@@ -58,7 +58,7 @@ var (
 
 	// select options
 	AwsAdvancedOptDone     = "Done"
-	AdvancedOptAgentless   = "Additional Agentless options"
+	AdvancedOptAgentless   = "Additional Agentless options (placeholder)"
 	AdvancedOptCloudTrail  = "Additional CloudTrail options"
 	AdvancedOptIamRole     = "Configure Lacework integration with an existing IAM role"
 	AdvancedOptAwsAccounts = "Add additional AWS Accounts to Lacework"
@@ -803,7 +803,7 @@ func askAdvancedAwsOptions(config *aws.GenerateAwsTfConfigurationArgs, extraStat
 		// we can have other accounts even if we only have Config integration (Scenario 7)
 		var options []string
 
-		// Only show Advanced CloudTrail options if CloudTrail integration is set to true
+		// Only show Advanced Agentless options if Agentless integration is set to true
 		if config.Agentless {
 			options = append(options, AdvancedOptAgentless)
 		}

--- a/cli/cmd/generate_aws.go
+++ b/cli/cmd/generate_aws.go
@@ -58,7 +58,7 @@ var (
 
 	// select options
 	AwsAdvancedOptDone     = "Done"
-	AdvancedOptAgentless   = "Additional Agentless options (placeholder)"
+	AdvancedOptAgentless   = "Additional Agentless options"
 	AdvancedOptCloudTrail  = "Additional CloudTrail options"
 	AdvancedOptIamRole     = "Configure Lacework integration with an existing IAM role"
 	AdvancedOptAwsAccounts = "Add additional AWS Accounts to Lacework"
@@ -803,7 +803,7 @@ func askAdvancedAwsOptions(config *aws.GenerateAwsTfConfigurationArgs, extraStat
 		// we can have other accounts even if we only have Config integration (Scenario 7)
 		var options []string
 
-		// Only show Advanced Agentless options if Agentless integration is set to true
+		// Only show Advanced CloudTrail options if CloudTrail integration is set to true
 		if config.Agentless {
 			options = append(options, AdvancedOptAgentless)
 		}

--- a/cli/docs/lacework_generate_cloud-account_aws.md
+++ b/cli/docs/lacework_generate_cloud-account_aws.md
@@ -37,35 +37,38 @@ lacework generate cloud-account aws [flags]
 ### Options
 
 ```
-      --agentless                             enable agentless integration
-      --apply                                 run terraform apply without executing plan or prompting
-      --aws_assume_role string                specify aws assume role
-      --aws_profile string                    specify aws profile
-      --aws_region string                     specify aws region
-      --aws_subaccount strings                configure an additional aws account; value format must be <aws profile>:<region>
-      --bucket_encryption_enabled             enable S3 bucket encryption when creating bucket (default true)
-      --bucket_name string                    specify bucket name when creating bucket
-      --bucket_sse_key_arn string             specify existing KMS encryption key arn for bucket
-      --cloudtrail                            enable cloudtrail integration
-      --cloudtrail_name string                specify name of cloudtrail integration
-      --config                                enable config integration
-      --config_name string                    specify name of config integration
-      --consolidated_cloudtrail               use consolidated trail
-      --existing_bucket_arn string            specify existing cloudtrail S3 bucket ARN
-      --existing_iam_role_arn string          specify existing iam role arn to use
-      --existing_iam_role_externalid string   specify existing iam role external_id to use
-      --existing_iam_role_name string         specify existing iam role name to use
-      --existing_sns_topic_arn string         specify existing SNS topic arn
-  -h, --help                                  help for aws
-      --lacework_aws_account_id string        the Lacework AWS root account id
-      --output string                         location to write generated content (default is ~/lacework/aws)
-      --sns_topic_encryption_enabled          enable encryption on SNS topic when creating one (default true)
-      --sns_topic_encryption_key_arn string   specify existing KMS encryption key arn for SNS topic
-      --sns_topic_name string                 specify SNS topic name if creating new one
-      --sqs_encryption_enabled                enable encryption on SQS queue when creating (default true)
-      --sqs_encryption_key_arn string         specify existing KMS encryption key arn for SQS queue
-      --sqs_queue_name string                 specify SQS queue name if creating new one
-      --use_s3_bucket_notification            enable S3 bucket notifications
+      --agentless                                 enable agentless integration
+      --agentless_management_account_id string    AWS management account ID for Agentless integration
+      --agentless_monitored_account_ids strings   AWS monitored account IDs for Agentless integrations
+      --apply                                     run terraform apply without executing plan or prompting
+      --aws_organization                          enable organization integration
+      --aws_assume_role string                    specify aws assume role
+      --aws_profile string                        specify aws profile
+      --aws_region string                         specify aws region
+      --aws_subaccount strings                    configure an additional aws account; value format must be <aws profile>:<region>
+      --bucket_encryption_enabled                 enable S3 bucket encryption when creating bucket (default true)
+      --bucket_name string                        specify bucket name when creating bucket
+      --bucket_sse_key_arn string                 specify existing KMS encryption key arn for bucket
+      --cloudtrail                                enable cloudtrail integration
+      --cloudtrail_name string                    specify name of cloudtrail integration
+      --config                                    enable config integration
+      --config_name string                        specify name of config integration
+      --consolidated_cloudtrail                   use consolidated trail
+      --existing_bucket_arn string                specify existing cloudtrail S3 bucket ARN
+      --existing_iam_role_arn string              specify existing iam role arn to use
+      --existing_iam_role_externalid string       specify existing iam role external_id to use
+      --existing_iam_role_name string             specify existing iam role name to use
+      --existing_sns_topic_arn string             specify existing SNS topic arn
+  -h, --help                                      help for aws
+      --lacework_aws_account_id string            the Lacework AWS root account id
+      --output string                             location to write generated content (default is ~/lacework/aws)
+      --sns_topic_encryption_enabled              enable encryption on SNS topic when creating one (default true)
+      --sns_topic_encryption_key_arn string       specify existing KMS encryption key arn for SNS topic
+      --sns_topic_name string                     specify SNS topic name if creating new one
+      --sqs_encryption_enabled                    enable encryption on SQS queue when creating (default true)
+      --sqs_encryption_key_arn string             specify existing KMS encryption key arn for SQS queue
+      --sqs_queue_name string                     specify SQS queue name if creating new one
+      --use_s3_bucket_notification                enable S3 bucket notifications
 ```
 
 ### Options inherited from parent commands

--- a/cli/docs/lacework_generate_cloud-account_aws.md
+++ b/cli/docs/lacework_generate_cloud-account_aws.md
@@ -41,8 +41,8 @@ lacework generate cloud-account aws [flags]
       --agentless_management_account_id string    AWS management account ID for Agentless integration
       --agentless_monitored_account_ids strings   AWS monitored account IDs for Agentless integrations
       --apply                                     run terraform apply without executing plan or prompting
-      --aws_organization                          enable organization integration
       --aws_assume_role string                    specify aws assume role
+      --aws_organization                          enable organization integration
       --aws_profile string                        specify aws profile
       --aws_region string                         specify aws region
       --aws_subaccount strings                    configure an additional aws account; value format must be <aws profile>:<region>

--- a/integration/aws_generation_test.go
+++ b/integration/aws_generation_test.go
@@ -68,7 +68,7 @@ func TestGenerationAwsSimple(t *testing.T) {
 	assert.Contains(t, final, "Terraform code saved in")
 
 	// Create the TF directly with lwgenerate and validate same result via CLI
-	buildTf, _ := aws.NewTerraform(region, true, true, true,
+	buildTf, _ := aws.NewTerraform(region, false, true, true, true,
 		aws.WithBucketEncryptionEnabled(true),
 		aws.WithSnsTopicEncryptionEnabled(true),
 		aws.WithSqsEncryptionEnabled(true),
@@ -118,7 +118,7 @@ func TestGenerationAwsCustomizedOutputLocation(t *testing.T) {
 	result, _ := os.ReadFile(filepath.FromSlash(fmt.Sprintf("%s/main.tf", dir)))
 
 	// Create the TF directly with lwgenerate and validate same result via CLI
-	buildTf, _ := aws.NewTerraform(region, true, true, true,
+	buildTf, _ := aws.NewTerraform(region, false, true, true, true,
 		aws.WithBucketEncryptionEnabled(true),
 		aws.WithSnsTopicEncryptionEnabled(true),
 		aws.WithSqsEncryptionEnabled(true),
@@ -155,7 +155,7 @@ func TestGenerationAwsConfigOnly(t *testing.T) {
 	assert.Contains(t, final, "Terraform code saved in")
 
 	// Create the TF directly with lwgenerate and validate same result via CLI
-	buildTf, _ := aws.NewTerraform(region, false, true, false,
+	buildTf, _ := aws.NewTerraform(region, false, false, true, false,
 		aws.WithBucketEncryptionEnabled(true),
 		aws.WithSnsTopicEncryptionEnabled(true),
 		aws.WithSqsEncryptionEnabled(true),
@@ -193,7 +193,7 @@ func TestGenerationAwsAdvancedOptsDone(t *testing.T) {
 	assert.Contains(t, final, "Terraform code saved in")
 
 	// Create the TF directly with lwgenerate and validate same result via CLI
-	buildTf, _ := aws.NewTerraform(region, true, true, true,
+	buildTf, _ := aws.NewTerraform(region, false, true, true, true,
 		aws.WithBucketEncryptionEnabled(true),
 		aws.WithSnsTopicEncryptionEnabled(true),
 		aws.WithSqsEncryptionEnabled(true),
@@ -249,7 +249,7 @@ func TestGenerationAwsAdvancedOptsConsolidated(t *testing.T) {
 	assert.Contains(t, final, "Terraform code saved in")
 
 	// Create the TF directly with lwgenerate and validate same result via CLI
-	buildTf, _ := aws.NewTerraform(region, true, true, true,
+	buildTf, _ := aws.NewTerraform(region, false, true, true, true,
 		aws.UseConsolidatedCloudtrail(),
 		aws.WithBucketEncryptionEnabled(true),
 		aws.WithSnsTopicEncryptionEnabled(true),
@@ -302,7 +302,7 @@ func TestGenerationAwsAdvancedOptsUseExistingCloudtrail(t *testing.T) {
 	assert.Contains(t, final, "Terraform code saved in")
 
 	// Create the TF directly with lwgenerate and validate same result via CLI
-	buildTf, _ := aws.NewTerraform(region, true, true, true,
+	buildTf, _ := aws.NewTerraform(region, false, true, true, true,
 		aws.ExistingCloudtrailBucketArn("arn:aws:s3:::bucket_name"),
 		aws.WithBucketEncryptionEnabled(true),
 		aws.WithSnsTopicEncryptionEnabled(true),
@@ -367,7 +367,7 @@ func TestGenerationAwsAdvancedOptsConsolidatedWithSubAccounts(t *testing.T) {
 	assert.Contains(t, final, "Terraform code saved in")
 
 	// Create the TF directly with lwgenerate and validate same result via CLI
-	buildTf, _ := aws.NewTerraform(region, true, true, true,
+	buildTf, _ := aws.NewTerraform(region, false, true, true, true,
 		aws.UseConsolidatedCloudtrail(),
 		aws.WithAwsProfile("default"),
 		aws.WithSubaccounts(aws.NewAwsSubAccount("account1", "us-east-1"), aws.NewAwsSubAccount("account2", "us-east-2")),
@@ -416,7 +416,7 @@ func TestGenerationAwsAdvancedOptsConfigWithSubAccounts(t *testing.T) {
 	assert.Contains(t, final, "Terraform code saved in")
 
 	// Create the TF directly with lwgenerate and validate same result via CLI
-	buildTf, _ := aws.NewTerraform(region, false, true, false,
+	buildTf, _ := aws.NewTerraform(region, false, false, true, false,
 		aws.WithAwsProfile("default"),
 		aws.WithSubaccounts(aws.NewAwsSubAccount("account1", "us-east-1"), aws.NewAwsSubAccount("account2", "us-east-2")),
 	).Generate()
@@ -467,7 +467,7 @@ func TestGenerationAwsAdvancedOptsConsolidatedWithSubAccountsPassedByFlag(t *tes
 	assert.Contains(t, final, "Terraform code saved in")
 
 	// Create the TF directly with lwgenerate and validate same result via CLI
-	buildTf, _ := aws.NewTerraform(region, true, true, true,
+	buildTf, _ := aws.NewTerraform(region, false, true, true, true,
 		aws.UseConsolidatedCloudtrail(),
 		aws.WithAwsProfile("default"),
 		aws.WithSubaccounts(aws.NewAwsSubAccount("account1", "us-east-1"), aws.NewAwsSubAccount("account2", "us-east-2")),
@@ -515,7 +515,7 @@ func TestGenerationAwsAdvancedOptsUseExistingIAM(t *testing.T) {
 	assert.Contains(t, final, "Terraform code saved in")
 
 	// Create the TF directly with lwgenerate and validate same result via CLI
-	buildTf, _ := aws.NewTerraform(region, true, true, true,
+	buildTf, _ := aws.NewTerraform(region, false, true, true, true,
 		aws.UseExistingIamRole(aws.NewExistingIamRoleDetails(roleName, roleArn, roleExtId)),
 		aws.WithBucketEncryptionEnabled(true),
 		aws.WithSnsTopicEncryptionEnabled(true),
@@ -566,7 +566,7 @@ func TestGenerationAwsAdvancedOptsUseExistingElements(t *testing.T) {
 	assert.Contains(t, final, "Terraform code saved in")
 
 	// Create the TF directly with lwgenerate and validate same result via CLI
-	buildTf, _ := aws.NewTerraform(region, true, true, true,
+	buildTf, _ := aws.NewTerraform(region, false, true, true, true,
 		aws.ExistingCloudtrailBucketArn(bucketArn),
 		aws.ExistingSnsTopicArn(topicArn),
 		aws.WithSqsEncryptionEnabled(true),
@@ -628,7 +628,7 @@ func TestGenerationAwsAdvancedOptsCreateNewElements(t *testing.T) {
 	assert.Contains(t, final, "Terraform code saved in")
 
 	// Create the TF directly with lwgenerate and validate same result via CLI
-	buildTf, _ := aws.NewTerraform(region, true, true, true,
+	buildTf, _ := aws.NewTerraform(region, false, true, true, true,
 		aws.WithCloudtrailName(trailName),
 		aws.WithBucketName(bucketName),
 		aws.WithBucketEncryptionEnabled(true),
@@ -833,7 +833,7 @@ func TestGenerationAwsLaceworkProfile(t *testing.T) {
 	assert.Nil(t, runError)
 	assert.Contains(t, final, "Terraform code saved in")
 
-	buildTf, _ := aws.NewTerraform(region, true, true, true,
+	buildTf, _ := aws.NewTerraform(region, false, true, true, true,
 		aws.WithLaceworkProfile(awsProfile),
 	).Generate()
 	assert.Equal(t, buildTf, tfResult)
@@ -868,7 +868,7 @@ func TestGenerationAwsS3BucketNotification(t *testing.T) {
 	assert.Nil(t, runError)
 	assert.Contains(t, final, "Terraform code saved in")
 
-	buildTf, _ := aws.NewTerraform(region, false, false, true,
+	buildTf, _ := aws.NewTerraform(region, false, false, false, true,
 		aws.WithS3BucketNotification(true),
 	).Generate()
 	assert.Equal(t, buildTf, tfResult)
@@ -924,7 +924,7 @@ func TestGenerationAwsS3BucketNotificationInteractive(t *testing.T) {
 	assert.Nil(t, runError)
 	assert.Contains(t, final, "Terraform code saved in")
 
-	buildTf, _ := aws.NewTerraform(region, false, false, true,
+	buildTf, _ := aws.NewTerraform(region, false, false, false, true,
 		aws.WithS3BucketNotification(true),
 	).Generate()
 	assert.Equal(t, buildTf, tfResult)
@@ -965,7 +965,7 @@ func TestGenerationAgentlessOrganization(t *testing.T) {
 	assert.Contains(t, final, "Terraform code saved in")
 
 	// Create the TF directly with lwgenerate and validate same result via CLI
-	buildTf, _ := aws.NewTerraform(region, true, false, false,
+	buildTf, _ := aws.NewTerraform(region, true, true, false, false,
 		aws.UseConsolidatedCloudtrail(),
 		aws.WithAwsProfile("default-profile"),
 		aws.WithAgentlessManagementAccountID("123456789000"),

--- a/integration/aws_generation_test.go
+++ b/integration/aws_generation_test.go
@@ -951,6 +951,12 @@ func TestGenerationAgentlessOrganization(t *testing.T) {
 				MsgRsp{cmd.QuestionPrimaryAwsAccountProfile, "main"},
 				MsgRsp{cmd.QuestionAgentlessManagementAccountID, "123456789000"},
 				MsgRsp{cmd.QuestionAgentlessMonitoredAccountIDs, "123456789000,ou-abcd-12345678,r-abcd"},
+				MsgRsp{cmd.QuestionAgentlessMonitoredAccountProfile, "monitored-account-1"},
+				MsgRsp{cmd.QuestionAgentlessMonitoredAccountRegion, "us-west-2"},
+				MsgRsp{cmd.QuestionAgentlessMonitoredAccountAddMore, "y"},
+				MsgRsp{cmd.QuestionAgentlessMonitoredAccountProfile, "monitored-account-2"},
+				MsgRsp{cmd.QuestionAgentlessMonitoredAccountRegion, "us-east-1"},
+				MsgRsp{cmd.QuestionAgentlessMonitoredAccountAddMore, "n"},
 				MsgRsp{cmd.QuestionAwsAnotherAdvancedOpt, "y"},
 				MsgMenu{cmd.AwsAdvancedOptDone, 1},
 				MsgRsp{cmd.QuestionPrimaryAwsAccountProfile, "main"},
@@ -979,7 +985,14 @@ func TestGenerationAgentlessOrganization(t *testing.T) {
 		aws.WithAwsProfile("main"),
 		aws.WithAgentlessManagementAccountID("123456789000"),
 		aws.WithAgentlessMonitoredAccountIDs([]string{"123456789000", "ou-abcd-12345678", "r-abcd"}),
-		aws.WithSubaccounts(aws.NewAwsSubAccount("account1", "us-east-1"), aws.NewAwsSubAccount("account2", "us-east-2")),
+		aws.WithAgentlessMonitoredAccounts(
+			aws.NewAwsSubAccount("monitored-account-1", "us-west-2"),
+			aws.NewAwsSubAccount("monitored-account-2", "us-east-1"),
+		),
+		aws.WithSubaccounts(
+			aws.NewAwsSubAccount("account1", "us-east-1"),
+			aws.NewAwsSubAccount("account2", "us-east-2"),
+		),
 	).Generate()
 	assert.Equal(t, buildTf, tfResult)
 }

--- a/integration/aws_generation_test.go
+++ b/integration/aws_generation_test.go
@@ -930,8 +930,8 @@ func TestGenerationAwsS3BucketNotificationInteractive(t *testing.T) {
 	assert.Equal(t, buildTf, tfResult)
 }
 
-// Test using agentless with monitored accounts
-func TestGenerationAgentlessWithMonitoredAccounts(t *testing.T) {
+// Test Agentless organization integration
+func TestGenerationAgentlessOrganization(t *testing.T) {
 	os.Setenv("LW_NOCACHE", "true")
 	defer os.Setenv("LW_NOCACHE", "")
 	var final string
@@ -947,17 +947,10 @@ func TestGenerationAgentlessWithMonitoredAccounts(t *testing.T) {
 				MsgRsp{cmd.QuestionAwsRegion, region},
 				MsgRsp{cmd.QuestionAwsConfigAdvanced, "y"},
 				MsgMenu{cmd.AwsAdvancedOptDone, 0},
-				MsgRsp{cmd.QuestionAgentlessName, "custom_agentless_name"},
-				MsgRsp{cmd.QuestionEnableAgentlessMultiAccount, "y"},
+				MsgRsp{cmd.QuestionEnableAgentlessOrganization, "y"},
+				MsgRsp{cmd.QuestionPrimaryAwsAccountProfile, "default-profile"},
 				MsgRsp{cmd.QuestionAgentlessManagementAccountID, "123456789000"},
-				MsgRsp{cmd.QuestionAgentlessMonitoredAccountID, "123456789001"},
-				MsgRsp{cmd.QuestionAgentlessMonitoredAccountProfile, "monitored-account-1"},
-				MsgRsp{cmd.QuestionAgentlessMonitoredAccountRegion, "us-east-1"},
-				MsgRsp{cmd.QuestionAgentlessMonitoredAccountAddMore, "y"},
-				MsgRsp{cmd.QuestionAgentlessMonitoredAccountID, "123456789002"},
-				MsgRsp{cmd.QuestionAgentlessMonitoredAccountProfile, "monitored-account-2"},
-				MsgRsp{cmd.QuestionAgentlessMonitoredAccountRegion, "us-east-2"},
-				MsgRsp{cmd.QuestionAgentlessMonitoredAccountAddMore, "n"},
+				MsgRsp{cmd.QuestionAgentlessMonitoredAccountIDs, "123456789000,ou-abcd-12345678,r-abcd"},
 				MsgRsp{cmd.QuestionAwsAnotherAdvancedOpt, "n"},
 				MsgRsp{cmd.QuestionRunTfPlan, "n"},
 			})
@@ -972,14 +965,11 @@ func TestGenerationAgentlessWithMonitoredAccounts(t *testing.T) {
 	assert.Contains(t, final, "Terraform code saved in")
 
 	// Create the TF directly with lwgenerate and validate same result via CLI
-	buildTf, _ := aws.NewTerraform(region, true, true, true,
+	buildTf, _ := aws.NewTerraform(region, true, false, false,
 		aws.UseConsolidatedCloudtrail(),
-		aws.WithAwsProfile("default"),
-		aws.WithAgentlessName("custom_agentless_name"),
-		aws.WithAgentlessMonitoredAccounts(
-			aws.AwsSubAccount{AwsProfile: "monitored-account-1", AwsRegion: "us-east-1", AccountID: "123456789001"},
-			aws.AwsSubAccount{AwsProfile: "monitored-account-2", AwsRegion: "us-east-2", AccountID: "123456789002"},
-		),
+		aws.WithAwsProfile("default-profile"),
+		aws.WithAgentlessManagementAccountID("123456789000"),
+		aws.WithAgentlessMonitoredAccountIDs([]string{"123456789000", "ou-abcd-12345678", "r-abcd"}),
 	).Generate()
 	assert.Equal(t, buildTf, tfResult)
 }

--- a/integration/test_resources/help/generate_cloud-account_aws
+++ b/integration/test_resources/help/generate_cloud-account_aws
@@ -25,35 +25,38 @@ Available Commands:
   controltower Generate and/or execute Terraform code for ControlTower integration
 
 Flags:
-      --agentless                             enable agentless integration
-      --apply                                 run terraform apply without executing plan or prompting
-      --aws_assume_role string                specify aws assume role
-      --aws_profile string                    specify aws profile
-      --aws_region string                     specify aws region
-      --aws_subaccount strings                configure an additional aws account; value format must be <aws profile>:<region>
-      --bucket_encryption_enabled             enable S3 bucket encryption when creating bucket (default true)
-      --bucket_name string                    specify bucket name when creating bucket
-      --bucket_sse_key_arn string             specify existing KMS encryption key arn for bucket
-      --cloudtrail                            enable cloudtrail integration
-      --cloudtrail_name string                specify name of cloudtrail integration
-      --config                                enable config integration
-      --config_name string                    specify name of config integration
-      --consolidated_cloudtrail               use consolidated trail
-      --existing_bucket_arn string            specify existing cloudtrail S3 bucket ARN
-      --existing_iam_role_arn string          specify existing iam role arn to use
-      --existing_iam_role_externalid string   specify existing iam role external_id to use
-      --existing_iam_role_name string         specify existing iam role name to use
-      --existing_sns_topic_arn string         specify existing SNS topic arn
-  -h, --help                                  help for aws
-      --lacework_aws_account_id string        the Lacework AWS root account id
-      --output string                         location to write generated content (default is ~/lacework/aws)
-      --sns_topic_encryption_enabled          enable encryption on SNS topic when creating one (default true)
-      --sns_topic_encryption_key_arn string   specify existing KMS encryption key arn for SNS topic
-      --sns_topic_name string                 specify SNS topic name if creating new one
-      --sqs_encryption_enabled                enable encryption on SQS queue when creating (default true)
-      --sqs_encryption_key_arn string         specify existing KMS encryption key arn for SQS queue
-      --sqs_queue_name string                 specify SQS queue name if creating new one
-      --use_s3_bucket_notification            enable S3 bucket notifications
+      --agentless                                 enable agentless integration
+      --agentless_management_account_id string    AWS management account ID for Agentless integration
+      --agentless_monitored_account_ids strings   AWS monitored account IDs for Agentless integrations
+      --apply                                     run terraform apply without executing plan or prompting
+      --aws_organization                          enable organization integration
+      --aws_assume_role string                    specify aws assume role
+      --aws_profile string                        specify aws profile
+      --aws_region string                         specify aws region
+      --aws_subaccount strings                    configure an additional aws account; value format must be <aws profile>:<region>
+      --bucket_encryption_enabled                 enable S3 bucket encryption when creating bucket (default true)
+      --bucket_name string                        specify bucket name when creating bucket
+      --bucket_sse_key_arn string                 specify existing KMS encryption key arn for bucket
+      --cloudtrail                                enable cloudtrail integration
+      --cloudtrail_name string                    specify name of cloudtrail integration
+      --config                                    enable config integration
+      --config_name string                        specify name of config integration
+      --consolidated_cloudtrail                   use consolidated trail
+      --existing_bucket_arn string                specify existing cloudtrail S3 bucket ARN
+      --existing_iam_role_arn string              specify existing iam role arn to use
+      --existing_iam_role_externalid string       specify existing iam role external_id to use
+      --existing_iam_role_name string             specify existing iam role name to use
+      --existing_sns_topic_arn string             specify existing SNS topic arn
+  -h, --help                                      help for aws
+      --lacework_aws_account_id string            the Lacework AWS root account id
+      --output string                             location to write generated content (default is ~/lacework/aws)
+      --sns_topic_encryption_enabled              enable encryption on SNS topic when creating one (default true)
+      --sns_topic_encryption_key_arn string       specify existing KMS encryption key arn for SNS topic
+      --sns_topic_name string                     specify SNS topic name if creating new one
+      --sqs_encryption_enabled                    enable encryption on SQS queue when creating (default true)
+      --sqs_encryption_key_arn string             specify existing KMS encryption key arn for SQS queue
+      --sqs_queue_name string                     specify SQS queue name if creating new one
+      --use_s3_bucket_notification                enable S3 bucket notifications
 
 Global Flags:
   -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)

--- a/integration/test_resources/help/generate_cloud-account_aws
+++ b/integration/test_resources/help/generate_cloud-account_aws
@@ -29,8 +29,8 @@ Flags:
       --agentless_management_account_id string    AWS management account ID for Agentless integration
       --agentless_monitored_account_ids strings   AWS monitored account IDs for Agentless integrations
       --apply                                     run terraform apply without executing plan or prompting
-      --aws_organization                          enable organization integration
       --aws_assume_role string                    specify aws assume role
+      --aws_organization                          enable organization integration
       --aws_profile string                        specify aws profile
       --aws_region string                         specify aws region
       --aws_subaccount strings                    configure an additional aws account; value format must be <aws profile>:<region>

--- a/integration/test_resources/help/generate_cloud-account_aws_controltower
+++ b/integration/test_resources/help/generate_cloud-account_aws_controltower
@@ -45,8 +45,8 @@ Global Flags:
   -k, --api_key string                            access key id
   -s, --api_secret string                         secret access key
       --api_token string                          access token (replaces the use of api_key and api_secret)
-      --aws_organization                          enable organization integration
       --aws_assume_role string                    specify aws assume role
+      --aws_organization                          enable organization integration
       --aws_profile string                        specify aws profile
       --aws_region string                         specify aws region
       --aws_subaccount strings                    configure an additional aws account; value format must be <aws profile>:<region>

--- a/integration/test_resources/help/generate_cloud-account_aws_controltower
+++ b/integration/test_resources/help/generate_cloud-account_aws_controltower
@@ -38,39 +38,42 @@ Flags:
       --sqs_queue_name string            specify the name of the sqs queue
 
 Global Flags:
-  -a, --account string                        account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
-      --agentless                             enable agentless integration
-  -k, --api_key string                        access key id
-  -s, --api_secret string                     secret access key
-      --api_token string                      access token (replaces the use of api_key and api_secret)
-      --aws_assume_role string                specify aws assume role
-      --aws_profile string                    specify aws profile
-      --aws_region string                     specify aws region
-      --aws_subaccount strings                configure an additional aws account; value format must be <aws profile>:<region>
-      --bucket_encryption_enabled             enable S3 bucket encryption when creating bucket (default true)
-      --bucket_name string                    specify bucket name when creating bucket
-      --bucket_sse_key_arn string             specify existing KMS encryption key arn for bucket
-      --cloudtrail                            enable cloudtrail integration
-      --cloudtrail_name string                specify name of cloudtrail integration
-      --config                                enable config integration
-      --config_name string                    specify name of config integration
-      --consolidated_cloudtrail               use consolidated trail
-      --debug                                 turn on debug logging
-      --existing_bucket_arn string            specify existing cloudtrail S3 bucket ARN
-      --existing_iam_role_arn string          specify existing iam role arn to use
-      --existing_iam_role_externalid string   specify existing iam role external_id to use
-      --existing_iam_role_name string         specify existing iam role name to use
-      --existing_sns_topic_arn string         specify existing SNS topic arn
-      --json                                  switch commands output from human-readable to json format
-      --nocache                               turn off caching
-      --nocolor                               turn off colors
-      --noninteractive                        turn off interactive mode (disable spinners, prompts, etc.)
-      --organization                          access organization level data sets (org admins only)
-  -p, --profile string                        switch between profiles configured at ~/.lacework.toml
-      --sns_topic_encryption_enabled          enable encryption on SNS topic when creating one (default true)
-      --sns_topic_encryption_key_arn string   specify existing KMS encryption key arn for SNS topic
-      --sns_topic_name string                 specify SNS topic name if creating new one
-      --sqs_encryption_enabled                enable encryption on SQS queue when creating (default true)
-      --sqs_encryption_key_arn string         specify existing KMS encryption key arn for SQS queue
-      --subaccount string                     sub-account name inside your organization (org admins only)
-      --use_s3_bucket_notification            enable S3 bucket notifications
+  -a, --account string                            account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+      --agentless                                 enable agentless integration
+      --agentless_management_account_id string    AWS management account ID for Agentless integration
+      --agentless_monitored_account_ids strings   AWS monitored account IDs for Agentless integrations
+  -k, --api_key string                            access key id
+  -s, --api_secret string                         secret access key
+      --api_token string                          access token (replaces the use of api_key and api_secret)
+      --aws_organization                          enable organization integration
+      --aws_assume_role string                    specify aws assume role
+      --aws_profile string                        specify aws profile
+      --aws_region string                         specify aws region
+      --aws_subaccount strings                    configure an additional aws account; value format must be <aws profile>:<region>
+      --bucket_encryption_enabled                 enable S3 bucket encryption when creating bucket (default true)
+      --bucket_name string                        specify bucket name when creating bucket
+      --bucket_sse_key_arn string                 specify existing KMS encryption key arn for bucket
+      --cloudtrail                                enable cloudtrail integration
+      --cloudtrail_name string                    specify name of cloudtrail integration
+      --config                                    enable config integration
+      --config_name string                        specify name of config integration
+      --consolidated_cloudtrail                   use consolidated trail
+      --debug                                     turn on debug logging
+      --existing_bucket_arn string                specify existing cloudtrail S3 bucket ARN
+      --existing_iam_role_arn string              specify existing iam role arn to use
+      --existing_iam_role_externalid string       specify existing iam role external_id to use
+      --existing_iam_role_name string             specify existing iam role name to use
+      --existing_sns_topic_arn string             specify existing SNS topic arn
+      --json                                      switch commands output from human-readable to json format
+      --nocache                                   turn off caching
+      --nocolor                                   turn off colors
+      --noninteractive                            turn off interactive mode (disable spinners, prompts, etc.)
+      --organization                              access organization level data sets (org admins only)
+  -p, --profile string                            switch between profiles configured at ~/.lacework.toml
+      --sns_topic_encryption_enabled              enable encryption on SNS topic when creating one (default true)
+      --sns_topic_encryption_key_arn string       specify existing KMS encryption key arn for SNS topic
+      --sns_topic_name string                     specify SNS topic name if creating new one
+      --sqs_encryption_enabled                    enable encryption on SQS queue when creating (default true)
+      --sqs_encryption_key_arn string             specify existing KMS encryption key arn for SQS queue
+      --subaccount string                         sub-account name inside your organization (org admins only)
+      --use_s3_bucket_notification                enable S3 bucket notifications

--- a/lwgenerate/_examples/aws/main.go
+++ b/lwgenerate/_examples/aws/main.go
@@ -8,7 +8,7 @@ import (
 )
 
 func basic() {
-	hcl, err := aws.NewTerraform("us-east-1", true, true).Generate()
+	hcl, err := aws.NewTerraform("us-east-1", false, true, true, true).Generate()
 
 	if err != nil {
 		fmt.Println(err.Error())
@@ -21,6 +21,8 @@ func basic() {
 func customAwsProfile() {
 	hcl, err := aws.NewTerraform(
 		"us-east-1",
+		false,
+		true,
 		true,
 		true,
 		aws.WithAwsProfile("mycorp-profile")).Generate()
@@ -36,6 +38,8 @@ func customAwsProfile() {
 func consolidatedTrailWithSubAccounts() {
 	hcl, err := aws.NewTerraform(
 		"us-east-1",
+		false,
+		true,
 		true,
 		true,
 		aws.WithSubaccounts(

--- a/lwgenerate/aws/aws_test.go
+++ b/lwgenerate/aws/aws_test.go
@@ -51,6 +51,9 @@ func TestGenerationAgentlessOrganization(t *testing.T) {
 		WithAwsProfile("main"),
 		WithAgentlessManagementAccountID("123456789000"),
 		WithAgentlessMonitoredAccountIDs([]string{"123456789001", "ou-abcd-12345678"}),
+		WithAgentlessMonitoredAccounts(
+			NewAwsSubAccount("monitored-account-1", "us-west-2"),
+		),
 		WithSubaccounts(
 			NewAwsSubAccount("subaccount1", "us-east-1"),
 			NewAwsSubAccount("subaccount2", "us-east-2"),
@@ -526,6 +529,23 @@ provider "aws" {
   region  = "us-east-2"
 }
 
+provider "aws" {
+  alias   = "monitored-account-1"
+  profile = "monitored-account-1"
+  region  = "us-west-2"
+}
+
+module "lacework_aws_agentless_management_scanning_role" {
+  source                  = "lacework/agentless-scanning/aws"
+  version                 = "~> 0.6"
+  global_module_reference = module.lacework_aws_agentless_scanning_global
+  snapshot_role           = true
+
+  providers = {
+    aws = aws.main
+  }
+}
+
 module "lacework_aws_agentless_scanning_global" {
   source  = "lacework/agentless-scanning/aws"
   version = "~> 0.6"
@@ -552,14 +572,14 @@ module "lacework_aws_agentless_scanning_region_subaccount2" {
   }
 }
 
-module "lacework_aws_agentless_management_scanning_role" {
+module "lacework_aws_agentless_monitored_scanning_role_monitored-account-1" {
   source                  = "lacework/agentless-scanning/aws"
   version                 = "~> 0.6"
   global_module_reference = module.lacework_aws_agentless_scanning_global
   snapshot_role           = true
 
   providers = {
-    aws = aws.main
+    aws = aws.monitored-account-1
   }
 }
 

--- a/lwgenerate/aws/aws_test.go
+++ b/lwgenerate/aws/aws_test.go
@@ -25,28 +25,28 @@ func reqProviderAndRegion(extraInputs ...string) string {
 }
 
 func TestGenerationAgentless(t *testing.T) {
-	hcl, err := NewTerraform("us-east-2", true, false, false).Generate()
+	hcl, err := NewTerraform("us-east-2", false, true, false, false).Generate()
 	assert.Nil(t, err)
 	assert.NotNil(t, hcl)
 	assert.Equal(t, reqProviderAndRegion(moduleImportAgentless), hcl)
 }
 
 func TestGenerationCloudTrail(t *testing.T) {
-	hcl, err := NewTerraform("us-east-2", false, false, true).Generate()
+	hcl, err := NewTerraform("us-east-2", false, false, false, true).Generate()
 	assert.Nil(t, err)
 	assert.NotNil(t, hcl)
 	assert.Equal(t, reqProviderAndRegion(moduleImportCtWithoutConfig), hcl)
 }
 
 func TestGenerationConfig(t *testing.T) {
-	hcl, err := NewTerraform("us-east-2", false, true, false).Generate()
+	hcl, err := NewTerraform("us-east-2", false, false, true, false).Generate()
 	assert.Nil(t, err)
 	assert.NotNil(t, hcl)
 	assert.Equal(t, reqProviderAndRegion(moduleImportConfig), hcl)
 }
 
 func TestGenerationWithCustomAwsProfile(t *testing.T) {
-	hcl, err := NewTerraform("us-east-2", false, false, true, WithAwsProfile("myprofile")).Generate()
+	hcl, err := NewTerraform("us-east-2", false, false, false, true, WithAwsProfile("myprofile")).Generate()
 	assert.Nil(t, err)
 	assert.NotNil(t, hcl)
 	assert.Equal(
@@ -57,21 +57,21 @@ func TestGenerationWithCustomAwsProfile(t *testing.T) {
 }
 
 func TestGenerationAgentlessAndConfigAndCloudtrail(t *testing.T) {
-	hcl, err := NewTerraform("us-east-2", true, true, true).Generate()
+	hcl, err := NewTerraform("us-east-2", false, true, true, true).Generate()
 	assert.Nil(t, err)
 	assert.NotNil(t, hcl)
 	assert.Equal(t, reqProviderAndRegion(moduleImportConfig, moduleImportCtWithConfig, moduleImportAgentless), hcl)
 }
 
 func TestGenerationWithLaceworkProvider(t *testing.T) {
-	hcl, err := NewTerraform("us-east-2", false, false, true, WithLaceworkProfile("test-profile")).Generate()
+	hcl, err := NewTerraform("us-east-2", false, false, false, true, WithLaceworkProfile("test-profile")).Generate()
 	assert.Nil(t, err)
 	assert.NotNil(t, hcl)
 	assert.Equal(t, reqProviderAndRegion(laceworkProvider, moduleImportCtWithoutConfig), hcl)
 }
 
 func TestGenerationWithLaceworkAccountID(t *testing.T) {
-	hcl, err := NewTerraform("us-east-2", true, true, true, WithLaceworkAccountID("123456789")).Generate()
+	hcl, err := NewTerraform("us-east-2", false, true, true, true, WithLaceworkAccountID("123456789")).Generate()
 	assert.Nil(t, err)
 	assert.NotNil(t, hcl)
 	assert.Equal(t, reqProviderAndRegion(moduleImportConfigWithLaceworkAccountID, moduleImportCtWithLaceworkAccountID, moduleImportAgentless), hcl)
@@ -107,7 +107,7 @@ func TestGenerationCloudtrailExistingSns(t *testing.T) {
 func TestGenerationCloudtrailSnsWithEncryption(t *testing.T) {
 	snsTopicName := "sns-topic-name"
 	snsEncryptionArn := "arn:aws:kms:us-west-2:249446771485:key/2537e820-be82-4ded-8dca-504e199b0903"
-	hcl, err := NewTerraform("us-east-2", false, false, true,
+	hcl, err := NewTerraform("us-east-2", false, false, false, true,
 		WithSnsTopicName(snsTopicName),
 		WithSnsTopicEncryptionEnabled(true),
 		WithSnsTopicEncryptionKeyArn(snsEncryptionArn),
@@ -119,7 +119,7 @@ func TestGenerationCloudtrailSnsWithEncryption(t *testing.T) {
 
 func TestGenerationCloudtrailSnsWithNoEncryption(t *testing.T) {
 	snsTopicName := "sns-topic-name"
-	hcl, err := NewTerraform("us-east-2", false, false, true,
+	hcl, err := NewTerraform("us-east-2", false, false, false, true,
 		WithSnsTopicName(snsTopicName),
 		WithSnsTopicEncryptionEnabled(false),
 	).Generate()
@@ -130,7 +130,7 @@ func TestGenerationCloudtrailSnsWithNoEncryption(t *testing.T) {
 
 func TestGenerationCloudtrailSnsWithEncrytptionNotSet(t *testing.T) {
 	snsTopicName := "sns-topic-name"
-	hcl, err := NewTerraform("us-east-2", false, false, true,
+	hcl, err := NewTerraform("us-east-2", false, false, false, true,
 		WithSnsTopicName(snsTopicName),
 	).Generate()
 	assert.Nil(t, err)
@@ -141,7 +141,7 @@ func TestGenerationCloudtrailSnsWithEncrytptionNotSet(t *testing.T) {
 func TestGenerationCloudtrailSqsWithEncryption(t *testing.T) {
 	ssqQueueName := "sqs-queue-name"
 	sqsEncryptionArn := "arn:aws:kms:us-west-2:249446771485:key/2537e820-be82-4ded-8dca-504e199b0903"
-	hcl, err := NewTerraform("us-east-2", false, false, true,
+	hcl, err := NewTerraform("us-east-2", false, false, false, true,
 		WithSqsQueueName(ssqQueueName),
 		WithSqsEncryptionEnabled(true),
 		WithSqsEncryptionKeyArn(sqsEncryptionArn),
@@ -153,7 +153,7 @@ func TestGenerationCloudtrailSqsWithEncryption(t *testing.T) {
 
 func TestGenerationCloudtrailSqsWithNoEncryption(t *testing.T) {
 	ssqQueueName := "sqs-queue-name"
-	hcl, err := NewTerraform("us-east-2", false, false, true,
+	hcl, err := NewTerraform("us-east-2", false, false, false, true,
 		WithSqsQueueName(ssqQueueName),
 		WithSqsEncryptionEnabled(false),
 	).Generate()
@@ -164,7 +164,7 @@ func TestGenerationCloudtrailSqsWithNoEncryption(t *testing.T) {
 
 func TestGenerationCloudtrailSqsWithWithEncryptionNotSet(t *testing.T) {
 	ssqQueueName := "sqs-queue-name"
-	hcl, err := NewTerraform("us-east-2", false, false, true,
+	hcl, err := NewTerraform("us-east-2", false, false, false, true,
 		WithSqsQueueName(ssqQueueName),
 	).Generate()
 	assert.Nil(t, err)
@@ -178,7 +178,7 @@ func TestGenerationCloudtrailAllEncryptionElementsSet(t *testing.T) {
 	snsTopicName := "sns-topic-name"
 	ssqQueueName := "sqs-queue-name"
 	encryptionArn := "arn:aws:kms:us-west-2:249446771485:key/2537e820-be82-4ded-8dca-504e199b0903"
-	hcl, err := NewTerraform("us-east-2", false, false, true,
+	hcl, err := NewTerraform("us-east-2", false, false, false, true,
 		WithCloudtrailName(cloudTrailName),
 		WithBucketName(s3BucketName),
 		WithBucketEncryptionEnabled(true),
@@ -237,6 +237,7 @@ func TestGenerationCloudtrailExistingRole(t *testing.T) {
 
 func TestConsolidatedCtWithMultipleAccounts(t *testing.T) {
 	data, err := NewTerraform("us-east-2",
+		false,
 		true,
 		true,
 		true,
@@ -279,17 +280,17 @@ func TestGenerationFailureWithNoRegionSet(t *testing.T) {
 var iamErrorString = "invalid inputs: when using an existing IAM role, existing role ARN, name, and external ID all must be set"
 
 func TestGenerationFailureWithIncompleteExistingIam(t *testing.T) {
-	_, err := NewTerraform("us-east-2", false, false, true,
+	_, err := NewTerraform("us-east-2", false, false, false, true,
 		UseExistingIamRole(&ExistingIamRoleDetails{Arn: "foo"})).Generate()
 	assert.Error(t, err)
 	assert.Equal(t, iamErrorString, err.Error())
 
-	_, err = NewTerraform("us-east-2", false, false, true,
+	_, err = NewTerraform("us-east-2", false, false, false, true,
 		UseExistingIamRole(&ExistingIamRoleDetails{Name: "foo"})).Generate()
 	assert.Error(t, err)
 	assert.Equal(t, iamErrorString, err.Error())
 
-	_, err = NewTerraform("us-east-2", false, false, true,
+	_, err = NewTerraform("us-east-2", false, false, false, true,
 		UseExistingIamRole(&ExistingIamRoleDetails{ExternalId: "foo"})).Generate()
 	assert.Error(t, err)
 	assert.Equal(t, iamErrorString, err.Error())
@@ -315,7 +316,7 @@ func TestGenerationPartialExistingIamValues(t *testing.T) {
 }
 
 func TestGenerationCloudTrailS3BucketNotification(t *testing.T) {
-	hcl, err := NewTerraform("us-east-2", false, false, true, WithS3BucketNotification(true)).Generate()
+	hcl, err := NewTerraform("us-east-2", false, false, false, true, WithS3BucketNotification(true)).Generate()
 	assert.Nil(t, err)
 	assert.NotNil(t, hcl)
 	assert.Equal(

--- a/lwgenerate/aws/aws_test.go
+++ b/lwgenerate/aws/aws_test.go
@@ -341,6 +341,7 @@ var awsProvider = `provider "aws" {
 `
 
 var awsProviderWithProfile = `provider "aws" {
+  alias   = "main"
   profile = "myprofile"
   region  = "us-east-2"
 }

--- a/lwgenerate/hcl.go
+++ b/lwgenerate/hcl.go
@@ -234,6 +234,13 @@ func (m *HclResource) ToResourceBlock() (*hclwrite.Block, error) {
 		block.Body().SetAttributeTraversal("provider", CreateSimpleTraversal(m.providerDetails))
 	}
 
+	if m.blocks != nil {
+		for _, b := range m.blocks {
+			block.Body().AppendNewline()
+			block.Body().AppendBlock(b)
+		}
+	}
+
 	return block, nil
 }
 
@@ -251,6 +258,9 @@ type HclResource struct {
 	// accepted.  Unfortunately map[string]hcl.Traversal is not a format that is supported by hclwrite.SetAttributeValue
 	// today so we must work around it (https://github.com/hashicorp/hcl/issues/347).
 	providerDetails []string
+
+	// optional. Generic blocks
+	blocks []*hclwrite.Block
 }
 
 type HclResourceModifier func(p *HclResource)
@@ -270,6 +280,13 @@ func HclResourceWithAttributesAndProviderDetails(attrs map[string]interface{},
 	return func(p *HclResource) {
 		p.attributes = attrs
 		p.providerDetails = providerDetails
+	}
+}
+
+// HclResourceWithGenericBlocks sets the generic blocks within the resource
+func HclResourceWithGenericBlocks(blocks ...*hclwrite.Block) HclResourceModifier {
+	return func(p *HclResource) {
+		p.blocks = blocks
 	}
 }
 

--- a/lwgenerate/hcl.go
+++ b/lwgenerate/hcl.go
@@ -208,7 +208,7 @@ func (m *HclModule) ToBlock() (*hclwrite.Block, error) {
 
 	if m.providerDetails != nil {
 		block.Body().AppendNewline()
-		block.Body().SetAttributeRaw("providers", createMapTraversalTokens(m.providerDetails))
+		block.Body().SetAttributeRaw("providers", CreateMapTraversalTokens(m.providerDetails))
 	}
 
 	return block, nil
@@ -441,7 +441,7 @@ func HclCreateGenericBlock(hcltype string, labels []string, attr map[string]inte
 
 // Create tokens for map of traversals.  Used as a workaround for writing complex types where the built-in
 // SetAttributeValue won't work
-func createMapTraversalTokens(input map[string]string) hclwrite.Tokens {
+func CreateMapTraversalTokens(input map[string]string) hclwrite.Tokens {
 	// Sort input
 	var keys []string
 	for k := range input {


### PR DESCRIPTION
## Summary
- Base [PR](https://github.com/lacework/go-sdk/pull/1423)
- Support Agentless organization(multi-account) integration with auto snapshot. More details can be found [here](https://github.com/lacework/terraform-aws-agentless-scanning/blob/main/examples/multi-account-multi-region-auto-snapshot/README.md).

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## How did you test this change?
`make test`
`make integration-context-tests`

Run the noninteractive mode:
`lacework generate cloud-account aws --noninteractive --aws_organization --agentless --aws_region us-east-1 --agentless_management_account_id 123456789000 --agentless_monitored_account_ids 123456789000,ou-abcd-12345678,r-abcd --aws_subaccount subaccount1:us-east-2,subaccount2:us-east-3`

## Issue
https://lacework.atlassian.net/browse/GROW-2504
