### PR TITLE
fix: cdk backwards compatibility

### DIFF
--- a/lwcomponent/host_info.go
+++ b/lwcomponent/host_info.go
@@ -46,7 +46,7 @@ func NewHostInfo(dir string) (*HostInfo, error) {
 	return &info, nil
 }
 
-func CreateHostInfo(dir string, desc string, componentType Type) error {
+func CreateHostInfo(dir string, desc string, componentType Type) (*HostInfo, error) {
 	path := filepath.Join(dir, InfoFile)
 
 	if !file.FileExists(path) {
@@ -58,13 +58,13 @@ func CreateHostInfo(dir string, desc string, componentType Type) error {
 
 		buf := new(bytes.Buffer)
 		if err := json.NewEncoder(buf).Encode(info); err != nil {
-			return err
+			return nil, err
 		}
 
-		return os.WriteFile(path, buf.Bytes(), 0644)
+		return info, os.WriteFile(path, buf.Bytes(), 0644)
 	}
 
-	return nil
+	return NewHostInfo(dir)
 }
 
 func (h *HostInfo) Delete() error {


### PR DESCRIPTION
## Summary

CDK v1 wasn't recognising prototype components.

## How did you test this change?

Installing and running components, while switching between prototype and v1 code paths.