### PR TITLE
chore: update user flow and validation for using existing CloudTrail

### DIFF
--- a/lwgenerate/aws/aws_test.go
+++ b/lwgenerate/aws/aws_test.go
@@ -257,7 +257,7 @@ func TestGenerationCloudtrailExistingBucket(t *testing.T) {
 	existingBucketArn := "arn:aws:s3:::test-bucket-12345"
 	data, err := createCloudtrail(&GenerateAwsTfConfigurationArgs{
 		Cloudtrail:                  true,
-		CloudtrailUseExistingS3:     true,
+		CloudtrailUseExistingTrail:  true,
 		ExistingCloudtrailBucketArn: existingBucketArn,
 	})
 	assert.Nil(t, err)


### PR DESCRIPTION
## Summary

For the aws generate command, if using existing trail:
- Make the prompt questions required for trail name, S3 bucket ARN and SNS topic ARN, 
- Add validations for the required fields to existing trial.

## How did you test this change?

Manual test by running `lacework generate cloud-account aws`

## Issue

https://lacework.atlassian.net/browse/GROW-2715
