### PR TITLE
feat(GROW-2590): CDK .dev file info

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -212,16 +212,8 @@ protoc-python: install-tools
 		--grpc_python_out=./cli/cdk/python proto/v1/*.proto
 
 .PHONY: install-cli
-install-cli: build-cli-cross-platform ## Build and install the Lacework CLI binary at /usr/local/bin/lacework
-ifeq (x86_64, $(shell uname -m))
-	mv bin/$(PACKAGENAME)-$(shell uname -s | tr '[:upper:]' '[:lower:]')-amd64 /usr/local/bin/$(CLINAME)
-else ifeq (arm64, $(shell uname -m))
-	mv bin/$(PACKAGENAME)-$(shell uname -s | tr '[:upper:]' '[:lower:]')-arm64 /usr/local/bin/$(CLINAME)
-else ifeq (aarch64, $(shell uname -m))
-	mv bin/$(PACKAGENAME)-$(shell uname -s | tr '[:upper:]' '[:lower:]')-arm64 /usr/local/bin/$(CLINAME)
-else
-	mv bin/$(PACKAGENAME)-$(shell uname -s | tr '[:upper:]' '[:lower:]')-386 /usr/local/bin/$(CLINAME)
-endif
+install-cli: build ## Build and install the Lacework CLI binary at /usr/local/bin/lacework
+	mv bin/lacework /usr/local/bin/$(CLINAME)
 	@echo "\nThe lacework cli has been installed at /usr/local/bin"
 
 .PHONY: release

--- a/lwcomponent/api_info.go
+++ b/lwcomponent/api_info.go
@@ -15,13 +15,14 @@ type ApiInfo interface {
 }
 
 type apiInfo struct {
-	id          int32
-	name        string
-	version     semver.Version
-	allVersions []*semver.Version
-	desc        string
-	sizeKB      int64
-	deprecated  bool
+	id            int32
+	name          string
+	version       semver.Version
+	allVersions   []*semver.Version
+	desc          string
+	sizeKB        int64
+	deprecated    bool
+	componentType Type
 }
 
 func NewAPIInfo(
@@ -32,15 +33,17 @@ func NewAPIInfo(
 	desc string,
 	size int64,
 	deprecated bool,
+	componentType Type,
 ) ApiInfo {
 	return &apiInfo{
-		id:          id,
-		name:        name,
-		version:     *version,
-		allVersions: allVersions,
-		desc:        desc,
-		sizeKB:      size,
-		deprecated:  deprecated,
+		id:            id,
+		name:          name,
+		version:       *version,
+		allVersions:   allVersions,
+		desc:          desc,
+		sizeKB:        size,
+		deprecated:    deprecated,
+		componentType: componentType,
 	}
 }
 

--- a/lwcomponent/api_info_test.go
+++ b/lwcomponent/api_info_test.go
@@ -17,7 +17,7 @@ func TestApiInfoId(t *testing.T) {
 
 	var id int32 = 23
 
-	info := lwcomponent.NewAPIInfo(id, "test", version, allVersions, "", 0, false)
+	info := lwcomponent.NewAPIInfo(id, "test", version, allVersions, "", 0, false, lwcomponent.BinaryType)
 
 	result := info.Id()
 	assert.Equal(t, id, result)
@@ -32,7 +32,7 @@ func TestApiInfoLatestVersion(t *testing.T) {
 		panic(err)
 	}
 
-	info := lwcomponent.NewAPIInfo(1, "test", version, allVersions, "", 0, false)
+	info := lwcomponent.NewAPIInfo(1, "test", version, allVersions, "", 0, false, lwcomponent.BinaryType)
 
 	result := info.LatestVersion()
 	assert.Equal(t, expectedVer, result.String())

--- a/lwcomponent/catalog_test.go
+++ b/lwcomponent/catalog_test.go
@@ -896,7 +896,14 @@ func CreateLocalComponent(componentName string, version string, development bool
 	}
 
 	if development {
-		if _, err := os.Create(filepath.Join(path, lwcomponent.DevelopmentFile)); err != nil {
+		data, err := json.Marshal(lwcomponent.DevInfo{Name: componentName, Version: version, Desc: "", ComponentType: lwcomponent.BinaryType})
+		if err != nil {
+			panic(err)
+		}
+
+		fmt.Println(filepath.Join(path, lwcomponent.DevelopmentFile))
+
+		if err := os.WriteFile(filepath.Join(path, lwcomponent.DevelopmentFile), data, os.ModePerm); err != nil {
 			panic(err)
 		}
 	}

--- a/lwcomponent/cdk_component.go
+++ b/lwcomponent/cdk_component.go
@@ -25,7 +25,7 @@ type CDKComponent struct {
 	stage    Stager
 }
 
-func NewCDKComponent(name string, componentType Type, apiInfo ApiInfo, hostInfo HostInfo) CDKComponent {
+func NewCDKComponent(name string, desc string, componentType Type, apiInfo ApiInfo, hostInfo HostInfo) CDKComponent {
 	var (
 		exec Executer = &nonExecutable{}
 	)
@@ -48,12 +48,13 @@ func NewCDKComponent(name string, componentType Type, apiInfo ApiInfo, hostInfo 
 	}
 
 	return CDKComponent{
-		Name:     name,
-		Type:     componentType,
-		Status:   status,
-		Exec:     exec,
-		apiInfo:  apiInfo,
-		hostInfo: hostInfo,
+		Name:        name,
+		Description: desc,
+		Type:        componentType,
+		Status:      status,
+		Exec:        exec,
+		apiInfo:     apiInfo,
+		hostInfo:    hostInfo,
 	}
 }
 

--- a/lwcomponent/cdk_component_test.go
+++ b/lwcomponent/cdk_component_test.go
@@ -14,7 +14,7 @@ func TestNewCDKComponent(t *testing.T) {
 	defer ResetHome(home)
 
 	t.Run("UnknownStatus", func(t *testing.T) {
-		component := lwcomponent.NewCDKComponent("unknown", lwcomponent.BinaryType, nil, nil)
+		component := lwcomponent.NewCDKComponent("unknown", "", lwcomponent.BinaryType, nil, nil)
 
 		assert.Equal(t, lwcomponent.UnknownStatus, component.Status)
 	})
@@ -25,9 +25,9 @@ func TestNewCDKComponent(t *testing.T) {
 		version, _ := semver.NewVersion("1.1.1")
 		allVersions := []*semver.Version{version}
 
-		apiInfo := lwcomponent.NewAPIInfo(1, name, version, allVersions, "", 1, false)
+		apiInfo := lwcomponent.NewAPIInfo(1, name, version, allVersions, "", 1, false, lwcomponent.BinaryType)
 
-		component := lwcomponent.NewCDKComponent(name, lwcomponent.BinaryType, apiInfo, nil)
+		component := lwcomponent.NewCDKComponent(name, "", lwcomponent.BinaryType, apiInfo, nil)
 
 		assert.Equal(t, lwcomponent.NotInstalled, component.Status)
 	})
@@ -41,7 +41,7 @@ func TestNewCDKComponent(t *testing.T) {
 		version, _ := semver.NewVersion(ver)
 		allVersions := []*semver.Version{version}
 
-		apiInfo := lwcomponent.NewAPIInfo(1, name, version, allVersions, "", 1, false)
+		apiInfo := lwcomponent.NewAPIInfo(1, name, version, allVersions, "", 1, false, lwcomponent.BinaryType)
 
 		CreateLocalComponent(name, ver, false)
 
@@ -49,7 +49,7 @@ func TestNewCDKComponent(t *testing.T) {
 
 		hostInfo := lwcomponent.NewHostInfo(filepath.Join(dir, name))
 
-		component := lwcomponent.NewCDKComponent(name, lwcomponent.BinaryType, apiInfo, hostInfo)
+		component := lwcomponent.NewCDKComponent(name, "", lwcomponent.BinaryType, apiInfo, hostInfo)
 
 		assert.Equal(t, lwcomponent.Installed, component.Status)
 	})
@@ -65,7 +65,7 @@ func TestNewCDKComponent(t *testing.T) {
 		installedVersion, _ := semver.NewVersion(installVer)
 		allVersions := []*semver.Version{version, installedVersion}
 
-		apiInfo := lwcomponent.NewAPIInfo(1, name, version, allVersions, "", 1, false)
+		apiInfo := lwcomponent.NewAPIInfo(1, name, version, allVersions, "", 1, false, lwcomponent.BinaryType)
 
 		CreateLocalComponent(name, installVer, false)
 
@@ -73,7 +73,7 @@ func TestNewCDKComponent(t *testing.T) {
 
 		hostInfo := lwcomponent.NewHostInfo(filepath.Join(dir, name))
 
-		component := lwcomponent.NewCDKComponent(name, lwcomponent.BinaryType, apiInfo, hostInfo)
+		component := lwcomponent.NewCDKComponent(name, "", lwcomponent.BinaryType, apiInfo, hostInfo)
 
 		assert.Equal(t, lwcomponent.UpdateAvailable, component.Status)
 	})
@@ -90,7 +90,7 @@ func TestNewCDKComponent(t *testing.T) {
 
 		hostInfo := lwcomponent.NewHostInfo(filepath.Join(dir, name))
 
-		component := lwcomponent.NewCDKComponent(name, lwcomponent.BinaryType, nil, hostInfo)
+		component := lwcomponent.NewCDKComponent(name, "", lwcomponent.BinaryType, nil, hostInfo)
 
 		assert.Equal(t, lwcomponent.InstalledDeprecated, component.Status)
 	})
@@ -106,12 +106,12 @@ func TestNewCDKComponent(t *testing.T) {
 
 		CreateLocalComponent(name, ver, false)
 
-		apiInfo := lwcomponent.NewAPIInfo(1, name, version, allVersions, "", 1, true)
+		apiInfo := lwcomponent.NewAPIInfo(1, name, version, allVersions, "", 1, true, lwcomponent.BinaryType)
 
 		dir, _ := lwcomponent.CatalogCacheDir()
 		hostInfo := lwcomponent.NewHostInfo(filepath.Join(dir, name))
 
-		component := lwcomponent.NewCDKComponent(name, lwcomponent.BinaryType, apiInfo, hostInfo)
+		component := lwcomponent.NewCDKComponent(name, "", lwcomponent.BinaryType, apiInfo, hostInfo)
 
 		assert.Equal(t, lwcomponent.InstalledDeprecated, component.Status)
 	})
@@ -124,9 +124,9 @@ func TestNewCDKComponent(t *testing.T) {
 		version, _ := semver.NewVersion("1.1.1")
 		allVersions := []*semver.Version{version}
 
-		apiInfo := lwcomponent.NewAPIInfo(1, name, version, allVersions, "", 1, true)
+		apiInfo := lwcomponent.NewAPIInfo(1, name, version, allVersions, "", 1, true, lwcomponent.BinaryType)
 
-		component := lwcomponent.NewCDKComponent(name, lwcomponent.BinaryType, apiInfo, nil)
+		component := lwcomponent.NewCDKComponent(name, "", lwcomponent.BinaryType, apiInfo, nil)
 
 		assert.Equal(t, lwcomponent.NotInstalledDeprecated, component.Status)
 	})
@@ -141,7 +141,7 @@ func TestNewCDKComponent(t *testing.T) {
 		version, _ := semver.NewVersion(apiVer)
 		allVersions := []*semver.Version{version}
 
-		apiInfo := lwcomponent.NewAPIInfo(1, name, version, allVersions, "", 1, false)
+		apiInfo := lwcomponent.NewAPIInfo(1, name, version, allVersions, "", 1, false, lwcomponent.BinaryType)
 
 		CreateLocalComponent(name, installVer, false)
 
@@ -149,7 +149,7 @@ func TestNewCDKComponent(t *testing.T) {
 
 		hostInfo := lwcomponent.NewHostInfo(filepath.Join(dir, name))
 
-		component := lwcomponent.NewCDKComponent(name, lwcomponent.BinaryType, apiInfo, hostInfo)
+		component := lwcomponent.NewCDKComponent(name, "", lwcomponent.BinaryType, apiInfo, hostInfo)
 
 		assert.Equal(t, lwcomponent.Tainted, component.Status)
 	})
@@ -166,7 +166,7 @@ func TestNewCDKComponent(t *testing.T) {
 
 		hostInfo := lwcomponent.NewHostInfo(filepath.Join(dir, name))
 
-		component := lwcomponent.NewCDKComponent(name, lwcomponent.BinaryType, nil, hostInfo)
+		component := lwcomponent.NewCDKComponent(name, "", lwcomponent.BinaryType, nil, hostInfo)
 
 		assert.Equal(t, lwcomponent.Development, component.Status)
 	})
@@ -180,7 +180,7 @@ func TestNewCDKComponent(t *testing.T) {
 		version, _ := semver.NewVersion(ver)
 		allVersions := []*semver.Version{version}
 
-		apiInfo := lwcomponent.NewAPIInfo(1, name, version, allVersions, "", 1, false)
+		apiInfo := lwcomponent.NewAPIInfo(1, name, version, allVersions, "", 1, false, lwcomponent.BinaryType)
 
 		CreateLocalComponent(name, ver, false)
 
@@ -188,7 +188,7 @@ func TestNewCDKComponent(t *testing.T) {
 
 		hostInfo := lwcomponent.NewHostInfo(filepath.Join(dir, name))
 
-		component := lwcomponent.NewCDKComponent(name, lwcomponent.BinaryType, apiInfo, hostInfo)
+		component := lwcomponent.NewCDKComponent(name, "", lwcomponent.BinaryType, apiInfo, hostInfo)
 
 		_, _, err := component.Exec.Execute([]string{}, "")
 		assert.Nil(t, err)
@@ -203,7 +203,7 @@ func TestNewCDKComponent(t *testing.T) {
 		version, _ := semver.NewVersion(ver)
 		allVersions := []*semver.Version{version}
 
-		apiInfo := lwcomponent.NewAPIInfo(1, name, version, allVersions, "", 1, false)
+		apiInfo := lwcomponent.NewAPIInfo(1, name, version, allVersions, "", 1, false, lwcomponent.BinaryType)
 
 		CreateLocalComponent(name, ver, false)
 
@@ -211,7 +211,7 @@ func TestNewCDKComponent(t *testing.T) {
 
 		hostInfo := lwcomponent.NewHostInfo(filepath.Join(dir, name))
 
-		component := lwcomponent.NewCDKComponent(name, lwcomponent.CommandType, apiInfo, hostInfo)
+		component := lwcomponent.NewCDKComponent(name, "", lwcomponent.CommandType, apiInfo, hostInfo)
 
 		_, _, err := component.Exec.Execute([]string{}, "")
 		assert.Nil(t, err)
@@ -226,7 +226,7 @@ func TestNewCDKComponent(t *testing.T) {
 		version, _ := semver.NewVersion(ver)
 		allVersions := []*semver.Version{version}
 
-		apiInfo := lwcomponent.NewAPIInfo(1, name, version, allVersions, "", 1, false)
+		apiInfo := lwcomponent.NewAPIInfo(1, name, version, allVersions, "", 1, false, lwcomponent.BinaryType)
 
 		CreateLocalComponent(name, ver, false)
 
@@ -234,7 +234,7 @@ func TestNewCDKComponent(t *testing.T) {
 
 		hostInfo := lwcomponent.NewHostInfo(filepath.Join(dir, name))
 
-		component := lwcomponent.NewCDKComponent(name, lwcomponent.LibraryType, apiInfo, hostInfo)
+		component := lwcomponent.NewCDKComponent(name, "", lwcomponent.LibraryType, apiInfo, hostInfo)
 
 		_, _, err := component.Exec.Execute([]string{}, "")
 		assert.Equal(t, lwcomponent.ErrNonExecutable, err)
@@ -249,7 +249,7 @@ func TestNewCDKComponent(t *testing.T) {
 		version, _ := semver.NewVersion(ver)
 		allVersions := []*semver.Version{version}
 
-		apiInfo := lwcomponent.NewAPIInfo(1, name, version, allVersions, "", 1, false)
+		apiInfo := lwcomponent.NewAPIInfo(1, name, version, allVersions, "", 1, false, lwcomponent.BinaryType)
 
 		CreateLocalComponent(name, ver, false)
 
@@ -257,7 +257,7 @@ func TestNewCDKComponent(t *testing.T) {
 
 		hostInfo := lwcomponent.NewHostInfo(filepath.Join(dir, name))
 
-		component := lwcomponent.NewCDKComponent(name, lwcomponent.StandaloneType, apiInfo, hostInfo)
+		component := lwcomponent.NewCDKComponent(name, "", lwcomponent.StandaloneType, apiInfo, hostInfo)
 
 		_, _, err := component.Exec.Execute([]string{}, "")
 		assert.Equal(t, lwcomponent.ErrNonExecutable, err)

--- a/lwcomponent/dev_info.go
+++ b/lwcomponent/dev_info.go
@@ -1,0 +1,41 @@
+package lwcomponent
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/Masterminds/semver"
+	"github.com/pkg/errors"
+)
+
+type DevInfo struct {
+	ComponentType Type
+	Desc          string
+	Name          string
+	Version       string
+}
+
+func NewDevInfo(dir string) (*DevInfo, error) {
+	path := filepath.Join(dir, DevelopmentFile)
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, errors.Errorf("unable to read %s file", path)
+	}
+
+	info := DevInfo{}
+
+	err = json.Unmarshal(data, &info)
+	if err != nil {
+		return nil, errors.Errorf("unable to unmarshal %s file", path)
+	}
+
+	_, err = semver.NewVersion(info.Version)
+	if err != nil {
+		return nil, errors.Wrap(err, fmt.Sprintf("development component '%s' version '%s'", info.Name, info.Version))
+	}
+
+	return &info, nil
+}


### PR DESCRIPTION
## Summary

CDK v1 code path now using `.dev` file data.

We only need to compile for our platform when we install the CLI using make.  This is a lot faster.

## How did you test this change?

1. `lacework component switch techally`
2. `lacework component dev tester`
3. `lacework component switch qan`
4.

```
> lacework component list
       STATUS                 NAME              VERSION                   DESCRIPTION
-------------------+-------------------------+-----------+--------------------------------------------
  Installed          tester                    0.0.0-dev   (dev-mode) testing stuff

Components version: 0.3.0
```

## Issue

https://lacework.atlassian.net/browse/GROW-2590