### PR TITLE
fix: update policy_exceptions_test.go

### DIFF
--- a/integration/policy_exceptions_test.go
+++ b/integration/policy_exceptions_test.go
@@ -21,6 +21,8 @@ func TestPolicyExceptionCreate(t *testing.T) {
 			c.SendLine("TEST CLI")
 			expectString(t, c, "Add constraint \"accountIds\"")
 			c.SendLine("n")
+			expectString(t, c, "Add constraint \"arns\"")
+			c.SendLine("n")
 			expectString(t, c, "Add constraint \"regionNames\"")
 			c.SendLine("n")
 			expectString(t, c, "Add constraint \"resourceNames\"")


### PR DESCRIPTION
## Summary

go-sdk test is broken due to the change in https://github.com/lacework/services/pull/18387/files#diff-4d159a775505a4026f5a01f03d33bc1a534aecb098169c95b386156e956f3419R174

Add `arns` to policy_exceptions_test.go to fix it

## How did you test this change?

make integration-only

## Issue

CodeFresh pipeline failed: https://g.codefresh.io/build/659d1922df1107d2516cb8b3?step=integration&tab=output&logs=terminal
