### PR TITLE
fix(cli): avoid panic while updating progress

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,10 @@ help:
 prepare: git-env install-tools go-vendor ## Initialize the go environment
 
 .PHONY: test
-test: prepare ## Run all go-sdk tests
+test: prepare test-only ## Run all go-sdk tests
+
+.PHONY: test-only
+test-only: ## Run all go-sdk tests only (without prepare)
 	$(eval PACKAGES := $(shell go list ./... | grep -v integration))
 	gotestsum -f testname --rerun-fails=3 --packages="$(PACKAGES)" \
 		-- -v -cover -run=$(regex) -coverprofile=$(COVERAGEOUT) $(PACKAGES)

--- a/integration/component_test.go
+++ b/integration/component_test.go
@@ -109,6 +109,11 @@ func TestCDKComponentInstall(t *testing.T) {
 	out = run(t, dir, "component-example")
 	assert.Contains(t, out, "component")
 
+	outBytes, errBytes, exitcode := LaceworkCLIWithHome(dir, "component", "install", "component-example")
+	assert.NotContains(t, outBytes.String(), "Installation completed.", "STDOUT should be empty")
+	assert.Contains(t, errBytes.String(), "already installed")
+	assert.Equal(t, 1, exitcode, "EXITCODE is not the expected one")
+
 	cleanup(dir)
 }
 

--- a/lwcomponent/cdk_component.go
+++ b/lwcomponent/cdk_component.go
@@ -124,34 +124,32 @@ func (c *CDKComponent) EnterDevMode() error {
 	return nil
 }
 
-func (c *CDKComponent) InstalledVersion() (version *semver.Version) {
-	var err error
-
+func (c *CDKComponent) InstalledVersion() *semver.Version {
 	if c.HostInfo != nil {
-		version, err = c.HostInfo.Version()
+		version, err := c.HostInfo.Version()
 		if err == nil {
-			return
+			return version
 		}
 
 		if componentDir, err := c.Dir(); err == nil {
 			if devInfo, err := newDevInfo(componentDir); err == nil {
 				version, err = semver.NewVersion(devInfo.Version)
 				if err == nil {
-					return
+					return version
 				}
 			}
 		}
 	}
 
-	return
+	return nil
 }
 
-func (c *CDKComponent) LatestVersion() (version *semver.Version) {
+func (c *CDKComponent) LatestVersion() *semver.Version {
 	if c.ApiInfo != nil {
-		version = c.ApiInfo.Version
+		return c.ApiInfo.Version
 	}
 
-	return
+	return nil
 }
 
 func (c *CDKComponent) PrintSummary() []string {

--- a/lwcomponent/http_test.go
+++ b/lwcomponent/http_test.go
@@ -1,4 +1,4 @@
-package lwcomponent_test
+package lwcomponent
 
 import (
 	"fmt"
@@ -7,8 +7,10 @@ import (
 	"os"
 	"testing"
 
-	"github.com/lacework/go-sdk/lwcomponent"
 	"github.com/stretchr/testify/assert"
+
+	capturer "github.com/lacework/go-sdk/internal/capturer"
+	"github.com/lacework/go-sdk/lwlogger"
 )
 
 func TestDownloadFile(t *testing.T) {
@@ -33,7 +35,7 @@ func TestDownloadFile(t *testing.T) {
 	})
 
 	t.Run("happy path", func(t *testing.T) {
-		err = lwcomponent.DownloadFile(file.Name(), fmt.Sprintf("%s%s", server.URL, urlPath))
+		err = DownloadFile(file.Name(), fmt.Sprintf("%s%s", server.URL, urlPath))
 		assert.Nil(t, err)
 
 		buf, err := os.ReadFile(file.Name())
@@ -53,14 +55,33 @@ func TestDownloadFile(t *testing.T) {
 			}
 		})
 
-		err = lwcomponent.DownloadFile(file.Name(), fmt.Sprintf("%s%s", server.URL, "/err"))
+		logsCaptured := capturer.CaptureOutput(func() {
+			log = lwlogger.New("INFO").Sugar()
+			err = DownloadFile(file.Name(), fmt.Sprintf("%s%s", server.URL, "/err"))
+		})
 		assert.NotNil(t, err)
-		assert.Equal(t, lwcomponent.DefaultMaxRetry+1, count)
+		assert.Equal(t, DefaultMaxRetry+1, count)
+
+		assert.Contains(t, logsCaptured, "WARN RESTY Get")
+		assert.Contains(t, logsCaptured, "/err\": EOF")
+		assert.Contains(t, logsCaptured, "Attempt 4") // the fifth attempt will error
+		assert.Contains(t, logsCaptured, "ERROR RESTY Get")
+		assert.Contains(t, logsCaptured, "Failed to download component")
+		assert.Contains(t, logsCaptured, "trace_infoo")
 	})
 
 	t.Run("url error", func(t *testing.T) {
-		err = lwcomponent.DownloadFile(file.Name(), "")
+		logsCaptured := capturer.CaptureOutput(func() {
+			log = lwlogger.New("INFO").Sugar()
+			err = DownloadFile(file.Name(), "")
+		})
 		assert.NotNil(t, err)
 		assert.False(t, os.IsTimeout(err))
+
+		assert.Contains(t, logsCaptured, "WARN RESTY Get")
+		assert.Contains(t, logsCaptured, "Attempt 4") // the fifth attempt will error
+		assert.Contains(t, logsCaptured, "ERROR RESTY Get")
+		assert.Contains(t, logsCaptured, "Failed to download component")
+		assert.Contains(t, logsCaptured, "trace_info")
 	})
 }

--- a/lwcomponent/http_test.go
+++ b/lwcomponent/http_test.go
@@ -67,7 +67,7 @@ func TestDownloadFile(t *testing.T) {
 		assert.Contains(t, logsCaptured, "Attempt 4") // the fifth attempt will error
 		assert.Contains(t, logsCaptured, "ERROR RESTY Get")
 		assert.Contains(t, logsCaptured, "Failed to download component")
-		assert.Contains(t, logsCaptured, "trace_infoo")
+		assert.Contains(t, logsCaptured, "trace_info")
 	})
 
 	t.Run("url error", func(t *testing.T) {


### PR DESCRIPTION
## Summary

While installing new component, we are seeing a panic similar to:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x40 pc=0x10534999c]

goroutine 11 [running]:
github.com/lacework/go-sdk/cli/cmd.downloadProgress(0x14000820060?, {0x14000888120?, 0x0?}, 0x0)
	/codefresh/volume/go-sdk/cli/cmd/component.go:1177 +0x27c
github.com/lacework/go-sdk/cli/cmd.prototypeRunComponentsInstall.func1({0x14000888120?, 0x0?}, 0x1400005c8a0?)
	/codefresh/volume/go-sdk/cli/cmd/component.go:925 +0x34
created by github.com/lacework/go-sdk/lwcomponent.State.Install in goroutine 1
	/codefresh/volume/go-sdk/lwcomponent/component.go:279 +0x594
```

This is due to the fact that we were updating the progress `Suffix` unsafely. The fix is to use the
CLI functions to start a new progress every time we have an update inside the download func.

Additional things in this PR:
* Fixed infinite loop when trying to install a component that is already installed
* Added a make directive `test-only` to run only unit tests without `prepare`
* Enabled HTTP Tracing to output more information about the `EOF` error we are seeing
* A few styling improvements

## How did you test this change?

Updated tests and ran multiple `install` and `uninstall`.

## Issue

https://lacework.atlassian.net/browse/GROW-2765
