### PR TITLE
ci: fix release trigger workflow

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -59,6 +59,9 @@ jobs:
     container:
       image: techallylw/ally-releases:1.21.0
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Trigger release
         if: github.ref == 'refs/heads/main'
         env:


### PR DESCRIPTION
## Summary

test-build workflow broken and we are unable to trigger a release.

https://github.com/lacework/go-sdk/actions/runs/7987657718
