### PR TITLE
feat(GROW-2487): v1 component commands

### DIFF
--- a/api/components.go
+++ b/api/components.go
@@ -22,6 +22,7 @@ type LatestComponentVersion struct {
 	Version       string `json:"version"`
 	Size          int64  `json:"size"`
 	ComponentType string `json:"type"`
+	Deprecated    bool   `json:"deprecated"`
 }
 
 func (svc *ComponentsService) ListComponents(os string, arch string) (response ListComponentsResponse, err error) {
@@ -41,6 +42,7 @@ type ComponentVersions struct {
 	Name           string   `json:"name"`
 	Description    string   `json:"description"`
 	Component_type string   `json:"type"`
+	Deprecated     bool     `json:"deprecated"`
 	Versions       []string `json:"versions"`
 }
 

--- a/lwcomponent/api_info.go
+++ b/lwcomponent/api_info.go
@@ -10,6 +10,8 @@ type ApiInfo interface {
 	LatestVersion() *semver.Version
 
 	AllVersions() []*semver.Version
+
+	Deprecated() bool
 }
 
 type apiInfo struct {
@@ -19,6 +21,7 @@ type apiInfo struct {
 	allVersions []*semver.Version
 	desc        string
 	sizeKB      int64
+	deprecated  bool
 }
 
 func NewAPIInfo(
@@ -28,6 +31,7 @@ func NewAPIInfo(
 	allVersions []*semver.Version,
 	desc string,
 	size int64,
+	deprecated bool,
 ) ApiInfo {
 	return &apiInfo{
 		id:          id,
@@ -36,6 +40,7 @@ func NewAPIInfo(
 		allVersions: allVersions,
 		desc:        desc,
 		sizeKB:      size,
+		deprecated:  deprecated,
 	}
 }
 
@@ -43,10 +48,17 @@ func (a *apiInfo) Id() int32 {
 	return a.id
 }
 
+// AllVersions implements ApiInfo.
+func (a *apiInfo) AllVersions() []*semver.Version {
+	return a.allVersions
+}
+
+// LatestVersion implements ApiInfo.
 func (a *apiInfo) LatestVersion() *semver.Version {
 	return &a.version
 }
 
-func (a *apiInfo) AllVersions() []*semver.Version {
-	return a.allVersions
+// Deprecated implements ApiInfo.
+func (a *apiInfo) Deprecated() bool {
+	return a.deprecated
 }

--- a/lwcomponent/api_info_test.go
+++ b/lwcomponent/api_info_test.go
@@ -17,7 +17,7 @@ func TestApiInfoId(t *testing.T) {
 
 	var id int32 = 23
 
-	info := lwcomponent.NewAPIInfo(id, "test", version, allVersions, "", 0)
+	info := lwcomponent.NewAPIInfo(id, "test", version, allVersions, "", 0, false)
 
 	result := info.Id()
 	assert.Equal(t, id, result)
@@ -32,7 +32,7 @@ func TestApiInfoLatestVersion(t *testing.T) {
 		panic(err)
 	}
 
-	info := lwcomponent.NewAPIInfo(1, "test", version, allVersions, "", 0)
+	info := lwcomponent.NewAPIInfo(1, "test", version, allVersions, "", 0, false)
 
 	result := info.LatestVersion()
 	assert.Equal(t, expectedVer, result.String())

--- a/lwcomponent/catalog_test.go
+++ b/lwcomponent/catalog_test.go
@@ -348,9 +348,9 @@ func TestCatalogGetComponent(t *testing.T) {
 		assert.Equal(t, version, ver.String())
 	})
 
-	t.Run("deprecated", func(t *testing.T) {
+	t.Run("installed deprecated", func(t *testing.T) {
 		var (
-			name    = "deprecated"
+			name    = "installed deprecated"
 			version = "1.1.0"
 		)
 
@@ -365,7 +365,7 @@ func TestCatalogGetComponent(t *testing.T) {
 		component, err := catalog.GetComponent(name)
 		assert.NotNil(t, component)
 		assert.Nil(t, err)
-		assert.Equal(t, lwcomponent.Deprecated, component.Status)
+		assert.Equal(t, lwcomponent.InstalledDeprecated, component.Status)
 
 		ver := component.InstalledVersion()
 		assert.Equal(t, version, ver.String())
@@ -408,8 +408,7 @@ func TestCatalogListComponentVersions(t *testing.T) {
 		assert.NotNil(t, component)
 		assert.Nil(t, err)
 
-		vers, err := catalog.ListComponentVersions(component)
-		assert.Nil(t, err)
+		vers := catalog.ListComponentVersions(component)
 
 		for idx, v := range versions {
 			assert.Equal(t, v, vers[idx].String())
@@ -810,10 +809,11 @@ func generateComponentsResponse(prefix string, count int) string {
 
 	for idx = 0; idx < int32(count); idx++ {
 		component := api.LatestComponentVersion{
-			Id:      idx,
-			Name:    fmt.Sprintf("%s-%d", prefix, idx),
-			Version: fmt.Sprintf("%d.0.0", idx),
-			Size:    512,
+			Id:         idx,
+			Name:       fmt.Sprintf("%s-%d", prefix, idx),
+			Version:    fmt.Sprintf("%d.0.0", idx),
+			Size:       512,
+			Deprecated: false,
 		}
 
 		components = append(components, component)
@@ -847,9 +847,10 @@ func generateInvalidComponentsResponse() string {
 func generateComponentVersionsResponse(name string, versions []string) string {
 	response := api.ListComponentVersionsResponse{
 		Data: []api.ComponentVersions{{
-			Id:       1,
-			Name:     name,
-			Versions: versions,
+			Id:         1,
+			Name:       name,
+			Deprecated: false,
+			Versions:   versions,
 		}},
 	}
 

--- a/lwcomponent/cdk_component.go
+++ b/lwcomponent/cdk_component.go
@@ -31,7 +31,7 @@ func NewCDKComponent(name string, componentType Type, apiInfo ApiInfo, hostInfo 
 	status := status(apiInfo, hostInfo)
 
 	switch status {
-	case Installed, UpdateAvailable, Deprecated, Development:
+	case Installed, UpdateAvailable, InstalledDeprecated, Development:
 		{
 			dir := hostInfo.Dir()
 
@@ -84,7 +84,7 @@ func (c *CDKComponent) PrintSummary() []string {
 	)
 
 	switch c.Status {
-	case Installed, Deprecated, Development, UpdateAvailable, Tainted:
+	case Installed, InstalledDeprecated, NotInstalledDeprecated, Development, UpdateAvailable, Tainted:
 		version, err = c.hostInfo.Version()
 		if err != nil {
 			panic(err)
@@ -123,6 +123,10 @@ func status(apiInfo ApiInfo, hostInfo HostInfo) Status {
 				return Tainted
 			}
 
+			if apiInfo.Deprecated() {
+				return InstalledDeprecated
+			}
+
 			latestVer := apiInfo.LatestVersion()
 			if latestVer.GreaterThan(installedVer) {
 				return UpdateAvailable
@@ -133,12 +137,16 @@ func status(apiInfo ApiInfo, hostInfo HostInfo) Status {
 			if hostInfo.Development() {
 				return Development
 			} else {
-				return Deprecated
+				return InstalledDeprecated
 			}
 		}
 	}
 
 	if apiInfo != nil && hostInfo == nil {
+		if apiInfo.Deprecated() {
+			return NotInstalledDeprecated
+		}
+
 		return NotInstalled
 	}
 

--- a/lwcomponent/cdk_component_test.go
+++ b/lwcomponent/cdk_component_test.go
@@ -25,7 +25,7 @@ func TestNewCDKComponent(t *testing.T) {
 		version, _ := semver.NewVersion("1.1.1")
 		allVersions := []*semver.Version{version}
 
-		apiInfo := lwcomponent.NewAPIInfo(1, name, version, allVersions, "", 1)
+		apiInfo := lwcomponent.NewAPIInfo(1, name, version, allVersions, "", 1, false)
 
 		component := lwcomponent.NewCDKComponent(name, lwcomponent.BinaryType, apiInfo, nil)
 
@@ -41,7 +41,7 @@ func TestNewCDKComponent(t *testing.T) {
 		version, _ := semver.NewVersion(ver)
 		allVersions := []*semver.Version{version}
 
-		apiInfo := lwcomponent.NewAPIInfo(1, name, version, allVersions, "", 1)
+		apiInfo := lwcomponent.NewAPIInfo(1, name, version, allVersions, "", 1, false)
 
 		CreateLocalComponent(name, ver, false)
 
@@ -65,7 +65,7 @@ func TestNewCDKComponent(t *testing.T) {
 		installedVersion, _ := semver.NewVersion(installVer)
 		allVersions := []*semver.Version{version, installedVersion}
 
-		apiInfo := lwcomponent.NewAPIInfo(1, name, version, allVersions, "", 1)
+		apiInfo := lwcomponent.NewAPIInfo(1, name, version, allVersions, "", 1, false)
 
 		CreateLocalComponent(name, installVer, false)
 
@@ -78,9 +78,9 @@ func TestNewCDKComponent(t *testing.T) {
 		assert.Equal(t, lwcomponent.UpdateAvailable, component.Status)
 	})
 
-	t.Run("Deprecated", func(t *testing.T) {
+	t.Run("Installed Deprecated No API", func(t *testing.T) {
 		var (
-			name string = "deprecated"
+			name string = "installed-deprecated-no-api"
 			ver  string = "1.1.1"
 		)
 
@@ -92,7 +92,43 @@ func TestNewCDKComponent(t *testing.T) {
 
 		component := lwcomponent.NewCDKComponent(name, lwcomponent.BinaryType, nil, hostInfo)
 
-		assert.Equal(t, lwcomponent.Deprecated, component.Status)
+		assert.Equal(t, lwcomponent.InstalledDeprecated, component.Status)
+	})
+
+	t.Run("Installed Deprecated API", func(t *testing.T) {
+		var (
+			name string = "installed-deprecated-api"
+			ver  string = "1.1.1"
+		)
+
+		version, _ := semver.NewVersion(ver)
+		allVersions := []*semver.Version{version}
+
+		CreateLocalComponent(name, ver, false)
+
+		apiInfo := lwcomponent.NewAPIInfo(1, name, version, allVersions, "", 1, true)
+
+		dir, _ := lwcomponent.CatalogCacheDir()
+		hostInfo := lwcomponent.NewHostInfo(filepath.Join(dir, name))
+
+		component := lwcomponent.NewCDKComponent(name, lwcomponent.BinaryType, apiInfo, hostInfo)
+
+		assert.Equal(t, lwcomponent.InstalledDeprecated, component.Status)
+	})
+
+	t.Run("Not Installed Deprecated", func(t *testing.T) {
+		var (
+			name string = "not-installed-deprecated"
+		)
+
+		version, _ := semver.NewVersion("1.1.1")
+		allVersions := []*semver.Version{version}
+
+		apiInfo := lwcomponent.NewAPIInfo(1, name, version, allVersions, "", 1, true)
+
+		component := lwcomponent.NewCDKComponent(name, lwcomponent.BinaryType, apiInfo, nil)
+
+		assert.Equal(t, lwcomponent.NotInstalledDeprecated, component.Status)
 	})
 
 	t.Run("Tainted", func(t *testing.T) {
@@ -105,7 +141,7 @@ func TestNewCDKComponent(t *testing.T) {
 		version, _ := semver.NewVersion(apiVer)
 		allVersions := []*semver.Version{version}
 
-		apiInfo := lwcomponent.NewAPIInfo(1, name, version, allVersions, "", 1)
+		apiInfo := lwcomponent.NewAPIInfo(1, name, version, allVersions, "", 1, false)
 
 		CreateLocalComponent(name, installVer, false)
 
@@ -144,7 +180,7 @@ func TestNewCDKComponent(t *testing.T) {
 		version, _ := semver.NewVersion(ver)
 		allVersions := []*semver.Version{version}
 
-		apiInfo := lwcomponent.NewAPIInfo(1, name, version, allVersions, "", 1)
+		apiInfo := lwcomponent.NewAPIInfo(1, name, version, allVersions, "", 1, false)
 
 		CreateLocalComponent(name, ver, false)
 
@@ -167,7 +203,7 @@ func TestNewCDKComponent(t *testing.T) {
 		version, _ := semver.NewVersion(ver)
 		allVersions := []*semver.Version{version}
 
-		apiInfo := lwcomponent.NewAPIInfo(1, name, version, allVersions, "", 1)
+		apiInfo := lwcomponent.NewAPIInfo(1, name, version, allVersions, "", 1, false)
 
 		CreateLocalComponent(name, ver, false)
 
@@ -190,7 +226,7 @@ func TestNewCDKComponent(t *testing.T) {
 		version, _ := semver.NewVersion(ver)
 		allVersions := []*semver.Version{version}
 
-		apiInfo := lwcomponent.NewAPIInfo(1, name, version, allVersions, "", 1)
+		apiInfo := lwcomponent.NewAPIInfo(1, name, version, allVersions, "", 1, false)
 
 		CreateLocalComponent(name, ver, false)
 
@@ -213,7 +249,7 @@ func TestNewCDKComponent(t *testing.T) {
 		version, _ := semver.NewVersion(ver)
 		allVersions := []*semver.Version{version}
 
-		apiInfo := lwcomponent.NewAPIInfo(1, name, version, allVersions, "", 1)
+		apiInfo := lwcomponent.NewAPIInfo(1, name, version, allVersions, "", 1, false)
 
 		CreateLocalComponent(name, ver, false)
 

--- a/lwcomponent/local_component.go
+++ b/lwcomponent/local_component.go
@@ -1,1 +1,0 @@
-package lwcomponent

--- a/lwcomponent/status.go
+++ b/lwcomponent/status.go
@@ -26,9 +26,10 @@ const (
 	UnknownStatus Status = iota
 	Development
 	NotInstalled
+	NotInstalledDeprecated
 	Installed
+	InstalledDeprecated
 	UpdateAvailable
-	Deprecated
 	Tainted
 )
 
@@ -42,7 +43,7 @@ func (s Status) Color() *color.Color {
 		return color.New(color.FgGreen, color.Bold)
 	case UpdateAvailable:
 		return color.New(color.FgYellow, color.Bold)
-	case Deprecated, Tainted:
+	case InstalledDeprecated, NotInstalledDeprecated, Tainted:
 		return color.New(color.FgRed, color.Bold)
 	default:
 		return color.New(color.FgRed, color.Bold)
@@ -53,16 +54,18 @@ func (s Status) String() string {
 	switch s {
 	case Development:
 		return "Development"
-	case NotInstalled:
-		return "Not Installed"
 	case Installed:
 		return "Installed"
+	case InstalledDeprecated:
+		return "Installed (Deprecated)"
+	case NotInstalled:
+		return "Not Installed"
+	case NotInstalledDeprecated:
+		return "Not Installed (Deprecated)"
+	case Tainted:
+		return "Tainted (Please update)"
 	case UpdateAvailable:
 		return "Update Available"
-	case Deprecated:
-		return "Deprecated"
-	case Tainted:
-		return "Tainted(Please update)"
 	default:
 		return "Unknown"
 	}


### PR DESCRIPTION
## Summary

CLI now loads v1 components along side the prototype code.  These v1 components can be executed.

## How did you test this change?

- configure the CLI to use the `customerdemo` env
- install `iac` + `sca` components
- switch the CLI to use the `qan` env
- install the `component-example` component

```
...
Commands from components:
  component-example
  iac                     Infrastructure as Code (IaC) scanner
  preflight               (dev-mode) preflight
  sca                     Software Component Analysis
...
```

```
> lacework component-example -v
component-example version 0.7.30
> lacework component-example
Hello, component!
```

## Issue

https://lacework.atlassian.net/browse/GROW-2487
