### PR TITLE
fix: use buffered channel for downloadComplete to prevent blocking

### DIFF
--- a/cli/cmd/component.go
+++ b/cli/cmd/component.go
@@ -413,7 +413,7 @@ func runComponentsInstall(cmd *cobra.Command, args []string) (err error) {
 func installComponent(args []string) (err error) {
 	var (
 		componentName    string                 = args[0]
-		downloadComplete                        = make(chan int8)
+		downloadComplete                        = make(chan int8, 1)
 		params           map[string]interface{} = make(map[string]interface{})
 		start            time.Time
 	)


### PR DESCRIPTION


## Summary

Prior to this commit if an error occurred before the download progress function could start, the CLI would block writing to the downloadComplete channel


## How did you test this change?

manual execution & unit tests 

## Issue

https://lacework.atlassian.net/browse/GROW-2895