### PR TITLE
chore: use AlertRule subCategory in stead of eventCategory

### DIFF
--- a/api/_examples/alert-rules/main.go
+++ b/api/_examples/alert-rules/main.go
@@ -34,13 +34,13 @@ func main() {
 	}
 
 	rule := api.AlertRuleConfig{
-		Channels:        []string{"TECHALLY_000000000000AAAAAAAAAAAAAAAAAAAA"},
-		Description:     "This is a test alert rule",
-		Severities:      api.AlertRuleSeverities{api.AlertRuleSeverityHigh},
-		ResourceGroups:  []string{"TECHALLY_000000000000AAAAAAAAAAAAAAAAAAAA"},
-		EventCategories: []string{"Compliance"},
-		AlertCategories: []string{"Policy"},
-		AlertSources:    []string{"AWS"},
+		Channels:           []string{"TECHALLY_000000000000AAAAAAAAAAAAAAAAAAAA"},
+		Description:        "This is a test alert rule",
+		Severities:         api.AlertRuleSeverities{api.AlertRuleSeverityHigh},
+		ResourceGroups:     []string{"TECHALLY_000000000000AAAAAAAAAAAAAAAAAAAA"},
+		AlertSubCategories: []string{"Compliance"},
+		AlertCategories:    []string{"Policy"},
+		AlertSources:       []string{"AWS"},
 	}
 
 	myAlertRule := api.NewAlertRule("MyTestAlertRule",

--- a/api/alert_rules.go
+++ b/api/alert_rules.go
@@ -58,19 +58,6 @@ var AlertRuleSubCategories = []string{
 	"K8sActivity",
 }
 
-// var AlertRuleEventCategories = []string{
-// 	"Compliance",
-// 	"App",
-// 	"Cloud",
-// 	"File",
-// 	"Machine",
-// 	"User",
-// 	"Platform",
-// 	"K8sActivity",
-// 	"Registry",
-// 	"SystemCall",
-// }
-
 type alertRuleSeverity int
 
 type AlertRuleSeverities []alertRuleSeverity

--- a/api/alert_rules.go
+++ b/api/alert_rules.go
@@ -40,16 +40,36 @@ var AlertRuleCategories = []string{"Anomaly", "Policy", "Composite"}
 // Valid inputs for AlertRule SubCategories property
 var AlertRuleSubCategories = []string{
 	"Compliance",
-	"App",
-	"Cloud",
+	"Application",
+	"Cloud Activity",
 	"File",
 	"Machine",
 	"User",
 	"Platform",
-	"K8sActivity",
+	"Kubernetes Activity",
 	"Registry",
 	"SystemCall",
+	"Host Vulnerability",
+	"Container Vulnerability",
+	"Threat Intel",
+	// Deprecated eventCategory values
+	"App",
+	"Cloud",
+	"K8sActivity",
 }
+
+// var AlertRuleEventCategories = []string{
+// 	"Compliance",
+// 	"App",
+// 	"Cloud",
+// 	"File",
+// 	"Machine",
+// 	"User",
+// 	"Platform",
+// 	"K8sActivity",
+// 	"Registry",
+// 	"SystemCall",
+// }
 
 type alertRuleSeverity int
 
@@ -142,6 +162,24 @@ func convertSeverityInt(sev int) alertRuleSeverity {
 	}
 }
 
+// Convert deprecated eventCatory values to subCategory values
+func convertEventCategories(categories []string) []string {
+	var res []string
+	for _, c := range categories {
+		switch c {
+		case "App":
+			res = append(res, "Application")
+		case "Cloud":
+			res = append(res, "Cloud Activity")
+		case "K8sActivity":
+			res = append(res, "Kubernetes Activity")
+		default:
+			res = append(res, c)
+		}
+	}
+	return res
+}
+
 const (
 	AlertRuleSeverityCritical alertRuleSeverity = 1
 	AlertRuleSeverityHigh     alertRuleSeverity = 2
@@ -179,14 +217,14 @@ func NewAlertRule(name string, rule AlertRuleConfig) AlertRule {
 		Channels: rule.Channels,
 		Type:     AlertRuleEventType,
 		Filter: AlertRuleFilter{
-			Name:            name,
-			Enabled:         1,
-			Description:     rule.Description,
-			Severity:        rule.Severities.toInt(),
-			ResourceGroups:  rule.ResourceGroups,
-			EventCategories: rule.EventCategories,
-			AlertCategories: rule.AlertCategories,
-			AlertSources:    rule.AlertSources,
+			Name:               name,
+			Enabled:            1,
+			Description:        rule.Description,
+			Severity:           rule.Severities.toInt(),
+			ResourceGroups:     rule.ResourceGroups,
+			AlertSubCategories: convertEventCategories(rule.AlertSubCategories),
+			AlertCategories:    rule.AlertCategories,
+			AlertSources:       rule.AlertSources,
 		},
 	}
 }
@@ -251,13 +289,13 @@ func (svc *AlertRulesService) Get(guid string, response interface{}) error {
 }
 
 type AlertRuleConfig struct {
-	Channels        []string
-	Description     string
-	Severities      AlertRuleSeverities
-	ResourceGroups  []string
-	EventCategories []string
-	AlertCategories []string
-	AlertSources    []string
+	Channels           []string
+	Description        string
+	Severities         AlertRuleSeverities
+	ResourceGroups     []string
+	AlertSubCategories []string
+	AlertCategories    []string
+	AlertSources       []string
 }
 
 type AlertRule struct {
@@ -273,7 +311,7 @@ type AlertRuleFilter struct {
 	Description          string   `json:"description,omitempty"`
 	Severity             []int    `json:"severity"`
 	ResourceGroups       []string `json:"resourceGroups"`
-	EventCategories      []string `json:"eventCategory"`
+	AlertSubCategories   []string `json:"subCategory"`
 	AlertCategories      []string `json:"category"`
 	AlertSources         []string `json:"source,omitempty"`
 	CreatedOrUpdatedTime string   `json:"createdOrUpdatedTime,omitempty"`

--- a/api/alert_rules_test.go
+++ b/api/alert_rules_test.go
@@ -307,10 +307,10 @@ func singleMockAlertRule(id string) string {
             "severity": [
                 2
             ],
-            "eventCategory": [
+            "subCategory": [
                 "Compliance",
                 "SystemCall"
-			],
+            ],
             "category": [
                 "Policy",
                 "Anomaly"
@@ -320,7 +320,7 @@ func singleMockAlertRule(id string) string {
                 "Agent",
                 "K8s"
             ]
-	  },
+    },
       "mcGuid": %q,
         "intgGuidList": [
             "TECHALLY_000000000000AAAAAAAAAAAAAAAAAAAA"

--- a/api/alert_rules_test.go
+++ b/api/alert_rules_test.go
@@ -222,13 +222,13 @@ func TestAlertRuleUpdate(t *testing.T) {
 
 	alertRule := api.NewAlertRule("rule_name",
 		api.AlertRuleConfig{
-			Channels:        []string{"TECHALLY_000000000000AAAAAAAAAAAAAAAAAAAA"},
-			Description:     "This is a test alert rule",
-			Severities:      api.AlertRuleSeverities{api.AlertRuleSeverityHigh},
-			ResourceGroups:  []string{"TECHALLY_100000000000AAAAAAAAAAAAAAAAAAAB"},
-			EventCategories: []string{"Compliance", "SystemCall"},
-			AlertSources:    []string{"AWS", "Agent", "K8s"},
-			AlertCategories: []string{"Policy", "Anomaly"},
+			Channels:           []string{"TECHALLY_000000000000AAAAAAAAAAAAAAAAAAAA"},
+			Description:        "This is a test alert rule",
+			Severities:         api.AlertRuleSeverities{api.AlertRuleSeverityHigh},
+			ResourceGroups:     []string{"TECHALLY_100000000000AAAAAAAAAAAAAAAAAAAB"},
+			AlertSubCategories: []string{"Compliance", "SystemCall"},
+			AlertSources:       []string{"AWS", "Agent", "K8s"},
+			AlertCategories:    []string{"Policy", "Anomaly"},
 		},
 	)
 	assert.Equal(t, "rule_name", alertRule.Filter.Name, "alert rule name mismatch")
@@ -240,7 +240,7 @@ func TestAlertRuleUpdate(t *testing.T) {
 	if assert.NoError(t, err) {
 		assert.NotNil(t, response)
 		assert.Equal(t, intgGUID, response.Data.Guid)
-		assert.Contains(t, response.Data.Filter.EventCategories, "Compliance", "SystemCall")
+		assert.Contains(t, response.Data.Filter.AlertSubCategories, "Compliance", "SystemCall")
 		assert.Contains(t, response.Data.Filter.AlertCategories, "Policy", "Anomaly")
 		assert.Contains(t, response.Data.Filter.AlertSources, "AWS", "Agent", "K8s")
 		assert.Contains(t, response.Data.Filter.ResourceGroups, "TECHALLY_100000000000AAAAAAAAAAAAAAAAAAAB")

--- a/cli/cmd/alert_rules.go
+++ b/cli/cmd/alert_rules.go
@@ -38,7 +38,7 @@ var (
 		Use:     "alert-rule",
 		Aliases: []string{"alert-rules", "ar"},
 		Short:   "Manage alert rules",
-		Long: `Manage alert rules to route events to the appropriate people or tools.		
+		Long: `Manage alert rules to route events to the appropriate people or tools.
 
 An alert rule has three parts:
 
@@ -176,7 +176,7 @@ func buildAlertRuleDetailsTable(rule api.AlertRule) string {
 		updatedTime = time.Unix(nano/1000, 0).Format(time.RFC3339)
 	}
 	details = append(details, []string{"SEVERITIES", strings.Join(severities, ", ")})
-	details = append(details, []string{"EVENT CATEGORIES", strings.Join(rule.Filter.EventCategories, ", ")})
+	details = append(details, []string{"EVENT CATEGORIES", strings.Join(rule.Filter.AlertSubCategories, ", ")})
 	details = append(details, []string{"DESCRIPTION", rule.Filter.Description})
 	details = append(details, []string{"UPDATED BY", rule.Filter.CreatedOrUpdatedBy})
 	details = append(details, []string{"LAST UPDATED", updatedTime})
@@ -298,12 +298,12 @@ func promptCreateAlertRule() (api.AlertRuleResponse, error) {
 	alertRule := api.NewAlertRule(
 		answers.Name,
 		api.AlertRuleConfig{
-			Description:     answers.Description,
-			Channels:        channels,
-			Severities:      api.NewAlertRuleSeverities(answers.Severities),
-			EventCategories: answers.EventCategories,
-			AlertCategories: alertCategories,
-			ResourceGroups:  groups,
+			Description:        answers.Description,
+			Channels:           channels,
+			Severities:         api.NewAlertRuleSeverities(answers.Severities),
+			AlertSubCategories: answers.EventCategories,
+			AlertCategories:    alertCategories,
+			ResourceGroups:     groups,
 		})
 
 	cli.StartProgress(" Creating alert rule...")

--- a/integration/alert_rules_test.go
+++ b/integration/alert_rules_test.go
@@ -108,12 +108,12 @@ func createAlertRuleWithSlackAlertChannel() (alertRule api.AlertRuleResponse, er
 	}
 
 	rule := api.NewAlertRule("Alert Rule Test", api.AlertRuleConfig{
-		Channels:        []string{slackChannel},
-		Description:     "This is a test Alert Rule",
-		Severities:      api.NewAlertRuleSeverities([]string{"Critical", "High"}),
-		EventCategories: []string{"Compliance"},
-		AlertCategories: []string{},
-		ResourceGroups:  []string{},
+		Channels:           []string{slackChannel},
+		Description:        "This is a test Alert Rule",
+		Severities:         api.NewAlertRuleSeverities([]string{"Critical", "High"}),
+		AlertSubCategories: []string{"Compliance"},
+		AlertCategories:    []string{},
+		ResourceGroups:     []string{},
 	})
 
 	return lacework.V2.AlertRules.Create(rule)

--- a/integration/test_resources/help/alert-rule
+++ b/integration/test_resources/help/alert-rule
@@ -1,4 +1,4 @@
-Manage alert rules to route events to the appropriate people or tools.		
+Manage alert rules to route events to the appropriate people or tools.
 
 An alert rule has three parts:
 


### PR DESCRIPTION
## Summary

- `eventCategory` is deprecated. A new field `subCategory` is added to the AlertRules API in [#14700](https://github.com/lacework/rainbow/pull/14700).
- There are 3 eventCategory values that are not in sync with subCategories: `App`, `Cloud` and `K8sActivity`. To support them for existing users, they are converted to corresponding subCategory values.

## How did you test this change?
`make test`
`make integration-context-tests`

## Issue
https://lacework.atlassian.net/browse/GROW-2490
