### PR TITLE
ci: fix update-homebrew-formula.yml

### DIFF
--- a/.github/workflows/chocolatey-release.yml
+++ b/.github/workflows/chocolatey-release.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   publish-chocolatey:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/update-cli-docs.yml
+++ b/.github/workflows/update-cli-docs.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   update-cli-docs:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     outputs:
       git-sha: ${{ steps.update.outputs.git-sha }}

--- a/.github/workflows/update-homebrew-formula.yml
+++ b/.github/workflows/update-homebrew-formula.yml
@@ -24,22 +24,24 @@ jobs:
         id: set-up-homebrew
         uses: Homebrew/actions/setup-homebrew@master
 
-      - name: Create local Homebrew tap
-        working-directory: homebrew-tap
-        run: |
-          brew tap-new lacework/lacework-cli --no-git
-          sudo cp -r . $(brew --repository)/Library/Taps/lacework/homebrew-lacework-cli/
+      # - name: Create local Homebrew tap
+      #   working-directory: homebrew-tap
+      #   run: |
+      #     brew tap-new lacework/lacework-cli --no-git
+      #     sudo cp -r . $(brew --repository)/Library/Taps/lacework/homebrew-lacework-cli/
 
       - name: Update CLI Version
+        working-directory: homebrew-tap
         env:
           GPG_SECRET_KEY: ${{ secrets.GPG_SECRET_KEY }}
           GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
-          CI: true
+          # CI: true
         run: |
-          sudo chmod -R 777 $(brew --repository)/Library/Taps/lacework/homebrew-lacework-cli/.git
-          cd $(brew --repository)/Library/Taps/lacework/homebrew-lacework-cli/
           echo "$GPG_SECRET_KEY" | base64 --decode | gpg --import --no-tty --batch --yes
           make update-cli-version
+
+      # sudo chmod -R 777 $(brew --repository)/Library/Taps/lacework/homebrew-lacework-cli/.git
+      # cd $(brew --repository)/Library/Taps/lacework/homebrew-lacework-cli/
 
       # - name: Notify Slack on Failure
       #   if: failure()

--- a/.github/workflows/update-homebrew-formula.yml
+++ b/.github/workflows/update-homebrew-formula.yml
@@ -2,6 +2,7 @@ name: Update Homebrew Formula
 
 on:
   workflow_dispatch:
+  pull_request:
   workflow_run:
     workflows: [Release]
     types:
@@ -9,6 +10,7 @@ on:
 
 jobs:
   update-homefrew-formula:
+    # iif: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -16,40 +18,46 @@ jobs:
         with:
           repository: lacework/homebrew-tap
           path: homebrew-tap
+
       - name: Set up Homebrew
         id: set-up-homebrew
         uses: Homebrew/actions/setup-homebrew@master
+
       - name: Update CLI Version
         working-directory: homebrew-tap
         env:
           GPG_SECRET_KEY: ${{ secrets.GPG_SECRET_KEY }}
           GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
         run: |
-          sudo apt-get update -y
-          sudo apt-get install gpg-agent -y
           echo "$GPG_SECRET_KEY" | base64 --decode | gpg --import --no-tty --batch --yes
-          make update-cli-version
-      - name: Notify Slack on Failure
-        if: failure()
-        uses: slackapi/slack-github-action@v1.25.0
-        with:
-          payload: |
-            {
-              "attachments": [
-                {
-                  "color": "#E92020",
-                  "blocks": [
-                    {
-                      "type": "section",
-                      "text": {
-                        "type": "mrkdwn",
-                        "text": "@oncall-growth-eng! There has been a failure that needs your attention. :rotating_light:\n*GitHub Workflow Failure*\ngo-sdk/update-homebrew-formula\n*Workflow Run*\n https://github.com/lacework/go-sdk/actions/runs/${{ github.run_id }}"
-                      }
-                    }
-                  ]
-                }
-              ]
-            }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_GROWTH_ENG_ALERTS }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+          export TAP_DIR=$(brew --repository)/Library/Taps/lacework/homebrew-lacework-cli/
+          brew tap-new lacework/lacework-cli --no-git
+          sudo cp -r . $TAP_DIR
+          cd $TAP_DIR
+          brew audit --formula lacework-cli --strict --fix
+
+      # make update-cli-version
+      # - name: Notify Slack on Failure
+      #   if: failure()
+      #   uses: slackapi/slack-github-action@v1.25.0
+      #   with:
+      #     payload: |
+      #       {
+      #         "attachments": [
+      #           {
+      #             "color": "#E92020",
+      #             "blocks": [
+      #               {
+      #                 "type": "section",
+      #                 "text": {
+      #                   "type": "mrkdwn",
+      #                   "text": "@oncall-growth-eng! There has been a failure that needs your attention. :rotating_light:\n*GitHub Workflow Failure*\ngo-sdk/update-homebrew-formula\n*Workflow Run*\n https://github.com/lacework/go-sdk/actions/runs/${{ github.run_id }}"
+      #                 }
+      #               }
+      #             ]
+      #           }
+      #         ]
+      #       }
+      #   env:
+      #     SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_GROWTH_ENG_ALERTS }}
+      #     SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/update-homebrew-formula.yml
+++ b/.github/workflows/update-homebrew-formula.yml
@@ -23,17 +23,19 @@ jobs:
         id: set-up-homebrew
         uses: Homebrew/actions/setup-homebrew@master
 
-      - name: Update CLI Version
+      - name: Create local Homebrew tap
         working-directory: homebrew-tap
+        run: |
+          brew tap-new lacework/lacework-cli --no-git
+          sudo cp -r . $(brew --repository)/Library/Taps/lacework/homebrew-lacework-cli/
+
+      - name: Update CLI Version
         env:
           GPG_SECRET_KEY: ${{ secrets.GPG_SECRET_KEY }}
           GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
         run: |
+          cd $(brew --repository)/Library/Taps/lacework/homebrew-lacework-cli/
           echo "$GPG_SECRET_KEY" | base64 --decode | gpg --import --no-tty --batch --yes
-          export TAP_DIR=$(brew --repository)/Library/Taps/lacework/homebrew-lacework-cli/
-          brew tap-new lacework/lacework-cli --no-git
-          sudo cp -r . $TAP_DIR
-          cd $TAP_DIR
           brew audit --formula lacework-cli --strict --fix
 
       # make update-cli-version

--- a/.github/workflows/update-homebrew-formula.yml
+++ b/.github/workflows/update-homebrew-formula.yml
@@ -2,7 +2,6 @@ name: Update Homebrew Formula
 
 on:
   workflow_dispatch:
-  pull_request:
   workflow_run:
     workflows: [Release]
     types:
@@ -10,7 +9,7 @@ on:
 
 jobs:
   update-homefrew-formula:
-    # iif: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -42,27 +41,27 @@ jobs:
           echo "$GPG_SECRET_KEY" | base64 --decode | gpg --import --no-tty --batch --yes
           make update-cli-version
 
-      # - name: Notify Slack on Failure
-      #   if: failure()
-      #   uses: slackapi/slack-github-action@v1.25.0
-      #   with:
-      #     payload: |
-      #       {
-      #         "attachments": [
-      #           {
-      #             "color": "#E92020",
-      #             "blocks": [
-      #               {
-      #                 "type": "section",
-      #                 "text": {
-      #                   "type": "mrkdwn",
-      #                   "text": "@oncall-growth-eng! There has been a failure that needs your attention. :rotating_light:\n*GitHub Workflow Failure*\ngo-sdk/update-homebrew-formula\n*Workflow Run*\n https://github.com/lacework/go-sdk/actions/runs/${{ github.run_id }}"
-      #                 }
-      #               }
-      #             ]
-      #           }
-      #         ]
-      #       }
-      #   env:
-      #     SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_GROWTH_ENG_ALERTS }}
-      #     SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+      - name: Notify Slack on Failure
+        if: failure()
+        uses: slackapi/slack-github-action@v1.25.0
+        with:
+          payload: |
+            {
+              "attachments": [
+                {
+                  "color": "#E92020",
+                  "blocks": [
+                    {
+                      "type": "section",
+                      "text": {
+                        "type": "mrkdwn",
+                        "text": "@oncall-growth-eng! There has been a failure that needs your attention. :rotating_light:\n*GitHub Workflow Failure*\ngo-sdk/update-homebrew-formula\n*Workflow Run*\n https://github.com/lacework/go-sdk/actions/runs/${{ github.run_id }}"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_GROWTH_ENG_ALERTS }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/update-homebrew-formula.yml
+++ b/.github/workflows/update-homebrew-formula.yml
@@ -33,12 +33,12 @@ jobs:
         env:
           GPG_SECRET_KEY: ${{ secrets.GPG_SECRET_KEY }}
           GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
+          CI: true
         run: |
           cd $(brew --repository)/Library/Taps/lacework/homebrew-lacework-cli/
           echo "$GPG_SECRET_KEY" | base64 --decode | gpg --import --no-tty --batch --yes
-          brew audit --formula lacework-cli --strict --fix
+          make update-cli-version
 
-      # make update-cli-version
       # - name: Notify Slack on Failure
       #   if: failure()
       #   uses: slackapi/slack-github-action@v1.25.0

--- a/.github/workflows/update-homebrew-formula.yml
+++ b/.github/workflows/update-homebrew-formula.yml
@@ -27,6 +27,7 @@ jobs:
         working-directory: homebrew-tap
         run: |
           brew tap-new lacework/lacework-cli --no-git
+          sudo chmod 777 $(brew --repository)/Library/Taps/lacework/homebrew-lacework-cli/
           sudo cp -r . $(brew --repository)/Library/Taps/lacework/homebrew-lacework-cli/
 
       - name: Update CLI Version

--- a/.github/workflows/update-homebrew-formula.yml
+++ b/.github/workflows/update-homebrew-formula.yml
@@ -18,6 +18,7 @@ jobs:
         with:
           repository: lacework/homebrew-tap
           path: homebrew-tap
+          token: ${{ github.token }}
 
       - name: Set up Homebrew
         id: set-up-homebrew

--- a/.github/workflows/update-homebrew-formula.yml
+++ b/.github/workflows/update-homebrew-formula.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           repository: lacework/homebrew-tap
           path: homebrew-tap
-          token: ${{ github.token }}
+          token: ${{ secrets.token }}
 
       - name: Set up Homebrew
         id: set-up-homebrew

--- a/.github/workflows/update-homebrew-formula.yml
+++ b/.github/workflows/update-homebrew-formula.yml
@@ -27,7 +27,7 @@ jobs:
         working-directory: homebrew-tap
         run: |
           brew tap-new lacework/lacework-cli --no-git
-          sudo chmod 777 $(brew --repository)/Library/Taps/lacework/homebrew-lacework-cli/
+          sudo chmod -R 777 $(brew --repository)/Library/Taps/lacework/homebrew-lacework-cli/
           sudo cp -r . $(brew --repository)/Library/Taps/lacework/homebrew-lacework-cli/
 
       - name: Update CLI Version

--- a/.github/workflows/update-homebrew-formula.yml
+++ b/.github/workflows/update-homebrew-formula.yml
@@ -24,24 +24,23 @@ jobs:
         id: set-up-homebrew
         uses: Homebrew/actions/setup-homebrew@master
 
-      # - name: Create local Homebrew tap
-      #   working-directory: homebrew-tap
-      #   run: |
-      #     brew tap-new lacework/lacework-cli --no-git
-      #     sudo cp -r . $(brew --repository)/Library/Taps/lacework/homebrew-lacework-cli/
+      - name: Create local Homebrew tap
+        working-directory: homebrew-tap
+        run: |
+          brew tap-new lacework/lacework-cli --no-git
+          sudo cp -r . $(brew --repository)/Library/Taps/lacework/homebrew-lacework-cli/
 
       - name: Update CLI Version
         working-directory: homebrew-tap
         env:
           GPG_SECRET_KEY: ${{ secrets.GPG_SECRET_KEY }}
           GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
-          # CI: true
+          CI: true
         run: |
+          sudo chmod -R 777 $(brew --repository)/Library/Taps/lacework/homebrew-lacework-cli/.git
+          cd $(brew --repository)/Library/Taps/lacework/homebrew-lacework-cli/
           echo "$GPG_SECRET_KEY" | base64 --decode | gpg --import --no-tty --batch --yes
           make update-cli-version
-
-      # sudo chmod -R 777 $(brew --repository)/Library/Taps/lacework/homebrew-lacework-cli/.git
-      # cd $(brew --repository)/Library/Taps/lacework/homebrew-lacework-cli/
 
       # - name: Notify Slack on Failure
       #   if: failure()

--- a/.github/workflows/update-homebrew-formula.yml
+++ b/.github/workflows/update-homebrew-formula.yml
@@ -27,7 +27,6 @@ jobs:
         working-directory: homebrew-tap
         run: |
           brew tap-new lacework/lacework-cli --no-git
-          sudo chmod -R 777 $(brew --repository)/Library/Taps/lacework/homebrew-lacework-cli/
           sudo cp -r . $(brew --repository)/Library/Taps/lacework/homebrew-lacework-cli/
 
       - name: Update CLI Version
@@ -36,6 +35,7 @@ jobs:
           GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
           CI: true
         run: |
+          sudo chmod -R 777 $(brew --repository)/Library/Taps/lacework/homebrew-lacework-cli/.git
           cd $(brew --repository)/Library/Taps/lacework/homebrew-lacework-cli/
           echo "$GPG_SECRET_KEY" | base64 --decode | gpg --import --no-tty --batch --yes
           make update-cli-version


### PR DESCRIPTION
## Summary

- Only trigger release downstream pipelines when `release` pipeline runs successfully.
- To update homebrew formula, a local homebrew tap needs to be created. Need to cd to the tap's directory and do `brew audit` with  `--fix`.

## How did you test this change?

https://github.com/lacework/go-sdk/actions/runs/8135421955


