### PR TITLE
ci: use workflow_run to trigger downstream release pipelines

### DIFF
--- a/.github/workflows/chocolatey-release.yml
+++ b/.github/workflows/chocolatey-release.yml
@@ -1,6 +1,11 @@
 name: Chocolatey Release
 
-on: workflow_dispatch
+on:
+  workflow_dispatch:
+  workflow_run:
+    workflows: [Release]
+    types:
+      - completed
 
 jobs:
   publish-chocolatey:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,21 +67,6 @@ jobs:
         run: |
           scripts/release_containers.sh
 
-      - name: Trigger Homebrew formula update
-        uses: benc-uk/workflow-dispatch@v1
-        with:
-          workflow: update-homebrew-formula.yml
-
-      - name: Trigger Trigger CLI docs update
-        uses: benc-uk/workflow-dispatch@v1
-        with:
-          workflow: update-cli-docs.yml
-
-      - name: Trigger Chocolatey package update
-        uses: benc-uk/workflow-dispatch@v1
-        with:
-          workflow: chocolatey-release.yml
-
       - name: Notify Slack on Failure
         uses: slackapi/slack-github-action@v1.25.0
         if: failure()

--- a/.github/workflows/update-cli-docs.yml
+++ b/.github/workflows/update-cli-docs.yml
@@ -2,6 +2,10 @@ name: Update CLI Docs
 
 on:
   workflow_dispatch:
+  workflow_run:
+    workflows: [Release]
+    types:
+      - completed
 
 jobs:
   update-cli-docs:

--- a/.github/workflows/update-homebrew-formula.yml
+++ b/.github/workflows/update-homebrew-formula.yml
@@ -2,6 +2,10 @@ name: Update Homebrew Formula
 
 on:
   workflow_dispatch:
+  workflow_run:
+    workflows: [Release]
+    types:
+      - completed
 
 jobs:
   update-homefrew-formula:


### PR DESCRIPTION
## Summary

Get rid of the 3rd Github action to dispatch workflows. Use `workflow_run` instead.

