### PR TITLE
fix: correct gcp generate audit-log flag

### DIFF
--- a/cli/cmd/generate_gcp.go
+++ b/cli/cmd/generate_gcp.go
@@ -317,7 +317,7 @@ func initGenerateGcpTfCommandFlags() {
 		false,
 		"enable agentless integration")
 	generateGcpTfCommand.PersistentFlags().BoolVar(
-		&GenerateGcpCommandState.Agentless,
+		&GenerateGcpCommandState.AuditLog,
 		"audit_log",
 		false,
 		"enable audit log integration")


### PR DESCRIPTION
## Summary

Correct the state for the audit_log flag

## How did you test this change?

Tests & manual execution

## Issue

N/A
