### PR TITLE
fix: do not log errors if version check fails

### DIFF
--- a/cli/cmd/version.go
+++ b/cli/cmd/version.go
@@ -25,13 +25,12 @@ import (
 	"strings"
 	"time"
 
-	"github.com/pkg/errors"
-	"github.com/spf13/cobra"
-
 	"github.com/lacework/go-sdk/internal/cache"
 	"github.com/lacework/go-sdk/internal/file"
 	"github.com/lacework/go-sdk/lwcomponent"
 	"github.com/lacework/go-sdk/lwupdater"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
 )
 
 var (
@@ -101,7 +100,7 @@ Set the environment variable 'LW_UPDATES_DISABLE=1' to avoid checking for update
 
 			// check the latest version of the cli
 			if _, err := versionCheck(); err != nil {
-				cli.Log.Errorw("unable to perform lacework cli version check",
+				cli.Log.Debugw("unable to perform lacework cli version check",
 					"error", err.Error())
 			}
 		},


### PR DESCRIPTION
## Summary
Zillow is complaining about error logs due to failure in the version check. This is probably due to GitHub rate limiting, but we should avoid logging too many errors. It is too verbose.

## How did you test this change?
No test

##
https://lacework.atlassian.net/browse/COD-2516