### PR TITLE
chore: fix trigger release

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -80,15 +80,14 @@ jobs:
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
 
   trigger-release:
+    needs: run-tests
+    if: github.ref_name == 'main'
     runs-on: ubuntu-latest
-    container:
-      image: techallylw/ally-releases:1.21.0
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
       - name: Trigger release
-        if: github.ref == 'refs/heads/main'
         env:
           GPG_SECRET_KEY: ${{ secrets.GPG_SECRET_KEY }}
           GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}


### PR DESCRIPTION
## Summary

Getting the error `fatal: detected dubious ownership in repository at '/__w/go-sdk/go-sdk'` which may be caused by using the container. This PR removes the use of the container and makes sure the trigger-release job runs after the tests

## How did you test this change?

<!--
  How exactly did you verify that your PR solves the issue you wanted to solve?
  Include any other relevant information such as how to use the new functionality, screenshots, etc.
-->

