### PR TITLE
chore: use CDK v1 API for lacework component dev

### DIFF
--- a/cli/cmd/component.go
+++ b/cli/cmd/component.go
@@ -187,6 +187,17 @@ func (c *cliState) LoadComponents() {
 		}
 
 		version := component.InstalledVersion()
+		componentDir, err := component.Dir()
+		if err != nil {
+			c.Log.Debugw("unable to find component directory", "error", err)
+			return
+		}
+		if devInfo, _ := lwcomponent.NewDevInfo(componentDir); devInfo != nil {
+			if devVersion, _ := semver.NewVersion(devInfo.Version); devVersion != nil {
+				version = devVersion
+			}
+		}
+
 		if version != nil && component.Exec.Executable() {
 			componentCmd := &cobra.Command{
 				Use:                   component.Name,

--- a/cli/cmd/component_dev.go
+++ b/cli/cmd/component_dev.go
@@ -92,7 +92,7 @@ func devModeComponent(args []string) error {
 
 	cli.StartProgress("Loading components Catalog...")
 
-	catalog, err := lwcomponent.NewCatalog(cli.LwApi, lwcomponent.NewStageTarGz)
+	catalog, err := lwcomponent.NewCatalog(cli.LwApi, lwcomponent.NewStageTarGz, false)
 	defer catalog.Persist()
 
 	cli.StopProgress()

--- a/lwcomponent/catalog_test.go
+++ b/lwcomponent/catalog_test.go
@@ -304,7 +304,7 @@ func TestCatalogGetComponent(t *testing.T) {
 		_, home := FakeHome()
 		defer ResetHome(home)
 
-		CreateLocalComponent(name, version, true)
+		CreateLocalComponent(name, version, false)
 
 		catalog, err := lwcomponent.NewCatalog(client, newTestStage, true)
 		assert.Nil(t, err)


### PR DESCRIPTION
## Summary

For the `lacework component dev` command:

- Call CDK v1 API to fetch components info.
- If The `.dev` specs file exists, show the version value in `.dev` instead of `.version` (same behavior as prototype code).

## How did you test this change?

- Run `lacework component dev test-component` to test a new component is created correctly in dev mode 
- Run `lacework component install spm-opa` and `lacework component dev spm-opa` to test an installed component is moved into dev mode. 

## Issue

https://lacework.atlassian.net/browse/GROW-2597
