### PR TITLE
feat(cli): gRPC command to debug CDK components

### DIFF
--- a/cli/cmd/grpc.go
+++ b/cli/cmd/grpc.go
@@ -1,0 +1,50 @@
+//
+// Author:: Salim Afiune Maya (<afiune@lacework.net>)
+// Copyright:: Copyright 2024, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cmd
+
+import (
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	// grpcCmd is a hidden command that developers use to debug CDK components
+	grpcCmd = &cobra.Command{
+		Use:    "grpc",
+		Hidden: true,
+		Short:  "Starts a CDK gRPC server (developer mode)",
+		Args:   cobra.NoArgs,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			cli.OutputHuman("\nDevelopment mode for CDK components")
+			cli.OutputHuman("\n===================================\n\n")
+			cli.OutputHuman("When debugging a component, it might expect some environment variables and a\n")
+			cli.OutputHuman("running gRPC server, this command starts the CDK server and shows the variables\n")
+			cli.OutputHuman("that your component might need:\n\n")
+			vars := cli.envs()
+			cli.OutputHuman("export %s", strings.Join(vars, " \\\n  "))
+			cli.OutputHuman("\n\n'Ctrl+c' to stop the server. ")
+			return cli.Serve()
+		},
+	}
+)
+
+func init() {
+	rootCmd.AddCommand(grpcCmd)
+}


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/lacework/go-sdk) and create your branch from `main`
  2. Run `make prepare` in the repository root
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`make test`)
  5. Format your code (`make fmt`)
  6. Make sure your code lints (`make lint`)
  7. If you are updating the Lacework CLI, make sure it compiles (`make build-cli-cross-platform`)
  8. Follow the commit message standard (`type(scope): subject`) documented in [DEVELOPER_GUIDELINES.md](https://github.com/lacework/go-sdk/blob/main/DEVELOPER_GUIDELINES.md#commit-message-standard)
  9. If you haven't already, configure signed commits by [telling git about your signing key](https://docs.github.com/en/github/authenticating-to-github/managing-commit-signature-verification/telling-git-about-your-signing-key) and [signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)

  Learn more about contributing: https://github.com/lacework/go-sdk/blob/main/CONTRIBUTING.md
-->

## Summary

When debugging a CDK component, it might expect some environment variables and a
running gRPC server, this command starts the CDK server and shows the variables that
a component might need.

_**NOTE that this command is hidden.**_

## How did you test this change?

1. Ran the command.
2. (on a new terminal) Exported the env variables
3. (on the same terminal) Started a component that depends on the gRPC server and envs

Used https://github.com/lacework-dev/cdk-preflight component for testing.

## Example Output
```
➜  go-sdk git:(afiune/cli/grpc-cmd) lacework grpc

Development mode for CDK components
===================================

When debugging a component, it might expect some environment variables and a
running gRPC server, this command starts the CDK server and shows the variables
that your component might need:

export LW_PROFILE=default \
  LW_ACCOUNT=foo \
  LW_SUBACCOUNT=bar \
  LW_API_KEY=USERABC_E4BF749A1CD6203 \
  LW_API_SECRET= _abc123secret \
  LW_API_TOKEN= _xyz456cool \
  LW_ORGANIZATION=false \
  LW_NONINTERACTIVE=false \
  LW_NOCACHE=false \
  LW_NOCOLOR= \
  LW_LOG=ERROR \
  LW_JSON=false \
  LW_CDK_TARGET=localhost:1123 \
  LW_API_SERVER_URL=https://foo.lacework.net \
  LW_CLI_VERSION=1.43.1-dev

'Ctrl+c' to stop the server.
```
## Issue

https://lacework.atlassian.net/browse/GROW-2683
