### PR TITLE
build(release): fix chocolately release action

### DIFF
--- a/.github/workflows/chocolatey-release.yml
+++ b/.github/workflows/chocolatey-release.yml
@@ -3,7 +3,6 @@ on: workflow_dispatch
 jobs:
   publish-chocolatey:
     runs-on: windows-latest
-
     steps:
       - uses: actions/checkout@v4
         with:
@@ -11,8 +10,9 @@ jobs:
           fetch-depth: 0
 
       - name: Running integration tests
-        image: lacework/win-golang:1.18-20h2
         shell: pwsh
+        env:
+          API_KEY: ${{ secrets.CHOCO_KEY }}
         run: |
           # install chocolatey
           Set-ExecutionPolicy Bypass -Scope Process -Force


### PR DESCRIPTION
## Summary

Since the Codefresh action to release the SDK to Chocolatey is no longer available a github action needed to be created.

## How did you test this change?


Used actionlint and ran the github action successfully. 

## Issue

https://lacework.atlassian.net/browse/GROW-2554