### PR TITLE
chore: make agentless_monitored_accounts optional

### DIFF
--- a/cli/cmd/generate_aws.go
+++ b/cli/cmd/generate_aws.go
@@ -44,10 +44,8 @@ var (
 	QuestionAgentlessMonitoredAccountIDsHelp = "Please provide a comma seprated list that may " +
 		"contain account IDs, OUs, or the organization root (e.g. 123456789000,ou-abcd-12345678,r-abcd)."
 
-	QuestionAgentlessMonitoredAccountProfile  = "Monitored AWS account profile:"
-	QuestionAgentlessMonitoredAccountRegion   = "Monitored AWS account region:"
-	QuestionAgentlessMonitoredAccountAddMore  = "Add another monitored AWS account?"
-	QuestionAgentlessMonitoredAccountsReplace = "Currently configured monitored accounts: %s, replace?"
+	QuestionAgentlessMonitoredAccountProfile = "Monitored AWS account profile:"
+	QuestionAgentlessMonitoredAccountRegion  = "Monitored AWS account region:"
 
 	// Config questions
 	QuestionEnableConfig                    = "Enable configuration integration?"

--- a/cli/cmd/generate_aws.go
+++ b/cli/cmd/generate_aws.go
@@ -776,17 +776,50 @@ func promptAgentlessQuestions(config *aws.GenerateAwsTfConfigurationArgs) error 
 		}
 
 		config.AgentlessMonitoredAccountIDs = strings.Split(monitoredAccountIDListInput, ",")
+		config.AgentlessMonitoredAccounts = []aws.AwsSubAccount{}
 
-		if err := promptAwsAccountsQuestions(
-			&config.AgentlessMonitoredAccounts,
-			IconAgentless,
-			QuestionAgentlessMonitoredAccountProfile,
-			QuestionAgentlessMonitoredAccountRegion,
-			QuestionAgentlessMonitoredAccountAddMore,
-			QuestionAgentlessMonitoredAccountsReplace,
-			false,
-		); err != nil {
-			return err
+		// Get single account IDs
+		for _, accountID := range config.AgentlessMonitoredAccountIDs {
+			ok, err := regexp.MatchString(AwsAccountIDRegex, accountID)
+			if err != nil {
+				return errors.Wrap(err, "failed to validate input")
+			}
+			if ok {
+				var profile, region string
+				profileMessage := fmt.Sprintf(
+					"%s for account %s:",
+					QuestionAgentlessMonitoredAccountProfile[:len(QuestionAgentlessMonitoredAccountProfile)-1],
+					accountID,
+				)
+				regionMessage := fmt.Sprintf(
+					"%s for account %s:",
+					QuestionAgentlessMonitoredAccountRegion[:len(QuestionAgentlessMonitoredAccountRegion)-1],
+					accountID,
+				)
+				if err := SurveyMultipleQuestionWithValidation([]SurveyQuestionWithValidationArgs{
+					{
+						Icon:     IconAgentless,
+						Prompt:   &survey.Input{Message: profileMessage},
+						Opts:     []survey.AskOpt{survey.WithValidator(validateAwsProfile)},
+						Required: true,
+						Response: &profile,
+					},
+					{
+						Icon:     IconAgentless,
+						Prompt:   &survey.Input{Message: regionMessage},
+						Opts:     []survey.AskOpt{survey.WithValidator(validateAwsRegion)},
+						Required: true,
+						Response: &region,
+					},
+				}); err != nil {
+					return err
+				}
+				alias := fmt.Sprintf("%s-%s", profile, region)
+				config.AgentlessMonitoredAccounts = append(
+					config.AgentlessMonitoredAccounts,
+					aws.AwsSubAccount{AwsProfile: profile, AwsRegion: region, Alias: alias},
+				)
+			}
 		}
 	}
 

--- a/integration/aws_generation_test.go
+++ b/integration/aws_generation_test.go
@@ -70,7 +70,7 @@ func TestGenerationAwsNoninteractive(t *testing.T) {
 		"--agentless_monitored_account_ids",
 		"123456789000,ou-abcd-12345678,r-abcd",
 		"--agentless_monitored_accounts",
-		"monitored-1:us-west-1,monitored-2:us-west-2",
+		"monitored-1:us-west-1",
 		"--agentless_scanning_accounts",
 		"scanning-1:us-east-1,scanning-2:us-east-2",
 		"--config_lacework_account",
@@ -138,7 +138,6 @@ func TestGenerationAwsNoninteractive(t *testing.T) {
 		aws.WithAgentlessMonitoredAccountIDs([]string{"123456789000", "ou-abcd-12345678", "r-abcd"}),
 		aws.WithAgentlessMonitoredAccounts(
 			aws.NewAwsSubAccount("monitored-1", "us-west-1", "monitored-1-us-west-1"),
-			aws.NewAwsSubAccount("monitored-2", "us-west-2", "monitored-2-us-west-2"),
 		),
 		aws.WithAgentlessScanningAccounts(
 			aws.NewAwsSubAccount("scanning-1", "us-east-1", "scanning-1-us-east-1"),
@@ -224,6 +223,9 @@ func TestGenerationAwsAgentlessOrganization(t *testing.T) {
 	defer os.Setenv("LW_NOCACHE", "")
 	var final string
 
+	monitoredProfileQuestion := "Monitored AWS account profile for account 123456789000"
+	monitoredRegionQuestion := "Monitored AWS account region for account 123456789000"
+
 	// Run CLI
 	tfResult := runGenerateTest(t,
 		func(c *expect.Console) {
@@ -234,12 +236,8 @@ func TestGenerationAwsAgentlessOrganization(t *testing.T) {
 				MsgRsp{cmd.QuestionEnableAgentless, "y"},
 				MsgRsp{cmd.QuestionAgentlessManagementAccountID, "123456789000"},
 				MsgRsp{cmd.QuestionAgentlessMonitoredAccountIDs, "123456789000,ou-abcd-12345678,r-abcd"},
-				MsgRsp{cmd.QuestionAgentlessMonitoredAccountProfile, "monitored-1"},
-				MsgRsp{cmd.QuestionAgentlessMonitoredAccountRegion, "us-west-1"},
-				MsgRsp{cmd.QuestionAgentlessMonitoredAccountAddMore, "y"},
-				MsgRsp{cmd.QuestionAgentlessMonitoredAccountProfile, "monitored-2"},
-				MsgRsp{cmd.QuestionAgentlessMonitoredAccountRegion, "us-west-2"},
-				MsgRsp{cmd.QuestionAgentlessMonitoredAccountAddMore, "n"},
+				MsgRsp{monitoredProfileQuestion, "monitored-1"},
+				MsgRsp{monitoredRegionQuestion, "us-west-1"},
 				MsgRsp{cmd.QuestionAgentlessScanningAccountProfile, "scanning-1"},
 				MsgRsp{cmd.QuestionAgentlessScanningAccountRegion, "us-east-1"},
 				MsgRsp{cmd.QuestionAgentlessScanningAccountAddMore, "y"},
@@ -269,7 +267,6 @@ func TestGenerationAwsAgentlessOrganization(t *testing.T) {
 		aws.WithAgentlessMonitoredAccountIDs([]string{"123456789000", "ou-abcd-12345678", "r-abcd"}),
 		aws.WithAgentlessMonitoredAccounts(
 			aws.NewAwsSubAccount("monitored-1", "us-west-1", "monitored-1-us-west-1"),
-			aws.NewAwsSubAccount("monitored-2", "us-west-2", "monitored-2-us-west-2"),
 		),
 		aws.WithAgentlessScanningAccounts(
 			aws.NewAwsSubAccount("scanning-1", "us-east-1", "scanning-1-us-east-1"),

--- a/lwgenerate/aws/aws.go
+++ b/lwgenerate/aws/aws.go
@@ -310,13 +310,10 @@ func (args *GenerateAwsTfConfigurationArgs) Validate() error {
 				return errors.New("must specify monitored account ID list for Agentless organization integration")
 			}
 			if len(args.AgentlessMonitoredAccounts) == 0 {
-				// profile/region is required for single account IDs
+				// profile/region is required for single accounts
 				for _, accountID := range args.AgentlessMonitoredAccountIDs {
-					ok, err := regexp.MatchString(`^\d{12}$`, accountID)
-					if err != nil {
-						return errors.Wrap(err, "failed to validate input")
-					}
-					if ok {
+					regex, _ := regexp.Compile(`^\d{12}$`)
+					if regex.MatchString(accountID) {
 						return errors.New("must specify profile/region for single monitored accounts" +
 							" for Agentless organization integration")
 					}


### PR DESCRIPTION
## Summary

Only require `--agentless_monitored_accounts` when single account ids are provided.

## How did you test this change?

`make test`
`make integration-context-tests`

Only prompt user to enter profile/region for single accounts:
<img width="709" alt="Screenshot 2023-11-17 at 1 38 22 PM" src="https://github.com/lacework/go-sdk/assets/7945666/3a7ba8e8-8c34-4bed-9795-f0bbc392a14a">

## Issue
https://lacework.atlassian.net/browse/GROW-2586
