### PR TITLE
fix: component install windows

### DIFF
--- a/lwcomponent/staging.go
+++ b/lwcomponent/staging.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/Masterminds/semver"
 	"github.com/lacework/go-sdk/internal/file"
+	dircopy "github.com/otiai10/copy"
 	"github.com/pkg/errors"
 )
 
@@ -73,19 +74,8 @@ func (s *stageTarGz) Commit(targetDir string) (err error) {
 		return
 	}
 
-	dirEntries, err := os.ReadDir(s.dir)
-	if err != nil {
+	if err = dircopy.Copy(s.dir, targetDir); err != nil {
 		return
-	}
-
-	for _, entry := range dirEntries {
-		src := filepath.Join(s.dir, entry.Name())
-		dst := filepath.Join(targetDir, entry.Name())
-
-		err = os.Rename(src, dst)
-		if err != nil {
-			return err
-		}
 	}
 
 	return


### PR DESCRIPTION
## Summary

Windows doesn't allow the rename of opened files.  Instead copy the files.

## How did you test this change?

Tested on OSX and Windows amd64.

## Issue

https://lacework.atlassian.net/browse/GROW-2772