### PR TITLE
feat(RAIN-91461): support Rego in query validate

### DIFF
--- a/api/lql_validate.go
+++ b/api/lql_validate.go
@@ -19,7 +19,8 @@
 package api
 
 type ValidateQuery struct {
-	QueryText string `json:"queryText"`
+	QueryText     string  `json:"queryText"`
+	QueryLanguage *string `json:"queryLanguage,omitempty" yaml:"queryLanguage,omitempty"`
 }
 
 func (svc *QueryService) Validate(vq ValidateQuery) (

--- a/api/lql_validate_test.go
+++ b/api/lql_validate_test.go
@@ -24,9 +24,11 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/lacework/go-sdk/api"
 	"github.com/lacework/go-sdk/internal/lacework"
-	"github.com/stretchr/testify/assert"
+	"github.com/lacework/go-sdk/internal/pointer"
 )
 
 var (
@@ -56,8 +58,8 @@ func TestQueryValidateMethod(t *testing.T) {
 	assert.Nil(t, err)
 }
 
-func TestQueryValidateOK(t *testing.T) {
-	mockResponse := mockQueryDataResponse(newQueryJSON)
+func testQueryValidateOKHelper(t *testing.T, expectedResponseData string, testQuery api.ValidateQuery) {
+	mockResponse := mockQueryDataResponse(expectedResponseData)
 
 	fakeServer := lacework.MockServer()
 	fakeServer.MockAPI(
@@ -78,9 +80,21 @@ func TestQueryValidateOK(t *testing.T) {
 	_ = json.Unmarshal([]byte(mockResponse), &validateExpected)
 
 	var validateActual api.QueryResponse
-	validateActual, err = c.V2.Query.Validate(validateQuery)
+	validateActual, err = c.V2.Query.Validate(testQuery)
 	assert.Nil(t, err)
 	assert.Equal(t, validateExpected, validateActual)
+}
+
+func TestLQLQueryValidateOK(t *testing.T) {
+	testQueryValidateOKHelper(t, newQueryJSON, validateQuery)
+}
+
+func TestRegoQueryValidateOK(t *testing.T) {
+	validateRegoQuery := api.ValidateQuery{
+		QueryText:     newRegoQueryText,
+		QueryLanguage: pointer.Of("Rego"),
+	}
+	testQueryValidateOKHelper(t, newRegoQueryJSON, validateRegoQuery)
 }
 
 func TestQueryValidateError(t *testing.T) {

--- a/cli/cmd/lql_validate.go
+++ b/cli/cmd/lql_validate.go
@@ -89,7 +89,8 @@ func validateQuery(cmd *cobra.Command, args []string) error {
 
 func validateQueryAndOutput(nq api.NewQuery) error {
 	vq := api.ValidateQuery{
-		QueryText: nq.QueryText,
+		QueryText:     nq.QueryText,
+		QueryLanguage: nq.QueryLanguage,
 	}
 
 	cli.StartProgress(" Validating query...")


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/lacework/go-sdk) and create your branch from `main`
  2. Run `make prepare` in the repository root
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`make test`)
  5. Format your code (`make fmt`)
  6. Make sure your code lints (`make lint`)
  7. If you are updating the Lacework CLI, make sure it compiles (`make build-cli-cross-platform`)
  8. Follow the commit message standard (`type(scope): subject`) documented in [DEVELOPER_GUIDELINES.md](https://github.com/lacework/go-sdk/blob/main/DEVELOPER_GUIDELINES.md#commit-message-standard)
  9. If you haven't already, configure signed commits by [telling git about your signing key](https://docs.github.com/en/github/authenticating-to-github/managing-commit-signature-verification/telling-git-about-your-signing-key) and [signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)

  Learn more about contributing: https://github.com/lacework/go-sdk/blob/main/CONTRIBUTING.md
-->

## Summary

This is to support an extra field queryLanguage in the input for query validation command.  It’s optional, by default it should be LQL

## How did you test this change?

* build and install the CLI from source: make prepare && make install-cli
* Create a file containing a Rego query:
```
$ cat /Users/kchen/proj/opa/rego_query.yaml
---
queryId: TestRegoQueryViaCli2
queryLanguage: Rego
queryText: |-
  package lacework.policies.lacework_global_134
  import future.keywords
  import data.lacework
  import data.lacework.assessment
  source := lacework.aws.cfg.list("s3", "list-buckets")
  assess := assessment.violation(input, "just because")
```
*  Query validate command can be executed successfully against the file:
```
$ /usr/local/bin/lacework query validate  -f /Users/kchen/proj/opa/rego_query.yaml
Query validated successfully. Time for 🍕
```

## Issue

<!--
  Include the link to a Jira/Github issue
-->
