### PR TITLE
fix: idempotent component install update

### DIFF
--- a/cli/cmd/component.go
+++ b/cli/cmd/component.go
@@ -625,8 +625,8 @@ func updateComponent(args []string) (err error) {
 	}
 
 	if installedVersion.Equal(targetVersion) {
-		return errors.Errorf("You are already running version %s of this component",
-			color.HiYellowString(installedVersion.String()))
+		cli.OutputHuman("Component %s is version %s.\n", component.Name, component.InstalledVersion())
+		return nil
 	}
 
 	cli.StartProgress(fmt.Sprintf("Staging component %s...", color.HiYellowString(componentName)))

--- a/cli/cmd/component.go
+++ b/cli/cmd/component.go
@@ -435,7 +435,7 @@ func installComponent(args []string) (err error) {
 
 	installedVersion := component.InstalledVersion()
 	if installedVersion != nil {
-		cli.OutputHuman("Component %s is already installed. To upgrade run '%s'",
+		cli.OutputHuman("Component %s is already installed. To upgrade run '%s'\n",
 			component.Name,
 			color.HiGreenString("lacework component update %s", component.Name))
 		return nil

--- a/cli/cmd/component.go
+++ b/cli/cmd/component.go
@@ -28,6 +28,7 @@ import (
 	"github.com/olekukonko/tablewriter"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/lacework/go-sdk/lwcomponent"
 )
@@ -76,11 +77,12 @@ var (
 
 	// componentsUpdateCmd represents the update sub-command inside the components command
 	componentsUpdateCmd = &cobra.Command{
-		Use:   "update <component>",
-		Short: "Update an existing component",
-		Long:  `Update an existing component`,
-		Args:  cobra.ExactArgs(1),
-		RunE:  runComponentsUpdate,
+		Use:     "update <component>",
+		Aliases: []string{"upgrade"},
+		Short:   "Update an existing component",
+		Long:    `Update an existing component`,
+		Args:    cobra.ExactArgs(1),
+		RunE:    runComponentsUpdate,
 	}
 
 	// componentsUninstallCmd represents the uninstall sub-command inside the components command
@@ -434,7 +436,7 @@ func installComponent(args []string) (err error) {
 
 	installedVersion := component.InstalledVersion()
 	if installedVersion != nil {
-		cli.OutputHuman("Component %s is already installed\n", component.Name)
+		cli.OutputHuman("Component %s is already installed. To upgrade run 'lacework component update %s'\n", component.Name, component.Name)
 		return nil
 	}
 
@@ -871,6 +873,7 @@ func componentsToTable() [][]string {
 		// we display the current version instead
 		if currentVersion, err := cdata.CurrentVersion(); err == nil {
 			version = currentVersion.String()
+			assert.Contains(t, out, "component")
 		}
 
 		out = append(out, []string{

--- a/cli/cmd/component.go
+++ b/cli/cmd/component.go
@@ -434,11 +434,8 @@ func installComponent(args []string) (err error) {
 
 	installedVersion := component.InstalledVersion()
 	if installedVersion != nil {
-		return errors.Errorf(
-			"component %s is already installed. To upgrade run '%s'",
-			color.HiYellowString(componentName),
-			color.HiGreenString("lacework component upgrade %s", componentName),
-		)
+		cli.OutputHuman("Component %s is already installed\n", component.Name)
+		return nil
 	}
 
 	cli.OutputChecklist(successIcon, fmt.Sprintf("Component %s found\n", component.Name))

--- a/cli/cmd/component.go
+++ b/cli/cmd/component.go
@@ -28,7 +28,6 @@ import (
 	"github.com/olekukonko/tablewriter"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"github.com/stretchr/testify/assert"
 
 	"github.com/lacework/go-sdk/lwcomponent"
 )
@@ -436,7 +435,9 @@ func installComponent(args []string) (err error) {
 
 	installedVersion := component.InstalledVersion()
 	if installedVersion != nil {
-		cli.OutputHuman("Component %s is already installed. To upgrade run 'lacework component update %s'\n", component.Name, component.Name)
+		cli.OutputHuman("Component %s is already installed. To upgrade run '%s'",
+			component.Name,
+			color.HiGreenString("lacework component update %s", component.Name))
 		return nil
 	}
 
@@ -627,7 +628,7 @@ func updateComponent(args []string) (err error) {
 	}
 
 	if installedVersion.Equal(targetVersion) {
-		cli.OutputHuman("Component %s is version %s.\n", component.Name, component.InstalledVersion())
+		cli.OutputHuman("Component %s is version %s.\n", component.Name, color.HiYellowString(installedVersion.String()))
 		return nil
 	}
 
@@ -873,7 +874,6 @@ func componentsToTable() [][]string {
 		// we display the current version instead
 		if currentVersion, err := cdata.CurrentVersion(); err == nil {
 			version = currentVersion.String()
-			assert.Contains(t, out, "component")
 		}
 
 		out = append(out, []string{

--- a/integration/component_test.go
+++ b/integration/component_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestCDKComponentList(t *testing.T) {
+func TestComponentList(t *testing.T) {
 	dir := setup()
 
 	out := run(t, dir, "component", "list")
@@ -38,7 +38,7 @@ func TestCDKComponentList(t *testing.T) {
 	cleanup(dir)
 }
 
-func TestCDKComponentListJSON(t *testing.T) {
+func TestComponentListJSON(t *testing.T) {
 	dir := setup()
 
 	out := run(t, dir, "component", "list", "--json")
@@ -60,7 +60,7 @@ func TestCDKComponentListJSON(t *testing.T) {
 	cleanup(dir)
 }
 
-func TestCDKComponentShow(t *testing.T) {
+func TestComponentShow(t *testing.T) {
 	dir := setup()
 
 	out := run(t, dir, "component", "show", "component-example")
@@ -74,7 +74,7 @@ func TestCDKComponentShow(t *testing.T) {
 	cleanup(dir)
 }
 
-func TestCDKComponentShowJSON(t *testing.T) {
+func TestComponentShowJSON(t *testing.T) {
 	dir := setup()
 
 	out := run(t, dir, "component", "show", "component-example", "--json")
@@ -95,7 +95,7 @@ func TestCDKComponentShowJSON(t *testing.T) {
 	cleanup(dir)
 }
 
-func TestCDKComponentInstall(t *testing.T) {
+func TestComponentInstall(t *testing.T) {
 	dir := setup()
 
 	run(t, dir, "component", "install", "component-example")
@@ -109,15 +109,12 @@ func TestCDKComponentInstall(t *testing.T) {
 	out = run(t, dir, "component-example")
 	assert.Contains(t, out, "component")
 
-	outBytes, errBytes, exitcode := LaceworkCLIWithHome(dir, "component", "install", "component-example")
-	assert.NotContains(t, outBytes.String(), "Installation completed.", "STDOUT should be empty")
-	assert.Contains(t, errBytes.String(), "already installed")
-	assert.Equal(t, 1, exitcode, "EXITCODE is not the expected one")
+	run(t, dir, "component", "install", "component-example")
 
 	cleanup(dir)
 }
 
-func TestCDKComponentUpdate(t *testing.T) {
+func TestComponentUpdate(t *testing.T) {
 	dir := setup()
 
 	run(t, dir, "component", "install", "component-example", "--version", "0.9.0")
@@ -142,7 +139,7 @@ func TestCDKComponentUpdate(t *testing.T) {
 	cleanup(dir)
 }
 
-func TestCDKComponentUninstall(t *testing.T) {
+func TestComponentUninstall(t *testing.T) {
 	dir := setup()
 
 	run(t, dir, "component", "install", "component-example")
@@ -164,7 +161,7 @@ func TestCDKComponentUninstall(t *testing.T) {
 	cleanup(dir)
 }
 
-func TestCDKComponentDev(t *testing.T) {
+func TestComponentDev(t *testing.T) {
 	dir := setup()
 
 	// GoLang scaffolding is too slow for the test
@@ -184,7 +181,7 @@ func TestCDKComponentDev(t *testing.T) {
 	cleanup(dir)
 }
 
-func TestCDKComponentDevEnter(t *testing.T) {
+func TestComponentDevEnter(t *testing.T) {
 	dir := setup()
 
 	run(t, dir, "component", "install", "component-example")

--- a/integration/component_test.go
+++ b/integration/component_test.go
@@ -129,6 +129,13 @@ func TestComponentUpdate(t *testing.T) {
 		assert.Contains(t, out, "component")
 	})
 
+	t.Run("upgrade", func(t *testing.T) {
+		run(t, dir, "component", "update", "component-example", "--version", "0.9.1")
+
+		run(t, dir, "component-example")
+		assert.Contains(t, out, "component")
+	})
+
 	t.Run("downgrade", func(t *testing.T) {
 		run(t, dir, "component", "update", "component-example", "--version", "0.8.0")
 


### PR DESCRIPTION
## Summary

We shouldn't return an error when a user runs `component install` on an already installed component.  Context https://lacework.slack.com/archives/C04974WUG0K/p1711013967046719.

The prototype `component install` will reinstall an installed component.  This PR changes the behaviour of the v1 CDK code to do nothing and just return success when a user attempts to install an already installed component.

Same goes for `component update`.

## How did you test this change?

```
bin/lacework component install iac
Component iac is already installed. To upgrade run 'lacework component update iac'
> echo $?
0
```

```
> bin/lacework component update iac
 [✓] Component iac found
Component iac is version 0.6.22.
> echo $?
0
```