### PR TITLE
fix(GROW-2791): v1 component JSON

### DIFF
--- a/lwcomponent/catalog_test.go
+++ b/lwcomponent/catalog_test.go
@@ -88,7 +88,7 @@ func TestCatalogNewCatalog(t *testing.T) {
 		name := fmt.Sprintf("%s-%d", prefix, 1)
 		version := fmt.Sprintf("%d.0.0", 1)
 
-		CreateLocalComponent(name, version, false)
+		CreateLocalComponent(name, version, false, lwcomponent.BinaryType)
 
 		catalog, err := lwcomponent.NewCatalog(client, newTestStage)
 		assert.NotNil(t, catalog)
@@ -147,7 +147,7 @@ func TestCatalogNewCatalog(t *testing.T) {
 			api.WithURL(fakeServer.URL()),
 		)
 
-		CreateLocalComponent(name, "invalid-version", false)
+		CreateLocalComponent(name, "invalid-version", false, lwcomponent.BinaryType)
 
 		catalog, err := lwcomponent.NewCatalog(client, newTestStage)
 		assert.NotNil(t, catalog)
@@ -195,11 +195,11 @@ func TestCatalogNewCachedCatalog(t *testing.T) {
 			cachedComponentsApiInfo[name] = lwcomponent.NewAPIInfo(1, name, latestVersion, allVersions, "", 1, false, lwcomponent.BinaryType)
 		}
 
-		CreateLocalComponent("testComponentWithApiInfo-0", "5.4.3", false)
-		CreateLocalComponent("testComponentWithApiInfo-1", "1.0.0", false)
-		CreateLocalComponent("testComponentWithApiInfo-2", "2.0.1", false)
-		CreateLocalComponent("testComponentWithApiInfo-3", "3.0.1", true)
-		CreateLocalComponent("testComponent", "0.0.1-dev", true)
+		CreateLocalComponent("testComponentWithApiInfo-0", "5.4.3", false, lwcomponent.BinaryType)
+		CreateLocalComponent("testComponentWithApiInfo-1", "1.0.0", false, lwcomponent.BinaryType)
+		CreateLocalComponent("testComponentWithApiInfo-2", "2.0.1", false, lwcomponent.BinaryType)
+		CreateLocalComponent("testComponentWithApiInfo-3", "3.0.1", true, lwcomponent.BinaryType)
+		CreateLocalComponent("testComponent", "0.0.1-dev", true, lwcomponent.BinaryType)
 
 		catalog, err := lwcomponent.NewCachedCatalog(client, newTestStage, cachedComponentsApiInfo)
 		assert.NotNil(t, catalog)
@@ -285,7 +285,7 @@ func TestCatalogComponentCount(t *testing.T) {
 		defer ResetHome(home)
 
 		for i := 0; i < apiCount; i++ {
-			CreateLocalComponent(fmt.Sprintf("%s-%d", prefix, i), fmt.Sprintf("%d.0.0", i), false)
+			CreateLocalComponent(fmt.Sprintf("%s-%d", prefix, i), fmt.Sprintf("%d.0.0", i), false, lwcomponent.BinaryType)
 		}
 
 		catalog, err := lwcomponent.NewCatalog(client, newTestStage)
@@ -299,7 +299,7 @@ func TestCatalogComponentCount(t *testing.T) {
 		defer ResetHome(home)
 
 		for i := 0; i < deprecatedCount; i++ {
-			CreateLocalComponent(fmt.Sprintf("deprecated-%d", i), fmt.Sprintf("%d.0.0", i), false)
+			CreateLocalComponent(fmt.Sprintf("deprecated-%d", i), fmt.Sprintf("%d.0.0", i), false, lwcomponent.BinaryType)
 		}
 
 		catalog, err := lwcomponent.NewCatalog(client, newTestStage)
@@ -313,7 +313,7 @@ func TestCatalogComponentCount(t *testing.T) {
 		defer ResetHome(home)
 
 		for i := 0; i < developmentCount; i++ {
-			CreateLocalComponent(fmt.Sprintf("dev-%d", i), fmt.Sprintf("%d.0.0", i), true)
+			CreateLocalComponent(fmt.Sprintf("dev-%d", i), fmt.Sprintf("%d.0.0", i), true, lwcomponent.BinaryType)
 		}
 
 		catalog, err := lwcomponent.NewCatalog(client, newTestStage)
@@ -327,11 +327,11 @@ func TestCatalogComponentCount(t *testing.T) {
 		defer ResetHome(home)
 
 		for i := 0; i < deprecatedCount; i++ {
-			CreateLocalComponent(fmt.Sprintf("all-deprecated-%d", i), fmt.Sprintf("%d.0.0", i), false)
+			CreateLocalComponent(fmt.Sprintf("all-deprecated-%d", i), fmt.Sprintf("%d.0.0", i), false, lwcomponent.BinaryType)
 		}
 
 		for i := 0; i < developmentCount; i++ {
-			CreateLocalComponent(fmt.Sprintf("all-dev-%d", i), fmt.Sprintf("%d.0.0", i), true)
+			CreateLocalComponent(fmt.Sprintf("all-dev-%d", i), fmt.Sprintf("%d.0.0", i), true, lwcomponent.BinaryType)
 		}
 
 		catalog, err := lwcomponent.NewCatalog(client, newTestStage)
@@ -380,7 +380,7 @@ func TestCatalogGetComponent(t *testing.T) {
 		_, home := FakeHome()
 		defer ResetHome(home)
 
-		CreateLocalComponent(name, version, false)
+		CreateLocalComponent(name, version, false, lwcomponent.BinaryType)
 
 		catalog, err := lwcomponent.NewCatalog(client, newTestStage)
 		assert.Nil(t, err)
@@ -412,7 +412,7 @@ func TestCatalogGetComponent(t *testing.T) {
 		_, home := FakeHome()
 		defer ResetHome(home)
 
-		CreateLocalComponent(name, version, true)
+		CreateLocalComponent(name, version, true, lwcomponent.BinaryType)
 
 		catalog, err := lwcomponent.NewCatalog(client, newTestStage)
 		assert.Nil(t, err)
@@ -435,7 +435,7 @@ func TestCatalogGetComponent(t *testing.T) {
 		_, home := FakeHome()
 		defer ResetHome(home)
 
-		CreateLocalComponent(name, version, false)
+		CreateLocalComponent(name, version, false, lwcomponent.BinaryType)
 
 		catalog, err := lwcomponent.NewCatalog(client, newTestStage)
 		assert.Nil(t, err)
@@ -657,7 +657,7 @@ func TestCatalogStage(t *testing.T) {
 	})
 
 	t.Run("already installed", func(t *testing.T) {
-		CreateLocalComponent(name, version, false)
+		CreateLocalComponent(name, version, false, lwcomponent.BinaryType)
 
 		catalog, err := lwcomponent.NewCatalog(client, newTestStage)
 		assert.NotNil(t, catalog)
@@ -889,7 +889,7 @@ func TestCatalogDelete(t *testing.T) {
 	t.Run("delete-installed", func(t *testing.T) {
 		name := fmt.Sprintf("%s-1", prefix)
 
-		CreateLocalComponent(name, version, false)
+		CreateLocalComponent(name, version, false, lwcomponent.BinaryType)
 
 		catalog, err := lwcomponent.NewCatalog(client, newTestStage)
 		assert.NotNil(t, catalog)
@@ -913,7 +913,7 @@ func TestCatalogDelete(t *testing.T) {
 	t.Run("delete-development", func(t *testing.T) {
 		name := "delete-dev"
 
-		CreateLocalComponent(name, version, true)
+		CreateLocalComponent(name, version, true, lwcomponent.BinaryType)
 
 		catalog, err := lwcomponent.NewCatalog(client, newTestStage)
 		assert.NotNil(t, catalog)
@@ -952,7 +952,7 @@ func TestCatalogDelete(t *testing.T) {
 	t.Run("delete-twice", func(t *testing.T) {
 		name := fmt.Sprintf("%s-2", prefix)
 
-		CreateLocalComponent(name, version, false)
+		CreateLocalComponent(name, version, false, lwcomponent.BinaryType)
 
 		catalog, err := lwcomponent.NewCatalog(client, newTestStage)
 		assert.NotNil(t, catalog)
@@ -1054,7 +1054,7 @@ func generateFetchResponse(id int32, name string, version string, url string) st
 	return string(result)
 }
 
-func CreateLocalComponent(componentName string, version string, development bool) {
+func CreateLocalComponent(componentName string, version string, development bool, componentType lwcomponent.Type) {
 	dir, err := lwcomponent.CatalogCacheDir()
 	if err != nil {
 		panic(err)
@@ -1082,7 +1082,7 @@ func CreateLocalComponent(componentName string, version string, development bool
 		panic(err)
 	}
 
-	info := lwcomponent.HostInfo{Dir: "", Description: "", ComponentType: lwcomponent.BinaryType}
+	info := lwcomponent.HostInfo{Dir: "", Desc: "", ComponentType: componentType}
 	data, err := json.Marshal(info)
 	if err != nil {
 		panic(err)

--- a/lwcomponent/cdk_component.go
+++ b/lwcomponent/cdk_component.go
@@ -32,7 +32,7 @@ type CDKComponent struct {
 	stage    Stager
 }
 
-func NewCDKComponent(name string, desc string, componentType Type, apiInfo *ApiInfo, hostInfo *HostInfo) CDKComponent {
+func NewCDKComponent(apiInfo *ApiInfo, hostInfo *HostInfo) CDKComponent {
 	var (
 		exec Executer = &nonExecutable{}
 	)
@@ -44,8 +44,8 @@ func NewCDKComponent(name string, desc string, componentType Type, apiInfo *ApiI
 		{
 			dir := hostInfo.Dir
 
-			if componentType == BinaryType || componentType == CommandType {
-				exec = NewExecuable(name, dir)
+			if hostInfo.ComponentType == BinaryType || hostInfo.ComponentType == CommandType {
+				exec = NewExecuable(hostInfo.Name, dir)
 			}
 		}
 	default:
@@ -54,15 +54,31 @@ func NewCDKComponent(name string, desc string, componentType Type, apiInfo *ApiI
 		}
 	}
 
-	return CDKComponent{
-		Name:        name,
-		Description: desc,
-		Type:        componentType,
-		Status:      status,
-		Exec:        exec,
-		ApiInfo:     apiInfo,
-		HostInfo:    hostInfo,
+	if apiInfo != nil {
+		return CDKComponent{
+			Name:        apiInfo.Name,
+			Description: apiInfo.Desc,
+			Type:        apiInfo.ComponentType,
+			Status:      status,
+			Exec:        exec,
+			ApiInfo:     apiInfo,
+			HostInfo:    hostInfo,
+		}
 	}
+
+	if hostInfo != nil {
+		return CDKComponent{
+			Name:        hostInfo.Name,
+			Description: hostInfo.Desc,
+			Type:        hostInfo.ComponentType,
+			Status:      status,
+			Exec:        exec,
+			ApiInfo:     apiInfo,
+			HostInfo:    hostInfo,
+		}
+	}
+
+	return CDKComponent{}
 }
 
 func (c *CDKComponent) Dir() (string, error) {

--- a/lwcomponent/cdk_component_test.go
+++ b/lwcomponent/cdk_component_test.go
@@ -14,7 +14,7 @@ func TestNewCDKComponent(t *testing.T) {
 	defer ResetHome(home)
 
 	t.Run("UnknownStatus", func(t *testing.T) {
-		component := lwcomponent.NewCDKComponent("unknown", "", lwcomponent.BinaryType, nil, nil)
+		component := lwcomponent.NewCDKComponent(nil, &lwcomponent.HostInfo{Name: "unknown"})
 
 		assert.Equal(t, lwcomponent.UnknownStatus, component.Status)
 	})
@@ -27,7 +27,7 @@ func TestNewCDKComponent(t *testing.T) {
 
 		apiInfo := lwcomponent.NewAPIInfo(1, name, version, allVersions, "", 1, false, lwcomponent.BinaryType)
 
-		component := lwcomponent.NewCDKComponent(name, "", lwcomponent.BinaryType, apiInfo, nil)
+		component := lwcomponent.NewCDKComponent(apiInfo, nil)
 
 		assert.Equal(t, lwcomponent.NotInstalled, component.Status)
 	})
@@ -43,13 +43,13 @@ func TestNewCDKComponent(t *testing.T) {
 
 		apiInfo := lwcomponent.NewAPIInfo(1, name, version, allVersions, "", 1, false, lwcomponent.BinaryType)
 
-		CreateLocalComponent(name, ver, false)
+		CreateLocalComponent(name, ver, false, lwcomponent.BinaryType)
 
 		dir, _ := lwcomponent.CatalogCacheDir()
 
-		hostInfo, _ := lwcomponent.NewHostInfo(filepath.Join(dir, name))
+		hostInfo, _ := lwcomponent.LoadHostInfo(filepath.Join(dir, name))
 
-		component := lwcomponent.NewCDKComponent(name, "", lwcomponent.BinaryType, apiInfo, hostInfo)
+		component := lwcomponent.NewCDKComponent(apiInfo, hostInfo)
 
 		assert.Equal(t, lwcomponent.Installed, component.Status)
 	})
@@ -67,13 +67,13 @@ func TestNewCDKComponent(t *testing.T) {
 
 		apiInfo := lwcomponent.NewAPIInfo(1, name, version, allVersions, "", 1, false, lwcomponent.BinaryType)
 
-		CreateLocalComponent(name, installVer, false)
+		CreateLocalComponent(name, installVer, false, lwcomponent.BinaryType)
 
 		dir, _ := lwcomponent.CatalogCacheDir()
 
-		hostInfo, _ := lwcomponent.NewHostInfo(filepath.Join(dir, name))
+		hostInfo, _ := lwcomponent.LoadHostInfo(filepath.Join(dir, name))
 
-		component := lwcomponent.NewCDKComponent(name, "", lwcomponent.BinaryType, apiInfo, hostInfo)
+		component := lwcomponent.NewCDKComponent(apiInfo, hostInfo)
 
 		assert.Equal(t, lwcomponent.UpdateAvailable, component.Status)
 	})
@@ -84,13 +84,13 @@ func TestNewCDKComponent(t *testing.T) {
 			ver  string = "1.1.1"
 		)
 
-		CreateLocalComponent(name, ver, false)
+		CreateLocalComponent(name, ver, false, lwcomponent.BinaryType)
 
 		dir, _ := lwcomponent.CatalogCacheDir()
 
-		hostInfo, _ := lwcomponent.NewHostInfo(filepath.Join(dir, name))
+		hostInfo, _ := lwcomponent.LoadHostInfo(filepath.Join(dir, name))
 
-		component := lwcomponent.NewCDKComponent(name, "", lwcomponent.BinaryType, nil, hostInfo)
+		component := lwcomponent.NewCDKComponent(nil, hostInfo)
 
 		assert.Equal(t, lwcomponent.InstalledDeprecated, component.Status)
 	})
@@ -104,14 +104,14 @@ func TestNewCDKComponent(t *testing.T) {
 		version, _ := semver.NewVersion(ver)
 		allVersions := []*semver.Version{version}
 
-		CreateLocalComponent(name, ver, false)
+		CreateLocalComponent(name, ver, false, lwcomponent.BinaryType)
 
 		apiInfo := lwcomponent.NewAPIInfo(1, name, version, allVersions, "", 1, true, lwcomponent.BinaryType)
 
 		dir, _ := lwcomponent.CatalogCacheDir()
-		hostInfo, _ := lwcomponent.NewHostInfo(filepath.Join(dir, name))
+		hostInfo, _ := lwcomponent.LoadHostInfo(filepath.Join(dir, name))
 
-		component := lwcomponent.NewCDKComponent(name, "", lwcomponent.BinaryType, apiInfo, hostInfo)
+		component := lwcomponent.NewCDKComponent(apiInfo, hostInfo)
 
 		assert.Equal(t, lwcomponent.InstalledDeprecated, component.Status)
 	})
@@ -126,7 +126,7 @@ func TestNewCDKComponent(t *testing.T) {
 
 		apiInfo := lwcomponent.NewAPIInfo(1, name, version, allVersions, "", 1, true, lwcomponent.BinaryType)
 
-		component := lwcomponent.NewCDKComponent(name, "", lwcomponent.BinaryType, apiInfo, nil)
+		component := lwcomponent.NewCDKComponent(apiInfo, nil)
 
 		assert.Equal(t, lwcomponent.NotInstalledDeprecated, component.Status)
 	})
@@ -143,13 +143,13 @@ func TestNewCDKComponent(t *testing.T) {
 
 		apiInfo := lwcomponent.NewAPIInfo(1, name, version, allVersions, "", 1, false, lwcomponent.BinaryType)
 
-		CreateLocalComponent(name, installVer, false)
+		CreateLocalComponent(name, installVer, false, lwcomponent.BinaryType)
 
 		dir, _ := lwcomponent.CatalogCacheDir()
 
-		hostInfo, _ := lwcomponent.NewHostInfo(filepath.Join(dir, name))
+		hostInfo, _ := lwcomponent.LoadHostInfo(filepath.Join(dir, name))
 
-		component := lwcomponent.NewCDKComponent(name, "", lwcomponent.BinaryType, apiInfo, hostInfo)
+		component := lwcomponent.NewCDKComponent(apiInfo, hostInfo)
 
 		assert.Equal(t, lwcomponent.Tainted, component.Status)
 	})
@@ -160,13 +160,13 @@ func TestNewCDKComponent(t *testing.T) {
 			ver  string = "1.1.1"
 		)
 
-		CreateLocalComponent(name, ver, true)
+		CreateLocalComponent(name, ver, true, lwcomponent.BinaryType)
 
 		dir, _ := lwcomponent.CatalogCacheDir()
 
-		hostInfo, _ := lwcomponent.NewHostInfo(filepath.Join(dir, name))
+		hostInfo, _ := lwcomponent.LoadHostInfo(filepath.Join(dir, name))
 
-		component := lwcomponent.NewCDKComponent(name, "", lwcomponent.BinaryType, nil, hostInfo)
+		component := lwcomponent.NewCDKComponent(nil, hostInfo)
 
 		assert.Equal(t, lwcomponent.Development, component.Status)
 	})
@@ -182,13 +182,13 @@ func TestNewCDKComponent(t *testing.T) {
 
 		apiInfo := lwcomponent.NewAPIInfo(1, name, version, allVersions, "", 1, false, lwcomponent.BinaryType)
 
-		CreateLocalComponent(name, ver, false)
+		CreateLocalComponent(name, ver, false, lwcomponent.BinaryType)
 
 		dir, _ := lwcomponent.CatalogCacheDir()
 
-		hostInfo, _ := lwcomponent.NewHostInfo(filepath.Join(dir, name))
+		hostInfo, _ := lwcomponent.LoadHostInfo(filepath.Join(dir, name))
 
-		component := lwcomponent.NewCDKComponent(name, "", lwcomponent.BinaryType, apiInfo, hostInfo)
+		component := lwcomponent.NewCDKComponent(apiInfo, hostInfo)
 
 		_, _, err := component.Exec.Execute([]string{}, "")
 		assert.Nil(t, err)
@@ -205,13 +205,13 @@ func TestNewCDKComponent(t *testing.T) {
 
 		apiInfo := lwcomponent.NewAPIInfo(1, name, version, allVersions, "", 1, false, lwcomponent.BinaryType)
 
-		CreateLocalComponent(name, ver, false)
+		CreateLocalComponent(name, ver, false, lwcomponent.BinaryType)
 
 		dir, _ := lwcomponent.CatalogCacheDir()
 
-		hostInfo, _ := lwcomponent.NewHostInfo(filepath.Join(dir, name))
+		hostInfo, _ := lwcomponent.LoadHostInfo(filepath.Join(dir, name))
 
-		component := lwcomponent.NewCDKComponent(name, "", lwcomponent.CommandType, apiInfo, hostInfo)
+		component := lwcomponent.NewCDKComponent(apiInfo, hostInfo)
 
 		_, _, err := component.Exec.Execute([]string{}, "")
 		assert.Nil(t, err)
@@ -226,15 +226,15 @@ func TestNewCDKComponent(t *testing.T) {
 		version, _ := semver.NewVersion(ver)
 		allVersions := []*semver.Version{version}
 
-		apiInfo := lwcomponent.NewAPIInfo(1, name, version, allVersions, "", 1, false, lwcomponent.BinaryType)
+		apiInfo := lwcomponent.NewAPIInfo(1, name, version, allVersions, "", 1, false, lwcomponent.LibraryType)
 
-		CreateLocalComponent(name, ver, false)
+		CreateLocalComponent(name, ver, false, lwcomponent.LibraryType)
 
 		dir, _ := lwcomponent.CatalogCacheDir()
 
-		hostInfo, _ := lwcomponent.NewHostInfo(filepath.Join(dir, name))
+		hostInfo, _ := lwcomponent.LoadHostInfo(filepath.Join(dir, name))
 
-		component := lwcomponent.NewCDKComponent(name, "", lwcomponent.LibraryType, apiInfo, hostInfo)
+		component := lwcomponent.NewCDKComponent(apiInfo, hostInfo)
 
 		_, _, err := component.Exec.Execute([]string{}, "")
 		assert.Equal(t, lwcomponent.ErrNonExecutable, err)
@@ -249,15 +249,15 @@ func TestNewCDKComponent(t *testing.T) {
 		version, _ := semver.NewVersion(ver)
 		allVersions := []*semver.Version{version}
 
-		apiInfo := lwcomponent.NewAPIInfo(1, name, version, allVersions, "", 1, false, lwcomponent.BinaryType)
+		apiInfo := lwcomponent.NewAPIInfo(1, name, version, allVersions, "", 1, false, lwcomponent.StandaloneType)
 
-		CreateLocalComponent(name, ver, false)
+		CreateLocalComponent(name, ver, false, lwcomponent.StandaloneType)
 
 		dir, _ := lwcomponent.CatalogCacheDir()
 
-		hostInfo, _ := lwcomponent.NewHostInfo(filepath.Join(dir, name))
+		hostInfo, _ := lwcomponent.LoadHostInfo(filepath.Join(dir, name))
 
-		component := lwcomponent.NewCDKComponent(name, "", lwcomponent.StandaloneType, apiInfo, hostInfo)
+		component := lwcomponent.NewCDKComponent(apiInfo, hostInfo)
 
 		_, _, err := component.Exec.Execute([]string{}, "")
 		assert.Equal(t, lwcomponent.ErrNonExecutable, err)


### PR DESCRIPTION
## Summary

Now have a CLI level `componentJSON`.  We can change the underlying CDKComponent without breaking the JSON output.

I refactored parts of the code as a cleanup.

## How did you test this change?

Unit testing

Local testing:
- install, update, list, show, uninstall
- dev mode new
- dev mode enter existing

```
> bin/lacework component show component-example --json
{
  "deprecated": false,
  "description": "Component description",
  "latest_version": "0.9.1",
  "name": "component-example",
  "status": "Installed",
  "type": "CLI_COMMAND",
  "version": "0.9.1"
}
```

## Issue

https://lacework.atlassian.net/browse/GROW-2791