### PR TITLE
feat: added owner and team fields

### DIFF
--- a/api/v2_vulnerabilities.go
+++ b/api/v2_vulnerabilities.go
@@ -527,7 +527,9 @@ type VulnerabilityHostMachineTags struct {
 	InternalIP                            string `json:"InternalIp"`
 	LwTokenShort                          string `json:"LwTokenShort"`
 	Name                                  string `json:"Name"`
+	Owner                                 string `json:"Owner"`
 	SubnetID                              string `json:"SubnetId"`
+	Team                                  string `json:"Team"`
 	VMInstanceType                        string `json:"VmInstanceType"`
 	VMProvider                            string `json:"VmProvider"`
 	VpcID                                 string `json:"VpcId"`


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/lacework/go-sdk) and create your branch from `main`
  2. Run `make prepare` in the repository root
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`make test`)
  5. Format your code (`make fmt`)
  6. Make sure your code lints (`make lint`)
  7. If you are updating the Lacework CLI, make sure it compiles (`make build-cli-cross-platform`)
  8. Follow the commit message standard (`type(scope): subject`) documented in [DEVELOPER_GUIDELINES.md](https://github.com/lacework/go-sdk/blob/main/DEVELOPER_GUIDELINES.md#commit-message-standard)
  9. If you haven't already, configure signed commits by [telling git about your signing key](https://docs.github.com/en/github/authenticating-to-github/managing-commit-signature-verification/telling-git-about-your-signing-key) and [signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)

  Learn more about contributing: https://github.com/lacework/go-sdk/blob/main/CONTRIBUTING.md
-->

## Summary

We are using these two fields in our internal tool (Team and Owner), and they were missing from the Client.

## How did you test this change?

I pulled the information from those fields in our local tooling by using a go.mod replace statement to override our lacework client with a local version.

## Issue

https://github.com/lacework/go-sdk/issues/1615