### PR TITLE
ci: fix TestContainerVulnerabilityCommandsEndToEnd

### DIFF
--- a/cli/cmd/vuln_container_show_assessments.go
+++ b/cli/cmd/vuln_container_show_assessments.go
@@ -108,10 +108,8 @@ func searchLastestEvaluationGuid(sha string) (string, error) {
 		// provided sha was not an image digest, try using it as an image id instead
 		cli.Log.Infow("retrieve image assessment", "image_id", sha)
 		assessment, err = cli.LwApi.V2.Vulnerabilities.Containers.SearchAllPages(api.SearchFilter{
-			TimeFilter: &api.TimeFilter{
-				StartTime: &before,
-				EndTime:   &now,
-			},
+			Returns:    filter.Returns,
+			TimeFilter: filter.TimeFilter,
 			Filters: []api.Filter{{
 				Expression: "eq",
 				Field:      "evalCtx.image_info.id",

--- a/integration/container_vulnerability_test.go
+++ b/integration/container_vulnerability_test.go
@@ -266,9 +266,7 @@ type containerVulnerabilityScan struct {
 	Status    string `json:"status"`
 }
 
-// Unstable test disabled as part of GROW-1396
 func TestContainerVulnerabilityCommandsEndToEnd(t *testing.T) {
-	t.Parallel()
 	var (
 		out      bytes.Buffer
 		err      bytes.Buffer


### PR DESCRIPTION
## Summary

I have a feeling that the problem of this test is that we run all the `t.Run()` statements in parallel, I think.

## How did you test this change?

Run integration tests locally. CI should be green.

## Issue

N/A