### PR TITLE
fix(GROW-2831): correct handling for resourceTags in policy exceptions

### DIFF
--- a/cli/cmd/policy_exceptions.go
+++ b/cli/cmd/policy_exceptions.go
@@ -323,7 +323,7 @@ func promptAddExceptionConstraints(policy api.Policy) ([]api.PolicyExceptionCons
 		answer, err := promptAskConstraintsQuestion(q)
 
 		if err != nil {
-			return []api.PolicyExceptionConstraint{}, nil
+			return []api.PolicyExceptionConstraint{}, err
 		}
 
 		if answer != nil {


### PR DESCRIPTION
## Summary

Prior to this change the data format for resource tags was sent incorrectly, resulting in an ineffectual policy. This corrects that format issue so the policy works.

## How did you test this change?

Manual execution & passing tests

## Issue

https://lacework.atlassian.net/browse/GROW-2831
