### PR TITLE
fix: reduce component API usage

### DIFF
--- a/cli/cmd/component_dev.go
+++ b/cli/cmd/component_dev.go
@@ -92,7 +92,7 @@ func devModeComponent(args []string) error {
 
 	cli.StartProgress("Loading components Catalog...")
 
-	catalog, err := LoadCatalog()
+	catalog, err := LoadCatalog(componentName, false)
 
 	cli.StopProgress()
 	if err != nil {

--- a/lwcomponent/catalog.go
+++ b/lwcomponent/catalog.go
@@ -245,7 +245,6 @@ func (c *Catalog) Delete(component *CDKComponent) (err error) {
 func NewCatalog(
 	client *api.Client,
 	stageConstructor StageConstructor,
-	includeComponentVersions bool,
 ) (*Catalog, error) {
 	if stageConstructor == nil {
 		return nil, errors.New("StageConstructor is not specified to create new catalog")
@@ -271,12 +270,6 @@ func NewCatalog(
 		}
 
 		var allVersions []*semver.Version
-		if includeComponentVersions {
-			allVersions, err = listComponentVersions(client, c.Id)
-			if err != nil {
-				return nil, errors.Wrap(err, fmt.Sprintf("unable to fetch component '%s' versions", c.Name))
-			}
-		}
 
 		apiInfo := NewAPIInfo(c.Id, c.Name, ver, allVersions, c.Description, c.Size, c.Deprecated, Type(c.ComponentType))
 		cdkComponents[c.Name] = NewCDKComponent(c.Name, c.Description, Type(c.ComponentType), apiInfo, nil)

--- a/lwcomponent/catalog_test.go
+++ b/lwcomponent/catalog_test.go
@@ -52,7 +52,7 @@ func TestCatalogNewCatalog(t *testing.T) {
 			api.WithURL(fakeServer.URL()),
 		)
 
-		catalog, err := lwcomponent.NewCatalog(client, newTestStage, false)
+		catalog, err := lwcomponent.NewCatalog(client, newTestStage)
 		assert.NotNil(t, catalog)
 		assert.Nil(t, err)
 	})
@@ -90,7 +90,7 @@ func TestCatalogNewCatalog(t *testing.T) {
 
 		CreateLocalComponent(name, version, false)
 
-		catalog, err := lwcomponent.NewCatalog(client, newTestStage, true)
+		catalog, err := lwcomponent.NewCatalog(client, newTestStage)
 		assert.NotNil(t, catalog)
 		assert.Nil(t, err)
 
@@ -117,7 +117,7 @@ func TestCatalogNewCatalog(t *testing.T) {
 			api.WithURL(fakeServer.URL()),
 		)
 
-		catalog, err := lwcomponent.NewCatalog(client, newTestStage, false)
+		catalog, err := lwcomponent.NewCatalog(client, newTestStage)
 		assert.Nil(t, catalog)
 		assert.NotNil(t, err)
 	})
@@ -149,7 +149,7 @@ func TestCatalogNewCatalog(t *testing.T) {
 
 		CreateLocalComponent(name, "invalid-version", false)
 
-		catalog, err := lwcomponent.NewCatalog(client, newTestStage, false)
+		catalog, err := lwcomponent.NewCatalog(client, newTestStage)
 		assert.NotNil(t, catalog)
 		assert.Nil(t, err)
 
@@ -274,7 +274,7 @@ func TestCatalogComponentCount(t *testing.T) {
 		_, home := FakeHome()
 		defer ResetHome(home)
 
-		catalog, err := lwcomponent.NewCatalog(client, newTestStage, false)
+		catalog, err := lwcomponent.NewCatalog(client, newTestStage)
 		assert.NotNil(t, catalog)
 		assert.Nil(t, err)
 		assert.Equal(t, apiCount, catalog.ComponentCount())
@@ -288,7 +288,7 @@ func TestCatalogComponentCount(t *testing.T) {
 			CreateLocalComponent(fmt.Sprintf("%s-%d", prefix, i), fmt.Sprintf("%d.0.0", i), false)
 		}
 
-		catalog, err := lwcomponent.NewCatalog(client, newTestStage, false)
+		catalog, err := lwcomponent.NewCatalog(client, newTestStage)
 		assert.NotNil(t, catalog)
 		assert.Nil(t, err)
 		assert.Equal(t, apiCount, catalog.ComponentCount())
@@ -302,7 +302,7 @@ func TestCatalogComponentCount(t *testing.T) {
 			CreateLocalComponent(fmt.Sprintf("deprecated-%d", i), fmt.Sprintf("%d.0.0", i), false)
 		}
 
-		catalog, err := lwcomponent.NewCatalog(client, newTestStage, false)
+		catalog, err := lwcomponent.NewCatalog(client, newTestStage)
 		assert.NotNil(t, catalog)
 		assert.Nil(t, err)
 		assert.Equal(t, apiCount+deprecatedCount, catalog.ComponentCount())
@@ -316,7 +316,7 @@ func TestCatalogComponentCount(t *testing.T) {
 			CreateLocalComponent(fmt.Sprintf("dev-%d", i), fmt.Sprintf("%d.0.0", i), true)
 		}
 
-		catalog, err := lwcomponent.NewCatalog(client, newTestStage, false)
+		catalog, err := lwcomponent.NewCatalog(client, newTestStage)
 		assert.NotNil(t, catalog)
 		assert.Nil(t, err)
 		assert.Equal(t, apiCount+developmentCount, catalog.ComponentCount())
@@ -334,7 +334,7 @@ func TestCatalogComponentCount(t *testing.T) {
 			CreateLocalComponent(fmt.Sprintf("all-dev-%d", i), fmt.Sprintf("%d.0.0", i), true)
 		}
 
-		catalog, err := lwcomponent.NewCatalog(client, newTestStage, false)
+		catalog, err := lwcomponent.NewCatalog(client, newTestStage)
 		assert.NotNil(t, catalog)
 		assert.Nil(t, err)
 		assert.Equal(t, apiCount+deprecatedCount+developmentCount, catalog.ComponentCount())
@@ -382,7 +382,7 @@ func TestCatalogGetComponent(t *testing.T) {
 
 		CreateLocalComponent(name, version, false)
 
-		catalog, err := lwcomponent.NewCatalog(client, newTestStage, true)
+		catalog, err := lwcomponent.NewCatalog(client, newTestStage)
 		assert.Nil(t, err)
 
 		component, err := catalog.GetComponent(name)
@@ -395,7 +395,7 @@ func TestCatalogGetComponent(t *testing.T) {
 		_, home := FakeHome()
 		defer ResetHome(home)
 
-		catalog, err := lwcomponent.NewCatalog(client, newTestStage, false)
+		catalog, err := lwcomponent.NewCatalog(client, newTestStage)
 		assert.Nil(t, err)
 
 		component, err := catalog.GetComponent("component-example")
@@ -414,7 +414,7 @@ func TestCatalogGetComponent(t *testing.T) {
 
 		CreateLocalComponent(name, version, true)
 
-		catalog, err := lwcomponent.NewCatalog(client, newTestStage, false)
+		catalog, err := lwcomponent.NewCatalog(client, newTestStage)
 		assert.Nil(t, err)
 
 		component, err := catalog.GetComponent(name)
@@ -437,7 +437,7 @@ func TestCatalogGetComponent(t *testing.T) {
 
 		CreateLocalComponent(name, version, false)
 
-		catalog, err := lwcomponent.NewCatalog(client, newTestStage, false)
+		catalog, err := lwcomponent.NewCatalog(client, newTestStage)
 		assert.Nil(t, err)
 
 		component, err := catalog.GetComponent(name)
@@ -478,7 +478,7 @@ func TestCatalogListComponentVersions(t *testing.T) {
 			api.WithURL(fakeServer.URL()),
 		)
 
-		catalog, err := lwcomponent.NewCatalog(client, newTestStage, false)
+		catalog, err := lwcomponent.NewCatalog(client, newTestStage)
 		assert.NotNil(t, catalog)
 		assert.Nil(t, err)
 
@@ -516,7 +516,7 @@ func TestCatalogListComponentVersions(t *testing.T) {
 			api.WithURL(fakeServer.URL()),
 		)
 
-		catalog, err := lwcomponent.NewCatalog(client, newTestStage, false)
+		catalog, err := lwcomponent.NewCatalog(client, newTestStage)
 		assert.NotNil(t, catalog)
 		assert.Nil(t, err)
 
@@ -575,7 +575,7 @@ func TestCatalogStage(t *testing.T) {
 		api.WithURL(fakeServer.URL()),
 	)
 
-	catalog, err := lwcomponent.NewCatalog(client, newTestStage, false)
+	catalog, err := lwcomponent.NewCatalog(client, newTestStage)
 	assert.NotNil(t, catalog)
 	assert.Nil(t, err)
 
@@ -592,7 +592,7 @@ func TestCatalogStage(t *testing.T) {
 	t.Run("already installed", func(t *testing.T) {
 		CreateLocalComponent(name, version, false)
 
-		catalog, err := lwcomponent.NewCatalog(client, newTestStage, false)
+		catalog, err := lwcomponent.NewCatalog(client, newTestStage)
 		assert.NotNil(t, catalog)
 		assert.Nil(t, err)
 
@@ -733,7 +733,7 @@ func TestCatalogInstall(t *testing.T) {
 		api.WithToken("TOKEN"),
 		api.WithURL(fakeServer.URL()))
 
-	catalog, err := lwcomponent.NewCatalog(client, newTestStage, false)
+	catalog, err := lwcomponent.NewCatalog(client, newTestStage)
 	assert.NotNil(t, catalog)
 	assert.Nil(t, err)
 
@@ -808,7 +808,7 @@ func TestCatalogDelete(t *testing.T) {
 
 		CreateLocalComponent(name, version, false)
 
-		catalog, err := lwcomponent.NewCatalog(client, newTestStage, false)
+		catalog, err := lwcomponent.NewCatalog(client, newTestStage)
 		assert.NotNil(t, catalog)
 		assert.Nil(t, err)
 
@@ -832,7 +832,7 @@ func TestCatalogDelete(t *testing.T) {
 
 		CreateLocalComponent(name, version, true)
 
-		catalog, err := lwcomponent.NewCatalog(client, newTestStage, false)
+		catalog, err := lwcomponent.NewCatalog(client, newTestStage)
 		assert.NotNil(t, catalog)
 		assert.Nil(t, err)
 
@@ -854,7 +854,7 @@ func TestCatalogDelete(t *testing.T) {
 	t.Run("delete-not-installed", func(t *testing.T) {
 		name := fmt.Sprintf("%s-1", prefix)
 
-		catalog, err := lwcomponent.NewCatalog(client, newTestStage, false)
+		catalog, err := lwcomponent.NewCatalog(client, newTestStage)
 		assert.NotNil(t, catalog)
 		assert.Nil(t, err)
 
@@ -871,7 +871,7 @@ func TestCatalogDelete(t *testing.T) {
 
 		CreateLocalComponent(name, version, false)
 
-		catalog, err := lwcomponent.NewCatalog(client, newTestStage, false)
+		catalog, err := lwcomponent.NewCatalog(client, newTestStage)
 		assert.NotNil(t, catalog)
 		assert.Nil(t, err)
 

--- a/lwcomponent/cdk_component.go
+++ b/lwcomponent/cdk_component.go
@@ -212,6 +212,10 @@ func status(apiInfo *ApiInfo, hostInfo *HostInfo) Status {
 }
 
 func isTainted(apiInfo *ApiInfo, installedVer *semver.Version) bool {
+	if len(apiInfo.AllVersions) == 0 {
+		return false
+	}
+
 	for _, ver := range apiInfo.AllVersions {
 		if ver.Equal(installedVer) {
 			return false


### PR DESCRIPTION
## Summary

Every `lacework component list` makes N+1 API calls: API `list all components`, and for N components API `list all versions`.

This PR proposes to fix this by only calling the `list all versions` API endpoint when a users runs `lacework component show`.  This means that `lacework component list` is a single API call, and `lacework component show` is 2 API calls.

The catch is that a user will only see the `Tainted` status after they run `lacework component show`.  Until they run that command, the version will be `Update Available`.

## How did you test this change?

```
> bin/lacework component list
       STATUS                 NAME             VERSION                  DESCRIPTION
-------------------+-------------------------+---------+--------------------------------------------
  Update Available   component-example         0.6.0     Component description

> bin/lacework component show component-example
          STATUS                  NAME          VERSION        DESCRIPTION
--------------------------+-------------------+---------+------------------------
  Tainted (Please update)   component-example   0.6.0     Component description

The following versions of this component are available to install:
 - 0.8.0
 - 0.8.1
 - 0.8.2

The currently installed version 0.6.0 is no longer available to install.

> bin/lacework component list
          STATUS                     NAME             VERSION                  DESCRIPTION
--------------------------+-------------------------+---------+--------------------------------------------
  Tainted (Please update)   component-example         0.6.0     Component description
```

## Issue

https://lacework.atlassian.net/browse/GROW-2771