### PR TITLE
fix: set telemetry dataset

### DIFF
--- a/cli/cmd/honeyvent.go
+++ b/cli/cmd/honeyvent.go
@@ -95,11 +95,6 @@ const (
 // could be modified during a command execution to add extra parameters such
 // as error message, feature data, etc.
 func (c *cliState) InitHoneyvent() {
-	hc := libhoney.Config{
-		Dataset: HoneyDataset,
-	}
-	_ = libhoney.Init(hc)
-
 	c.Event = &api.Honeyvent{
 		Os:            runtime.GOOS,
 		Arch:          runtime.GOARCH,
@@ -111,6 +106,7 @@ func (c *cliState) InitHoneyvent() {
 		CfgVersion:    c.CfgVersion,
 		TraceID:       newID(),
 		InstallMethod: installMethod(),
+		Dataset:       HoneyDataset,
 	}
 }
 

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -82,7 +82,6 @@ func cliPersistentPreRun(cmd *cobra.Command, args []string) error {
 	cli.Event.Command = cmd.CommandPath()
 	cli.Event.Args = args
 	cli.Event.Flags = parseFlags(os.Args[1:])
-	cli.SendHoneyvent()
 
 	switch cmd.Use {
 	case "help [command]", "configure", "version", "docs <directory>", "generate-pkg-manifest":
@@ -106,6 +105,7 @@ func cliPersistentPreRun(cmd *cobra.Command, args []string) error {
 			}
 		}
 	}
+	cli.SendHoneyvent()
 	return nil
 }
 


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/lacework/go-sdk) and create your branch from `main`
  2. Run `make prepare` in the repository root
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`make test`)
  5. Format your code (`make fmt`)
  6. Make sure your code lints (`make lint`)
  7. If you are updating the Lacework CLI, make sure it compiles (`make build-cli-cross-platform`)
  8. Follow the commit message standard (`type(scope): subject`) documented in [DEVELOPER_GUIDELINES.md](https://github.com/lacework/go-sdk/blob/main/DEVELOPER_GUIDELINES.md#commit-message-standard)
  9. If you haven't already, configure signed commits by [telling git about your signing key](https://docs.github.com/en/github/authenticating-to-github/managing-commit-signature-verification/telling-git-about-your-signing-key) and [signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)

  Learn more about contributing: https://github.com/lacework/go-sdk/blob/main/CONTRIBUTING.md
-->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

Dataset is not being set for honeycomb

## How did you test this change?

Run cmd and check honeycomb dataset

## Issue

<!--
  Include the link to a Jira/Github issue
-->

https://lacework.atlassian.net/browse/GROW-2728