### PR TITLE
feat: expose raw machine tags for external automation

### DIFF
--- a/api/v2_vulnerabilities.go
+++ b/api/v2_vulnerabilities.go
@@ -517,6 +517,21 @@ func (v *VulnerabilityHost) GetMachineTags() (machineTags VulnerabilityHostMachi
 	return
 }
 
+func (v *VulnerabilityHost) GetMachineTagsRaw() (map[string]interface{}, error) {
+	jsonTags, err := json.Marshal(v.MachineTags)
+	if err != nil {
+		return nil, err
+	}
+
+	var rawTags map[string]interface{}
+
+	if err := json.Unmarshal(jsonTags, &rawTags); err != nil {
+		return nil, err
+	}
+
+	return rawTags, nil
+}
+
 type VulnerabilityHostMachineTags struct {
 	Account                               string `json:"Account"`
 	AmiID                                 string `json:"AmiId"`

--- a/api/v2_vulnerabilities_test.go
+++ b/api/v2_vulnerabilities_test.go
@@ -437,6 +437,19 @@ func TestV2Vulnerabilities_Hosts_AllPages(t *testing.T) {
 	}
 }
 
+func TestV2Vulnerabilities_HostGetAwsMachineTagsRaw(t *testing.T) {
+	var mockHostResponse api.VulnerabilitiesHostResponse
+	err := json.Unmarshal([]byte(mockVulnerabilitiesHostsResponseSetTags(vulnerabilityHostAwsMachineTags)), &mockHostResponse)
+	assert.NoError(t, err)
+
+	tags, err := mockHostResponse.Data[0].GetMachineTagsRaw()
+	assert.NoError(t, err)
+	assert.Equal(t, tags["Account"], "123456789038")
+	assert.Equal(t, tags["AmiId"], "ami-1234567890540c038")
+	assert.Equal(t, tags["ExternalIp"], "1.5.8.9")
+	assert.Equal(t, tags["Hostname"], "ip-192-168-28-69.us-east-2.compute.internal")
+}
+
 func TestV2Vulnerabilities_HostGetAwsMachineTags(t *testing.T) {
 	var mockHostResponse api.VulnerabilitiesHostResponse
 	err := json.Unmarshal([]byte(mockVulnerabilitiesHostsResponseSetTags(vulnerabilityHostAwsMachineTags)), &mockHostResponse)


### PR DESCRIPTION

## Summary

Enable raw access to the machine tags without marshaling to a known struct

## How did you test this change?

Unit test

## Issue

Fixes #1615
