### PR TITLE
chore: fetch all history for prepare-release

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -11,6 +11,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: main
+          fetch-depth: 0
 
       - name: Setup Go
         uses: actions/setup-go@v4


### PR DESCRIPTION
## Summary

set `fetch-depth: 0` to fetch all history of the repo.

