### PR TITLE
fix: component windows extension

### DIFF
--- a/lwcomponent/catalog.go
+++ b/lwcomponent/catalog.go
@@ -172,7 +172,13 @@ func (c *Catalog) Stage(
 }
 
 func (c *Catalog) Verify(component *CDKComponent) (err error) {
-	data, err := os.ReadFile(filepath.Join(component.stage.Directory(), component.Name))
+	path := filepath.Join(component.stage.Directory(), component.Name)
+
+	if operatingSystem == "windows" {
+		path = fmt.Sprintf("%s.exe", path)
+	}
+
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return
 	}
@@ -215,9 +221,15 @@ func (c *Catalog) Install(component *CDKComponent) (err error) {
 		return
 	}
 
+	path := filepath.Join(component.stage.Directory(), component.Name)
+
+	if operatingSystem == "windows" {
+		path = fmt.Sprintf("%s.exe", path)
+	}
+
 	if component.ApiInfo != nil &&
 		(component.ApiInfo.ComponentType == BinaryType || component.ApiInfo.ComponentType == CommandType) {
-		if err := os.Chmod(filepath.Join(componentDir, component.Name), 0744); err != nil {
+		if err := os.Chmod(path, 0744); err != nil {
 			return errors.Wrap(err, "unable to make component executable")
 		}
 	}

--- a/lwcomponent/host_info.go
+++ b/lwcomponent/host_info.go
@@ -139,7 +139,13 @@ func (h *HostInfo) Validate() (err error) {
 		return errors.New(fmt.Sprintf("missing file '%s'", componentName))
 	}
 
-	if !file.FileExists(filepath.Join(h.Dir, componentName)) {
+	path := filepath.Join(h.Dir, componentName)
+
+	if operatingSystem == "windows" {
+		path = fmt.Sprintf("%s.exe", path)
+	}
+
+	if !file.FileExists(path) {
 		return errors.New(fmt.Sprintf("missing file '%s'", componentName))
 	}
 

--- a/lwcomponent/staging.go
+++ b/lwcomponent/staging.go
@@ -4,6 +4,7 @@ import (
 	"archive/tar"
 	"compress/gzip"
 	"encoding/base64"
+	"fmt"
 	"io"
 	"net/url"
 	"os"
@@ -174,8 +175,14 @@ func (s *stageTarGz) Validate() (err error) {
 		return errors.Errorf("missing file '%s'", s.name)
 	}
 
-	if !file.FileExists(filepath.Join(s.dir, s.name)) {
-		return errors.Errorf("missing file '%s'", s.name)
+	path := filepath.Join(s.dir, s.name)
+
+	if operatingSystem == "windows" {
+		path = fmt.Sprintf("%s.exe", path)
+	}
+
+	if !file.FileExists(path) {
+		return errors.Errorf("missing file '%s'", path)
 	}
 
 	return


### PR DESCRIPTION

## Summary

Need to use the `.exe` file extension on windows

## How did you test this change?

tested on windows with SCA.  Install, update, running component

## Issue

https://lacework.atlassian.net/browse/GROW-2784
