### PR TITLE
feat(cli): Add time filter to vulnerability host list-cve command

### DIFF
--- a/cli/cmd/vuln_host.go
+++ b/cli/cmd/vuln_host.go
@@ -87,6 +87,7 @@ func init() {
 	)
 
 	setTimeRangeFlags(
+		vulHostListCvesCmd.Flags(),
 		vulHostListHostsCmd.Flags(),
 	)
 

--- a/integration/host_vulnerability_test.go
+++ b/integration/host_vulnerability_test.go
@@ -85,6 +85,37 @@ func TestHostVulnerabilityCommandListCves(t *testing.T) {
 		"STDOUT breadcrumbs changed, please update")
 }
 
+func TestHostVulnerabilityCommandListCvesWithTimeFlag(t *testing.T) {
+	out, err, exitcode := LaceworkCLIWithTOMLConfig("vulnerability", "host", "list-cves", "--start", "-2h@d", "--end", "@d")
+	expectedHeaders := []string{
+		"CVE",
+		"SEVERITY",
+		"SCORE",
+		"PACKAGE",
+		"CURRENT VERSION",
+		"FIX VERSION",
+		"OS VERSION",
+		"HOSTS",
+		"PKG STATUS",
+		"VULN STATUS",
+	}
+	t.Run("verify table headers", func(t *testing.T) {
+		for _, header := range expectedHeaders {
+			assert.Contains(t, out.String(), header,
+				"STDOUT table headers changed, please check")
+		}
+	})
+	assert.Empty(t,
+		err.String(),
+		"STDERR should be empty")
+	assert.Equal(t, 0, exitcode,
+		"EXITCODE is not the expected one")
+
+	assert.Contains(t, out.String(),
+		"Try adding '--active' to only show vulnerabilities of packages actively running.",
+		"STDOUT breadcrumbs changed, please update")
+}
+
 func TestHostVulnerabilityCommandsEndToEnd(t *testing.T) {
 	var (
 		out          bytes.Buffer

--- a/integration/test_resources/help/vulnerability_host_list-cves
+++ b/integration/test_resources/help/vulnerability_host_list-cves
@@ -11,10 +11,13 @@ Usage:
 Flags:
       --active            only show vulnerabilities of packages actively running in your environment
       --csv               output vulnerability assessment in CSV format
+      --end string        end of the time range (default "now")
       --fixable           only show fixable vulnerabilities
   -h, --help              help for list-cves
       --packages          show a list of packages with CVE count
+      --range string      natural time range for query
       --severity string   filter vulnerability assessment by severity threshold (critical, high, medium, low, info)
+      --start string      start of the time range (default "-24h")
 
 Global Flags:
   -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/lacework/go-sdk) and create your branch from `main`
  2. Run `make prepare` in the repository root
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`make test`)
  5. Format your code (`make fmt`)
  6. Make sure your code lints (`make lint`)
  7. If you are updating the Lacework CLI, make sure it compiles (`make build-cli-cross-platform`)
  8. Follow the commit message standard (`type(scope): subject`) documented in [DEVELOPER_GUIDELINES.md](https://github.com/lacework/go-sdk/blob/main/DEVELOPER_GUIDELINES.md#commit-message-standard)
  9. If you haven't already, configure signed commits by [telling git about your signing key](https://docs.github.com/en/github/authenticating-to-github/managing-commit-signature-verification/telling-git-about-your-signing-key) and [signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)

  Learn more about contributing: https://github.com/lacework/go-sdk/blob/main/CONTRIBUTING.md
-->

## Summary
The `lacework vulnerability host list-cves` command is timing out for some customers with a large amount of data. The command defaults to a 24 hour window. We can replicate this by calling the API with the same 24h window and it times out. Enable the start time, end time, and range flags to enable querying smaller amounts of data. 

## How did you test this change?
Passed unit tests
Passed integration tests
Build CLI locally and manually tested the flags

## Issue
https://lacework.atlassian.net/browse/LINK-2415
https://lacework.atlassian.net/browse/RAIN-91480
