### PR TITLE
chore(CLI): persist CDK API data in disk

### DIFF
--- a/cli/cmd/component.go
+++ b/cli/cmd/component.go
@@ -343,7 +343,12 @@ func listComponents() error {
 	if err != nil {
 		return errors.Wrap(err, "unable to load component Catalog")
 	}
-	defer catalog.Persist()
+	defer func() {
+		err := catalog.Persist()
+		if err != nil {
+			cli.Log.Errorf("unable to save component catalog into cdk_cache: %s", err.Error())
+		}
+	}()
 
 	if cli.JSONOutput() {
 		return cli.OutputJSON(catalog)
@@ -415,7 +420,12 @@ func installComponent(cmd *cobra.Command, args []string) (err error) {
 	if err != nil {
 		return
 	}
-	defer catalog.PersistComponent(component)
+	defer func() {
+		err := catalog.PersistComponent(component)
+		if err != nil {
+			cli.Log.Errorf("unable to save component %s into cdk_cache: %s", component.Name, err.Error())
+		}
+	}()
 
 	cli.OutputChecklist(successIcon, fmt.Sprintf("Component %s found\n", component.Name))
 
@@ -515,7 +525,12 @@ func showComponent(args []string) error {
 	if err != nil {
 		return err
 	}
-	defer catalog.PersistComponent(component)
+	defer func() {
+		err := catalog.PersistComponent(component)
+		if err != nil {
+			cli.Log.Errorf("unable to save component %s into cdk_cache: %s", component.Name, err.Error())
+		}
+	}()
 
 	if cli.JSONOutput() {
 		return cli.OutputJSON(component)
@@ -589,7 +604,12 @@ func updateComponent(args []string) (err error) {
 	if err != nil {
 		return err
 	}
-	defer catalog.PersistComponent(component)
+	defer func() {
+		err := catalog.PersistComponent(component)
+		if err != nil {
+			cli.Log.Errorf("unable to save component %s into cdk_cache: %s", component.Name, err.Error())
+		}
+	}()
 
 	cli.OutputChecklist(successIcon, fmt.Sprintf("Component %s found\n", component.Name))
 
@@ -715,7 +735,12 @@ func deleteComponent(args []string) (err error) {
 	if err != nil {
 		return err
 	}
-	defer catalog.PersistComponent(component)
+	defer func() {
+		err := catalog.PersistComponent(component)
+		if err != nil {
+			cli.Log.Errorf("unable to save component %s into cdk_cache: %s", component.Name, err.Error())
+		}
+	}()
 
 	cli.OutputChecklist(successIcon, fmt.Sprintf("Component %s found\n", component.Name))
 

--- a/cli/cmd/component_dev.go
+++ b/cli/cmd/component_dev.go
@@ -93,7 +93,6 @@ func devModeComponent(args []string) error {
 	cli.StartProgress("Loading components Catalog...")
 
 	catalog, err := lwcomponent.NewCatalog(cli.LwApi, lwcomponent.NewStageTarGz, false)
-	defer catalog.Persist()
 
 	cli.StopProgress()
 	if err != nil {

--- a/lwcomponent/api_info.go
+++ b/lwcomponent/api_info.go
@@ -4,27 +4,15 @@ import (
 	"github.com/Masterminds/semver"
 )
 
-type ApiInfo interface {
-	Id() int32
-
-	LatestVersion() *semver.Version
-
-	AllVersions() []*semver.Version
-
-	Deprecated() bool
-
-	Size() int64
-}
-
-type apiInfo struct {
-	id            int32
-	name          string
-	version       semver.Version
-	allVersions   []*semver.Version
-	desc          string
-	sizeKB        int64
-	deprecated    bool
-	componentType Type
+type ApiInfo struct {
+	Id            int32             `json:"id"`
+	Name          string            `json:"name"`
+	Version       semver.Version    `json:"version"`
+	AllVersions   []*semver.Version `json:"allVersions"`
+	Desc          string            `json:"desc"`
+	SizeKB        int64             `json:"sizeKB"`
+	Deprecated    bool              `json:"deprecated"`
+	ComponentType Type              `json:"componentType"`
 }
 
 func NewAPIInfo(
@@ -36,39 +24,15 @@ func NewAPIInfo(
 	size int64,
 	deprecated bool,
 	componentType Type,
-) ApiInfo {
-	return &apiInfo{
-		id:            id,
-		name:          name,
-		version:       *version,
-		allVersions:   allVersions,
-		desc:          desc,
-		sizeKB:        size,
-		deprecated:    deprecated,
-		componentType: componentType,
+) *ApiInfo {
+	return &ApiInfo{
+		Id:            id,
+		Name:          name,
+		Version:       *version,
+		AllVersions:   allVersions,
+		Desc:          desc,
+		SizeKB:        size,
+		Deprecated:    deprecated,
+		ComponentType: componentType,
 	}
-}
-
-func (a *apiInfo) Id() int32 {
-	return a.id
-}
-
-// AllVersions implements ApiInfo.
-func (a *apiInfo) AllVersions() []*semver.Version {
-	return a.allVersions
-}
-
-// LatestVersion implements ApiInfo.
-func (a *apiInfo) LatestVersion() *semver.Version {
-	return &a.version
-}
-
-// Deprecated implements ApiInfo.
-func (a *apiInfo) Deprecated() bool {
-	return a.deprecated
-}
-
-// Size implements ApiInfo.
-func (a *apiInfo) Size() int64 {
-	return a.sizeKB
 }

--- a/lwcomponent/api_info_test.go
+++ b/lwcomponent/api_info_test.go
@@ -19,7 +19,7 @@ func TestApiInfoId(t *testing.T) {
 
 	info := lwcomponent.NewAPIInfo(id, "test", version, allVersions, "", 0, false, lwcomponent.BinaryType)
 
-	result := info.Id()
+	result := info.Id
 	assert.Equal(t, id, result)
 }
 
@@ -34,6 +34,6 @@ func TestApiInfoLatestVersion(t *testing.T) {
 
 	info := lwcomponent.NewAPIInfo(1, "test", version, allVersions, "", 0, false, lwcomponent.BinaryType)
 
-	result := info.LatestVersion()
+	result := info.Version
 	assert.Equal(t, expectedVer, result.String())
 }

--- a/lwcomponent/catalog.go
+++ b/lwcomponent/catalog.go
@@ -24,7 +24,6 @@ const (
 )
 
 func CatalogV1Enabled(client *api.Client) bool {
-	return true
 	response, err := client.V2.FeatureFlags.GetFeatureFlagsMatchingPrefix(featureFlag)
 	if err != nil {
 		return false
@@ -126,7 +125,7 @@ func (c *Catalog) GetComponent(name string) (*CDKComponent, error) {
 
 func (c *Catalog) ListComponentVersions(component *CDKComponent) (versions []*semver.Version, err error) {
 	if component.ApiInfo == nil {
-		err = errors.Errorf("component '%s' api info  already installed", component.Name)
+		err = errors.Errorf("component '%s' api info not available", component.Name)
 		return
 	}
 

--- a/lwcomponent/cdk_component.go
+++ b/lwcomponent/cdk_component.go
@@ -18,21 +18,21 @@ const (
 )
 
 type CDKComponent struct {
-	Name           string
-	Description    string
-	Type           Type
-	Status         Status
-	InstallMessage string
-	UpdateMessage  string
+	Name           string `json:"name"`
+	Description    string `json:"description"`
+	Type           Type   `json:"type"`
+	Status         Status `json:"-"`
+	InstallMessage string `json:"installMessage,omitempty"`
+	UpdateMessage  string `json:"updateMessage,omitempty"`
 
-	Exec Executer
+	Exec Executer `json:"-"`
 
-	ApiInfo  ApiInfo
-	HostInfo HostInfo
+	ApiInfo  *ApiInfo  `json:"apiInfo,omitempty"`
+	HostInfo *HostInfo `json:"-"`
 	stage    Stager
 }
 
-func NewCDKComponent(name string, desc string, componentType Type, apiInfo ApiInfo, hostInfo HostInfo) CDKComponent {
+func NewCDKComponent(name string, desc string, componentType Type, apiInfo *ApiInfo, hostInfo *HostInfo) CDKComponent {
 	var (
 		exec Executer = &nonExecutable{}
 	)
@@ -42,7 +42,7 @@ func NewCDKComponent(name string, desc string, componentType Type, apiInfo ApiIn
 	switch status {
 	case Installed, UpdateAvailable, InstalledDeprecated, Development:
 		{
-			dir := hostInfo.Dir()
+			dir := hostInfo.Dir
 
 			if componentType == BinaryType || componentType == CommandType {
 				exec = NewExecuable(name, dir)
@@ -116,6 +116,15 @@ func (c *CDKComponent) InstalledVersion() (version *semver.Version) {
 		if err == nil {
 			return
 		}
+
+		if componentDir, err := c.Dir(); err == nil {
+			if devInfo, err := NewDevInfo(componentDir); err == nil {
+				version, err = semver.NewVersion(devInfo.Version)
+				if err == nil {
+					return
+				}
+			}
+		}
 	}
 
 	return
@@ -123,7 +132,7 @@ func (c *CDKComponent) InstalledVersion() (version *semver.Version) {
 
 func (c *CDKComponent) LatestVersion() (version *semver.Version) {
 	if c.ApiInfo != nil {
-		version = c.ApiInfo.LatestVersion()
+		version = &c.ApiInfo.Version
 	}
 
 	return
@@ -133,26 +142,13 @@ func (c *CDKComponent) PrintSummary() []string {
 	var (
 		colorize *color.Color
 		version  *semver.Version
-		err      error
 	)
 
 	switch c.Status {
-	case Installed, InstalledDeprecated, NotInstalledDeprecated, UpdateAvailable, Tainted:
-		version, err = c.HostInfo.Version()
-		if err != nil {
-			panic(err)
-		}
-	case NotInstalled:
-		version = c.ApiInfo.LatestVersion()
-	case Development:
-		devInfo, err := NewDevInfo(c.HostInfo.Dir())
-		if err != nil {
-			panic(err)
-		}
-		version, err = semver.NewVersion(devInfo.Version)
-		if err != nil {
-			panic(err)
-		}
+	case Installed, InstalledDeprecated, UpdateAvailable, Development, Tainted:
+		version = c.InstalledVersion()
+	case NotInstalled, NotInstalledDeprecated:
+		version = &c.ApiInfo.Version
 	default:
 		version = &semver.Version{}
 	}
@@ -167,7 +163,7 @@ func (c *CDKComponent) PrintSummary() []string {
 	}
 }
 
-func status(apiInfo ApiInfo, hostInfo HostInfo) Status {
+func status(apiInfo *ApiInfo, hostInfo *HostInfo) Status {
 	status := UnknownStatus
 
 	if hostInfo != nil {
@@ -189,11 +185,11 @@ func status(apiInfo ApiInfo, hostInfo HostInfo) Status {
 				return Tainted
 			}
 
-			if apiInfo.Deprecated() {
+			if apiInfo.Deprecated {
 				return InstalledDeprecated
 			}
 
-			latestVer := apiInfo.LatestVersion()
+			latestVer := apiInfo.Version
 			if latestVer.GreaterThan(installedVer) {
 				return UpdateAvailable
 			} else {
@@ -205,7 +201,7 @@ func status(apiInfo ApiInfo, hostInfo HostInfo) Status {
 	}
 
 	if apiInfo != nil && hostInfo == nil {
-		if apiInfo.Deprecated() {
+		if apiInfo.Deprecated {
 			return NotInstalledDeprecated
 		}
 
@@ -215,8 +211,8 @@ func status(apiInfo ApiInfo, hostInfo HostInfo) Status {
 	return status
 }
 
-func isTainted(apiInfo ApiInfo, installedVer *semver.Version) bool {
-	for _, ver := range apiInfo.AllVersions() {
+func isTainted(apiInfo *ApiInfo, installedVer *semver.Version) bool {
+	for _, ver := range apiInfo.AllVersions {
 		if ver.Equal(installedVer) {
 			return false
 		}

--- a/lwcomponent/cdk_executable.go
+++ b/lwcomponent/cdk_executable.go
@@ -21,6 +21,8 @@ type Executer interface {
 	Execute(args []string, envs ...string) (stdout string, stderr string, err error)
 
 	ExecuteInline(args []string, envs ...string) (err error)
+
+	Path() string
 }
 
 type executable struct {
@@ -34,6 +36,10 @@ func NewExecuable(name string, dir string) Executer {
 	}
 
 	return &executable{path: path}
+}
+
+func (e *executable) Path() string {
+	return e.path
 }
 
 func (e *executable) Executable() bool {
@@ -106,4 +112,8 @@ func (e *nonExecutable) Execute(args []string, envs ...string) (stdout string, s
 
 func (e *nonExecutable) ExecuteInline(args []string, envs ...string) (err error) {
 	return ErrNonExecutable
+}
+
+func (e *nonExecutable) Path() string {
+	return ""
 }

--- a/lwcomponent/host_info.go
+++ b/lwcomponent/host_info.go
@@ -17,56 +17,36 @@ var (
 	DevelopmentFile = ".dev"
 )
 
-type HostInfo interface {
-	Delete() error
-
-	Development() bool
-
-	Dir() string
-
-	Name() string
-
-	Signature() (sig []byte, err error)
-
-	Validate() error
-
-	Version() (*semver.Version, error)
+type HostInfo struct {
+	Dir string
 }
 
-type hostInfo struct {
-	dir string
+func NewHostInfo(dir string) *HostInfo {
+	return &HostInfo{dir}
 }
 
-func NewHostInfo(dir string) HostInfo {
-	return &hostInfo{dir}
+func (h *HostInfo) Delete() error {
+	return os.RemoveAll(h.Dir)
 }
 
-func (h *hostInfo) Delete() error {
-	return os.RemoveAll(h.dir)
-}
-
-func (h *hostInfo) Development() bool {
-	return file.FileExists(filepath.Join(h.dir, DevelopmentFile))
-}
-
-func (h *hostInfo) Dir() string {
-	return h.dir
+func (h *HostInfo) Development() bool {
+	return file.FileExists(filepath.Join(h.Dir, DevelopmentFile))
 }
 
 // Returns the Component name
 //
 // The Component name is the same as the name of the base directory
-func (h *hostInfo) Name() string {
-	return filepath.Base(h.dir)
+func (h *HostInfo) Name() string {
+	return filepath.Base(h.Dir)
 }
 
-func (h *hostInfo) Signature() (sig []byte, err error) {
-	_, err = os.Stat(h.dir)
+func (h *HostInfo) Signature() (sig []byte, err error) {
+	_, err = os.Stat(h.Dir)
 	if os.IsNotExist(err) {
 		return
 	}
 
-	path := filepath.Join(h.dir, SignatureFile)
+	path := filepath.Join(h.Dir, SignatureFile)
 	if !file.FileExists(path) {
 		return
 	}
@@ -79,15 +59,15 @@ func (h *hostInfo) Signature() (sig []byte, err error) {
 	return
 }
 
-func (h *hostInfo) Version() (version *semver.Version, err error) {
-	_, err = os.Stat(h.dir)
+func (h *HostInfo) Version() (version *semver.Version, err error) {
+	_, err = os.Stat(h.Dir)
 	if os.IsNotExist(err) {
 		return
 	}
 
-	path := filepath.Join(h.dir, VersionFile)
+	path := filepath.Join(h.Dir, VersionFile)
 	if !file.FileExists(path) {
-		return
+		return nil, errors.New("missing .verion file")
 	}
 
 	data, err := os.ReadFile(path)
@@ -98,8 +78,8 @@ func (h *hostInfo) Version() (version *semver.Version, err error) {
 	return semver.NewVersion(strings.TrimSpace(string(data)))
 }
 
-func (h *hostInfo) Validate() (err error) {
-	data, err := os.ReadFile(filepath.Join(h.dir, VersionFile))
+func (h *HostInfo) Validate() (err error) {
+	data, err := os.ReadFile(filepath.Join(h.Dir, VersionFile))
 	if err != nil {
 		return
 	}
@@ -113,11 +93,11 @@ func (h *hostInfo) Validate() (err error) {
 
 	componentName := h.Name()
 
-	if !file.FileExists(filepath.Join(h.dir, SignatureFile)) {
+	if !file.FileExists(filepath.Join(h.Dir, SignatureFile)) {
 		return errors.New(fmt.Sprintf("missing file '%s'", componentName))
 	}
 
-	if !file.FileExists(filepath.Join(h.dir, componentName)) {
+	if !file.FileExists(filepath.Join(h.Dir, componentName)) {
 		return errors.New(fmt.Sprintf("missing file '%s'", componentName))
 	}
 


### PR DESCRIPTION
## Summary

- When `lacework component list` is run, fetch components API data and store it into `cdk_cache` file.
- When `lacework component show/install/update/uninstall` is run, upsert the corresponding component into `cdk_cache`
- In the command init phase(`cli.LoadComponents()` is called), load components from `cdk_cache`

## How did you test this change?

Manually run all the `lacework component` commands

## Issue

https://lacework.atlassian.net/browse/GROW-2481
