### PR TITLE
chore: set checkout ref to main for prepare-release

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.ref }}
+          ref: main
 
       - name: Setup Go
         uses: actions/setup-go@v4


### PR DESCRIPTION
## Summary

Check out the main instead of a commit SHA

