### PR TITLE
fix: improve error message when token generate fails in cli

### DIFF
--- a/cli/cmd/cache.go
+++ b/cli/cmd/cache.go
@@ -28,6 +28,7 @@ import (
 	"github.com/lacework/go-sdk/internal/format"
 	"github.com/mitchellh/hashstructure/v2"
 	"github.com/peterbourgon/diskv/v3"
+	"github.com/pkg/errors"
 )
 
 const MaxCacheSize = 1024 * 1024 * 1024
@@ -163,7 +164,7 @@ func (c *cliState) WriteCachedToken() error {
 	if c.Token == "" || c.cachedTokenExpiryEminent() {
 		response, err := c.LwApi.GenerateToken()
 		if err != nil {
-			return err
+			return errors.New("Failed to generate token. Validate your credentials are properly configured and not expired.")
 		}
 
 		c.Log.Debugw("saving token",


### PR DESCRIPTION

## Summary

Currently if there are issues generating a token during the CLI startup process the response message is the raw API response. This commit parses that response a bit and pads the error with a bit more information.

## How did you test this change?

Tests & manual execution

## Issue

https://lacework.atlassian.net/browse/GROW-2632
