### PR TITLE
fix(GROW-2556): enable azure storage account infra encryption

### DIFF
--- a/lwgenerate/azure/azure.go
+++ b/lwgenerate/azure/azure.go
@@ -468,6 +468,12 @@ func createActivityLog(args *GenerateAzureTfConfigurationArgs) ([]*hclwrite.Bloc
 			attributes["storage_account_resource_group"] = args.StorageAccountResourceGroup
 		}
 
+		// if a new storage account is being created (i.e., ExistingStorageAccount is false), enable infrastructure
+		// encryption
+		if !args.ExistingStorageAccount {
+			attributes["infrastructure_encryption_enabled"] = true
+		}
+
 		// Set the location if needed
 		if args.StorageLocation != "" {
 			attributes["location"] = args.StorageLocation

--- a/lwgenerate/azure/test-data/activity-log-with-all-subscriptions.tf
+++ b/lwgenerate/azure/test-data/activity-log-with-all-subscriptions.tf
@@ -21,11 +21,12 @@ module "az_ad_application" {
 }
 
 module "az_activity_log" {
-  source                      = "lacework/activity-log/azure"
-  version                     = "~> 2.0"
-  all_subscriptions           = true
-  application_id              = module.az_ad_application.application_id
-  application_password        = module.az_ad_application.application_password
-  service_principal_id        = module.az_ad_application.service_principal_id
-  use_existing_ad_application = true
+  source                            = "lacework/activity-log/azure"
+  version                           = "~> 2.0"
+  all_subscriptions                 = true
+  application_id                    = module.az_ad_application.application_id
+  application_password              = module.az_ad_application.application_password
+  infrastructure_encryption_enabled = true
+  service_principal_id              = module.az_ad_application.service_principal_id
+  use_existing_ad_application       = true
 }

--- a/lwgenerate/azure/test-data/activity-log-with-lacework-profile.tf
+++ b/lwgenerate/azure/test-data/activity-log-with-lacework-profile.tf
@@ -25,10 +25,11 @@ module "az_ad_application" {
 }
 
 module "az_activity_log" {
-  source                      = "lacework/activity-log/azure"
-  version                     = "~> 2.0"
-  application_id              = module.az_ad_application.application_id
-  application_password        = module.az_ad_application.application_password
-  service_principal_id        = module.az_ad_application.service_principal_id
-  use_existing_ad_application = true
+  source                            = "lacework/activity-log/azure"
+  version                           = "~> 2.0"
+  application_id                    = module.az_ad_application.application_id
+  application_password              = module.az_ad_application.application_password
+  infrastructure_encryption_enabled = true
+  service_principal_id              = module.az_ad_application.service_principal_id
+  use_existing_ad_application       = true
 }

--- a/lwgenerate/azure/test-data/activity-log-with-list-subscriptions.tf
+++ b/lwgenerate/azure/test-data/activity-log-with-list-subscriptions.tf
@@ -21,11 +21,12 @@ module "az_ad_application" {
 }
 
 module "az_activity_log" {
-  source                      = "lacework/activity-log/azure"
-  version                     = "~> 2.0"
-  application_id              = module.az_ad_application.application_id
-  application_password        = module.az_ad_application.application_password
-  service_principal_id        = module.az_ad_application.service_principal_id
-  subscription_ids            = ["test-id-1", "test-id-2", "test-id-3"]
-  use_existing_ad_application = true
+  source                            = "lacework/activity-log/azure"
+  version                           = "~> 2.0"
+  application_id                    = module.az_ad_application.application_id
+  application_password              = module.az_ad_application.application_password
+  infrastructure_encryption_enabled = true
+  service_principal_id              = module.az_ad_application.service_principal_id
+  subscription_ids                  = ["test-id-1", "test-id-2", "test-id-3"]
+  use_existing_ad_application       = true
 }

--- a/lwgenerate/azure/test-data/activity-log-with-location.tf
+++ b/lwgenerate/azure/test-data/activity-log-with-location.tf
@@ -21,11 +21,12 @@ module "az_ad_application" {
 }
 
 module "az_activity_log" {
-  source                      = "lacework/activity-log/azure"
-  version                     = "~> 2.0"
-  application_id              = module.az_ad_application.application_id
-  application_password        = module.az_ad_application.application_password
-  location                    = "West US 2"
-  service_principal_id        = module.az_ad_application.service_principal_id
-  use_existing_ad_application = true
+  source                            = "lacework/activity-log/azure"
+  version                           = "~> 2.0"
+  application_id                    = module.az_ad_application.application_id
+  application_password              = module.az_ad_application.application_password
+  infrastructure_encryption_enabled = true
+  location                          = "West US 2"
+  service_principal_id              = module.az_ad_application.service_principal_id
+  use_existing_ad_application       = true
 }

--- a/lwgenerate/azure/test-data/activity_log_with_config.tf
+++ b/lwgenerate/azure/test-data/activity_log_with_config.tf
@@ -30,10 +30,11 @@ module "az_config" {
 }
 
 module "az_activity_log" {
-  source                      = "lacework/activity-log/azure"
-  version                     = "~> 2.0"
-  application_id              = module.az_ad_application.application_id
-  application_password        = module.az_ad_application.application_password
-  service_principal_id        = module.az_ad_application.service_principal_id
-  use_existing_ad_application = true
+  source                            = "lacework/activity-log/azure"
+  version                           = "~> 2.0"
+  application_id                    = module.az_ad_application.application_id
+  application_password              = module.az_ad_application.application_password
+  infrastructure_encryption_enabled = true
+  service_principal_id              = module.az_ad_application.service_principal_id
+  use_existing_ad_application       = true
 }

--- a/lwgenerate/azure/test-data/activity_log_without_config.tf
+++ b/lwgenerate/azure/test-data/activity_log_without_config.tf
@@ -21,10 +21,11 @@ module "az_ad_application" {
 }
 
 module "az_activity_log" {
-  source                      = "lacework/activity-log/azure"
-  version                     = "~> 2.0"
-  application_id              = module.az_ad_application.application_id
-  application_password        = module.az_ad_application.application_password
-  service_principal_id        = module.az_ad_application.service_principal_id
-  use_existing_ad_application = true
+  source                            = "lacework/activity-log/azure"
+  version                           = "~> 2.0"
+  application_id                    = module.az_ad_application.application_id
+  application_password              = module.az_ad_application.application_password
+  infrastructure_encryption_enabled = true
+  service_principal_id              = module.az_ad_application.service_principal_id
+  use_existing_ad_application       = true
 }

--- a/lwgenerate/azure/test-data/customer-ad-details.tf
+++ b/lwgenerate/azure/test-data/customer-ad-details.tf
@@ -26,11 +26,12 @@ module "az_config" {
 }
 
 module "az_activity_log" {
-  source                      = "lacework/activity-log/azure"
-  version                     = "~> 2.0"
-  application_id              = "AD-Test-Application-ID"
-  application_password        = "AD-Test-Password"
-  lacework_integration_name   = "Test Activity Log Rename"
-  service_principal_id        = "AD-Test-Principal-ID"
-  use_existing_ad_application = true
+  source                            = "lacework/activity-log/azure"
+  version                           = "~> 2.0"
+  application_id                    = "AD-Test-Application-ID"
+  application_password              = "AD-Test-Password"
+  infrastructure_encryption_enabled = true
+  lacework_integration_name         = "Test Activity Log Rename"
+  service_principal_id              = "AD-Test-Principal-ID"
+  use_existing_ad_application       = true
 }

--- a/lwgenerate/azure/test-data/renamed_activity_log.tf
+++ b/lwgenerate/azure/test-data/renamed_activity_log.tf
@@ -21,11 +21,12 @@ module "az_ad_application" {
 }
 
 module "az_activity_log" {
-  source                      = "lacework/activity-log/azure"
-  version                     = "~> 2.0"
-  application_id              = module.az_ad_application.application_id
-  application_password        = module.az_ad_application.application_password
-  lacework_integration_name   = "Test Activity Log Rename"
-  service_principal_id        = module.az_ad_application.service_principal_id
-  use_existing_ad_application = true
+  source                            = "lacework/activity-log/azure"
+  version                           = "~> 2.0"
+  application_id                    = module.az_ad_application.application_id
+  application_password              = module.az_ad_application.application_password
+  infrastructure_encryption_enabled = true
+  lacework_integration_name         = "Test Activity Log Rename"
+  service_principal_id              = module.az_ad_application.service_principal_id
+  use_existing_ad_application       = true
 }

--- a/lwgenerate/azure/test-data/renamed_config_and_activity_log.tf
+++ b/lwgenerate/azure/test-data/renamed_config_and_activity_log.tf
@@ -31,11 +31,12 @@ module "az_config" {
 }
 
 module "az_activity_log" {
-  source                      = "lacework/activity-log/azure"
-  version                     = "~> 2.0"
-  application_id              = module.az_ad_application.application_id
-  application_password        = module.az_ad_application.application_password
-  lacework_integration_name   = "Test Activity Log Rename"
-  service_principal_id        = module.az_ad_application.service_principal_id
-  use_existing_ad_application = true
+  source                            = "lacework/activity-log/azure"
+  version                           = "~> 2.0"
+  application_id                    = module.az_ad_application.application_id
+  application_password              = module.az_ad_application.application_password
+  infrastructure_encryption_enabled = true
+  lacework_integration_name         = "Test Activity Log Rename"
+  service_principal_id              = module.az_ad_application.service_principal_id
+  use_existing_ad_application       = true
 }


### PR DESCRIPTION
## Summary

Enable Infrastructure Encryption by default when creating a new Azure Storage Account for activity log integration.

## How did you test this change?

* updated automated tests
* executed manually

## Issue

https://lacework.atlassian.net/browse/GROW-2556