### PR TITLE
fix: component args

### DIFF
--- a/cli/cmd/component_args_test.go
+++ b/cli/cmd/component_args_test.go
@@ -75,6 +75,65 @@ func TestComponentArgs(t *testing.T) {
 				"--debug",
 			},
 		},
+		{
+			[]string{
+				"iac", "negative-values", "--time", "-24h",
+			},
+			[]string{
+				"iac", "negative-values", "--time", "-24h",
+			},
+			[]string{},
+		},
+		{
+			// We do not have access to the component flag configuration and therefore cannot
+			// support the shorthand expansion of `-xyz` -> `-x -y -z`.  We have to treat it as
+			// `x=yz` and pass through to the component.
+			[]string{
+				"iac", "shorthands", "-xyz",
+			},
+			[]string{
+				"iac", "shorthands", "-xyz",
+			},
+			[]string{},
+		},
+		{
+			[]string{
+				"iac", "long-assign", "--xyz=value",
+			},
+			[]string{
+				"iac", "long-assign", "--xyz=value",
+			},
+			[]string{},
+		},
+		{
+			[]string{
+				"iac", "short-assign", "-x=value", "-y=true", "-t -24h", "-n=1234", "-n1234",
+			},
+			[]string{
+				"iac", "short-assign", "-x=value", "-y=true", "-t -24h", "-n=1234", "-n1234",
+			},
+			[]string{},
+		},
+		{
+			// -x=true -y=true -z="hello"
+			[]string{
+				"iac", "bool-str-assign", "-xyz", "hello", "-x",
+			},
+			[]string{
+				"iac", "bool-str-assign", "-xyz", "hello", "-x",
+			},
+			[]string{},
+		},
+		{
+			// -x=true -y=true -z="hello"
+			[]string{
+				"iac", "bool-str-assign", "-xyz=hello",
+			},
+			[]string{
+				"iac", "bool-str-assign", "-xyz=hello",
+			},
+			[]string{},
+		},
 	} {
 		p := componentArgParser{}
 		p.parseArgs(flags, k.args)

--- a/cli/cmd/component_args_test.go
+++ b/cli/cmd/component_args_test.go
@@ -115,6 +115,23 @@ func TestComponentArgs(t *testing.T) {
 			[]string{},
 		},
 		{
+			[]string{
+				"sca", "scan", "--key=projectId=${CI_PROJECT_ID}",
+				"--link", "https://github.com/lacework-dev/project-abc/blob/foo/$FILENAME#L$LINENUMBER",
+				"--tool-paths=checkov=/app/checkov,opal=/app/lacework-opal-releases/latest/opal",
+				"--fail", "High=2",
+				"--foo=",
+			},
+			[]string{
+				"sca", "scan", "--key=projectId=${CI_PROJECT_ID}",
+				"--link", "https://github.com/lacework-dev/project-abc/blob/foo/$FILENAME#L$LINENUMBER",
+				"--tool-paths=checkov=/app/checkov,opal=/app/lacework-opal-releases/latest/opal",
+				"--fail", "High=2",
+				"--foo=",
+			},
+			[]string{},
+		},
+		{
 			// -x=true -y=true -z="hello"
 			[]string{
 				"iac", "bool-str-assign", "-xyz", "hello", "-x",


### PR DESCRIPTION
## Summary

If a component flag is followed by an argument that has a `-` prefix, we treat it as an argument, and not as a shorthand flag.

I added further tests based on we need to [support](https://github.com/spf13/pflag?tab=readme-ov-file#command-line-flag-syntax).

There is a problem.  We are unable to handle both shorthand expansion like `-xyz` -> `-x -y -z` and shorthand assignment such as `-n1234`, `-n1234` is equivalent to `-n=1234` and `-n 1234`.  We cannot lookup the component flags to know that `-n1234` should not be expanded.  Just pass through to the component and let the component parse.

## How did you test this change?

Inputs based on https://github.com/spf13/pflag?tab=readme-ov-file#command-line-flag-syntax

Unit testing and manual

## Issue

https://lacework.atlassian.net/browse/GROW-2677