### PR TITLE
chore: add CloudTrail Control Tower to generate AWS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ integration-context-tests: install-tools ## Run integration tests with build tag
 
 .PHONY: integration-generation-only
 integration-generation-only: ## Run integration tests
-	PATH="$(PWD)/bin:${PATH}" go test -v github.com/lacework/go-sdk/integration -timeout 30m -run "^TestGeneration" -tags="generation"
+	PATH="$(PWD)/bin:${PATH}" go test -v github.com/lacework/go-sdk/integration -timeout 30m -run "^TestGenerationAws" -tags="generation"
 
 .PHONY: integration-only
 integration-only: install-tools ## Run integration tests

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ integration-context-tests: install-tools ## Run integration tests with build tag
 
 .PHONY: integration-generation-only
 integration-generation-only: ## Run integration tests
-	PATH="$(PWD)/bin:${PATH}" go test -v github.com/lacework/go-sdk/integration -timeout 30m -run "^TestGenerationAws" -tags="generation"
+	PATH="$(PWD)/bin:${PATH}" go test -v github.com/lacework/go-sdk/integration -timeout 30m -run "^TestGeneration" -tags="generation"
 
 .PHONY: integration-only
 integration-only: install-tools ## Run integration tests

--- a/cli/cmd/generate_aws.go
+++ b/cli/cmd/generate_aws.go
@@ -1012,7 +1012,9 @@ func promptCloudtrailQuestions(
 		return nil
 	}
 
-	promptCloudtrailControlTowerQuestions(config)
+	if err := promptCloudtrailControlTowerQuestions(config); err != nil {
+		return err
+	}
 
 	noControlTower := !config.ControlTower
 

--- a/cli/docs/lacework_generate_cloud-account_aws.md
+++ b/cli/docs/lacework_generate_cloud-account_aws.md
@@ -63,6 +63,10 @@ lacework generate cloud-account aws [flags]
       --config_organization_id string             specify AWS organization ID for Config organization integration
       --config_organization_units strings         specify AWS organization units for Config organization integration
       --consolidated_cloudtrail                   use consolidated trail
+      --controltower                              enable Control Tower integration
+      --controltower_audit_account string         specify AWS Control Tower Audit account; value format must be <aws profile>:<region>
+      --controltower_kms_key_arn string           specify AWS Control Tower custom kMS key ARN
+      --controltower_log_archive_account string   specify AWS Control Tower Log Archive account; value format must be <aws profile>:<region>
       --existing_bucket_arn string                specify existing cloudtrail S3 bucket ARN
       --existing_iam_role_arn string              specify existing iam role arn to use
       --existing_iam_role_externalid string       specify existing iam role external_id to use

--- a/integration/aws_generation_test.go
+++ b/integration/aws_generation_test.go
@@ -436,6 +436,7 @@ func TestGenerationAwsCloudtrailOrganization(t *testing.T) {
 				MsgRsp{cmd.QuestionEnableAgentless, "n"},
 				MsgRsp{cmd.QuestionEnableConfig, "n"},
 				MsgRsp{cmd.QuestionEnableCloudtrail, "y"},
+				MsgRsp{cmd.QuestionControlTower, "n"},
 				MsgRsp{cmd.QuestionCloudtrailUseConsolidated, "y"},
 				MsgRsp{cmd.QuestionCloudtrailAdvanced, "y"},
 				MsgMenu{cmd.OptCloudtrailOrg, 0},
@@ -480,6 +481,62 @@ func TestGenerationAwsCloudtrailOrganization(t *testing.T) {
 		aws.WithAwsRegion("us-east-2"),
 		aws.WithConsolidatedCloudtrail(true),
 		aws.WithOrgAccountMappings(orgAccountMappings),
+	).Generate()
+	assert.Equal(t, buildTf, tfResult)
+}
+
+// Test CloudTrail Control Tower integration
+func TestGenerationAwsCloudtrailControlTower(t *testing.T) {
+	os.Setenv("LW_NOCACHE", "true")
+	defer os.Setenv("LW_NOCACHE", "")
+	var final string
+
+	s3BucketArn := "arn:aws:s3:::bucket-name"
+	snsTopicArn := "arn:aws:sns:us-east-2:249446771485:topic-name"
+
+	// Run CLI
+	tfResult := runGenerateTest(t,
+		func(c *expect.Console) {
+			expectsCliOutput(t, c, []MsgRspHandler{
+				MsgRsp{cmd.QuestionEnableAwsOrganization, "y"},
+				MsgRsp{cmd.QuestionMainAwsProfile, "main"},
+				MsgRsp{cmd.QuestionMainAwsRegion, "us-east-2"},
+				MsgRsp{cmd.QuestionEnableAgentless, "n"},
+				MsgRsp{cmd.QuestionEnableConfig, "n"},
+				MsgRsp{cmd.QuestionEnableCloudtrail, "y"},
+				MsgRsp{cmd.QuestionControlTower, "y"},
+				MsgRsp{cmd.QuestionControlTowerS3BucketArn, s3BucketArn},
+				MsgRsp{cmd.QuestionControlTowerSnsTopicArn, snsTopicArn},
+				MsgRsp{cmd.QuestionControlTowerAuditAccountProfile, "audit"},
+				MsgRsp{cmd.QuestionControlTowerAuditAccountRegion, "us-west-1"},
+				MsgRsp{cmd.QuestionControlTowerLogArchiveAccountProfile, "log-archive"},
+				MsgRsp{cmd.QuestionControlTowerLogArchiveAccountRegion, "us-west-2"},
+				MsgRsp{cmd.QuestionCloudtrailAdvanced, "n"},
+				MsgRsp{cmd.QuestionAwsOutputLocation, ""},
+				MsgRsp{cmd.QuestionRunTfPlan, "n"},
+			})
+			final, _ = c.ExpectEOF()
+		},
+		"generate",
+		"cloud-account",
+		"aws",
+	)
+
+	auditAccount := aws.NewAwsSubAccount("audit", "us-west-1", "audit-us-west-1")
+	logArchiveAccount := aws.NewAwsSubAccount("log-archive", "us-west-2", "log-archive-us-west-2")
+
+	// Ensure CLI ran correctly
+	assert.Contains(t, final, "Terraform code saved in")
+
+	// Create the TF directly with lwgenerate and validate same result via CLI
+	buildTf, _ := aws.NewTerraform(true, false, false, true,
+		aws.WithAwsProfile("main"),
+		aws.WithAwsRegion("us-east-2"),
+		aws.WithControlTower(true),
+		aws.WithControlTowerAuditAccount(&auditAccount),
+		aws.WithControlTowerLogArchiveAccount(&logArchiveAccount),
+		aws.WithExistingCloudtrailBucketArn(s3BucketArn),
+		aws.WithExistingSnsTopicArn(snsTopicArn),
 	).Generate()
 	assert.Equal(t, buildTf, tfResult)
 }

--- a/integration/test_resources/help/generate_cloud-account_aws
+++ b/integration/test_resources/help/generate_cloud-account_aws
@@ -51,6 +51,10 @@ Flags:
       --config_organization_id string             specify AWS organization ID for Config organization integration
       --config_organization_units strings         specify AWS organization units for Config organization integration
       --consolidated_cloudtrail                   use consolidated trail
+      --controltower                              enable Control Tower integration
+      --controltower_audit_account string         specify AWS Control Tower Audit account; value format must be <aws profile>:<region>
+      --controltower_kms_key_arn string           specify AWS Control Tower custom kMS key ARN
+      --controltower_log_archive_account string   specify AWS Control Tower Log Archive account; value format must be <aws profile>:<region>
       --existing_bucket_arn string                specify existing cloudtrail S3 bucket ARN
       --existing_iam_role_arn string              specify existing iam role arn to use
       --existing_iam_role_externalid string       specify existing iam role external_id to use

--- a/integration/test_resources/help/generate_cloud-account_aws_controltower
+++ b/integration/test_resources/help/generate_cloud-account_aws_controltower
@@ -67,6 +67,10 @@ Global Flags:
       --config_organization_id string             specify AWS organization ID for Config organization integration
       --config_organization_units strings         specify AWS organization units for Config organization integration
       --consolidated_cloudtrail                   use consolidated trail
+      --controltower                              enable Control Tower integration
+      --controltower_audit_account string         specify AWS Control Tower Audit account; value format must be <aws profile>:<region>
+      --controltower_kms_key_arn string           specify AWS Control Tower custom kMS key ARN
+      --controltower_log_archive_account string   specify AWS Control Tower Log Archive account; value format must be <aws profile>:<region>
       --debug                                     turn on debug logging
       --existing_bucket_arn string                specify existing cloudtrail S3 bucket ARN
       --existing_iam_role_arn string              specify existing iam role arn to use


### PR DESCRIPTION
## Summary

- Add [CloudTrail Control Tower](https://github.com/lacework/terraform-aws-cloudtrail-controltower/tree/main) support to `lacework generate cloud-account aws --aws_organization --cloudtrail --controltower` to generate terraform code 

## How did you test this change?

make test
make integration-generation-only

## Issue

https://lacework.atlassian.net/browse/GROW-2592
