### PR TITLE
feat: add org-cloudtrail to lw_generate

### DIFF
--- a/cli/cmd/generate_aws.go
+++ b/cli/cmd/generate_aws.go
@@ -68,7 +68,7 @@ var (
 
 	// select options
 	AwsAdvancedOptDone     = "Done"
-	AdvancedOptAgentless   = "Additional Agentless options"
+	AdvancedOptAgentless   = "Additional Agentless options (placeholder)"
 	AdvancedOptCloudTrail  = "Additional CloudTrail options"
 	AdvancedOptIamRole     = "Configure Lacework integration with an existing IAM role"
 	AdvancedOptAwsAccounts = "Add additional AWS Accounts to Lacework"
@@ -976,7 +976,7 @@ func askAdvancedAwsOptions(config *aws.GenerateAwsTfConfigurationArgs, extraStat
 		// we can have other accounts even if we only have Config integration (Scenario 7)
 		var options []string
 
-		// Only show Advanced CloudTrail options if CloudTrail integration is set to true
+		// Only show Advanced Agentless options if Agentless integration is set to true
 		if config.Agentless {
 			options = append(options, AdvancedOptAgentless)
 		}

--- a/cli/cmd/generate_aws.go
+++ b/cli/cmd/generate_aws.go
@@ -976,7 +976,7 @@ func askAdvancedAwsOptions(config *aws.GenerateAwsTfConfigurationArgs, extraStat
 		// we can have other accounts even if we only have Config integration (Scenario 7)
 		var options []string
 
-		// Only show Advanced Agentless options if Agentless integration is set to true
+		// Only show Advanced CloudTrail options if CloudTrail integration is set to true
 		if config.Agentless {
 			options = append(options, AdvancedOptAgentless)
 		}

--- a/integration/test_resources/help/generate_cloud-account_aws
+++ b/integration/test_resources/help/generate_cloud-account_aws
@@ -39,6 +39,7 @@ Flags:
       --bucket_sse_key_arn string                 specify existing KMS encryption key arn for bucket
       --cloudtrail                                enable cloudtrail integration
       --cloudtrail_name string                    specify name of cloudtrail integration
+      --cloudtrail_org_account_mapping string     Org account mapping json string. Example: '{"default_lacework_account":"main", "mapping": [{ "aws_accounts": ["123456789011"], "lacework_account": "sub-account-1"}]}'
       --config                                    enable config integration
       --config_name string                        specify name of config integration
       --consolidated_cloudtrail                   use consolidated trail

--- a/integration/test_resources/help/generate_cloud-account_aws_controltower
+++ b/integration/test_resources/help/generate_cloud-account_aws_controltower
@@ -55,6 +55,7 @@ Global Flags:
       --bucket_sse_key_arn string                 specify existing KMS encryption key arn for bucket
       --cloudtrail                                enable cloudtrail integration
       --cloudtrail_name string                    specify name of cloudtrail integration
+      --cloudtrail_org_account_mapping string     Org account mapping json string. Example: '{"default_lacework_account":"main", "mapping": [{ "aws_accounts": ["123456789011"], "lacework_account": "sub-account-1"}]}'
       --config                                    enable config integration
       --config_name string                        specify name of config integration
       --consolidated_cloudtrail                   use consolidated trail

--- a/lwgenerate/aws/aws.go
+++ b/lwgenerate/aws/aws.go
@@ -2,6 +2,7 @@
 package aws
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -50,6 +51,48 @@ func NewExistingIamRoleDetails(name string, arn string, externalId string) *Exis
 	}
 }
 
+type OrgAccountMapping struct {
+	DefaultLaceworkAccount string          `json:"default_lacework_account"`
+	Mapping                []OrgAccountMap `json:"mapping"`
+}
+
+func (orgMap *OrgAccountMapping) IsEmpty() bool {
+	return len(orgMap.Mapping) == 0 && orgMap.DefaultLaceworkAccount == ""
+}
+
+func (orgMap *OrgAccountMapping) ToMap() (map[string]any, error) {
+	var mappings []map[string]any
+	mappingsJsonString, err := json.Marshal(orgMap.Mapping)
+	if err != nil {
+		return nil, err
+	}
+	err = json.Unmarshal(mappingsJsonString, &mappings)
+	if err != nil {
+		return nil, err
+	}
+
+	orgMap.Mapping = []OrgAccountMap{}
+
+	result := make(map[string]any)
+	jsonString, err := json.Marshal(orgMap)
+	if err != nil {
+		return nil, err
+	}
+
+	err = json.Unmarshal(jsonString, &result)
+	if err != nil {
+		return nil, err
+	}
+
+	result["mapping"] = mappings
+	return result, nil
+}
+
+type OrgAccountMap struct {
+	LaceworkAccount string   `json:"lacework_account"`
+	AwsAccounts     []string `json:"aws_accounts"`
+}
+
 type AwsSubAccount struct {
 	// The name of the AwsProfile to use (in AWS configuration)
 	AwsProfile string
@@ -94,6 +137,15 @@ type GenerateAwsTfConfigurationArgs struct {
 
 	// Optional name for CloudTrail
 	CloudtrailName string
+
+	// Should we configure AWS organization mappings?
+	AwsOrganizationMappings bool
+
+	// Cloudtrail organization account mappings
+	OrgAccountMappings OrgAccountMapping
+
+	// OrgAccountMapping json used for flag input
+	OrgAccountMappingsJson string
 
 	// Should we configure CSPM integration in LW?
 	Config bool
@@ -328,6 +380,13 @@ func WithSubaccounts(subaccounts ...AwsSubAccount) AwsTerraformModifier {
 func WithCloudtrailName(cloudtrailName string) AwsTerraformModifier {
 	return func(c *GenerateAwsTfConfigurationArgs) {
 		c.CloudtrailName = cloudtrailName
+	}
+}
+
+// WithOrgAccountMappings add optional name for Organization account mappings
+func WithOrgAccountMappings(mapping OrgAccountMapping) AwsTerraformModifier {
+	return func(c *GenerateAwsTfConfigurationArgs) {
+		c.OrgAccountMappings = mapping
 	}
 }
 
@@ -669,6 +728,19 @@ func createCloudtrail(args *GenerateAwsTfConfigurationArgs) (*hclwrite.Block, er
 
 		if args.S3BucketNotification {
 			attributes["use_s3_bucket_notification"] = true
+		}
+
+		// Aws Organization CloudTrail
+		if args.AwsOrganization {
+			attributes["is_organization_trail"] = true
+
+			if !args.OrgAccountMappings.IsEmpty() {
+				orgAccountMappings, err := args.OrgAccountMappings.ToMap()
+				if err != nil {
+					return nil, errors.Wrap(err, "unable to parse 'org_account_mappings'")
+				}
+				attributes["org_account_mappings"] = []map[string]any{orgAccountMappings}
+			}
 		}
 
 		if len(args.SubAccounts) > 0 {


### PR DESCRIPTION
Branched from https://github.com/lacework/go-sdk/pull/1424

## Summary
Add support for organization cloudtrail setting in the lw_generate cloudtrail module

``` module "cloudtrail" {
  source  = "lacework/cloudtrail/aws"
  version = "2.8.0"

  is_organization_trail = true

    org_account_mappings = [{
        default_lacework_account = "main"
        
        mapping = [
            {
                lacework_account = "lw-sub-account"
                aws_accounts     = "123456789011"
            },
        ]
    }]
}
```

## How did you test this change?
- [x] `integration/aws_generation_test.go`
  - [x] `TestGenerationAwsCloudtrailOrganization`
  - [x] `TestGenerationCloudtrailOrgMappingsNonInteractive`
  - [x] `TestGenerationAwsCloudtrailOrganizationAccountMappings`

## Issue
https://lacework.atlassian.net/browse/GROW-2504
