### PR TITLE
ci(COD-2330): remove the Semgrep install step

### DIFF
--- a/.github/workflows/lacework-code-analysis.yml
+++ b/.github/workflows/lacework-code-analysis.yml
@@ -25,8 +25,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 2
-      # TODO: remove once Semgrep is packaged in SAST
-      - run: python3 -m pip install semgrep==1.50.0
       - name: Checkout old
         if: ${{ matrix.target == 'old' }}
         run: git checkout HEAD^1


### PR DESCRIPTION
## Summary

Installing Semgrep is no longer required to run Lacework FAST alongside SCA in GitHub Actions.

## How did you test this change?

Tested by the CI here: https://github.com/lacework/go-sdk/actions/runs/8114115657

## Issue

[COD-2330](https://lacework.atlassian.net/browse/COD-2330)

[COD-2330]: https://lacework.atlassian.net/browse/COD-2330?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ