### PR TITLE
test: set LW_API_TOKEN for integration tests

### DIFF
--- a/cli/cmd/cache.go
+++ b/cli/cmd/cache.go
@@ -20,6 +20,7 @@ package cmd
 
 import (
 	"encoding/json"
+	"os"
 	"path"
 	"strings"
 	"time"
@@ -182,6 +183,9 @@ func (c *cliState) WriteCachedToken() error {
 		c.Token = response.Token
 		c.tokenCache.Token = response.Token
 		c.tokenCache.ExpiresAt = response.ExpiresAt
+		if os.Getenv("LW_CLI_INTEGRATION_MODE") != "" {
+			os.Setenv("LW_API_TOKEN", response.Token)
+		}
 	}
 	return nil
 }

--- a/cli/cmd/cache.go
+++ b/cli/cmd/cache.go
@@ -20,7 +20,6 @@ package cmd
 
 import (
 	"encoding/json"
-	"os"
 	"path"
 	"strings"
 	"time"
@@ -183,9 +182,6 @@ func (c *cliState) WriteCachedToken() error {
 		c.Token = response.Token
 		c.tokenCache.Token = response.Token
 		c.tokenCache.ExpiresAt = response.ExpiresAt
-		if os.Getenv("LW_CLI_INTEGRATION_MODE") != "" {
-			os.Setenv("LW_API_TOKEN", response.Token)
-		}
 	}
 	return nil
 }

--- a/cli/cmd/cli_state.go
+++ b/cli/cmd/cli_state.go
@@ -245,7 +245,7 @@ func (c *cliState) NewClient() error {
 			api.WithTokenAndExpiration(c.Token, c.tokenCache.ExpiresAt))
 	} else if c.Token != "" {
 		apiOpts = append(apiOpts, api.WithToken(c.Token))
-	} else if os.Getenv("LW_CLI_INTEGRATION_MODE") != "" && os.Getenv("LW_API_TOKEN") != "" {
+	} else if os.Getenv("LW_API_TOKEN") != "" {
 		apiOpts = append(apiOpts, api.WithToken(os.Getenv("LW_API_TOKEN")))
 	}
 

--- a/cli/cmd/cli_state.go
+++ b/cli/cmd/cli_state.go
@@ -245,6 +245,8 @@ func (c *cliState) NewClient() error {
 			api.WithTokenAndExpiration(c.Token, c.tokenCache.ExpiresAt))
 	} else if c.Token != "" {
 		apiOpts = append(apiOpts, api.WithToken(c.Token))
+	} else if os.Getenv("LW_CLI_INTEGRATION_MODE") != "" && os.Getenv("LW_API_TOKEN") != "" {
+		apiOpts = append(apiOpts, api.WithToken(os.Getenv("LW_API_TOKEN")))
 	}
 
 	apiOpts = append(apiOpts,

--- a/integration/framework_test.go
+++ b/integration/framework_test.go
@@ -54,6 +54,7 @@ var (
 	tfPath   string
 	tf       *tfexec.Terraform
 	execPath string
+	token    string
 )
 
 // Use this function to execute a real lacework CLI command, under the hood the function
@@ -119,6 +120,20 @@ func NewLaceworkCLI(workingDir string, stdin io.Reader, args ...string) *exec.Cm
 		// add unique environment variable to notify the CLI that
 		// it is being executed to run our integration test suite
 		env = append(env, "LW_CLI_INTEGRATION_MODE=true")
+
+		if token == "" {
+			fmt.Println("Generating access token")
+			lacework, err := laceworkIntegrationTestClient()
+			if err != nil {
+				log.Fatal(err)
+			}
+			response, err := lacework.GenerateToken()
+			if err != nil {
+				log.Fatal(err)
+			}
+			token = response.Token
+			env = append(env, fmt.Sprintf("LW_API_TOKEN=%s", response.Token))
+		}
 
 		cmd.Env = env
 	}

--- a/integration/framework_test.go
+++ b/integration/framework_test.go
@@ -116,6 +116,10 @@ func NewLaceworkCLI(workingDir string, stdin io.Reader, args ...string) *exec.Cm
 		if os.Getenv(ciTestingUpdaterEnv) == "" {
 			env = append(env, fmt.Sprintf("%s=1", lwupdater.DisableEnv))
 		}
+		// add unique environment variable to notify the CLI that
+		// it is being executed to run our integration test suite
+		env = append(env, "LW_CLI_INTEGRATION_MODE=true")
+
 		cmd.Env = env
 	}
 	return cmd
@@ -149,10 +153,6 @@ func runLaceworkCLI(workingDir string, args ...string) (stdout bytes.Buffer, std
 	// set interactive mode by default for tests, since that's
 	// what they expect
 	cmd.Env = append(cmd.Env, "LW_NONINTERACTIVE=false")
-
-	// add unique environment variable to notify the CLI that
-	// it is being executed to run our integration test suite
-	cmd.Env = append(cmd.Env, "LW_CLI_INTEGRATION_MODE=true")
 
 	exitcode, err := runLaceworkCLIFromCmd(cmd)
 	if exitcode == 999 {


### PR DESCRIPTION
## Summary

When running integration tests, set the LW_API_TOKEN env to avoid abusing the /access_token endpoint which has a rate limit.

## How did you test this change?

Run tests with logs. Verify that the token is reused.

## Issue

https://lacework.atlassian.net/browse/GROW-2770
