### PR TITLE
fix: component download AWS XML error

### DIFF
--- a/cli/cmd/component.go
+++ b/cli/cmd/component.go
@@ -443,10 +443,11 @@ func installComponent(args []string) (err error) {
 	}
 
 	stageClose, err := catalog.Stage(component, versionArg, progressClosure)
+	defer stageClose()
 	if err != nil {
+		cli.StopProgress()
 		return
 	}
-	defer stageClose()
 
 	downloadComplete <- 0
 
@@ -631,10 +632,11 @@ func updateComponent(args []string) (err error) {
 	}
 
 	stageClose, err := catalog.Stage(component, versionArg, progressClosure)
+	defer stageClose()
 	if err != nil {
+		cli.StopProgress()
 		return
 	}
-	defer stageClose()
 
 	downloadComplete <- 0
 
@@ -879,7 +881,7 @@ func componentsToTable() [][]string {
 	return out
 }
 
-func prototypeRunComponentsInstall(cmd *cobra.Command, args []string) (err error) {
+func prototypeRunComponentsInstall(_ *cobra.Command, args []string) (err error) {
 	var (
 		componentName    string                 = args[0]
 		downloadComplete                        = make(chan int8)

--- a/lwcomponent/staging.go
+++ b/lwcomponent/staging.go
@@ -28,6 +28,8 @@ type Stager interface {
 
 	Download(progressClosure func(filepath string, sizeB int64)) error
 
+	Filename() string
+
 	Signature() (sig []byte, err error)
 
 	Unpack() error
@@ -85,6 +87,10 @@ func (s *stageTarGz) Commit(targetDir string) (err error) {
 
 func (s *stageTarGz) Directory() string {
 	return s.dir
+}
+
+func (s *stageTarGz) Filename() string {
+	return filepath.Base(s.artifactUrl.Path)
 }
 
 func (s *stageTarGz) Download(progressClosure func(filepath string, sizeB int64)) (err error) {

--- a/lwcomponent/staging_test.go
+++ b/lwcomponent/staging_test.go
@@ -103,12 +103,12 @@ func TestStagingTarGzUnpack(t *testing.T) {
 	assert.NotNil(t, stage)
 	defer stage.Close()
 
-	makeGzip(name, makeTar(name, "1.1.1", stage.Directory(), componentData, sigData))
+	MakeGzip(name, MakeTar(name, "1.1.1", stage.Directory(), componentData, sigData))
 
 	stage.Unpack()
 }
 
-func makeTar(name string, version string, dir string, data string, sig string) string {
+func MakeTar(name string, version string, dir string, data string, sig string) string {
 	tarname := fmt.Sprintf("%s.tar", name)
 	path := filepath.Join(dir, tarname)
 
@@ -147,7 +147,7 @@ func makeTar(name string, version string, dir string, data string, sig string) s
 	return path
 }
 
-func makeGzip(name, path string) string {
+func MakeGzip(name, path string) string {
 	reader, err := os.Open(path)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
## Summary

AWS returns an XML error message when there is an issue with the presigned URL.

## How did you test this change?

New unit test and locally against the `gdevus1` cluster.

Problem:
```
> lacework component install component-example --version 0.8.2
 [✓] Component component-example found
| Staging component component-example... Downloaded: 0mb

...

- Staging component component-example... Downloaded: 0mb ERROR gzip: invalid header
```

Improvement:
```
> bin/lacework component install component-example --version 0.8.2                                                                             ~/Workspace/Lacework/go-sdk
 [✓] Component component-example found

...

ERROR Code: PermanentRedirect.  Message: The bucket you are attempting to access must be addressed using the specified endpoint. Please send all future requests to this endpoint.
```

## Issue

https://lacework.atlassian.net/browse/GROW-2765