### PR TITLE
ci: fix TestComplianceAwsGetReportRecommendationID

### DIFF
--- a/integration/compliance_aws_test.go
+++ b/integration/compliance_aws_test.go
@@ -204,7 +204,7 @@ func _TestComplianceAwsGetAllReportType(t *testing.T) {
 }
 func TestComplianceAwsGetReportRecommendationID(t *testing.T) {
 	account := os.Getenv("LW_INT_TEST_AWS_ACC")
-	out, err, exitcode := LaceworkCLIWithTOMLConfig("compliance", "aws", "get-report", account, "--type", "AWS_CIS_14", "2.1.1")
+	out, err, exitcode := LaceworkCLIWithTOMLConfig("compliance", "aws", "get-report", account, "--type", "AWS_CIS_14", "lacework-global-34")
 
 	assert.Contains(t, err.String(), "--type has been deprecated,")
 	assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")


### PR DESCRIPTION
## Summary

RecommendationID 2.1.1 disappeared for some reason. Use `lacework-global-34` instead.

## How did you test this change?

run `make integration-only regex=TestComplianceAwsGetReportRecommendationID`
