### PR TITLE
ci: integration tests pipeline improvements

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -5,7 +5,7 @@ on:
     - cron: '0 10 * * *' # Run every day at 10AM UTC
 
 jobs:
-  run-tests:
+  run-linting-and-unit-tests:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -18,7 +18,7 @@ jobs:
         with:
           go-version: 1.21.x
 
-      - name: Run linting tests
+      - name: Run linting
         id: update
         run: |
           make prepare
@@ -30,9 +30,62 @@ jobs:
         run: |
           make coverage-ci
 
+      # TODO Display test report
+
+      - name: Notify Slack on Failure
+        uses: slackapi/slack-github-action@v1.25.0
+        if: failure()
+        with:
+          payload: |
+            {
+              "attachments": [
+                {
+                  "color": "#E92020",
+                  "blocks": [
+                    {
+                      "type": "section",
+                      "text": {
+                        "type": "mrkdwn",
+                        "text": "@oncall-growth-eng! There has been a failure that needs your attention. :rotating_light:\n*GitHub Workflow Failure*\ngo-sdk/nightly-build\n*Workflow Run*\n https://github.com/lacework/go-sdk/actions/runs/${{ github.run_id }}"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_GROWTH_ENG_ALERTS }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+
+  run-integration-tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # To run integration tests with different tags in parallel
+        index: [0, 1, 2, 3, 4]
+    steps:
+      # To wait for the existing nightly-build run to complete to avoid running same integration tests at the same time
+      - name: Turnstyle
+        uses: softprops/turnstyle@v1
+        with:
+          same-branch-only: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.TOKEN }}
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+
+      - name: Setup Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: 1.21.x
+
       - name: Build cross-platform binaries
         run: |
-          make build-cli-cross-platform
+          make prepare
+          make build
 
       - name: Run integration tests
         env:
@@ -41,11 +94,9 @@ jobs:
           CI_API_KEY: ${{ secrets.CI_API_KEY }}
           CI_API_SECRET: ${{ secrets.CI_API_SECRET }}
           LW_INT_TEST_AWS_ACC: ${{ secrets.LW_INT_TEST_AWS_ACC }}
-        # need vim for integrations test of inline editing LQL queries
+          LW_CLI_BIN: lacework
         run: |
-          sudo apt-get update
-          sudo apt-get install -y vim
-          make integration-only
+          make integration-only-subset index=${{ matrix.index }}
 
       - name: Notify Slack on Failure
         uses: slackapi/slack-github-action@v1.25.0

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -97,6 +97,7 @@ jobs:
           CI_API_KEY: ${{ secrets.CI_API_KEY }}
           CI_API_SECRET: ${{ secrets.CI_API_SECRET }}
           LW_INT_TEST_AWS_ACC: ${{ secrets.LW_INT_TEST_AWS_ACC }}
+          LW_CLI_BIN: bin/lacework
         run: |
           make integration-only-subset index=${{ matrix.index }}
 

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -99,6 +99,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y vim
+          make prepare
           make integration-only-subset index=${{ matrix.index }}
 
   trigger-release:

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -97,7 +97,7 @@ jobs:
           CI_API_KEY: ${{ secrets.CI_API_KEY }}
           CI_API_SECRET: ${{ secrets.CI_API_SECRET }}
           LW_INT_TEST_AWS_ACC: ${{ secrets.LW_INT_TEST_AWS_ACC }}
-          LW_CLI_BIN: bin/lacework
+          LW_CLI_BIN: lacework
         run: |
           make integration-only-subset index=${{ matrix.index }}
 

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -65,7 +65,7 @@ jobs:
     strategy:
       matrix:
         # To run integration tests with different tags in parallel
-        index: [0, 1, 2]
+        index: [0, 1, 2, 3, 4]
     steps:
       # To wait for the existing test-build run to complete to avoid running same integration tests at the same time
       - name: Turnstyle
@@ -85,10 +85,10 @@ jobs:
         with:
           go-version: 1.21.x
 
-      - name: Build cross-platform binaries
+      - name: Build binary
         run: |
           make prepare
-          make build-cli-cross-platform
+          make build
 
       - name: Run integration tests
         env:
@@ -98,8 +98,6 @@ jobs:
           CI_API_SECRET: ${{ secrets.CI_API_SECRET }}
           LW_INT_TEST_AWS_ACC: ${{ secrets.LW_INT_TEST_AWS_ACC }}
         run: |
-          sudo apt-get update
-          sudo apt-get install -y vim
           make integration-only-subset index=${{ matrix.index }}
 
   trigger-release:

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -85,10 +85,10 @@ jobs:
         with:
           go-version: 1.21.x
 
-      - name: Build binary
+      - name: Build cross-platform binaries
         run: |
           make prepare
-          make build
+          make build-cli-cross-platform
 
       - name: Run integration tests
         env:
@@ -97,7 +97,6 @@ jobs:
           CI_API_KEY: ${{ secrets.CI_API_KEY }}
           CI_API_SECRET: ${{ secrets.CI_API_SECRET }}
           LW_INT_TEST_AWS_ACC: ${{ secrets.LW_INT_TEST_AWS_ACC }}
-          LW_CLI_BIN: lacework
         run: |
           make integration-only-subset index=${{ matrix.index }}
 

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -35,30 +35,30 @@ jobs:
 
       # TODO Display test report
 
-      # - name: Notify Slack on Failure
-      #   uses: slackapi/slack-github-action@v1.25.0
-      #   if: failure()
-      #   with:
-      #     payload: |
-      #       {
-      #         "attachments": [
-      #           {
-      #             "color": "#E92020",
-      #             "blocks": [
-      #               {
-      #                 "type": "section",
-      #                 "text": {
-      #                   "type": "mrkdwn",
-      #                   "text": "@oncall-growth-eng! There has been a failure that needs your attention. :rotating_light:\n*GitHub Workflow Failure*\ngo-sdk/test-build\n*Workflow Run*\n https://github.com/lacework/go-sdk/actions/runs/${{ github.run_id }}"
-      #                 }
-      #               }
-      #             ]
-      #           }
-      #         ]
-      #       }
-      #   env:
-      #     SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_GROWTH_ENG_ALERTS }}
-      #     SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+      - name: Notify Slack on Failure
+        uses: slackapi/slack-github-action@v1.25.0
+        if: failure()
+        with:
+          payload: |
+            {
+              "attachments": [
+                {
+                  "color": "#E92020",
+                  "blocks": [
+                    {
+                      "type": "section",
+                      "text": {
+                        "type": "mrkdwn",
+                        "text": "@oncall-growth-eng! There has been a failure that needs your attention. :rotating_light:\n*GitHub Workflow Failure*\ngo-sdk/test-build\n*Workflow Run*\n https://github.com/lacework/go-sdk/actions/runs/${{ github.run_id }}"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_GROWTH_ENG_ALERTS }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
 
   run-integration-tests:
     runs-on: ubuntu-latest
@@ -100,6 +100,31 @@ jobs:
           LW_CLI_BIN: lacework
         run: |
           make integration-only-subset index=${{ matrix.index }}
+
+      - name: Notify Slack on Failure
+        uses: slackapi/slack-github-action@v1.25.0
+        if: failure()
+        with:
+          payload: |
+            {
+              "attachments": [
+                {
+                  "color": "#E92020",
+                  "blocks": [
+                    {
+                      "type": "section",
+                      "text": {
+                        "type": "mrkdwn",
+                        "text": "@oncall-growth-eng! There has been a failure that needs your attention. :rotating_light:\n*GitHub Workflow Failure*\ngo-sdk/test-build\n*Workflow Run*\n https://github.com/lacework/go-sdk/actions/runs/${{ github.run_id }}"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_GROWTH_ENG_ALERTS }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
 
   trigger-release:
     needs: [run-linting-and-unit-tests, run-integration-tests]

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -88,7 +88,7 @@ jobs:
       - name: Build cross-platform binaries
         run: |
           make prepare
-          make build-cli-cross-platform
+          make build
 
       - name: Run integration tests
         env:
@@ -97,6 +97,7 @@ jobs:
           CI_API_KEY: ${{ secrets.CI_API_KEY }}
           CI_API_SECRET: ${{ secrets.CI_API_SECRET }}
           LW_INT_TEST_AWS_ACC: ${{ secrets.LW_INT_TEST_AWS_ACC }}
+          LW_CLI_BIN: lacework
         run: |
           make integration-only-subset index=${{ matrix.index }}
 

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -8,10 +8,66 @@ on:
       - main
 
 jobs:
-  run-tests:
+  run-linting-and-unit-tests:
     runs-on: ubuntu-latest
     steps:
-      # To wait for the existing test-build run to complete
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+
+      - name: Setup Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: 1.21.x
+
+      - name: Run linting
+        id: update
+        run: |
+          make prepare
+          make lint
+          make fmt-check
+          make imports-check
+
+      - name: Run unit tests
+        run: |
+          make coverage-ci
+
+      # TODO Display test report
+
+      # - name: Notify Slack on Failure
+      #   uses: slackapi/slack-github-action@v1.25.0
+      #   if: failure()
+      #   with:
+      #     payload: |
+      #       {
+      #         "attachments": [
+      #           {
+      #             "color": "#E92020",
+      #             "blocks": [
+      #               {
+      #                 "type": "section",
+      #                 "text": {
+      #                   "type": "mrkdwn",
+      #                   "text": "@oncall-growth-eng! There has been a failure that needs your attention. :rotating_light:\n*GitHub Workflow Failure*\ngo-sdk/test-build\n*Workflow Run*\n https://github.com/lacework/go-sdk/actions/runs/${{ github.run_id }}"
+      #                 }
+      #               }
+      #             ]
+      #           }
+      #         ]
+      #       }
+      #   env:
+      #     SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_GROWTH_ENG_ALERTS }}
+      #     SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+
+  run-integration-tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # To run integration tests with different tags in parallel
+        index: [0, 1, 2]
+    steps:
+      # To wait for the existing test-build run to complete to avoid running same integration tests at the same time
       - name: Turnstyle
         uses: softprops/turnstyle@v1
         with:
@@ -29,18 +85,6 @@ jobs:
         with:
           go-version: 1.21.x
 
-      - name: Run linting tests
-        id: update
-        run: |
-          make prepare
-          make lint
-          make fmt-check
-          make imports-check
-
-      - name: Run unit tests
-        run: |
-          make coverage-ci
-
       - name: Build cross-platform binaries
         run: |
           make build-cli-cross-platform
@@ -55,37 +99,10 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y vim
-          make integration-only
-
-      # TODO Display test report
-
-      - name: Notify Slack on Failure
-        uses: slackapi/slack-github-action@v1.25.0
-        if: failure()
-        with:
-          payload: |
-            {
-              "attachments": [
-                {
-                  "color": "#E92020",
-                  "blocks": [
-                    {
-                      "type": "section",
-                      "text": {
-                        "type": "mrkdwn",
-                        "text": "@oncall-growth-eng! There has been a failure that needs your attention. :rotating_light:\n*GitHub Workflow Failure*\ngo-sdk/test-build\n*Workflow Run*\n https://github.com/lacework/go-sdk/actions/runs/${{ github.run_id }}"
-                      }
-                    }
-                  ]
-                }
-              ]
-            }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_GROWTH_ENG_ALERTS }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+          make integration-only-subset index=${{ matrix.index }}
 
   trigger-release:
-    needs: run-tests
+    needs: [run-linting-and-unit-tests, run-integration-tests]
     if: github.ref_name == 'main'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -87,6 +87,7 @@ jobs:
 
       - name: Build cross-platform binaries
         run: |
+          make prepare
           make build-cli-cross-platform
 
       - name: Run integration tests
@@ -99,7 +100,6 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y vim
-          make prepare
           make integration-only-subset index=${{ matrix.index }}
 
   trigger-release:

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ prepare: git-env install-tools go-vendor ## Initialize the go environment
 
 .PHONY: test
 test: prepare ## Run all go-sdk tests
-	gotestsum -f testname -- -v -cover -run=$(regex) -coverprofile=$(COVERAGEOUT) $(shell go list ./... | grep -v integration)
+	gotestsum -f testname --rerun-fails=3 --packages="./..." -- -v -cover -run=$(regex) -coverprofile=$(COVERAGEOUT) $(shell go list ./... | grep -v integration)
 
 .PHONY: integration
 integration: build-cli-cross-platform integration-only ## Build and run integration tests
@@ -80,7 +80,7 @@ integration-generation-only: ## Run integration tests
 
 .PHONY: integration-only
 integration-only: install-tools ## Run integration tests
-	PATH="$(PWD)/bin:${PATH}" gotestsum -f testname -- -v github.com/lacework/go-sdk/integration -timeout 30m \
+	PATH="$(PWD)/bin:${PATH}" gotestsum -f testname  --rerun-fails=3 --packages="./..." -- -v github.com/lacework/go-sdk/integration -timeout 30m \
 		-tags="$(INTEGRATION_TEST_TAGS)" -run=$(regex)
 
 .PHONY: integration-only-subset
@@ -89,7 +89,7 @@ integration-only-subset: install-tools ## Run a subset of integration tests
 	$(eval END := $(shell echo 7+$(index)*7 | bc))
 	$(eval LENGTH := ${words $(INTEGRATION_TEST_TAGS)})
 	if [ ${START} -le ${LENGTH} ]; then \
-		PATH="$(PWD)/bin:${PATH}" gotestsum -f testname -- -v github.com/lacework/go-sdk/integration -timeout 30m \
+		PATH="$(PWD)/bin:${PATH}" gotestsum -f testname  --rerun-fails=3 --packages="./..." -- -v github.com/lacework/go-sdk/integration -timeout 30m \
 			-tags="${wordlist $(START), $(END), $(INTEGRATION_TEST_TAGS)}" -run=$(regex) \
 		exit 1; \
 	fi

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,9 @@ prepare: git-env install-tools go-vendor ## Initialize the go environment
 
 .PHONY: test
 test: prepare ## Run all go-sdk tests
-	gotestsum -f testname --rerun-fails=3 --packages="./..." -- -v -cover -run=$(regex) -coverprofile=$(COVERAGEOUT) $(shell go list ./... | grep -v integration)
+	$(eval PACKAGES := $(shell go list ./... | grep -v integration))
+	gotestsum -f testname --rerun-fails=3 --packages="$(PACKAGES)" \
+		-- -v -cover -run=$(regex) -coverprofile=$(COVERAGEOUT) $(PACKAGES)
 
 .PHONY: integration
 integration: build-cli-cross-platform integration-only ## Build and run integration tests
@@ -80,8 +82,8 @@ integration-generation-only: ## Run integration tests
 
 .PHONY: integration-only
 integration-only: install-tools ## Run integration tests
-	PATH="$(PWD)/bin:${PATH}" gotestsum -f testname  --rerun-fails=3 --packages="./..." -- -v github.com/lacework/go-sdk/integration -timeout 30m \
-		-tags="$(INTEGRATION_TEST_TAGS)" -run=$(regex)
+	PATH="$(PWD)/bin:${PATH}" gotestsum -f testname  --rerun-fails=3 --packages="github.com/lacework/go-sdk/integration" \
+		-- -v github.com/lacework/go-sdk/integration -timeout 30m -tags="$(INTEGRATION_TEST_TAGS)" -run=$(regex)
 
 .PHONY: integration-only-subset
 integration-only-subset: install-tools ## Run a subset of integration tests
@@ -89,7 +91,8 @@ integration-only-subset: install-tools ## Run a subset of integration tests
 	$(eval END := $(shell echo 7+$(index)*7 | bc))
 	$(eval LENGTH := ${words $(INTEGRATION_TEST_TAGS)})
 	if [ ${START} -le ${LENGTH} ]; then \
-		PATH="$(PWD)/bin:${PATH}" gotestsum -f testname  --rerun-fails=3 --packages="./..." -- -v github.com/lacework/go-sdk/integration -timeout 30m \
+		PATH="$(PWD)/bin:${PATH}" gotestsum -f testname  --rerun-fails=3 --packages="github.com/lacework/go-sdk/integration" \
+			-- -v github.com/lacework/go-sdk/integration -timeout 30m \
 			-tags="${wordlist $(START), $(END), $(INTEGRATION_TEST_TAGS)}" -run=$(regex) \
 		exit 1; \
 	fi

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,28 @@ GOFLAGS=-mod=vendor
 CGO_ENABLED?=0
 export GOFLAGS GO_LDFLAGS CGO_ENABLED
 
+INTEGRATION_TEST_TAGS=account \
+	agent_token \
+	alert \
+	alert_rule \
+	alert_channel \
+	alert_profile \
+	agent \
+	configure \
+	cloud_account \
+	container_registry \
+	query \
+	policy \
+	help \
+	version \
+	generation \
+	compliance \
+	team_member \
+	vulnerability \
+	report_definitions \
+	component \
+	resource_groups
+
 .PHONY: help
 help:
 	@echo "-------------------------------------------------------------------"
@@ -58,28 +80,19 @@ integration-generation-only: ## Run integration tests
 
 .PHONY: integration-only
 integration-only: install-tools ## Run integration tests
-	PATH="$(PWD)/bin:${PATH}" gotestsum -f testname -- -v github.com/lacework/go-sdk/integration -timeout 30m -tags="\
-		account \
-		agent_token \
-		alert \
-		alert_rule \
-		alert_channel \
-		alert_profile \
-		agent \
-		configure \
-		cloud_account \
-		container_registry \
-		query \
-		policy \
-		help \
-		version \
-		generation \
-		compliance \
-		team_member \
-		vulnerability \
-		report_definitions \
-		component \
-		resource_groups" -run=$(regex)
+	PATH="$(PWD)/bin:${PATH}" gotestsum -f testname -- -v github.com/lacework/go-sdk/integration -timeout 30m \
+		-tags="$(INTEGRATION_TEST_TAGS)" -run=$(regex)
+
+.PHONY: integration-only-subset
+integration-only-subset: install-tools ## Run a subset of integration tests
+	$(eval START := $(shell echo 1+$(index)*7 | bc))
+	$(eval END := $(shell echo 7+$(index)*7 | bc))
+	$(eval LENGTH := ${words $(INTEGRATION_TEST_TAGS)})
+	if [ ${START} -le ${LENGTH} ]; then \
+		PATH="$(PWD)/bin:${PATH}" gotestsum -f testname -- -v github.com/lacework/go-sdk/integration -timeout 30m \
+			-tags="${wordlist $(START), $(END), $(INTEGRATION_TEST_TAGS)}" -run=$(regex) \
+		exit 1; \
+	fi
 
 .PHONY: integration-lql
 integration-lql: build-cli-cross-platform integration-lql-only ## Build and run lql integration tests

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ integration-generation-only: ## Run integration tests
 
 .PHONY: integration-only
 integration-only: install-tools ## Run integration tests
-	PATH="$(PWD)/bin:${PATH}" gotestsum -- -v github.com/lacework/go-sdk/integration -timeout 30m -tags="\
+	PATH="$(PWD)/bin:${PATH}" gotestsum -f testname -- -v github.com/lacework/go-sdk/integration -timeout 30m -tags="\
 		account \
 		agent_token \
 		alert \

--- a/Makefile
+++ b/Makefile
@@ -41,13 +41,13 @@ INTEGRATION_TEST_TAGS=account \
 	policy \
 	help \
 	version \
-	generation \
 	compliance \
 	team_member \
 	vulnerability \
 	report_definitions \
 	component \
-	resource_groups
+	resource_groups \
+	generation
 
 .PHONY: help
 help:
@@ -87,8 +87,8 @@ integration-only: install-tools ## Run integration tests
 
 .PHONY: integration-only-subset
 integration-only-subset: install-tools ## Run a subset of integration tests
-	$(eval START := $(shell echo 1+$(index)*7 | bc))
-	$(eval END := $(shell echo 7+$(index)*7 | bc))
+	$(eval START := $(shell echo 1+$(index)*5 | bc))
+	$(eval END := $(shell echo 5+$(index)*5 | bc))
 	$(eval LENGTH := ${words $(INTEGRATION_TEST_TAGS)})
 	if [ ${START} -le ${LENGTH} ]; then \
 		PATH="$(PWD)/bin:${PATH}" gotestsum -f testname  --rerun-fails=3 --packages="github.com/lacework/go-sdk/integration" \

--- a/cli/cmd/component_dev.go
+++ b/cli/cmd/component_dev.go
@@ -643,6 +643,10 @@ func cdkGoRunVerify(componentName string) error {
 }
 
 func laceworkCLIBinary() string {
+	if bin := os.Getenv("LW_CLI_BIN"); bin != "" {
+		return bin
+	}
+
 	if os.Getenv("LW_CLI_INTEGRATION_MODE") != "" {
 		return fmt.Sprintf(
 			"lacework-cli-%s-%s",

--- a/integration/alert_rules_test.go
+++ b/integration/alert_rules_test.go
@@ -1,3 +1,5 @@
+//go:build alert
+
 // Author:: Darren Murray (<darren.murray@lacework.net>)
 // Copyright:: Copyright 2021, Lacework Inc.
 // License:: Apache License, Version 2.0

--- a/integration/lql_create_test.go
+++ b/integration/lql_create_test.go
@@ -38,8 +38,7 @@ func TestQueryCreateHelp(t *testing.T) {
 
 func TestQueryCreateEditor(t *testing.T) {
 	out, err, exitcode := LaceworkCLIWithTOMLConfig("query", "create")
-	assert.Contains(t, out.String(), "Type a query to create")
-	assert.Contains(t, out.String(), "[Enter to launch editor]")
+	assert.Contains(t, out.String(), "Choose query language")
 	assert.Contains(t, err.String(), "ERROR unable to create query:")
 	assert.Equal(t, 1, exitcode, "EXITCODE is not the expected one")
 }

--- a/integration/lql_create_unix_test.go
+++ b/integration/lql_create_unix_test.go
@@ -38,6 +38,9 @@ func TestQueryCreateFromEditor(t *testing.T) {
 
 	_ = runFakeTerminalTestFromDir(t, dir,
 		func(c *expect.Console) {
+			expectString(t, c, "Choose query language")
+			c.SendLine("")
+			time.Sleep(time.Millisecond)
 			expectString(t, c, "Type a query to create")
 			c.SendLine("")
 			time.Sleep(time.Millisecond)


### PR DESCRIPTION
## Summary

- Use the [--rerun-fails](https://github.com/gotestyourself/gotestsum?tab=readme-ov-file#re-running-failed-tests) flag to rerun failed tests 2 more times.
- Run `make build` instead of `make build-cli-cross-platform` for faster build
- Use Github Action [job matrix](https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs) to run integration tests with different build tags in parallel.
- Fix LQL tests issues caused by the enabling of the [lpp_rego_enabled](https://app.launchdarkly.com/default/production/features/lpp_rego_enabled/history/65dcc9ea187bb70fc59002bd/details/diff) featured flag.

## How did you test this change?

https://github.com/lacework/go-sdk/actions/runs/8072320718

## Issue

https://lacework.atlassian.net/browse/GROW-2770
