### PR TITLE
docs(cli): declare --apply and --output on lacework generate

### DIFF
--- a/cli/cmd/generate.go
+++ b/cli/cmd/generate.go
@@ -31,7 +31,7 @@ var (
 		Long: `Generate code to onboard your account and deploy Lacework into various cloud environments.
 
 This command creates Infrastructure as Code (IaC) in the form of Terraform HCL, with the option of running
-Terraform and deploying Lacework into AWS, Azure, or GCP.
+Terraform and deploying Lacework into AWS, Azure, GCP or OCI.
 `,
 	}
 )
@@ -50,6 +50,18 @@ func init() {
 
 	// aws subcommands
 	generateAwsTfCommand.AddCommand(generateAwsControlTowerTfCommand)
+
+	// Common flags
+	generateTfCommand.PersistentFlags().Bool(
+		"apply",
+		false,
+		"run terraform apply without executing plan or prompting",
+	)
+	generateTfCommand.PersistentFlags().String(
+		"output",
+		"",
+		"location to write generated content",
+	)
 }
 
 type SurveyQuestionWithValidationArgs struct {

--- a/cli/cmd/generate_cloud_account.go
+++ b/cli/cmd/generate_cloud_account.go
@@ -10,7 +10,7 @@ var (
 		Long: `Generate cloud-account IaC to deploy Lacework into a cloud environment.
 
 This command creates Infrastructure as Code (IaC) in the form of Terraform HCL, with the option of running
-Terraform and deploying Lacework into AWS, Azure, or GCP.
+Terraform and deploying Lacework into AWS, Azure, GCP or OCI.
 `,
 	}
 )

--- a/cli/docs/lacework_generate.md
+++ b/cli/docs/lacework_generate.md
@@ -13,13 +13,15 @@ Generate code to onboard your account
 Generate code to onboard your account and deploy Lacework into various cloud environments.
 
 This command creates Infrastructure as Code (IaC) in the form of Terraform HCL, with the option of running
-Terraform and deploying Lacework into AWS, Azure, or GCP.
+Terraform and deploying Lacework into AWS, Azure, GCP or OCI.
 
 
 ### Options
 
 ```
-  -h, --help   help for generate
+      --apply           run terraform apply without executing plan or prompting
+  -h, --help            help for generate
+      --output string   location to write generated content
 ```
 
 ### Options inherited from parent commands
@@ -28,7 +30,7 @@ Terraform and deploying Lacework into AWS, Azure, or GCP.
   -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
-      --api_token string    access token (replaces the use of api_key and api_secret)
+      --api_token string    access token (replaces the use of api_key and api_secret)\
       --debug               turn on debug logging
       --json                switch commands output from human-readable to json format
       --nocache             turn off caching

--- a/cli/docs/lacework_generate.md
+++ b/cli/docs/lacework_generate.md
@@ -30,7 +30,7 @@ Terraform and deploying Lacework into AWS, Azure, GCP or OCI.
   -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
-      --api_token string    access token (replaces the use of api_key and api_secret)\
+      --api_token string    access token (replaces the use of api_key and api_secret)
       --debug               turn on debug logging
       --json                switch commands output from human-readable to json format
       --nocache             turn off caching

--- a/cli/docs/lacework_generate_cloud-account.md
+++ b/cli/docs/lacework_generate_cloud-account.md
@@ -13,7 +13,7 @@ Generate cloud integration IaC
 Generate cloud-account IaC to deploy Lacework into a cloud environment.
 
 This command creates Infrastructure as Code (IaC) in the form of Terraform HCL, with the option of running
-Terraform and deploying Lacework into AWS, Azure, or GCP.
+Terraform and deploying Lacework into AWS, Azure, GCP or OCI.
 
 
 ### Options
@@ -29,12 +29,14 @@ Terraform and deploying Lacework into AWS, Azure, or GCP.
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)
+      --apply               run terraform apply without executing plan or prompting
       --debug               turn on debug logging
       --json                switch commands output from human-readable to json format
       --nocache             turn off caching
       --nocolor             turn off colors
       --noninteractive      turn off interactive mode (disable spinners, prompts, etc.)
       --organization        access organization level data sets (org admins only)
+      --output string       location to write generated content
   -p, --profile string      switch between profiles configured at ~/.lacework.toml
       --subaccount string   sub-account name inside your organization (org admins only)
 ```

--- a/cli/docs/lacework_generate_k8s.md
+++ b/cli/docs/lacework_generate_k8s.md
@@ -29,12 +29,14 @@ Terraform and deploying Lacework into GKE.
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)
+      --apply               run terraform apply without executing plan or prompting
       --debug               turn on debug logging
       --json                switch commands output from human-readable to json format
       --nocache             turn off caching
       --nocolor             turn off colors
       --noninteractive      turn off interactive mode (disable spinners, prompts, etc.)
       --organization        access organization level data sets (org admins only)
+      --output string       location to write generated content
   -p, --profile string      switch between profiles configured at ~/.lacework.toml
       --subaccount string   sub-account name inside your organization (org admins only)
 ```

--- a/go.mod
+++ b/go.mod
@@ -59,6 +59,7 @@ require (
 	github.com/gabriel-vasile/mimetype v1.4.2
 	github.com/go-git/go-git/v5 v5.5.2
 	github.com/go-resty/resty/v2 v2.10.0
+	github.com/golang/protobuf v1.5.3
 	github.com/google/uuid v1.3.0
 	github.com/hashicorp/consul/sdk v0.13.1
 	github.com/mattn/go-isatty v0.0.18
@@ -101,7 +102,6 @@ require (
 	github.com/go-git/gcfg v1.5.0 // indirect
 	github.com/go-git/go-billy/v5 v5.4.0 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
-	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/google/btree v1.1.2 // indirect
 	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.2.3 // indirect

--- a/integration/test_resources/help/generate
+++ b/integration/test_resources/help/generate
@@ -1,7 +1,7 @@
 Generate code to onboard your account and deploy Lacework into various cloud environments.
 
 This command creates Infrastructure as Code (IaC) in the form of Terraform HCL, with the option of running
-Terraform and deploying Lacework into AWS, Azure, or GCP.
+Terraform and deploying Lacework into AWS, Azure, GCP or OCI.
 
 Usage:
   lacework generate [command]
@@ -14,7 +14,9 @@ Available Commands:
   k8s           Generate Kubernetes integration IaC
 
 Flags:
-  -h, --help   help for generate
+      --apply           run terraform apply without executing plan or prompting
+  -h, --help            help for generate
+      --output string   location to write generated content
 
 Global Flags:
   -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)

--- a/integration/test_resources/help/generate_cloud-account
+++ b/integration/test_resources/help/generate_cloud-account
@@ -1,7 +1,7 @@
 Generate cloud-account IaC to deploy Lacework into a cloud environment.
 
 This command creates Infrastructure as Code (IaC) in the form of Terraform HCL, with the option of running
-Terraform and deploying Lacework into AWS, Azure, or GCP.
+Terraform and deploying Lacework into AWS, Azure, GCP or OCI.
 
 Usage:
   lacework generate cloud-account [command]
@@ -23,12 +23,14 @@ Global Flags:
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)
+      --apply               run terraform apply without executing plan or prompting
       --debug               turn on debug logging
       --json                switch commands output from human-readable to json format
       --nocache             turn off caching
       --nocolor             turn off colors
       --noninteractive      turn off interactive mode (disable spinners, prompts, etc.)
       --organization        access organization level data sets (org admins only)
+      --output string       location to write generated content
   -p, --profile string      switch between profiles configured at ~/.lacework.toml
       --subaccount string   sub-account name inside your organization (org admins only)
 

--- a/integration/test_resources/help/generate_k8s
+++ b/integration/test_resources/help/generate_k8s
@@ -18,12 +18,14 @@ Global Flags:
   -k, --api_key string      access key id
   -s, --api_secret string   secret access key
       --api_token string    access token (replaces the use of api_key and api_secret)
+      --apply               run terraform apply without executing plan or prompting
       --debug               turn on debug logging
       --json                switch commands output from human-readable to json format
       --nocache             turn off caching
       --nocolor             turn off colors
       --noninteractive      turn off interactive mode (disable spinners, prompts, etc.)
       --organization        access organization level data sets (org admins only)
+      --output string       location to write generated content
   -p, --profile string      switch between profiles configured at ~/.lacework.toml
       --subaccount string   sub-account name inside your organization (org admins only)
 


### PR DESCRIPTION
## Summary

- `--apply` and `--output` flag are defined in all subcommands of `lacework generate`. This PR declares them on `lacework generate` so these two flags could show up in docs for `lacework generate`.
- Subcommands will keep their own declaration and variable binding for `--apply` and `--output`.

## How did you test this change?

`make build-cli-cross-platform`
`make integration-context-tests`

## Issue

https://lacework.atlassian.net/browse/GROW-2602
