### PR TITLE
feat(cdk): expose LW_PROFILE to components

### DIFF
--- a/cli/cmd/cdk.go
+++ b/cli/cmd/cdk.go
@@ -35,6 +35,7 @@ const defaultGrpcPort int = 1123
 // envs are all the environment variables passed to CDK components
 func (c *cliState) envs() []string {
 	return []string{
+		fmt.Sprintf("LW_PROFILE=%s", c.Profile),
 		fmt.Sprintf("LW_ACCOUNT=%s", c.Account),
 		fmt.Sprintf("LW_SUBACCOUNT=%s", c.Subaccount),
 		fmt.Sprintf("LW_API_KEY=%s", c.KeyID),


### PR DESCRIPTION


## Summary

Components might need to know the loaded profile to build other CLI commands,
this PR exposes the profile via environment variables.

https://lacework.atlassian.net/l/cp/GJYdDTXH

## How did you test this change?

Used the `preflight` component.

## Issue

N/A