### PR TITLE
fix: component download segv

### DIFF
--- a/cli/cmd/component.go
+++ b/cli/cmd/component.go
@@ -1144,11 +1144,14 @@ func downloadProgress(complete chan int8, path string, sizeB int64) {
 	defer file.Close()
 
 	var (
-		previous float64 = 0
-		stop     bool    = false
+		previous      float64 = 0
+		stop          bool    = false
+		spinnerSuffix string  = ""
 	)
 
-	spinnerSuffix := cli.spinner.Suffix
+	if cli.HumanOutput() {
+		spinnerSuffix = cli.spinner.Suffix
+	}
 
 	for !stop {
 		select {
@@ -1170,7 +1173,11 @@ func downloadProgress(complete chan int8, path string, sizeB int64) {
 				mb := float64(size) / (1 << 20)
 
 				if mb > previous {
-					cli.spinner.Suffix = fmt.Sprintf("%s Downloaded: %.0fmb", spinnerSuffix, mb)
+					if cli.HumanOutput() {
+						cli.spinner.Suffix = fmt.Sprintf("%s Downloaded: %.0fmb", spinnerSuffix, mb)
+					} else {
+						cli.OutputHuman("..Downloaded: %.0fmb", mb)
+					}
 
 					previous = mb
 				}
@@ -1178,7 +1185,11 @@ func downloadProgress(complete chan int8, path string, sizeB int64) {
 				percent := float64(size) / float64(sizeB) * 100
 
 				if percent > previous {
-					cli.spinner.Suffix = fmt.Sprintf("%s Downloaded: %.0f%s", spinnerSuffix, percent, "%")
+					if cli.HumanOutput() {
+						cli.spinner.Suffix = fmt.Sprintf("%s Downloaded: %.0f%s", spinnerSuffix, percent, "%")
+					} else {
+						cli.OutputHuman("..Downloaded: %.0f%s", percent, "%")
+					}
 
 					previous = percent
 				}

--- a/cli/cmd/component.go
+++ b/cli/cmd/component.go
@@ -1149,7 +1149,7 @@ func downloadProgress(complete chan int8, path string, sizeB int64) {
 		spinnerSuffix string  = ""
 	)
 
-	if cli.HumanOutput() {
+	if !cli.nonInteractive {
 		spinnerSuffix = cli.spinner.Suffix
 	}
 
@@ -1173,10 +1173,10 @@ func downloadProgress(complete chan int8, path string, sizeB int64) {
 				mb := float64(size) / (1 << 20)
 
 				if mb > previous {
-					if cli.HumanOutput() {
+					if !cli.nonInteractive {
 						cli.spinner.Suffix = fmt.Sprintf("%s Downloaded: %.0fmb", spinnerSuffix, mb)
 					} else {
-						cli.OutputHuman("..Downloaded: %.0fmb", mb)
+						cli.OutputHuman("..Downloaded: %.0fmb\n", mb)
 					}
 
 					previous = mb
@@ -1185,10 +1185,10 @@ func downloadProgress(complete chan int8, path string, sizeB int64) {
 				percent := float64(size) / float64(sizeB) * 100
 
 				if percent > previous {
-					if cli.HumanOutput() {
+					if !cli.nonInteractive {
 						cli.spinner.Suffix = fmt.Sprintf("%s Downloaded: %.0f%s", spinnerSuffix, percent, "%")
 					} else {
-						cli.OutputHuman("..Downloaded: %.0f%s", percent, "%")
+						cli.OutputHuman("..Downloaded: %.0f%s\n", percent, "%")
 					}
 
 					previous = percent


### PR DESCRIPTION
## Summary

Downloading components with `--noninteractive` leads to a segmentation fault - the CLI spinner hasn't been initialised.  

The fix is to wrap the spinner code with `!cli.nonInteractive`.

## How did you test this change?

#### Reproduce issue:

```
> bin/lacework component install sca --noninteractive
[signal SIGSEGV: segmentation violation code=0x2 addr=0x38 pc=0x101e290a4]

goroutine 13 [running]:
github.com/lacework/go-sdk/cli/cmd.downloadProgress(0x0?, {0x14000182360?, 0x0?}, 0x0)
	/Users/j0n/Workspace/Lacework/go-sdk/cli/cmd/component.go:1151 +0x84
github.com/lacework/go-sdk/cli/cmd.prototypeRunComponentsInstall.func1({0x14000182360?, 0x4?}, 0x0?)
	/Users/j0n/Workspace/Lacework/go-sdk/cli/cmd/component.go:925 +0x34
created by github.com/lacework/go-sdk/lwcomponent.State.Install in goroutine 1
	/Users/j0n/Workspace/Lacework/go-sdk/lwcomponent/component.go:279 +0x594
```

#### With fix:

```
> bin/lacework component install sca --noninteractive
[✓] Component sca found
..Downloaded: 0mb
..Downloaded: 0mb
..Downloaded: 2mb
..Downloaded: 5mb
..Downloaded: 8mb
..Downloaded: 11mb
..Downloaded: 15mb
..Downloaded: 19mb
..Downloaded: 22mb
..Downloaded: 26mb
..Downloaded: 30mb
..Downloaded: 33mb
..Downloaded: 37mb
..Downloaded: 41mb
..Downloaded: 45mb
..Downloaded: 50mb
..Downloaded: 54mb
..Downloaded: 58mb
..Downloaded: 62mb
..Downloaded: 65mb
..Downloaded: 68mb
..Downloaded: 71mb
..Downloaded: 75mb
 [✓] Component sca installed
 [✓] Component signature verified
 [✓] Component configured

Installation completed.

To check the version of SCA installed, run:

  lacework sca version
> bin/lacework component list
       STATUS                 NAME              VERSION                   DESCRIPTION
-------------------+-------------------------+-----------+--------------------------------------------
  Installed          sca                       0.0.80      Software Component Analysis
```

## Issue

https://lacework.atlassian.net/browse/GROW-2628