### PR TITLE
ci: fixes on release.yml and test-build.yml

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -23,6 +23,7 @@ jobs:
           GPG_SECRET_KEY: ${{ secrets.GPG_SECRET_KEY }}
           GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
           GITHUB_TOKEN: ${{ secrets.TOKEN }}
+          CI: true
         run: |
           make prepare
           echo "$GPG_SECRET_KEY" | base64 --decode | gpg --import --no-tty --batch --yes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,6 @@ name: Release
 
 on:
   workflow_dispatch:
-  pull_request:
   push:
     tags:
       - 'v*'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,7 @@ name: Release
 
 on:
   workflow_dispatch:
+  pull_request:
   push:
     tags:
       - 'v*'
@@ -16,7 +17,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.ref }}
+          # ref: ${{ github.ref }}
+          ref: v1.46.0
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -44,26 +46,26 @@ jobs:
           make prepare
           scripts/release.sh build
 
-      - name: Notify Slack to Sign Artifacts
-        uses: slackapi/slack-github-action@v1.25.0
-        with:
-          payload: |
-            {
-              "text": "<@U0279A42HV0> sign_cli ${{ github.ref_name }} https://github.com/lacework/go-sdk/actions/runs/${{ github.run_id }}"
-            }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_GROWTH_ENG_ALERTS }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+      # - name: Notify Slack to Sign Artifacts
+      #   uses: slackapi/slack-github-action@v1.25.0
+      #   with:
+      #     payload: |
+      #       {
+      #         "text": "<@U0279A42HV0> sign_cli ${{ github.ref_name }} https://github.com/lacework/go-sdk/actions/runs/${{ github.run_id }}"
+      #       }
+      #   env:
+      #     SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_GROWTH_ENG_ALERTS }}
+      #     SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
 
-      - name: Create Release
-        env:
-          GPG_SECRET_KEY: ${{ secrets.GPG_SECRET_KEY }}
-          GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
-          GITHUB_TOKEN: ${{ secrets.TOKEN }}
-        run: |
-          make prepare
-          echo "$GPG_SECRET_KEY" | base64 --decode | gpg --import --no-tty --batch --yes
-          scripts/release.sh publish
+      # - name: Create Release
+      #   env:
+      #     GPG_SECRET_KEY: ${{ secrets.GPG_SECRET_KEY }}
+      #     GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
+      #     GITHUB_TOKEN: ${{ secrets.TOKEN }}
+      #   run: |
+      #     make prepare
+      #     echo "$GPG_SECRET_KEY" | base64 --decode | gpg --import --no-tty --batch --yes
+      #     scripts/release.sh publish
 
       - name: Build/Push Docker Image
         env:
@@ -87,27 +89,27 @@ jobs:
         with:
           workflow: chocolatey-release.yml
 
-      - name: Notify Slack on Failure
-        uses: slackapi/slack-github-action@v1.25.0
-        if: failure()
-        with:
-          payload: |
-            {
-              "attachments": [
-                {
-                  "color": "#E92020",
-                  "blocks": [
-                    {
-                      "type": "section",
-                      "text": {
-                        "type": "mrkdwn",
-                        "text": "@oncall-growth-eng! There has been a failure that needs your attention. :rotating_light:\n*GitHub Workflow Failure*\ngo-sdk/release\n*Workflow Run*\n https://github.com/lacework/go-sdk/actions/runs/${{ github.run_id }}"
-                      }
-                    }
-                  ]
-                }
-              ]
-            }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_GROWTH_ENG_ALERTS }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+      # - name: Notify Slack on Failure
+      #   uses: slackapi/slack-github-action@v1.25.0
+      #   if: failure()
+      #   with:
+      #     payload: |
+      #       {
+      #         "attachments": [
+      #           {
+      #             "color": "#E92020",
+      #             "blocks": [
+      #               {
+      #                 "type": "section",
+      #                 "text": {
+      #                   "type": "mrkdwn",
+      #                   "text": "@oncall-growth-eng! There has been a failure that needs your attention. :rotating_light:\n*GitHub Workflow Failure*\ngo-sdk/release\n*Workflow Run*\n https://github.com/lacework/go-sdk/actions/runs/${{ github.run_id }}"
+      #                 }
+      #               }
+      #             ]
+      #           }
+      #         ]
+      #       }
+      #   env:
+      #     SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_GROWTH_ENG_ALERTS }}
+      #     SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,8 +17,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          # ref: ${{ github.ref }}
-          ref: v1.46.0
+          ref: ${{ github.ref }}
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -46,26 +45,26 @@ jobs:
           make prepare
           scripts/release.sh build
 
-      # - name: Notify Slack to Sign Artifacts
-      #   uses: slackapi/slack-github-action@v1.25.0
-      #   with:
-      #     payload: |
-      #       {
-      #         "text": "<@U0279A42HV0> sign_cli ${{ github.ref_name }} https://github.com/lacework/go-sdk/actions/runs/${{ github.run_id }}"
-      #       }
-      #   env:
-      #     SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_GROWTH_ENG_ALERTS }}
-      #     SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+      - name: Notify Slack to Sign Artifacts
+        uses: slackapi/slack-github-action@v1.25.0
+        with:
+          payload: |
+            {
+              "text": "<@U0279A42HV0> sign_cli ${{ github.ref_name }} https://github.com/lacework/go-sdk/actions/runs/${{ github.run_id }}"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_GROWTH_ENG_ALERTS }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
 
-      # - name: Create Release
-      #   env:
-      #     GPG_SECRET_KEY: ${{ secrets.GPG_SECRET_KEY }}
-      #     GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
-      #     GITHUB_TOKEN: ${{ secrets.TOKEN }}
-      #   run: |
-      #     make prepare
-      #     echo "$GPG_SECRET_KEY" | base64 --decode | gpg --import --no-tty --batch --yes
-      #     scripts/release.sh publish
+      - name: Create Release
+        env:
+          GPG_SECRET_KEY: ${{ secrets.GPG_SECRET_KEY }}
+          GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
+          GITHUB_TOKEN: ${{ secrets.TOKEN }}
+        run: |
+          make prepare
+          echo "$GPG_SECRET_KEY" | base64 --decode | gpg --import --no-tty --batch --yes
+          scripts/release.sh publish
 
       - name: Build/Push Docker Image
         env:
@@ -89,27 +88,27 @@ jobs:
         with:
           workflow: chocolatey-release.yml
 
-      # - name: Notify Slack on Failure
-      #   uses: slackapi/slack-github-action@v1.25.0
-      #   if: failure()
-      #   with:
-      #     payload: |
-      #       {
-      #         "attachments": [
-      #           {
-      #             "color": "#E92020",
-      #             "blocks": [
-      #               {
-      #                 "type": "section",
-      #                 "text": {
-      #                   "type": "mrkdwn",
-      #                   "text": "@oncall-growth-eng! There has been a failure that needs your attention. :rotating_light:\n*GitHub Workflow Failure*\ngo-sdk/release\n*Workflow Run*\n https://github.com/lacework/go-sdk/actions/runs/${{ github.run_id }}"
-      #                 }
-      #               }
-      #             ]
-      #           }
-      #         ]
-      #       }
-      #   env:
-      #     SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_GROWTH_ENG_ALERTS }}
-      #     SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+      - name: Notify Slack on Failure
+        uses: slackapi/slack-github-action@v1.25.0
+        if: failure()
+        with:
+          payload: |
+            {
+              "attachments": [
+                {
+                  "color": "#E92020",
+                  "blocks": [
+                    {
+                      "type": "section",
+                      "text": {
+                        "type": "mrkdwn",
+                        "text": "@oncall-growth-eng! There has been a failure that needs your attention. :rotating_light:\n*GitHub Workflow Failure*\ngo-sdk/release\n*Workflow Run*\n https://github.com/lacework/go-sdk/actions/runs/${{ github.run_id }}"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_GROWTH_ENG_ALERTS }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,15 +31,15 @@ jobs:
         with:
           go-version: 1.21.x
 
+      # - name: Login to Docker Hub
+      #   uses: docker/login-action@v3
+      #   with:
+      #     username: ${{ secrets.DOCKERHUB_USERNAME }}
+      #     password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v3
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Build Artifacts
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,11 +31,11 @@ jobs:
         with:
           go-version: 1.21.x
 
-      # - name: Login to Docker Hub
-      #   uses: docker/login-action@v3
-      #   with:
-      #     username: ${{ secrets.DOCKERHUB_USERNAME }}
-      #     password: ${{ secrets.DOCKERHUB_PASSWORD }}
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Set up Docker Buildx
         id: buildx

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+'
+      - 'v*'
 
 jobs:
   release:
@@ -66,6 +66,9 @@ jobs:
           scripts/release.sh publish
 
       - name: Build/Push Docker Image
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_PASS: ${{ secrets.DOCKERHUB_PASSWORD }}
         run: |
           scripts/release_containers.sh
 

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -7,81 +7,86 @@ on:
     branches:
       - main
 
-concurrency:
-  group: ${{ github.workflow }}
-
 jobs:
-  run-tests:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.ref }}
+  # run-tests:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     # To wait for the existing test-build run to complete
+  #     - name: Turnstyle
+  #       uses: softprops/turnstyle@v1
+  #       with:
+  #         same-branch-only: false
+  #       env:
+  #         GITHUB_TOKEN: ${{ secrets.TOKEN }}
 
-      - name: Setup Go
-        uses: actions/setup-go@v4
-        with:
-          go-version: 1.21.x
+  #     - name: Checkout repository
+  #       uses: actions/checkout@v4
+  #       with:
+  #         ref: ${{ github.ref }}
 
-      - name: Run linting tests
-        id: update
-        run: |
-          make prepare
-          make lint
-          make fmt-check
-          make imports-check
+  #     - name: Setup Go
+  #       uses: actions/setup-go@v4
+  #       with:
+  #         go-version: 1.21.x
 
-      - name: Run unit tests
-        run: |
-          make coverage-ci
+  #     - name: Run linting tests
+  #       id: update
+  #       run: |
+  #         make prepare
+  #         make lint
+  #         make fmt-check
+  #         make imports-check
 
-      - name: Build cross-platform binaries
-        run: |
-          make build-cli-cross-platform
+  #     - name: Run unit tests
+  #       run: |
+  #         make coverage-ci
 
-      - name: Run integration tests
-        env:
-          CI_ACCOUNT: ${{ secrets.CI_ACCOUNT }}
-          CI_SUBACCOUNT: ${{ secrets.CI_SUBACCOUNT }}
-          CI_API_KEY: ${{ secrets.CI_API_KEY }}
-          CI_API_SECRET: ${{ secrets.CI_API_SECRET }}
-          LW_INT_TEST_AWS_ACC: ${{ secrets.LW_INT_TEST_AWS_ACC }}
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y vim
-          make integration-only
+  #     - name: Build cross-platform binaries
+  #       run: |
+  #         make build-cli-cross-platform
 
-      # TODO Display test report
+  #     - name: Run integration tests
+  #       env:
+  #         CI_ACCOUNT: ${{ secrets.CI_ACCOUNT }}
+  #         CI_SUBACCOUNT: ${{ secrets.CI_SUBACCOUNT }}
+  #         CI_API_KEY: ${{ secrets.CI_API_KEY }}
+  #         CI_API_SECRET: ${{ secrets.CI_API_SECRET }}
+  #         LW_INT_TEST_AWS_ACC: ${{ secrets.LW_INT_TEST_AWS_ACC }}
+  #       run: |
+  #         sudo apt-get update
+  #         sudo apt-get install -y vim
+  #         make integration-only
 
-      - name: Notify Slack on Failure
-        uses: slackapi/slack-github-action@v1.25.0
-        if: failure()
-        with:
-          payload: |
-            {
-              "attachments": [
-                {
-                  "color": "#E92020",
-                  "blocks": [
-                    {
-                      "type": "section",
-                      "text": {
-                        "type": "mrkdwn",
-                        "text": "@oncall-growth-eng! There has been a failure that needs your attention. :rotating_light:\n*GitHub Workflow Failure*\ngo-sdk/test-build\n*Workflow Run*\n https://github.com/lacework/go-sdk/actions/runs/${{ github.run_id }}"
-                      }
-                    }
-                  ]
-                }
-              ]
-            }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_GROWTH_ENG_ALERTS }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+  #     # TODO Display test report
+
+  #     - name: Notify Slack on Failure
+  #       uses: slackapi/slack-github-action@v1.25.0
+  #       if: failure()
+  #       with:
+  #         payload: |
+  #           {
+  #             "attachments": [
+  #               {
+  #                 "color": "#E92020",
+  #                 "blocks": [
+  #                   {
+  #                     "type": "section",
+  #                     "text": {
+  #                       "type": "mrkdwn",
+  #                       "text": "@oncall-growth-eng! There has been a failure that needs your attention. :rotating_light:\n*GitHub Workflow Failure*\ngo-sdk/test-build\n*Workflow Run*\n https://github.com/lacework/go-sdk/actions/runs/${{ github.run_id }}"
+  #                     }
+  #                   }
+  #                 ]
+  #               }
+  #             ]
+  #           }
+  #       env:
+  #         SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_GROWTH_ENG_ALERTS }}
+  #         SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
 
   trigger-release:
-    needs: run-tests
-    if: github.ref_name == 'main'
+    # needs: run-tests
+    # iif: github.ref_name == 'main'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -94,32 +99,33 @@ jobs:
         env:
           GPG_SECRET_KEY: ${{ secrets.GPG_SECRET_KEY }}
           GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
+          GITHUB_TOKEN: ${{ secrets.TOKEN }}
           CI: true
         run: |
           echo "$GPG_SECRET_KEY" | base64 --decode | gpg --import --no-tty --batch --yes
           scripts/release.sh trigger
 
-      - name: Notify Slack on Failure
-        uses: slackapi/slack-github-action@v1.25.0
-        if: failure()
-        with:
-          payload: |
-            {
-              "attachments": [
-                {
-                  "color": "#E92020",
-                  "blocks": [
-                    {
-                      "type": "section",
-                      "text": {
-                        "type": "mrkdwn",
-                        "text": "@oncall-growth-eng! There has been a failure that needs your attention. :rotating_light:\n*GitHub Workflow Failure*\ngo-sdk/test-build\n*Workflow Run*\n https://github.com/lacework/go-sdk/actions/runs/${{ github.run_id }}"
-                      }
-                    }
-                  ]
-                }
-              ]
-            }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_GROWTH_ENG_ALERTS }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+      # - name: Notify Slack on Failure
+      #   uses: slackapi/slack-github-action@v1.25.0
+      #   if: failure()
+      #   with:
+      #     payload: |
+      #       {
+      #         "attachments": [
+      #           {
+      #             "color": "#E92020",
+      #             "blocks": [
+      #               {
+      #                 "type": "section",
+      #                 "text": {
+      #                   "type": "mrkdwn",
+      #                   "text": "@oncall-growth-eng! There has been a failure that needs your attention. :rotating_light:\n*GitHub Workflow Failure*\ngo-sdk/test-build\n*Workflow Run*\n https://github.com/lacework/go-sdk/actions/runs/${{ github.run_id }}"
+      #                 }
+      #               }
+      #             ]
+      #           }
+      #         ]
+      #       }
+      #   env:
+      #     SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_GROWTH_ENG_ALERTS }}
+      #     SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -8,125 +8,123 @@ on:
       - main
 
 jobs:
-  # run-tests:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     # To wait for the existing test-build run to complete
-  #     - name: Turnstyle
-  #       uses: softprops/turnstyle@v1
-  #       with:
-  #         same-branch-only: false
-  #       env:
-  #         GITHUB_TOKEN: ${{ secrets.TOKEN }}
+  run-tests:
+    runs-on: ubuntu-latest
+    steps:
+      # To wait for the existing test-build run to complete
+      - name: Turnstyle
+        uses: softprops/turnstyle@v1
+        with:
+          same-branch-only: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.TOKEN }}
 
-  #     - name: Checkout repository
-  #       uses: actions/checkout@v4
-  #       with:
-  #         ref: ${{ github.ref }}
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
 
-  #     - name: Setup Go
-  #       uses: actions/setup-go@v4
-  #       with:
-  #         go-version: 1.21.x
+      - name: Setup Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: 1.21.x
 
-  #     - name: Run linting tests
-  #       id: update
-  #       run: |
-  #         make prepare
-  #         make lint
-  #         make fmt-check
-  #         make imports-check
+      - name: Run linting tests
+        id: update
+        run: |
+          make prepare
+          make lint
+          make fmt-check
+          make imports-check
 
-  #     - name: Run unit tests
-  #       run: |
-  #         make coverage-ci
+      - name: Run unit tests
+        run: |
+          make coverage-ci
 
-  #     - name: Build cross-platform binaries
-  #       run: |
-  #         make build-cli-cross-platform
+      - name: Build cross-platform binaries
+        run: |
+          make build-cli-cross-platform
 
-  #     - name: Run integration tests
-  #       env:
-  #         CI_ACCOUNT: ${{ secrets.CI_ACCOUNT }}
-  #         CI_SUBACCOUNT: ${{ secrets.CI_SUBACCOUNT }}
-  #         CI_API_KEY: ${{ secrets.CI_API_KEY }}
-  #         CI_API_SECRET: ${{ secrets.CI_API_SECRET }}
-  #         LW_INT_TEST_AWS_ACC: ${{ secrets.LW_INT_TEST_AWS_ACC }}
-  #       run: |
-  #         sudo apt-get update
-  #         sudo apt-get install -y vim
-  #         make integration-only
+      - name: Run integration tests
+        env:
+          CI_ACCOUNT: ${{ secrets.CI_ACCOUNT }}
+          CI_SUBACCOUNT: ${{ secrets.CI_SUBACCOUNT }}
+          CI_API_KEY: ${{ secrets.CI_API_KEY }}
+          CI_API_SECRET: ${{ secrets.CI_API_SECRET }}
+          LW_INT_TEST_AWS_ACC: ${{ secrets.LW_INT_TEST_AWS_ACC }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y vim
+          make integration-only
 
-  #     # TODO Display test report
+      # TODO Display test report
 
-  #     - name: Notify Slack on Failure
-  #       uses: slackapi/slack-github-action@v1.25.0
-  #       if: failure()
-  #       with:
-  #         payload: |
-  #           {
-  #             "attachments": [
-  #               {
-  #                 "color": "#E92020",
-  #                 "blocks": [
-  #                   {
-  #                     "type": "section",
-  #                     "text": {
-  #                       "type": "mrkdwn",
-  #                       "text": "@oncall-growth-eng! There has been a failure that needs your attention. :rotating_light:\n*GitHub Workflow Failure*\ngo-sdk/test-build\n*Workflow Run*\n https://github.com/lacework/go-sdk/actions/runs/${{ github.run_id }}"
-  #                     }
-  #                   }
-  #                 ]
-  #               }
-  #             ]
-  #           }
-  #       env:
-  #         SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_GROWTH_ENG_ALERTS }}
-  #         SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+      - name: Notify Slack on Failure
+        uses: slackapi/slack-github-action@v1.25.0
+        if: failure()
+        with:
+          payload: |
+            {
+              "attachments": [
+                {
+                  "color": "#E92020",
+                  "blocks": [
+                    {
+                      "type": "section",
+                      "text": {
+                        "type": "mrkdwn",
+                        "text": "@oncall-growth-eng! There has been a failure that needs your attention. :rotating_light:\n*GitHub Workflow Failure*\ngo-sdk/test-build\n*Workflow Run*\n https://github.com/lacework/go-sdk/actions/runs/${{ github.run_id }}"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_GROWTH_ENG_ALERTS }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
 
   trigger-release:
-    # needs: run-tests
-    # iif: github.ref_name == 'main'
+    needs: run-tests
+    if: github.ref_name == 'main'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           ref: main
-          fetch-depth: 0
           token: ${{ secrets.TOKEN }}
 
       - name: Trigger release
         env:
           GPG_SECRET_KEY: ${{ secrets.GPG_SECRET_KEY }}
           GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
-          # GITHUB_TOKEN: ${{ secrets.TOKEN }}
           CI: true
         run: |
           echo "$GPG_SECRET_KEY" | base64 --decode | gpg --import --no-tty --batch --yes
           scripts/release.sh trigger
 
-      # - name: Notify Slack on Failure
-      #   uses: slackapi/slack-github-action@v1.25.0
-      #   if: failure()
-      #   with:
-      #     payload: |
-      #       {
-      #         "attachments": [
-      #           {
-      #             "color": "#E92020",
-      #             "blocks": [
-      #               {
-      #                 "type": "section",
-      #                 "text": {
-      #                   "type": "mrkdwn",
-      #                   "text": "@oncall-growth-eng! There has been a failure that needs your attention. :rotating_light:\n*GitHub Workflow Failure*\ngo-sdk/test-build\n*Workflow Run*\n https://github.com/lacework/go-sdk/actions/runs/${{ github.run_id }}"
-      #                 }
-      #               }
-      #             ]
-      #           }
-      #         ]
-      #       }
-      #   env:
-      #     SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_GROWTH_ENG_ALERTS }}
-      #     SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+      - name: Notify Slack on Failure
+        uses: slackapi/slack-github-action@v1.25.0
+        if: failure()
+        with:
+          payload: |
+            {
+              "attachments": [
+                {
+                  "color": "#E92020",
+                  "blocks": [
+                    {
+                      "type": "section",
+                      "text": {
+                        "type": "mrkdwn",
+                        "text": "@oncall-growth-eng! There has been a failure that needs your attention. :rotating_light:\n*GitHub Workflow Failure*\ngo-sdk/test-build\n*Workflow Run*\n https://github.com/lacework/go-sdk/actions/runs/${{ github.run_id }}"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_GROWTH_ENG_ALERTS }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -94,12 +94,13 @@ jobs:
         with:
           ref: main
           fetch-depth: 0
+          token: ${{ secrets.TOKEN }}
 
       - name: Trigger release
         env:
           GPG_SECRET_KEY: ${{ secrets.GPG_SECRET_KEY }}
           GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
-          GITHUB_TOKEN: ${{ secrets.TOKEN }}
+          # GITHUB_TOKEN: ${{ secrets.TOKEN }}
           CI: true
         run: |
           echo "$GPG_SECRET_KEY" | base64 --decode | gpg --import --no-tty --batch --yes

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -86,6 +86,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
 
       - name: Trigger release
         env:

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -91,6 +91,7 @@ jobs:
         env:
           GPG_SECRET_KEY: ${{ secrets.GPG_SECRET_KEY }}
           GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
+          CI: true
         run: |
           echo "$GPG_SECRET_KEY" | base64 --decode | gpg --import --no-tty --batch --yes
           scripts/release.sh trigger

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -271,6 +271,7 @@ push_release() {
   log "commiting and pushing the release to github"
   _version_no_tag=$(echo $VERSION | awk -F. '{printf("%d.%d.%d", $1, $2, $3)}')
   if [ "$CI" != "" ]; then
+    log "configuring git user email, user name and signingkey"
     git config --global user.email $git_email
     git config --global user.name $git_user
     git config --global user.signingkey $GPG_SIGNING_KEY
@@ -387,6 +388,7 @@ bump_version() {
 
   log "commiting and pushing the vertion bump to github"
   if [ "$CI" != "" ]; then
+    log "configuring git user email, user name and signingkey"
     git config --global user.email $git_email
     git config --global user.name $git_user
     git config --global user.signingkey $GPG_SIGNING_KEY


### PR DESCRIPTION
## Summary

- Add `CI` env for `release.sh`
- Add docker credentials for release.yml
- Add `token` to the checkout action in test-build.yml 
  - Can push commit to main now. A successful run: https://github.com/lacework/go-sdk/actions/runs/8024795426
- Use the `softprops/turnstyle` action to replace `concurrency` to only allow 1 running test-build.

