### PR TITLE
feat(cli): show query language in policies when available

### DIFF
--- a/api/policy.go
+++ b/api/policy.go
@@ -77,7 +77,6 @@ type NewPolicy struct {
 	PolicyID      string   `json:"policyId,omitempty" yaml:"policyId,omitempty" `
 	PolicyType    string   `json:"policyType" yaml:"policyType"`
 	QueryID       string   `json:"queryId" yaml:"queryId"`
-	QueryLanguage *string  `json:"queryLanguage,omitempty" yaml:"queryLanguage,omitempty"`
 	Title         string   `json:"title" yaml:"title"`
 	Enabled       bool     `json:"enabled" yaml:"enabled"`
 	Description   string   `json:"description" yaml:"description"`
@@ -173,25 +172,26 @@ func ParseUpdatePolicy(s string) (UpdatePolicy, error) {
 	return policy, errors.New("policy must be valid JSON or YAML")
 }
 
+type ExceptionConfigMap map[string][]PolicyExceptionConfigurationConstraints
 type Policy struct {
-	PolicyID               string                                               `json:"policyId" yaml:"policyId"`
-	PolicyType             string                                               `json:"policyType" yaml:"-"`
-	QueryID                string                                               `json:"queryId" yaml:"queryId"`
-	QueryLanguage          *string                                              `json:"queryLanguage,omitempty" yaml:"queryLanguage,omitempty"`
-	Title                  string                                               `json:"title" yaml:"title"`
-	Enabled                bool                                                 `json:"enabled" yaml:"enabled"`
-	Description            string                                               `json:"description" yaml:"description"`
-	Remediation            string                                               `json:"remediation" yaml:"remediation"`
-	Severity               string                                               `json:"severity" yaml:"severity"`
-	Limit                  int                                                  `json:"limit" yaml:"limit"`
-	EvalFrequency          string                                               `json:"evalFrequency" yaml:"evalFrequency"`
-	AlertEnabled           bool                                                 `json:"alertEnabled" yaml:"alertEnabled"`
-	AlertProfile           string                                               `json:"alertProfile" yaml:"alertProfile"`
-	Tags                   []string                                             `json:"tags" yaml:"tags"`
-	Owner                  string                                               `json:"owner" yaml:"-"`
-	LastUpdateTime         string                                               `json:"lastUpdateTime" yaml:"-"`
-	LastUpdateUser         string                                               `json:"lastUpdateUser" yaml:"-"`
-	ExceptionConfiguration map[string][]PolicyExceptionConfigurationConstraints `json:"exceptionConfiguration" yaml:"-"`
+	PolicyID               string             `json:"policyId" yaml:"policyId"`
+	PolicyType             string             `json:"policyType" yaml:"-"`
+	QueryID                string             `json:"queryId" yaml:"queryId"`
+	QueryLanguage          *string            `json:"queryLanguage,omitempty" yaml:"queryLanguage,omitempty"`
+	Title                  string             `json:"title" yaml:"title"`
+	Enabled                bool               `json:"enabled" yaml:"enabled"`
+	Description            string             `json:"description" yaml:"description"`
+	Remediation            string             `json:"remediation" yaml:"remediation"`
+	Severity               string             `json:"severity" yaml:"severity"`
+	Limit                  int                `json:"limit" yaml:"limit"`
+	EvalFrequency          string             `json:"evalFrequency" yaml:"evalFrequency"`
+	AlertEnabled           bool               `json:"alertEnabled" yaml:"alertEnabled"`
+	AlertProfile           string             `json:"alertProfile" yaml:"alertProfile"`
+	Tags                   []string           `json:"tags" yaml:"tags"`
+	Owner                  string             `json:"owner" yaml:"-"`
+	LastUpdateTime         string             `json:"lastUpdateTime" yaml:"-"`
+	LastUpdateUser         string             `json:"lastUpdateUser" yaml:"-"`
+	ExceptionConfiguration ExceptionConfigMap `json:"exceptionConfiguration" yaml:"-"`
 }
 
 type PolicyExceptionConfigurationConstraints struct {

--- a/api/policy.go
+++ b/api/policy.go
@@ -25,9 +25,10 @@ import (
 	"reflect"
 	"time"
 
-	"github.com/lacework/go-sdk/internal/array"
 	"github.com/pkg/errors"
 	"gopkg.in/yaml.v3"
+
+	"github.com/lacework/go-sdk/internal/array"
 )
 
 // PolicyService is a service that interacts with the Custom Policies
@@ -76,6 +77,7 @@ type NewPolicy struct {
 	PolicyID      string   `json:"policyId,omitempty" yaml:"policyId,omitempty" `
 	PolicyType    string   `json:"policyType" yaml:"policyType"`
 	QueryID       string   `json:"queryId" yaml:"queryId"`
+	QueryLanguage *string  `json:"queryLanguage,omitempty" yaml:"queryLanguage,omitempty"`
 	Title         string   `json:"title" yaml:"title"`
 	Enabled       bool     `json:"enabled" yaml:"enabled"`
 	Description   string   `json:"description" yaml:"description"`
@@ -175,6 +177,7 @@ type Policy struct {
 	PolicyID               string                                               `json:"policyId" yaml:"policyId"`
 	PolicyType             string                                               `json:"policyType" yaml:"-"`
 	QueryID                string                                               `json:"queryId" yaml:"queryId"`
+	QueryLanguage          *string                                              `json:"queryLanguage,omitempty" yaml:"queryLanguage,omitempty"`
 	Title                  string                                               `json:"title" yaml:"title"`
 	Enabled                bool                                                 `json:"enabled" yaml:"enabled"`
 	Description            string                                               `json:"description" yaml:"description"`

--- a/api/policy_test.go
+++ b/api/policy_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/aws/smithy-go/ptr"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/lacework/go-sdk/internal/pointer"
 	"github.com/lacework/go-sdk/lwseverity"
 
 	"github.com/lacework/go-sdk/api"
@@ -129,7 +128,6 @@ var (
 		PolicyID:      regoPolicyId,
 		PolicyType:    "Violation",
 		QueryID:       "MyRegoQuery",
-		QueryLanguage: pointer.Of("Rego"),
 		Title:         "My Rego Policy Title",
 		Enabled:       false,
 		Description:   "My Policy Description",
@@ -144,7 +142,6 @@ var (
 	"policyId": "%s",
 	"policyType": "%s",
 	"queryId": "%s",
-	"queryLanguage": "%s",
 	"title": "%s",
 	"enabled": %v,
 	"description": "%s",
@@ -154,7 +151,7 @@ var (
 	"limit": %d,
 	"alertEnabled": %v,
 	"alertProfile": "%s"
-}`, regoPolicy.PolicyID, regoPolicy.PolicyType, regoPolicy.QueryID, *regoPolicy.QueryLanguage, regoPolicy.Title,
+}`, regoPolicy.PolicyID, regoPolicy.PolicyType, regoPolicy.QueryID, regoPolicy.Title,
 		regoPolicy.Enabled, regoPolicy.Description, regoPolicy.Remediation, regoPolicy.Severity,
 		regoPolicy.EvalFrequency, regoPolicy.Limit, regoPolicy.AlertEnabled, regoPolicy.AlertProfile)
 )
@@ -192,8 +189,8 @@ func TestPolicyCreateMethod(t *testing.T) {
 	assert.Nil(t, err)
 }
 
-func testPolicyCreateOKHelper(t *testing.T, expectedPolicyData string, testPolicy api.NewPolicy) {
-	mockResponse := mockPolicyDataResponse(expectedPolicyData)
+func TestLqlPolicyCreateOK(t *testing.T) {
+	mockResponse := mockPolicyDataResponse(policyCreateData)
 
 	fakeServer := lacework.MockServer()
 	fakeServer.MockAPI(
@@ -213,17 +210,9 @@ func testPolicyCreateOKHelper(t *testing.T, expectedPolicyData string, testPolic
 	createExpected := api.PolicyResponse{}
 	_ = json.Unmarshal([]byte(mockResponse), &createExpected)
 
-	createActual, err := c.V2.Policy.Create(testPolicy)
+	createActual, err := c.V2.Policy.Create(newPolicy)
 	assert.Nil(t, err)
 	assert.Equal(t, createExpected, createActual)
-}
-
-func TestLqlPolicyCreateOK(t *testing.T) {
-	testPolicyCreateOKHelper(t, policyCreateData, newPolicy)
-}
-
-func TestRegoPolicyCreateOK(t *testing.T) {
-	testPolicyCreateOKHelper(t, regoPolicyCreateData, regoPolicy)
 }
 
 func TestPolicyCreateError(t *testing.T) {

--- a/cli/cmd/policy.go
+++ b/cli/cmd/policy.go
@@ -529,7 +529,7 @@ func showPolicy(_ *cobra.Command, args []string) error {
 	}
 
 	if cli.YAMLOutput() {
-		return cli.OutputYAML(&api.NewPolicy{
+		return cli.OutputYAML(&api.Policy{
 			PolicyID:      policyResponse.Data.PolicyID,
 			PolicyType:    policyResponse.Data.PolicyType,
 			QueryID:       policyResponse.Data.QueryID,

--- a/cli/cmd/policy.go
+++ b/cli/cmd/policy.go
@@ -29,13 +29,14 @@ import (
 	"strings"
 
 	"github.com/AlecAivazis/survey/v2"
-	"github.com/lacework/go-sdk/api"
-	"github.com/lacework/go-sdk/internal/pointer"
-	"github.com/lacework/go-sdk/lwseverity"
 	"github.com/olekukonko/tablewriter"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
+
+	"github.com/lacework/go-sdk/api"
+	"github.com/lacework/go-sdk/internal/pointer"
+	"github.com/lacework/go-sdk/lwseverity"
 )
 
 var (
@@ -532,6 +533,7 @@ func showPolicy(_ *cobra.Command, args []string) error {
 			PolicyID:      policyResponse.Data.PolicyID,
 			PolicyType:    policyResponse.Data.PolicyType,
 			QueryID:       policyResponse.Data.QueryID,
+			QueryLanguage: policyResponse.Data.QueryLanguage,
 			Title:         policyResponse.Data.Title,
 			Enabled:       policyResponse.Data.Enabled,
 			Description:   policyResponse.Data.Description,
@@ -590,6 +592,17 @@ func showPolicy(_ *cobra.Command, args []string) error {
 			)
 		}
 		// we know we are in human-readable format
+		if queryResponse.Data.QueryLanguage != nil {
+			cli.OutputHuman(renderOneLineCustomTable("QUERY LANGUAGE",
+				*queryResponse.Data.QueryLanguage,
+				tableFunc(func(t *tablewriter.Table) {
+					t.SetAlignment(tablewriter.ALIGN_LEFT)
+					t.SetColWidth(120)
+					t.SetBorder(false)
+					t.SetAutoWrapText(false)
+				}),
+			))
+		}
 		cli.OutputHuman(renderOneLineCustomTable("QUERY TEXT",
 			queryResponse.Data.QueryText,
 			tableFunc(func(t *tablewriter.Table) {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/lacework/go-sdk) and create your branch from `main`
  2. Run `make prepare` in the repository root
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`make test`)
  5. Format your code (`make fmt`)
  6. Make sure your code lints (`make lint`)
  7. If you are updating the Lacework CLI, make sure it compiles (`make build-cli-cross-platform`)
  8. Follow the commit message standard (`type(scope): subject`) documented in [DEVELOPER_GUIDELINES.md](https://github.com/lacework/go-sdk/blob/main/DEVELOPER_GUIDELINES.md#commit-message-standard)
  9. If you haven't already, configure signed commits by [telling git about your signing key](https://docs.github.com/en/github/authenticating-to-github/managing-commit-signature-verification/telling-git-about-your-signing-key) and [signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)

  Learn more about contributing: https://github.com/lacework/go-sdk/blob/main/CONTRIBUTING.md
-->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## How did you test this change?

* Create a policy using an existing Rego query: `/usr/local/bin/lacework policy create -f /Users/kchen/proj/opa/Rego_policy.yaml`
```
$ cat /Users/kchen/proj/opa/Rego_policy.yaml
---
  evaluatorId: Cloudtrail
  policyType: Violation
  queryId: TestRegoQueryViaCli2
  policyId: regopolicy-000
  enabled: true
  title: Test Policy for Rego Query
  description: For Rego policy testing
  remediation: |-
    Check that the console login was expected.
    AWS recommends to require MFA for all users.
  severity: high
  alertEnabled: true
  tags:
     - technique:Rego
 ```
* Show the policy:
```
$ /usr/local/bin/lacework policy show dev8-regopolicy-000
       POLICY ID        SEVERITY             TITLE               STATE    ALERT STATE   FREQUENCY                TAGS
----------------------+----------+----------------------------+---------+-------------+-----------+---------------------------------
  dev8-regopolicy-000   high       Test Policy for Rego Query   Enabled   Enabled       Hourly      technique:Rego, domain:AWS,
                                                                                                    subdomain:Configuration

                        POLICY DETAILS
--------------------------------------------------------------
    QUERY ID                      TestRegoQueryViaCli2
    POLICY TYPE                   Violation
    LIMIT                         1000
    ALERT PROFILE
    TAGS                          technique:Rego
                                  domain:AWS
                                  subdomain:Configuration
    OWNER                         kun.chen@lacework.net
    UPDATED AT                    2023-12-05T03:39:09.000Z
    UPDATED BY                    kun.chen@lacework.net
    EVALUATION FREQUENCY          Hourly
    VALID EXCEPTION CONSTRAINTS   None


        DESCRIPTION
---------------------------
  For Rego policy testing

                  REMEDIATION
------------------------------------------------
  Check that the console login was expected.

  AWS recommends to require MFA for all users.

  QUERY LANGUAGE
------------------
  Rego
                       QUERY TEXT
---------------------------------------------------------
  package lacework.policies.lacework_global_134
  import future.keywords
  import data.lacework
  import data.lacework.assessment
  source := lacework.aws.cfg.list("s3", "list-buckets")
  assess := assessment.violation(input, "just because")
```

* Show the policy in json format:
```
$ /usr/local/bin/lacework policy show dev8-regopolicy-000 --json
{
  "alertEnabled": true,
  "alertProfile": "",
  "description": "For Rego policy testing",
  "enabled": true,
  "evalFrequency": "Hourly",
  "exceptionConfiguration": null,
  "lastUpdateTime": "2023-12-05T03:39:09.000Z",
  "lastUpdateUser": "kun.chen@lacework.net",
  "limit": 1000,
  "owner": "kun.chen@lacework.net",
  "policyId": "dev8-regopolicy-000",
  "policyType": "Violation",
  "queryId": "TestRegoQueryViaCli2",
  "queryLanguage": "Rego",
  "remediation": "Check that the console login was expected.\nAWS recommends to require MFA for all users.",
  "severity": "high",
  "tags": [
    "technique:Rego",
    "domain:AWS",
    "subdomain:Configuration"
  ],
  "title": "Test Policy for Rego Query"
}
```
* list the policy with the tag `technique:Rego`
```
$ /usr/local/bin/lacework policy list --tag technique:Rego  --json
[
  {
    "alertEnabled": true,
    "alertProfile": "",
    "description": "For Rego policy testing",
    "enabled": true,
    "evalFrequency": "Hourly",
    "exceptionConfiguration": null,
    "lastUpdateTime": "2023-12-05T03:39:09.000Z",
    "lastUpdateUser": "kun.chen@lacework.net",
    "limit": 1000,
    "owner": "kun.chen@lacework.net",
    "policyId": "dev8-regopolicy-000",
    "policyType": "Violation",
    "queryId": "TestRegoQueryViaCli2",
    "queryLanguage": "Rego",
    "remediation": "Check that the console login was expected.\nAWS recommends to require MFA for all users.",
    "severity": "high",
    "tags": [
      "technique:Rego",
      "domain:AWS",
      "subdomain:Configuration"
    ],
    "title": "Test Policy for Rego Query"
  }
]
```
## Issue
https://lacework.atlassian.net/browse/RAIN-91470
