### PR TITLE
chore: Implement --aws_assume_role flag for CLI aws integration

### DIFF
--- a/cli/cmd/generate_aws.go
+++ b/cli/cmd/generate_aws.go
@@ -67,8 +67,9 @@ var (
 	// AwsArnRegex original source: https://regex101.com/r/pOfxYN/1
 	AwsArnRegex = `^arn:(?P<Partition>[^:\n]*):(?P<Service>[^:\n]*):(?P<Region>[^:\n]*):(?P<AccountID>[^:\n]*):(?P<Ignore>(?P<ResourceType>[^:\/\n]*)[:\/])?(?P<Resource>.*)$` //nolint
 	// AwsRegionRegex regex used for validating region input; note intentionally does not match gov cloud
-	AwsRegionRegex  = `(af|ap|ca|eu|me|sa|us)-(central|(north|south)?(east|west)?)-\d`
-	AwsProfileRegex = `([A-Za-z_0-9-]+)`
+	AwsRegionRegex     = `(af|ap|ca|eu|me|sa|us)-(central|(north|south)?(east|west)?)-\d`
+	AwsProfileRegex    = `([A-Za-z_0-9-]+)`
+	AwsAssumeRoleRegex = `^arn:(aws|aws-us-gov|aws-cn):iam::\d{12}:role\/.*$`
 
 	GenerateAwsCommandState      = &aws.GenerateAwsTfConfigurationArgs{}
 	GenerateAwsExistingRoleState = &aws.ExistingIamRoleDetails{}
@@ -112,6 +113,7 @@ See help output for more details on the parameter value(s) required for Terrafor
 			// Setup modifiers for NewTerraform constructor
 			mods := []aws.AwsTerraformModifier{
 				aws.WithAwsProfile(GenerateAwsCommandState.AwsProfile),
+				aws.WithAwsAssumeRole(GenerateAwsCommandState.AwsAssumeRole),
 				aws.WithLaceworkProfile(GenerateAwsCommandState.LaceworkProfile),
 				aws.WithLaceworkAccountID(GenerateAwsCommandState.LaceworkAccountID),
 				aws.ExistingCloudtrailBucketArn(GenerateAwsCommandState.ExistingCloudtrailBucketArn),
@@ -191,6 +193,15 @@ See help output for more details on the parameter value(s) required for Terrafor
 				return errors.Wrap(err, "failed to load command flags")
 			}
 			if err := validateOutputLocation(dirname); err != nil {
+				return err
+			}
+
+			// Validate aws assume role, if passed
+			assumeRole, err := cmd.Flags().GetString("aws_assume_role")
+			if err != nil {
+				return errors.Wrap(err, "failed to load command flags")
+			}
+			if err := validateAwsAssumeRole(assumeRole); assumeRole != "" && err != nil {
 				return err
 			}
 
@@ -353,6 +364,11 @@ func initGenerateAwsTfCommandFlags() {
 		"aws_profile",
 		"",
 		"specify aws profile")
+	generateAwsTfCommand.PersistentFlags().StringVar(
+		&GenerateAwsCommandState.AwsAssumeRole,
+		"aws_assume_role",
+		"",
+		"specify aws assume role")
 	generateAwsTfCommand.PersistentFlags().BoolVar(
 		&GenerateAwsCommandState.BucketEncryptionEnabled,
 		"bucket_encryption_enabled",
@@ -492,6 +508,11 @@ func validateAwsRegion(val interface{}) error {
 // survey.Validator for aws profile
 func validateAwsProfile(val interface{}) error {
 	return validateStringWithRegex(val, fmt.Sprintf(`^%s$`, AwsProfileRegex), "invalid profile name supplied")
+}
+
+// survey.Validator for aws profile
+func validateAwsAssumeRole(val interface{}) error {
+	return validateStringWithRegex(val, fmt.Sprintf(`^%s$`, AwsAssumeRoleRegex), "invalid assume name supplied")
 }
 
 func promptAgentlessQuestions(config *aws.GenerateAwsTfConfigurationArgs) error {

--- a/cli/cmd/generate_aws.go
+++ b/cli/cmd/generate_aws.go
@@ -69,7 +69,7 @@ var (
 	// AwsRegionRegex regex used for validating region input; note intentionally does not match gov cloud
 	AwsRegionRegex     = `(af|ap|ca|eu|me|sa|us)-(central|(north|south)?(east|west)?)-\d`
 	AwsProfileRegex    = `([A-Za-z_0-9-]+)`
-	AwsAssumeRoleRegex = `^arn:(aws|aws-us-gov|aws-cn):iam::\d{12}:role\/.*$`
+	AwsAssumeRoleRegex = `^arn:aws:iam::\d{12}:role\/.*$`
 
 	GenerateAwsCommandState      = &aws.GenerateAwsTfConfigurationArgs{}
 	GenerateAwsExistingRoleState = &aws.ExistingIamRoleDetails{}
@@ -512,7 +512,7 @@ func validateAwsProfile(val interface{}) error {
 
 // survey.Validator for aws profile
 func validateAwsAssumeRole(val interface{}) error {
-	return validateStringWithRegex(val, fmt.Sprintf(`^%s$`, AwsAssumeRoleRegex), "invalid assume name supplied")
+	return validateStringWithRegex(val, AwsAssumeRoleRegex, "invalid assume name supplied")
 }
 
 func promptAgentlessQuestions(config *aws.GenerateAwsTfConfigurationArgs) error {

--- a/cli/docs/lacework_generate_cloud-account_aws.md
+++ b/cli/docs/lacework_generate_cloud-account_aws.md
@@ -39,6 +39,7 @@ lacework generate cloud-account aws [flags]
 ```
       --agentless                             enable agentless integration
       --apply                                 run terraform apply without executing plan or prompting
+      --aws_assume_role string                specify aws assume role
       --aws_profile string                    specify aws profile
       --aws_region string                     specify aws region
       --aws_subaccount strings                configure an additional aws account; value format must be <aws profile>:<region>

--- a/integration/test_resources/help/generate_cloud-account_aws
+++ b/integration/test_resources/help/generate_cloud-account_aws
@@ -27,6 +27,7 @@ Available Commands:
 Flags:
       --agentless                             enable agentless integration
       --apply                                 run terraform apply without executing plan or prompting
+      --aws_assume_role string                specify aws assume role
       --aws_profile string                    specify aws profile
       --aws_region string                     specify aws region
       --aws_subaccount strings                configure an additional aws account; value format must be <aws profile>:<region>

--- a/integration/test_resources/help/generate_cloud-account_aws_controltower
+++ b/integration/test_resources/help/generate_cloud-account_aws_controltower
@@ -43,6 +43,7 @@ Global Flags:
   -k, --api_key string                        access key id
   -s, --api_secret string                     secret access key
       --api_token string                      access token (replaces the use of api_key and api_secret)
+      --aws_assume_role string                specify aws assume role
       --aws_profile string                    specify aws profile
       --aws_region string                     specify aws region
       --aws_subaccount strings                configure an additional aws account; value format must be <aws profile>:<region>


### PR DESCRIPTION
## Summary
Add the `--aws_assume_role` flag to `lacework generate cloud-account aws`

## How did you test this change?

`make test`
`make integration-context-tests`

Run `lacework generate cloud-account aws --noninteractive --agentless --config --cloudtrail --aws_profile org --aws_assume_role arn:aws:iam::123456789000:role/role_in_account_b --aws_region us-east-1 --aws_subaccount subaccount1:us-east-2,subaccount2:us-east-3`. Then verify the generated terraform code:
```
terraform {
  required_providers {
    lacework = {
      source  = "lacework/lacework"
      version = "~> 1.0"
    }
  }
}

provider "aws" {
  alias   = "main"
  profile = "org"
  region  = "us-east-1"

  assume_role {
    role_arn = "arn:aws:iam::123456789000:role/role_in_account_b"
  }
}

provider "aws" {
  alias   = "subaccount1"
  profile = "subaccount1"
  region  = "us-east-2"
}

provider "aws" {
  alias   = "subaccount2"
  profile = "subaccount2"
  region  = "us-east-3"
}

module "aws_config" {
  source  = "lacework/config/aws"
  version = "~> 0.5"

  providers = {
    aws = aws.main
  }
}

module "aws_config_subaccount1" {
  source  = "lacework/config/aws"
  version = "~> 0.5"

  providers = {
    aws = aws.subaccount1
  }
}

module "aws_config_subaccount2" {
  source  = "lacework/config/aws"
  version = "~> 0.5"

  providers = {
    aws = aws.subaccount2
  }
}

module "main_cloudtrail" {
  source                = "lacework/cloudtrail/aws"
  version               = "~> 2.7"
  iam_role_arn          = module.aws_config.iam_role_arn
  iam_role_external_id  = module.aws_config.external_id
  iam_role_name         = module.aws_config.iam_role_name
  use_existing_iam_role = true

  providers = {
    aws = aws.main
  }
}

module "lacework_aws_agentless_scanning_global" {
  source   = "lacework/agentless-scanning/aws"
  version  = "~> 0.6"
  global   = true
  regional = true
}

module "lacework_aws_agentless_scanning_region_subaccount1" {
  source                  = "lacework/agentless-scanning/aws"
  version                 = "~> 0.6"
  global_module_reference = module.lacework_aws_agentless_scanning_global
  regional                = true

  providers = {
    aws = aws.subaccount1
  }
}

module "lacework_aws_agentless_scanning_region_subaccount2" {
  source                  = "lacework/agentless-scanning/aws"
  version                 = "~> 0.6"
  global_module_reference = module.lacework_aws_agentless_scanning_global
  regional                = true

  providers = {
    aws = aws.subaccount2
  }
}
```

## Issue
https://lacework.atlassian.net/browse/GROW-2562
