### PR TITLE
feat: CDK v2 feature flag

### DIFF
--- a/lwcomponent/catalog.go
+++ b/lwcomponent/catalog.go
@@ -16,7 +16,7 @@ import (
 const (
 	componentCacheDir string = "components"
 	cdkCacheName      string = "cdk_cache"
-	featureFlag       string = "PUBLIC.cdk.v1"
+	featureFlag       string = "PUBLIC.cdk.v2"
 	operatingSystem   string = runtime.GOOS
 	architecture      string = runtime.GOARCH
 )


### PR DESCRIPTION
## Summary

GROW-2781 is a chicken-egg problem.  Solution is to update the feature flag to `v2` so that the CDK is only usable by CLI versions after the next release.

## Issue

Continuation from https://lacework.atlassian.net/browse/GROW-2781
