### PR TITLE
ci: fix tests and remove extra docker login in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,6 @@ name: Release
 
 on:
   workflow_dispatch:
-  pull_request:
   push:
     tags:
       - 'v*'
@@ -30,12 +29,6 @@ jobs:
         with:
           go-version: 1.21.x
 
-      # - name: Login to Docker Hub
-      #   uses: docker/login-action@v3
-      #   with:
-      #     username: ${{ secrets.DOCKERHUB_USERNAME }}
-      #     password: ${{ secrets.DOCKERHUB_PASSWORD }}
-
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v3
@@ -61,6 +54,7 @@ jobs:
           GPG_SECRET_KEY: ${{ secrets.GPG_SECRET_KEY }}
           GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
           GITHUB_TOKEN: ${{ secrets.TOKEN }}
+          CI: true
         run: |
           make prepare
           echo "$GPG_SECRET_KEY" | base64 --decode | gpg --import --no-tty --batch --yes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,7 @@ name: Release
 
 on:
   workflow_dispatch:
+  pull_request:
   push:
     tags:
       - 'v*'
@@ -29,11 +30,11 @@ jobs:
         with:
           go-version: 1.21.x
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+      # - name: Login to Docker Hub
+      #   uses: docker/login-action@v3
+      #   with:
+      #     username: ${{ secrets.DOCKERHUB_USERNAME }}
+      #     password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Set up Docker Buildx
         id: buildx

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Notify Slack on Failure
         uses: slackapi/slack-github-action@v1.25.0
-        if: failure()
+        if: failure() && github.event_name != 'pull_request'
         with:
           payload: |
             {
@@ -103,7 +103,7 @@ jobs:
 
       - name: Notify Slack on Failure
         uses: slackapi/slack-github-action@v1.25.0
-        if: failure()
+        if: failure() && github.event_name != 'pull_request'
         with:
           payload: |
             {

--- a/integration/lql_create_unix_test.go
+++ b/integration/lql_create_unix_test.go
@@ -48,13 +48,13 @@ func TestQueryCreateFromEditor(t *testing.T) {
 			c.Send(fmt.Sprintf("c$queryId: %s\x1b", queryID))
 			time.Sleep(time.Millisecond)
 			// Move to line number 5 and add source
-			c.Send("5GoCloudTrailRawEvents\x1b")
+			c.Send("5Gc$CloudTrailRawEvents\x1b")
 			time.Sleep(time.Millisecond)
-			// Move to line number 9 and add filter
-			c.Send("9GoEVENT_NAME like 'GetBucket%'\x1b")
+			// Move to line number 8 and add filter
+			c.Send("8Gc$EVENT_NAME like 'GetBucket%'\x1b")
 			time.Sleep(time.Millisecond)
-			// Move to line number 13 and add return
-			c.Send("13GoINSERT_ID\x1b")
+			// Move to line number 11 and add return
+			c.Send("11Gc$INSERT_ID\x1b")
 			time.Sleep(time.Millisecond)
 			c.SendLine(":wq!") // save and close
 			time.Sleep(time.Millisecond)
@@ -69,18 +69,6 @@ func TestQueryCreateFromEditor(t *testing.T) {
 		assert.Empty(t,
 			stderr.String(),
 			"STDERR should be empty")
-		assert.Contains(t,
-			stdout.String(),
-			"--- Select a datasource. To list all available datasources, use 'lacework query sources'.",
-			"STDOUT changed, please update")
-		assert.Contains(t,
-			stdout.String(),
-			"--- Add query filter(s), if any. If not, remove this block.",
-			"STDOUT changed, please update")
-		assert.Contains(t,
-			stdout.String(),
-			"--- List fields to return from the selected source. Use 'lacework query describe <datasource>'.",
-			"STDOUT changed, please update")
 		assert.Contains(t, stdout.String(), "CloudTrailRawEvents", "STDOUT changed, please update")
 		assert.Contains(t, stdout.String(), "EVENT_NAME like 'GetBucket%'", "STDOUT changed, please update")
 		assert.Contains(t, stdout.String(), "INSERT_ID", "STDOUT changed, please update")

--- a/integration/lql_update_unix_test.go
+++ b/integration/lql_update_unix_test.go
@@ -54,7 +54,7 @@ func TestQueryUpdateFromIDEditor(t *testing.T) {
 			c.SendLine("")
 			time.Sleep(time.Millisecond)
 			// Move to line number 4 and add comment "--- Updated from CLI Editor"
-			c.Send("4Go--- Updated from CLI Editor\x1b")
+			c.Send("4Gc$--- Updated from CLI Editor\x1b")
 			c.SendLine(":wq!") // save and close
 			time.Sleep(time.Millisecond)
 			expectString(t, c,


### PR DESCRIPTION
## Summary

- There is already `docker login` in release.sh. Remove the extra step.
- Fix the LQL query create/update tests
- Don't send Slack alerts in test-build for PRs.

## How did you test this change?

Run `test-build`

