### PR TITLE
fix(cdk): component install fails

### DIFF
--- a/lwcomponent/component.go
+++ b/lwcomponent/component.go
@@ -290,7 +290,7 @@ func (s State) Install(component *Component, version string) error {
 	//if the component was not an archive then nothing was created in the staging dir
 	//we must move it over
 	if _, err := os.Stat(stagingPath); errors.Is(err, os.ErrNotExist) {
-		err = os.Rename(downloadPath, stagingPath)
+		err = file.Copy(downloadPath, stagingPath)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
## Summary

Due to the use of os.Rename, component installs were failing when the temporary download folder was on a different volume than the destination folder. This impacted some AWS ec2 instance and probably containers. 

## How did you test this change?

built and ran on command line

## Issue

https://lacework.atlassian.net/browse/GROW-2581
