### PR TITLE
fix(component): List installed version instead of latest

### DIFF
--- a/cli/cmd/component.go
+++ b/cli/cmd/component.go
@@ -808,10 +808,19 @@ func componentsToTable() [][]string {
 			colorize = color.New(color.FgYellow, color.Bold)
 		}
 
+		// by default, we display the latest version
+		version := cdata.LatestVersion.String()
+
+		// but if the component is installed,
+		// we display the current version instead
+		if currentVersion, err := cdata.CurrentVersion(); err == nil {
+			version = currentVersion.String()
+		}
+
 		out = append(out, []string{
 			colorize.Sprintf(cdata.Status().String()),
 			cdata.Name,
-			cdata.LatestVersion.String(),
+			version,
 			cdata.Description,
 		})
 	}


### PR DESCRIPTION
## Summary

From @cody-lw:
> Minor brevity thing I noticed this morning, `lacework component list` will return the
> version available rather than the current installed version of a component.

This code tries to clarify that, when a component IS installed and HAS an update, we still display
the installed version, rather that the latest version.

Users can use `lacework component show <component>` to see where they are and what
can they upgrade to, example:
```
$ lacework component show sca
  NAME        STATUS                DESCRIPTION
-------+------------------+------------------------------
  sca    Update Available   Software Component Analysis

The following versions of this component are available to install:
 - 0.0.63
 - 0.0.64
 - 0.0.65
 - 0.0.66
 - 0.0.67
 - 0.0.68
 - 0.0.69
 - 0.0.70
 - 0.0.71
 - 0.0.72
 - 0.0.73
 - 0.0.74
 - 0.0.75 (installed)
 - 0.0.76
 - 0.0.77
 - 0.0.78
 - 0.0.79
```

## Issue

Reported via Slack.
