### PR TITLE
ci: fix verify-release.yml fetch-depth

### DIFF
--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -2,7 +2,6 @@ name: Verify Release
 
 on:
   workflow_dispatch:
-  pull_request:
   push:
     branches:
       - release
@@ -17,39 +16,32 @@ jobs:
           ref: release
           fetch-depth: 0
 
-      # - name: Setup Go
-      #   uses: actions/setup-go@v4
-      #   with:
-      #     go-version: 1.21.x
-
       - name: Verify release
         run: |
           git remote set-head origin main
           scripts/release.sh verify
 
-      # git checkout release
-      # git pull
-      # - name: Notify Slack on Failure
-      #   uses: slackapi/slack-github-action@v1.25.0
-      #   if: failure()
-      #   with:
-      #     payload: |
-      #       {
-      #         "attachments": [
-      #           {
-      #             "color": "#E92020",
-      #             "blocks": [
-      #               {
-      #                 "type": "section",
-      #                 "text": {
-      #                   "type": "mrkdwn",
-      #                   "text": "@oncall-growth-eng! There has been a failure that needs your attention. :rotating_light:\n*GitHub Workflow Failure*\ngo-sdk/verify-release\n*Workflow Run*\n https://github.com/lacework/go-sdk/actions/runs/${{ github.run_id }}"
-      #                 }
-      #               }
-      #             ]
-      #           }
-      #         ]
-      #       }
-      #   env:
-      #     SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_GROWTH_ENG_ALERTS }}
-      #     SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+      - name: Notify Slack on Failure
+        uses: slackapi/slack-github-action@v1.25.0
+        if: failure()
+        with:
+          payload: |
+            {
+              "attachments": [
+                {
+                  "color": "#E92020",
+                  "blocks": [
+                    {
+                      "type": "section",
+                      "text": {
+                        "type": "mrkdwn",
+                        "text": "@oncall-growth-eng! There has been a failure that needs your attention. :rotating_light:\n*GitHub Workflow Failure*\ngo-sdk/verify-release\n*Workflow Run*\n https://github.com/lacework/go-sdk/actions/runs/${{ github.run_id }}"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_GROWTH_ENG_ALERTS }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -2,6 +2,7 @@ name: Verify Release
 
 on:
   workflow_dispatch:
+  pull_request:
   push:
     branches:
       - release
@@ -13,7 +14,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.ref }}
+          # ref: ${{ github.ref }}
+          ref: release
+          fetch-depth: 0
 
       - name: Setup Go
         uses: actions/setup-go@v4

--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -25,29 +25,30 @@ jobs:
       - name: Verify release
         run: |
           git checkout release
+          git pull
           scripts/release.sh verify
 
-      - name: Notify Slack on Failure
-        uses: slackapi/slack-github-action@v1.25.0
-        if: failure()
-        with:
-          payload: |
-            {
-              "attachments": [
-                {
-                  "color": "#E92020",
-                  "blocks": [
-                    {
-                      "type": "section",
-                      "text": {
-                        "type": "mrkdwn",
-                        "text": "@oncall-growth-eng! There has been a failure that needs your attention. :rotating_light:\n*GitHub Workflow Failure*\ngo-sdk/verify-release\n*Workflow Run*\n https://github.com/lacework/go-sdk/actions/runs/${{ github.run_id }}"
-                      }
-                    }
-                  ]
-                }
-              ]
-            }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_GROWTH_ENG_ALERTS }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+      # - name: Notify Slack on Failure
+      #   uses: slackapi/slack-github-action@v1.25.0
+      #   if: failure()
+      #   with:
+      #     payload: |
+      #       {
+      #         "attachments": [
+      #           {
+      #             "color": "#E92020",
+      #             "blocks": [
+      #               {
+      #                 "type": "section",
+      #                 "text": {
+      #                   "type": "mrkdwn",
+      #                   "text": "@oncall-growth-eng! There has been a failure that needs your attention. :rotating_light:\n*GitHub Workflow Failure*\ngo-sdk/verify-release\n*Workflow Run*\n https://github.com/lacework/go-sdk/actions/runs/${{ github.run_id }}"
+      #                 }
+      #               }
+      #             ]
+      #           }
+      #         ]
+      #       }
+      #   env:
+      #     SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_GROWTH_ENG_ALERTS }}
+      #     SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: main
+          ref: refs/remotes/origin/release
           fetch-depth: 0
 
       - name: Setup Go
@@ -24,10 +24,10 @@ jobs:
 
       - name: Verify release
         run: |
-          git checkout release
-          git pull
           scripts/release.sh verify
 
+      # git checkout release
+      # git pull
       # - name: Notify Slack on Failure
       #   uses: slackapi/slack-github-action@v1.25.0
       #   if: failure()

--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -14,8 +14,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          # ref: ${{ github.ref }}
-          ref: release
+          ref: main
           fetch-depth: 0
 
       - name: Setup Go
@@ -25,6 +24,7 @@ jobs:
 
       - name: Verify release
         run: |
+          git checkout release
           scripts/release.sh verify
 
       - name: Notify Slack on Failure

--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -14,13 +14,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: refs/remotes/origin/release
+          ref: release
           fetch-depth: 0
 
-      - name: Setup Go
-        uses: actions/setup-go@v4
-        with:
-          go-version: 1.21.x
+      # - name: Setup Go
+      #   uses: actions/setup-go@v4
+      #   with:
+      #     go-version: 1.21.x
 
       - name: Verify release
         run: |

--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -24,6 +24,7 @@ jobs:
 
       - name: Verify release
         run: |
+          git remote set-head origin main
           scripts/release.sh verify
 
       # git checkout release


### PR DESCRIPTION
## Summary

Got error `fatal: ambiguous argument 'origin..HEAD':`. Set `fetch-depth: 0` to fetch all history and explicitly set HEAD to main.

## How did you test this change?

https://github.com/lacework/go-sdk/actions/runs/8174143700/job/22348240771?pr=1584
