### PR TITLE
chore: remove iam role attributes from CloudTrail if Config org enabled

### DIFF
--- a/lwgenerate/aws/aws.go
+++ b/lwgenerate/aws/aws.go
@@ -929,7 +929,7 @@ func createCloudtrail(args *GenerateAwsTfConfigurationArgs) (*hclwrite.Block, er
 			attributes["sqs_encryption_enabled "] = false
 		}
 	}
-	if args.ExistingIamRole.IsEmpty() && args.Config {
+	if args.ExistingIamRole.IsEmpty() && args.Config && !args.AwsOrganization {
 		attributes["use_existing_iam_role"] = true
 		attributes["iam_role_name"] = lwgenerate.CreateSimpleTraversal(
 			[]string{"module", "aws_config", "iam_role_name"})


### PR DESCRIPTION
## Summary

- Do not add IAM role attributes for CloudTrail when doing org integration for CloudTrail and Configuration

## How did you test this change?

make test
make integration-generation

## Issue

https://lacework.atlassian.net/browse/GROW-2587
