### PR TITLE
style(cli): fix component uninstall output

### DIFF
--- a/cli/cmd/component.go
+++ b/cli/cmd/component.go
@@ -746,12 +746,9 @@ func deleteComponent(args []string) (err error) {
 	cli.StopProgress()
 
 	cli.OutputChecklist(successIcon, "Component %s deleted\n", color.HiYellowString(component.Name))
-
-	msg := fmt.Sprintf(`\n- We will do better next time.\n\nDo you want to provide feedback?\nReach out to us at %s\n`,
-		color.HiCyanString("support@lacework.net"))
-
-	cli.OutputHuman(msg)
-
+	cli.OutputHuman("\n- We will do better next time.\n")
+	cli.OutputHuman("\nDo you want to provide feedback?\n")
+	cli.OutputHuman("Reach out to us at %s\n", color.HiCyanString("support@lacework.net"))
 	return
 }
 

--- a/integration/component_test.go
+++ b/integration/component_test.go
@@ -199,7 +199,13 @@ func TestCDKComponentDevEnter(t *testing.T) {
 	assert.True(t, found)
 	assert.Nil(t, err)
 
-	run(t, dir, "component", "uninstall", "component-example")
+	t.Run("uninstall", func(t *testing.T) {
+		out, err, exitcode := LaceworkCLIWithHome(dir, "component", "uninstall", "component-example")
+		assert.Empty(t, err.String(), "STDERR should be empty")
+		assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
+		assert.Contains(t, out.String(), "- We will do better next time.\n\nDo you want to provide feedback?\n",
+			"STDOUT json keys changed")
+	})
 
 	out = run(t, dir, "component", "list")
 


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/lacework/go-sdk) and create your branch from `main`
  2. Run `make prepare` in the repository root
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`make test`)
  5. Format your code (`make fmt`)
  6. Make sure your code lints (`make lint`)
  7. If you are updating the Lacework CLI, make sure it compiles (`make build-cli-cross-platform`)
  8. Follow the commit message standard (`type(scope): subject`) documented in [DEVELOPER_GUIDELINES.md](https://github.com/lacework/go-sdk/blob/main/DEVELOPER_GUIDELINES.md#commit-message-standard)
  9. If you haven't already, configure signed commits by [telling git about your signing key](https://docs.github.com/en/github/authenticating-to-github/managing-commit-signature-verification/telling-git-about-your-signing-key) and [signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)

  Learn more about contributing: https://github.com/lacework/go-sdk/blob/main/CONTRIBUTING.md
-->

## Summary

Fixing output when printing `\n` properly.

## How did you test this change?

Added unit tests

<img width="549" alt="Screenshot 2024-03-19 at 12 01 52 PM" src="https://github.com/lacework/go-sdk/assets/5712253/4fc2a785-ca16-4745-9df6-2a25e03fbd00">

## Issue
https://lacework.atlassian.net/browse/GROW-2790
