### PR TITLE
fix: always set alias "main" for the main profile

### DIFF
--- a/lwgenerate/aws/aws.go
+++ b/lwgenerate/aws/aws.go
@@ -750,11 +750,11 @@ func createAwsProvider(args *GenerateAwsTfConfigurationArgs) ([]*hclwrite.Block,
 	blocks := []*hclwrite.Block{}
 
 	attributes := map[string]interface{}{
+		"alias":  "main",
 		"region": args.AwsRegion,
 	}
 
 	if args.AwsProfile != "" {
-		attributes["alias"] = "main"
 		attributes["profile"] = args.AwsProfile
 	}
 

--- a/lwgenerate/aws/aws_test.go
+++ b/lwgenerate/aws/aws_test.go
@@ -377,6 +377,7 @@ var requiredProviders = `terraform {
 `
 
 var awsProvider = `provider "aws" {
+  alias  = "main"
   region = "us-east-2"
 }
 `


### PR DESCRIPTION
## Summary

Always set the alias to "main" for the main AWS provider

## How did you test this change?

- Run `lacework generate cloud-account aws --config='true' --cloudtrail='true' --aws_region='eu-central-1' --existing_bucket_arn='arn:aws:s3:::aws-cloudtrail-logs-66cc8675' --existing_sns_topic_arn='arn:aws:sns:eu-central-1:191155994050:aws-cloudtrail-logs-66cc8675' --noninteractive --lacework_aws_account_id='434813966438';`
- Run `terraform validate`

## Issue

https://lacework.atlassian.net/browse/GROW-2643