### PR TITLE
feat(PSP-1220): misc fixes in Azure Agentless cloud provider

### DIFF
--- a/api/cloud_accounts_azure_sidekick.go
+++ b/api/cloud_accounts_azure_sidekick.go
@@ -20,9 +20,8 @@ package api
 
 const (
 	AzureSubscriptionIntegration string = "SUBSCRIPTION"
-	AzureTenantIntegration string = "TENANT"
+	AzureTenantIntegration       string = "TENANT"
 )
-
 
 // GetAzureSidekick gets a single AzureSidekick integration matching the provided integration guid
 func (svc *CloudAccountsService) GetAzureSidekick(guid string) (
@@ -72,6 +71,8 @@ type AzureSidekickData struct {
 	ScanningSubscriptionId  string                   `json:"scanningSubscriptionId"`
 	TenantId                string                   `json:"tenantId"`
 	BlobContainerName       string                   `json:"blobContainerName"`
+	ScanningResourceGroupId string                   `json:"scanningResourceGroupId"`
+	StorageAccountUrl       string                   `json:"storageAccountUrl"`
 	SubscriptionList        string                   `json:"subscriptionList,omitempty"`
 	QueryText               string                   `json:"queryText,omitempty"`
 	ScanFrequency           int                      `json:"scanFrequency"` // in hours

--- a/api/cloud_accounts_azure_sidekick.go
+++ b/api/cloud_accounts_azure_sidekick.go
@@ -73,7 +73,7 @@ type AzureSidekickData struct {
 	BlobContainerName         string                   `json:"blobContainerName"`
 	ScanningResourceGroupName string                   `json:"scanningResourceGroupName"`
 	StorageAccountUrl         string                   `json:"storageAccountUrl"`
-	SubscriptionList          string                   `json:"subscriptionList,omitempty"`
+	SubscriptionsList         string                   `json:"subscriptionsList,omitempty"`
 	QueryText                 string                   `json:"queryText,omitempty"`
 	ScanFrequency             int                      `json:"scanFrequency"` // in hours
 	ScanContainers            bool                     `json:"scanContainers"`

--- a/api/cloud_accounts_azure_sidekick.go
+++ b/api/cloud_accounts_azure_sidekick.go
@@ -18,6 +18,12 @@
 
 package api
 
+const (
+	AzureSubscriptionIntegration string = "SUBSCRIPTION"
+	AzureTenantIntegration string = "TENANT"
+)
+
+
 // GetAzureSidekick gets a single AzureSidekick integration matching the provided integration guid
 func (svc *CloudAccountsService) GetAzureSidekick(guid string) (
 	response AzureSidekickIntegrationResponse,
@@ -76,6 +82,6 @@ type AzureSidekickData struct {
 }
 
 type AzureSidekickCredentials struct {
-	ClientID     string `json:"clientId"`
+	ClientId     string `json:"clientId"`
 	ClientSecret string `json:"clientSecret,omitempty"`
 }

--- a/api/cloud_accounts_azure_sidekick.go
+++ b/api/cloud_accounts_azure_sidekick.go
@@ -66,20 +66,20 @@ type V2AzureSidekickIntegration struct {
 }
 
 type AzureSidekickData struct {
-	Credentials             AzureSidekickCredentials `json:"credentials"`
-	IntegrationLevel        string                   `json:"integrationLevel"` // SUBSCRIPTION or TENANT
-	ScanningSubscriptionId  string                   `json:"scanningSubscriptionId"`
-	TenantId                string                   `json:"tenantId"`
-	BlobContainerName       string                   `json:"blobContainerName"`
-	ScanningResourceGroupId string                   `json:"scanningResourceGroupId"`
-	StorageAccountUrl       string                   `json:"storageAccountUrl"`
-	SubscriptionList        string                   `json:"subscriptionList,omitempty"`
-	QueryText               string                   `json:"queryText,omitempty"`
-	ScanFrequency           int                      `json:"scanFrequency"` // in hours
-	ScanContainers          bool                     `json:"scanContainers"`
-	ScanHostVulnerabilities bool                     `json:"scanHostVulnerabilities"`
-	ScanMultiVolume         bool                     `json:"scanMultiVolume"`
-	ScanStoppedInstances    bool                     `json:"scanStoppedInstances"`
+	Credentials               AzureSidekickCredentials `json:"credentials"`
+	IntegrationLevel          string                   `json:"integrationLevel"` // SUBSCRIPTION or TENANT
+	ScanningSubscriptionId    string                   `json:"scanningSubscriptionId"`
+	TenantId                  string                   `json:"tenantId"`
+	BlobContainerName         string                   `json:"blobContainerName"`
+	ScanningResourceGroupName string                   `json:"scanningResourceGroupName"`
+	StorageAccountUrl         string                   `json:"storageAccountUrl"`
+	SubscriptionList          string                   `json:"subscriptionList,omitempty"`
+	QueryText                 string                   `json:"queryText,omitempty"`
+	ScanFrequency             int                      `json:"scanFrequency"` // in hours
+	ScanContainers            bool                     `json:"scanContainers"`
+	ScanHostVulnerabilities   bool                     `json:"scanHostVulnerabilities"`
+	ScanMultiVolume           bool                     `json:"scanMultiVolume"`
+	ScanStoppedInstances      bool                     `json:"scanStoppedInstances"`
 }
 
 type AzureSidekickCredentials struct {

--- a/api/cloud_accounts_azure_sidekick_test.go
+++ b/api/cloud_accounts_azure_sidekick_test.go
@@ -32,15 +32,15 @@ import (
 // These two objects are used to test Create, Get and Update operations.
 var (
 	azureSidekickData = api.AzureSidekickData{
-		IntegrationLevel:        "SUBSCRIPTION",
-		ScanningSubscriptionId:  "54321",
-		TenantId:                "98765",
-		BlobContainerName:       "blobContainer",
-		ScanningResourceGroupId: "xxxx-xxxx",
-		StorageAccountUrl:       "https://abc.blob.core.windows.net",
-		ScanFrequency:           24,
-		ScanContainers:          true,
-		ScanHostVulnerabilities: true,
+		IntegrationLevel:          "SUBSCRIPTION",
+		ScanningSubscriptionId:    "54321",
+		TenantId:                  "98765",
+		BlobContainerName:         "blobContainer",
+		ScanningResourceGroupName: "xxxx-xxxx",
+		StorageAccountUrl:         "https://abc.blob.core.windows.net",
+		ScanFrequency:             24,
+		ScanContainers:            true,
+		ScanHostVulnerabilities:   true,
 		Credentials: api.AzureSidekickCredentials{
 			ClientId:     "Client123",
 			ClientSecret: "Secret",
@@ -50,15 +50,15 @@ var (
 	}
 
 	azureUpdatedSidekickData = api.AzureSidekickData{
-		IntegrationLevel:        "SUBSCRIPTION",
-		ScanningSubscriptionId:  "updated-54321",
-		TenantId:                "updated-98765",
-		BlobContainerName:       "updated-blobContainer",
-		ScanningResourceGroupId: "updated-xxxx-xxxx",
-		StorageAccountUrl:       "https://updated-abc.blob.core.windows.net",
-		ScanFrequency:           12,
-		ScanContainers:          false,
-		ScanHostVulnerabilities: true,
+		IntegrationLevel:          "SUBSCRIPTION",
+		ScanningSubscriptionId:    "updated-54321",
+		TenantId:                  "updated-98765",
+		BlobContainerName:         "updated-blobContainer",
+		ScanningResourceGroupName: "updated-xxxx-xxxx",
+		StorageAccountUrl:         "https://updated-abc.blob.core.windows.net",
+		ScanFrequency:             12,
+		ScanContainers:            false,
+		ScanHostVulnerabilities:   true,
 		Credentials: api.AzureSidekickCredentials{
 			ClientId:     "updated-Client123",
 			ClientSecret: "updated-Secret",
@@ -79,7 +79,7 @@ func TestCloudAccountsAzureSidekickCreate(t *testing.T) {
 	assert.Equal(t, integrationData.ScanningSubscriptionId, "54321")
 	assert.Equal(t, integrationData.TenantId, "98765")
 	assert.Equal(t, integrationData.BlobContainerName, "blobContainer")
-	assert.Equal(t, integrationData.ScanningResourceGroupId, "xxxx-xxxx")
+	assert.Equal(t, integrationData.ScanningResourceGroupName, "xxxx-xxxx")
 	assert.Equal(t, integrationData.StorageAccountUrl, "https://abc.blob.core.windows.net")
 	assert.Equal(t, integrationData.ScanFrequency, 24)
 	assert.Equal(t, integrationData.ScanContainers, true)
@@ -123,7 +123,7 @@ func TestCloudAccountsAzureSidekickGet(t *testing.T) {
 	assert.Equal(t, "54321", integrationData.ScanningSubscriptionId)
 	assert.Equal(t, "98765", integrationData.TenantId)
 	assert.Equal(t, "blobContainer", integrationData.BlobContainerName)
-	assert.Equal(t, integrationData.ScanningResourceGroupId, "xxxx-xxxx")
+	assert.Equal(t, integrationData.ScanningResourceGroupName, "xxxx-xxxx")
 	assert.Equal(t, integrationData.StorageAccountUrl, "https://abc.blob.core.windows.net")
 	assert.Equal(t, 24, integrationData.ScanFrequency)
 	assert.Equal(t, true, integrationData.ScanContainers)
@@ -155,7 +155,7 @@ func TestCloudAccountsAzureSidekickUpdate(t *testing.T) {
 			assert.Contains(t, body, "AzureSidekick", "wrong cloud account type")
 			assert.Contains(t, body, azureSidekickData.Credentials.ClientId, "wrong client ID")
 			assert.Contains(t, body, azureSidekickData.BlobContainerName, "wrong blob container name")
-			assert.Contains(t, body, azureSidekickData.ScanningResourceGroupId, "wrong scanning resource group id")
+			assert.Contains(t, body, azureSidekickData.ScanningResourceGroupName, "wrong scanning resource group name")
 			assert.Contains(t, body, azureSidekickData.StorageAccountUrl, "wrong storage account url")
 			assert.Contains(t, body, "enabled\":1", "cloud account is not enabled")
 		}
@@ -183,7 +183,7 @@ func TestCloudAccountsAzureSidekickUpdate(t *testing.T) {
 	assert.Equal(t, "54321", integrationData.ScanningSubscriptionId)
 	assert.Equal(t, "98765", integrationData.TenantId)
 	assert.Equal(t, "blobContainer", integrationData.BlobContainerName)
-	assert.Equal(t, integrationData.ScanningResourceGroupId, "xxxx-xxxx")
+	assert.Equal(t, integrationData.ScanningResourceGroupName, "xxxx-xxxx")
 	assert.Equal(t, integrationData.StorageAccountUrl, "https://abc.blob.core.windows.net")
 	assert.Equal(t, 24, integrationData.ScanFrequency)
 	assert.Equal(t, true, integrationData.ScanContainers)
@@ -209,7 +209,7 @@ func TestCloudAccountsAzureSidekickUpdate(t *testing.T) {
 	assert.Equal(t, "updated-54321", integrationData.ScanningSubscriptionId)
 	assert.Equal(t, "updated-98765", integrationData.TenantId)
 	assert.Equal(t, "updated-blobContainer", integrationData.BlobContainerName)
-	assert.Equal(t, integrationData.ScanningResourceGroupId, "updated-xxxx-xxxx")
+	assert.Equal(t, integrationData.ScanningResourceGroupName, "updated-xxxx-xxxx")
 	assert.Equal(t, integrationData.StorageAccountUrl, "https://updated-abc.blob.core.windows.net")
 	assert.Equal(t, 12, integrationData.ScanFrequency)
 	assert.Equal(t, false, integrationData.ScanContainers)
@@ -251,7 +251,7 @@ func getAzureData(id string, data api.AzureSidekickData) string {
   		"scanningSubscriptionId": "` + data.ScanningSubscriptionId + `",
   		"tenantId":  "` + data.TenantId + `",
   		"blobContainerName": "` + data.BlobContainerName + `",
-  		"scanningResourceGroupId": "` + data.ScanningResourceGroupId + `",
+  		"scanningResourceGroupName": "` + data.ScanningResourceGroupName + `",
   		"storageAccountUrl": "` + data.StorageAccountUrl + `",
   		"subscriptionList": "` + data.SubscriptionList + `",
   		"queryText": "` + data.QueryText + `",

--- a/api/cloud_accounts_azure_sidekick_test.go
+++ b/api/cloud_accounts_azure_sidekick_test.go
@@ -36,11 +36,13 @@ var (
 		ScanningSubscriptionId:  "54321",
 		TenantId:                "98765",
 		BlobContainerName:       "blobContainer",
+		ScanningResourceGroupId: "xxxx-xxxx",
+		StorageAccountUrl:       "https://abc.blob.core.windows.net",
 		ScanFrequency:           24,
 		ScanContainers:          true,
 		ScanHostVulnerabilities: true,
 		Credentials: api.AzureSidekickCredentials{
-			ClientID:     "Client123",
+			ClientId:     "Client123",
 			ClientSecret: "Secret",
 		},
 		SubscriptionList: "sub1,sub2",
@@ -52,11 +54,13 @@ var (
 		ScanningSubscriptionId:  "updated-54321",
 		TenantId:                "updated-98765",
 		BlobContainerName:       "updated-blobContainer",
+		ScanningResourceGroupId: "updated-xxxx-xxxx",
+		StorageAccountUrl:       "https://updated-abc.blob.core.windows.net",
 		ScanFrequency:           12,
 		ScanContainers:          false,
 		ScanHostVulnerabilities: true,
 		Credentials: api.AzureSidekickCredentials{
-			ClientID:     "updated-Client123",
+			ClientId:     "updated-Client123",
 			ClientSecret: "updated-Secret",
 		},
 		SubscriptionList: "updated-sub1,sub2",
@@ -75,11 +79,13 @@ func TestCloudAccountsAzureSidekickCreate(t *testing.T) {
 	assert.Equal(t, integrationData.ScanningSubscriptionId, "54321")
 	assert.Equal(t, integrationData.TenantId, "98765")
 	assert.Equal(t, integrationData.BlobContainerName, "blobContainer")
+	assert.Equal(t, integrationData.ScanningResourceGroupId, "xxxx-xxxx")
+	assert.Equal(t, integrationData.StorageAccountUrl, "https://abc.blob.core.windows.net")
 	assert.Equal(t, integrationData.ScanFrequency, 24)
 	assert.Equal(t, integrationData.ScanContainers, true)
 	assert.Equal(t, integrationData.ScanHostVulnerabilities, true)
 
-	assert.Equal(t, integrationData.Credentials.ClientID, "Client123")
+	assert.Equal(t, integrationData.Credentials.ClientId, "Client123")
 	assert.Equal(t, integrationData.Credentials.ClientSecret, "Secret")
 }
 
@@ -117,10 +123,12 @@ func TestCloudAccountsAzureSidekickGet(t *testing.T) {
 	assert.Equal(t, "54321", integrationData.ScanningSubscriptionId)
 	assert.Equal(t, "98765", integrationData.TenantId)
 	assert.Equal(t, "blobContainer", integrationData.BlobContainerName)
+	assert.Equal(t, integrationData.ScanningResourceGroupId, "xxxx-xxxx")
+	assert.Equal(t, integrationData.StorageAccountUrl, "https://abc.blob.core.windows.net")
 	assert.Equal(t, 24, integrationData.ScanFrequency)
 	assert.Equal(t, true, integrationData.ScanContainers)
 	assert.Equal(t, true, integrationData.ScanHostVulnerabilities)
-	assert.Equal(t, "Client123", integrationData.Credentials.ClientID)
+	assert.Equal(t, "Client123", integrationData.Credentials.ClientId)
 	assert.Equal(t, "Secret", integrationData.Credentials.ClientSecret)
 	assert.Equal(t, "sub1,sub2", integrationData.SubscriptionList)
 	assert.Equal(t, "queryText", integrationData.QueryText)
@@ -145,8 +153,10 @@ func TestCloudAccountsAzureSidekickUpdate(t *testing.T) {
 			assert.Contains(t, body, intgGUID, "INTG_GUID missing")
 			assert.Contains(t, body, "integration_test", "cloud account name is missing")
 			assert.Contains(t, body, "AzureSidekick", "wrong cloud account type")
-			assert.Contains(t, body, azureSidekickData.Credentials.ClientID, "wrong client ID")
+			assert.Contains(t, body, azureSidekickData.Credentials.ClientId, "wrong client ID")
 			assert.Contains(t, body, azureSidekickData.BlobContainerName, "wrong blob container name")
+			assert.Contains(t, body, azureSidekickData.ScanningResourceGroupId, "wrong scanning resource group id")
+			assert.Contains(t, body, azureSidekickData.StorageAccountUrl, "wrong storage account url")
 			assert.Contains(t, body, "enabled\":1", "cloud account is not enabled")
 		}
 
@@ -173,10 +183,12 @@ func TestCloudAccountsAzureSidekickUpdate(t *testing.T) {
 	assert.Equal(t, "54321", integrationData.ScanningSubscriptionId)
 	assert.Equal(t, "98765", integrationData.TenantId)
 	assert.Equal(t, "blobContainer", integrationData.BlobContainerName)
+	assert.Equal(t, integrationData.ScanningResourceGroupId, "xxxx-xxxx")
+	assert.Equal(t, integrationData.StorageAccountUrl, "https://abc.blob.core.windows.net")
 	assert.Equal(t, 24, integrationData.ScanFrequency)
 	assert.Equal(t, true, integrationData.ScanContainers)
 	assert.Equal(t, true, integrationData.ScanHostVulnerabilities)
-	assert.Equal(t, "Client123", integrationData.Credentials.ClientID)
+	assert.Equal(t, "Client123", integrationData.Credentials.ClientId)
 	assert.Equal(t, "Secret", integrationData.Credentials.ClientSecret)
 	assert.Equal(t, "sub1,sub2", integrationData.SubscriptionList)
 	assert.Equal(t, "queryText", integrationData.QueryText)
@@ -197,10 +209,12 @@ func TestCloudAccountsAzureSidekickUpdate(t *testing.T) {
 	assert.Equal(t, "updated-54321", integrationData.ScanningSubscriptionId)
 	assert.Equal(t, "updated-98765", integrationData.TenantId)
 	assert.Equal(t, "updated-blobContainer", integrationData.BlobContainerName)
+	assert.Equal(t, integrationData.ScanningResourceGroupId, "updated-xxxx-xxxx")
+	assert.Equal(t, integrationData.StorageAccountUrl, "https://updated-abc.blob.core.windows.net")
 	assert.Equal(t, 12, integrationData.ScanFrequency)
 	assert.Equal(t, false, integrationData.ScanContainers)
 	assert.Equal(t, true, integrationData.ScanHostVulnerabilities)
-	assert.Equal(t, "updated-Client123", integrationData.Credentials.ClientID)
+	assert.Equal(t, "updated-Client123", integrationData.Credentials.ClientId)
 	assert.Equal(t, "updated-Secret", integrationData.Credentials.ClientSecret)
 	assert.Equal(t, "updated-sub1,sub2", integrationData.SubscriptionList)
 	assert.Equal(t, "updated-queryText", integrationData.QueryText)
@@ -230,13 +244,15 @@ func getAzureData(id string, data api.AzureSidekickData) string {
   	"type": "AzureSidekick",
   	"data": {
   		"credentials": {
-  			"clientId": "` + data.Credentials.ClientID + `",
+  			"clientId": "` + data.Credentials.ClientId + `",
   			"clientSecret": "` + data.Credentials.ClientSecret + `"
   		},
   		"integrationLevel": "` + data.IntegrationLevel + `",
   		"scanningSubscriptionId": "` + data.ScanningSubscriptionId + `",
   		"tenantId":  "` + data.TenantId + `",
   		"blobContainerName": "` + data.BlobContainerName + `",
+  		"scanningResourceGroupId": "` + data.ScanningResourceGroupId + `",
+  		"storageAccountUrl": "` + data.StorageAccountUrl + `",
   		"subscriptionList": "` + data.SubscriptionList + `",
   		"queryText": "` + data.QueryText + `",
   		"scanFrequency": ` + scanFrequency + `,

--- a/api/cloud_accounts_azure_sidekick_test.go
+++ b/api/cloud_accounts_azure_sidekick_test.go
@@ -45,8 +45,8 @@ var (
 			ClientId:     "Client123",
 			ClientSecret: "Secret",
 		},
-		SubscriptionList: "sub1,sub2",
-		QueryText:        "queryText",
+		SubscriptionsList: "sub1,sub2",
+		QueryText:         "queryText",
 	}
 
 	azureUpdatedSidekickData = api.AzureSidekickData{
@@ -63,8 +63,8 @@ var (
 			ClientId:     "updated-Client123",
 			ClientSecret: "updated-Secret",
 		},
-		SubscriptionList: "updated-sub1,sub2",
-		QueryText:        "updated-queryText",
+		SubscriptionsList: "updated-sub1,sub2",
+		QueryText:         "updated-queryText",
 	}
 )
 
@@ -130,7 +130,7 @@ func TestCloudAccountsAzureSidekickGet(t *testing.T) {
 	assert.Equal(t, true, integrationData.ScanHostVulnerabilities)
 	assert.Equal(t, "Client123", integrationData.Credentials.ClientId)
 	assert.Equal(t, "Secret", integrationData.Credentials.ClientSecret)
-	assert.Equal(t, "sub1,sub2", integrationData.SubscriptionList)
+	assert.Equal(t, "sub1,sub2", integrationData.SubscriptionsList)
 	assert.Equal(t, "queryText", integrationData.QueryText)
 	assert.Equal(t, "token_"+integration.IntgGuid, integration.ServerToken)
 }
@@ -190,7 +190,7 @@ func TestCloudAccountsAzureSidekickUpdate(t *testing.T) {
 	assert.Equal(t, true, integrationData.ScanHostVulnerabilities)
 	assert.Equal(t, "Client123", integrationData.Credentials.ClientId)
 	assert.Equal(t, "Secret", integrationData.Credentials.ClientSecret)
-	assert.Equal(t, "sub1,sub2", integrationData.SubscriptionList)
+	assert.Equal(t, "sub1,sub2", integrationData.SubscriptionsList)
 	assert.Equal(t, "queryText", integrationData.QueryText)
 
 	// Step 3 - Get Updated data from Fake server
@@ -216,7 +216,7 @@ func TestCloudAccountsAzureSidekickUpdate(t *testing.T) {
 	assert.Equal(t, true, integrationData.ScanHostVulnerabilities)
 	assert.Equal(t, "updated-Client123", integrationData.Credentials.ClientId)
 	assert.Equal(t, "updated-Secret", integrationData.Credentials.ClientSecret)
-	assert.Equal(t, "updated-sub1,sub2", integrationData.SubscriptionList)
+	assert.Equal(t, "updated-sub1,sub2", integrationData.SubscriptionsList)
 	assert.Equal(t, "updated-queryText", integrationData.QueryText)
 }
 
@@ -233,7 +233,6 @@ func getAzureData(id string, data api.AzureSidekickData) string {
   	"createdOrUpdatedTime": "2021-06-01T19:28:00.092Z",
   	"enabled": 1,
   	"intgGuid": "` + id + `",
-  	"isOrg": 0,
   	"name": "integration_test",
   	"state": {
   		"details": {},
@@ -253,7 +252,7 @@ func getAzureData(id string, data api.AzureSidekickData) string {
   		"blobContainerName": "` + data.BlobContainerName + `",
   		"scanningResourceGroupName": "` + data.ScanningResourceGroupName + `",
   		"storageAccountUrl": "` + data.StorageAccountUrl + `",
-  		"subscriptionList": "` + data.SubscriptionList + `",
+  		"SubscriptionsList": "` + data.SubscriptionsList + `",
   		"queryText": "` + data.QueryText + `",
   		"scanFrequency": ` + scanFrequency + `,
   		"scanContainers":  ` + scanContainers + `,


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/lacework/go-sdk) and create your branch from `main`
  2. Run `make prepare` in the repository root
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`make test`)
  5. Format your code (`make fmt`)
  6. Make sure your code lints (`make lint`)
  7. If you are updating the Lacework CLI, make sure it compiles (`make build-cli-cross-platform`)
  8. Follow the commit message standard (`type(scope): subject`) documented in [DEVELOPER_GUIDELINES.md](https://github.com/lacework/go-sdk/blob/main/DEVELOPER_GUIDELINES.md#commit-message-standard)
  9. If you haven't already, configure signed commits by [telling git about your signing key](https://docs.github.com/en/github/authenticating-to-github/managing-commit-signature-verification/telling-git-about-your-signing-key) and [signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)

  Learn more about contributing: https://github.com/lacework/go-sdk/blob/main/CONTRIBUTING.md
-->

## Summary

There are two small changes in this PR:

1. Added integration level const strings which are used in tf provider (PR up soon)
2. Added new fields in integration object `ScanningResourceGroupName` and `StorageAccountUrl` 
3. remove unused `is_org` field
4. s/subscriptionList/subscriptionsList/g


## How did you test this change?

updated test.

## Issue

https://lacework.atlassian.net/browse/PSP-1220