### PR TITLE
feat: add riskInfo to container vulns

### DIFF
--- a/api/v2_vulnerabilities.go
+++ b/api/v2_vulnerabilities.go
@@ -381,6 +381,25 @@ type VulnerabilityContainer struct {
 		FixAvailable  int    `json:"fix_available"`
 		FixedVersion  string `json:"fixed_version"`
 	} `json:"fixInfo"`
+	RiskInfo struct {
+		Factors          []string `json:"factors"`
+		FactorsBreakdown struct {
+			ActiveContainers int `json:"active_containers"`
+			CveCounts        struct {
+				Critical int `json:"Critical"`
+				High     int `json:"High"`
+				Medium   int `json:"Medium"`
+				Other    int `json:"Other"`
+			} `json:"cve_counts"`
+			ExploitSummary struct {
+				DisclosureInWild    string `json:"disclosure_in_wild"`
+				ExploitPublic       string `json:"exploit_public"`
+				ExploitVirusMalware string `json:"exploit_virus_malware"`
+				ExploitWormified    string `json:"exploit_wormified"`
+			} `json:"exploit_summary"`
+			InternetReachability string `json:"internet_reachability"`
+		} `json:"factors_breakdown"`
+	} `json:"riskInfo"`
 	ImageID   string    `json:"imageId"`
 	Severity  string    `json:"severity"`
 	StartTime time.Time `json:"startTime"`

--- a/api/v2_vulnerabilities_test.go
+++ b/api/v2_vulnerabilities_test.go
@@ -274,6 +274,30 @@ func mockVulnerabilitiesContainersResponse() string {
         "fixed_version": ""
       },
       "imageId": "sha256:123472164cb78c4d04f57bd66201c775e2dab08fce394806a03a933c5daf9e48",
+      "riskInfo": {
+        "factors": [
+          "cve",
+          "reachability",
+		  "activeExploits",
+	      "knownExploits"
+	    ],
+	    "factors_breakdown": {
+	      "active_containers": 0,
+		  "cve_counts": {
+		    "Critical": 2,
+		    "High": 13,
+		    "Medium": 14,
+		    "Other": 20
+	      },
+		  "exploit_summary": {
+		    "disclosure_in_wild": "Yes",
+		    "exploit_public": "Yes",
+		    "exploit_virus_malware": "No",
+		    "exploit_wormified": "No"
+		  },
+	      "internet_reachability": "Unknown"
+  	    }
+      },
       "severity": "Low",
       "startTime": "2022-02-10T10:05:11.418Z",
       "status": "EXCEPTION",
@@ -342,6 +366,30 @@ func mockVulnerabilitiesContainersResponse() string {
         "fixed_version": ""
       },
       "imageId": "sha256:123472164cb78c4d04f57bd66201c775e2dab08fce394806a03a933c5daf9e48",
+      "riskInfo": {
+        "factors": [
+          "cve",
+          "reachability",
+		  "activeExploits",
+	      "knownExploits"
+	    ],
+	    "factors_breakdown": {
+	      "active_containers": 0,
+		  "cve_counts": {
+		    "Critical": 2,
+		    "High": 13,
+		    "Medium": 14,
+		    "Other": 20
+	      },
+		  "exploit_summary": {
+		    "disclosure_in_wild": "Yes",
+		    "exploit_public": "Yes",
+		    "exploit_virus_malware": "No",
+		    "exploit_wormified": "No"
+		  },
+	      "internet_reachability": "Unknown"
+  	    }
+      },
       "severity": "Info",
       "startTime": "2022-02-10T10:05:11.418Z",
       "status": "VULNERABLE",

--- a/cli/cmd/vuln_container_test.go
+++ b/cli/cmd/vuln_container_test.go
@@ -250,369 +250,464 @@ func TestVulnCtrCountPackages(t *testing.T) {
 
 var rawListAssessments = `
 {
-    "paging": {
-        "rows": 5000,
-        "totalRows": 6419,
-        "urls": {
-            "nextPage": "https://example.lacework.net/api/v2/Vulnerabilities/Containers/"
-        }
+  "paging": {
+    "rows": 5000,
+    "totalRows": 6419,
+    "urls": {
+      "nextPage": "https://example.lacework.net/api/v2/Vulnerabilities/Containers/"
+    }
+  },
+  "data": [
+    {
+      "evalCtx": {
+        "cve_batch_info": [
+          {
+            "cve_created_time": "2022-11-21 00:21:41.678000000"
+          }
+        ],
+        "exception_props": [
+          {
+            "exception_guid": "VULN_C44BF2CBE09F0E705565BEA1A0C1D2A5D1534857F2C7CDF8381",
+            "exception_name": "registry index.docker.io severity Low",
+            "exception_reason": "Accepted Risk"
+          }
+        ],
+        "image_info": {
+          "created_time": 1605140985874,
+          "digest": "sha256:77b2d2246518044ef95e3dbd029e51dd477788e5bf8e278e418685aabc3fe28a",
+          "id": "sha256:a65572164cb78c4d04f57bd66201c775e2dab08fce394806a03a933c5daf9e48",
+          "registry": "index.docker.io",
+          "repo": "techally-test/test-cli",
+          "scan_created_time": 1669055600,
+          "size": 360608563,
+          "status": "Success",
+          "tags": [
+            "latest"
+          ],
+          "type": "Docker"
+        },
+        "integration_props": {
+          "INTG_GUID": "TECHALLY_FC5485B5ACFF3DAFE77E8C8A734C6C2FAD7CAAC9F01313C",
+          "NAME": "Terraform-Dockerhub",
+          "REGISTRY_TYPE": "DOCKERHUB"
+        },
+        "is_reeval": false,
+        "request_source": "PLATFORM_SCANNER",
+        "scan_batch_id": "467a274c-f847-456b-b62d-13f9d88988cc-1669055607923432004",
+        "scan_request_props": {
+          "data_format_version": "1.0",
+          "props": {
+            "data_format_version": "1.0",
+            "scanner_version": "10.0.155"
+          },
+          "reqId": "2ac494a9-b7be-453a-81b9-7a2f1f9e2113",
+          "reqSource": "ondemand",
+          "scanCompletionUtcTime": 1669055607,
+          "scan_start_time": 1669055600,
+          "scanner_version": "10.0.155"
+        },
+        "vuln_batch_id": "7B2EDDD2D2D140ECA6B85001FC62AE45",
+        "vuln_created_time": "2022-11-21 00:21:41.678000000"
+      },
+      "evalGuid": "781865fdff984def2587b5f05065f0db",
+      "featureKey": {
+        "name": "example-1",
+        "namespace": "debian:9",
+        "version": "1.0.0"
+      },
+      "featureProps": {
+        "feed": "lacework",
+        "introduced_in": "example introduced in layer",
+        "layer": "sha256:sha256:572866ab72a68759e23b071fbbdce6341137c9606936b4fff9846f74997bbaac",
+        "src": "var/lib/dpkg/status",
+        "version_format": "dpkg"
+      },
+      "fixInfo": {
+        "fix_available": 1,
+        "fixed_version": "2.2.0-11+deb9u4"
+      },
+      "imageId": "sha256:a65572164cb78c4d04f57bd66201c775e2dab08fce394806a03a933c5daf9e48",
+      "severity": "Medium",
+      "startTime": "2022-11-21T18:33:28.076Z",
+      "status": "VULNERABLE",
+      "vulnId": "CVE-2029-21234"
     },
-"data": [
-{
-            "evalCtx": {
-                "cve_batch_info": [
-                    {
-                        "cve_created_time": "2022-11-21 00:21:41.678000000"
-                    }
-                ],
-                "exception_props": [
-                    {
-                        "exception_guid": "VULN_C44BF2CBE09F0E705565BEA1A0C1D2A5D1534857F2C7CDF8381",
-                        "exception_name": "registry index.docker.io severity Low",
-                        "exception_reason": "Accepted Risk"
-                    }
-                ],
-                "image_info": {
-                    "created_time": 1605140985874,
-                    "digest": "sha256:77b2d2246518044ef95e3dbd029e51dd477788e5bf8e278e418685aabc3fe28a",
-                    "id": "sha256:a65572164cb78c4d04f57bd66201c775e2dab08fce394806a03a933c5daf9e48",
-                    "registry": "index.docker.io",
-                    "repo": "techally-test/test-cli",
-                    "scan_created_time": 1669055600,
-                    "size": 360608563,
-                    "status": "Success",
-                    "tags": [
-                        "latest"
-                    ],
-                    "type": "Docker"
-                },
-                "integration_props": {
-                    "INTG_GUID": "TECHALLY_FC5485B5ACFF3DAFE77E8C8A734C6C2FAD7CAAC9F01313C",
-                    "NAME": "Terraform-Dockerhub",
-                    "REGISTRY_TYPE": "DOCKERHUB"
-                },
-                "is_reeval": false,
-                "request_source": "PLATFORM_SCANNER",
-                "scan_batch_id": "467a274c-f847-456b-b62d-13f9d88988cc-1669055607923432004",
-                "scan_request_props": {
-                    "data_format_version": "1.0",
-                    "props": {
-                        "data_format_version": "1.0",
-                        "scanner_version": "10.0.155"
-                    },
-                    "reqId": "2ac494a9-b7be-453a-81b9-7a2f1f9e2113",
-                    "reqSource": "ondemand",
-                    "scanCompletionUtcTime": 1669055607,
-                    "scan_start_time": 1669055600,
-                    "scanner_version": "10.0.155"
-                },
-                "vuln_batch_id": "7B2EDDD2D2D140ECA6B85001FC62AE45",
-                "vuln_created_time": "2022-11-21 00:21:41.678000000"
-            },
-            "evalGuid": "781865fdff984def2587b5f05065f0db",
-            "featureKey": {
-                "name": "example-1",
-                "namespace": "debian:9",
-                "version": "1.0.0"
-            },
-            "featureProps": {
-                "feed": "lacework",
-                "introduced_in": "example introduced in layer",
-                "layer": "sha256:sha256:572866ab72a68759e23b071fbbdce6341137c9606936b4fff9846f74997bbaac",
-                "src": "var/lib/dpkg/status",
-                "version_format": "dpkg"
-            },
-            "fixInfo": {
-                "fix_available": 1,
-                "fixed_version": "2.2.0-11+deb9u4"
-            },
-            "imageId": "sha256:a65572164cb78c4d04f57bd66201c775e2dab08fce394806a03a933c5daf9e48",
-            "severity": "Medium",
-            "startTime": "2022-11-21T18:33:28.076Z",
-            "status": "VULNERABLE",
-            "vulnId": "CVE-2029-21234"
+    {
+      "evalCtx": {
+        "cve_batch_info": [
+          {
+            "cve_created_time": "2022-11-21 19:05:48.075000000"
+          }
+        ],
+        "image_info": {
+          "created_time": 1588284823675,
+          "digest": "sha256:12b072fd2ce1732e4c2f0f601c2c12ea2ea657c9572d9ba477b1174d9159e123",
+          "id": "sha256:7652596622b05043763f962cff30edf01f6ea1ba29374f1703dda759dc9ff3a1",
+          "registry": "gcr.io",
+          "repo": "techally-test-2/exservice",
+          "scan_created_time": 1636768856,
+          "size": 14933503,
+          "status": "Success",
+          "tags": [
+            "v1.0.0"
+          ],
+          "type": "Docker"
         },
-{
-            "evalCtx": {
-                "cve_batch_info": [
-                    {
-                        "cve_created_time": "2022-11-21 19:05:48.075000000"
-                    }
-                ],
-                "image_info": {
-                    "created_time": 1588284823675,
-                    "digest": "sha256:12b072fd2ce1732e4c2f0f601c2c12ea2ea657c9572d9ba477b1174d9159e123",
-                    "id": "sha256:7652596622b05043763f962cff30edf01f6ea1ba29374f1703dda759dc9ff3a1",
-                    "registry": "gcr.io",
-                    "repo": "techally-test-2/exservice",
-                    "scan_created_time": 1636768856,
-                    "size": 14933503,
-                    "status": "Success",
-                    "tags": [
-                        "v1.0.0"
-                    ],
-                    "type": "Docker"
-                },
-                "integration_props": {},
-                "is_reeval": true,
-                "request_source": "PLATFORM_SCANNER",
-                "scan_batch_id": "cd1d57ca-c018-4ffd-ac07-6664bc7c7a85-1636768857524097264",
-                "scan_request_props": {
-                    "data_format_version": "1.0",
-                    "props": {
-                        "data_format_version": "1.0",
-                        "scanner_version": "0.2.2"
-                    },
-                    "scanCompletionUtcTime": 1636768857,
-                    "scan_start_time": 1636768856,
-                    "scanner_version": "0.2.2"
-                },
-                "vuln_batch_id": "E1BA1053AB374E4C968C689F0F013C9A",
-                "vuln_created_time": "2022-11-21 19:05:48.075000000"
-            },
-            "evalGuid": "097464827bb2d34b6f62c5ebbdab3385",
-            "featureKey": {
-                "name": "example-2",
-                "namespace": "alpine:v3.11",
-                "version": "1.2.0"
-            },
-            "featureProps": {
-                "feed": "n/a",
-                "introduced_in": "apk add --no-cache ca-certificates",
-                "layer": "sha256:sha256:e3693d3358098cb60aed2d9820d583add96dec7313befcf714ffc4d9c464a275",
-                "src": "",
-                "version_format": "apk"
-            },
-            "fixInfo": {
-                "fix_available": 0,
-                "fixed_version": ""
-            },
-            "imageId": "sha256:7652596622b05043763f962cff30edf01f6ea1ba29374f1703dda759dc9ff3a1",
-            "startTime": "2022-11-21T19:21:57.765Z",
-            "status": "VULNERABLE",
-            "severity": "Critical",
-            "vulnId": "CVE-2020-12345"
+        "integration_props": {},
+        "is_reeval": true,
+        "request_source": "PLATFORM_SCANNER",
+        "scan_batch_id": "cd1d57ca-c018-4ffd-ac07-6664bc7c7a85-1636768857524097264",
+        "scan_request_props": {
+          "data_format_version": "1.0",
+          "props": {
+            "data_format_version": "1.0",
+            "scanner_version": "0.2.2"
+          },
+          "scanCompletionUtcTime": 1636768857,
+          "scan_start_time": 1636768856,
+          "scanner_version": "0.2.2"
         },
-        {
-            "evalCtx": {
-                "cve_batch_info": [
-                    {
-                        "cve_created_time": "2022-11-21 19:05:48.075000000"
-                    }
-                ],
-                "image_info": {
-                    "created_time": 1588284823675,
-                    "digest": "sha256:15b072fd2ce1732e4c2f0f601c2c12ea2ea657c9572d9ba477b1174d9159e123",
-                    "id": "sha256:1252596622b05043763f962gff30adf01f6ea1ba29374f1703dda759dc9ab3a1",
-                    "registry": "gcr.io",
-                    "repo": "techally-test-4/exservice",
-                    "scan_created_time": 1636768856,
-                    "size": 14933503,
-                    "status": "Success",
-                    "tags": [
-                        "v1.0.0"
-                    ],
-                    "type": "Docker"
-                },
-                "integration_props": {},
-                "is_reeval": true,
-                "request_source": "PLATFORM_SCANNER",
-                "scan_batch_id": "cd1d57ca-c018-4ffd-ac07-6664bc7c7a85-1636768857524097264",
-                "scan_request_props": {
-                    "data_format_version": "1.0",
-                    "props": {
-                        "data_format_version": "1.0",
-                        "scanner_version": "0.2.2"
-                    },
-                    "scanCompletionUtcTime": 1636768857,
-                    "scan_start_time": 1636768856,
-                    "scanner_version": "0.2.2"
-                },
-                "vuln_batch_id": "E1BA1053AB374E4C968C689F0F013C9A",
-                "vuln_created_time": "2022-11-21 19:05:48.075000000"
-            },
-            "evalGuid": "097464827bb2d34b6f62c5ebbdab3385",
-            "featureKey": {
-                "name": "example-4",
-                "namespace": "alpine:v3.11",
-                "version": "1.0.0"
-            },
-            "featureProps": {
-                "feed": "lacework",
-                "introduced_in": "apk add --no-cache ca-certificates",
-                "layer": "sha256:sha256:e3693d3358098cb60aed2d9820d583add96dec7313befcf714ffc4d9c464a275",
-                "src": "",
-                "version_format": "apk"
-            },
-            "fixInfo": {
-                "fix_available": 1,
-                "fixed_version": "1.31.1-r11"
-            },
-            "imageId": "sha256:1252596622b05043763f962gff30adf01f6ea1ba29374f1703dda759dc9ab3a1",
-            "severity": "High",
-            "startTime": "2022-11-21T19:21:57.765Z",
-            "status": "VULNERABLE",
-            "vulnId": "CVE-2020-12345"
+        "vuln_batch_id": "E1BA1053AB374E4C968C689F0F013C9A",
+        "vuln_created_time": "2022-11-21 19:05:48.075000000"
+      },
+      "evalGuid": "097464827bb2d34b6f62c5ebbdab3385",
+      "featureKey": {
+        "name": "example-2",
+        "namespace": "alpine:v3.11",
+        "version": "1.2.0"
+      },
+      "featureProps": {
+        "feed": "n/a",
+        "introduced_in": "apk add --no-cache ca-certificates",
+        "layer": "sha256:sha256:e3693d3358098cb60aed2d9820d583add96dec7313befcf714ffc4d9c464a275",
+        "src": "",
+        "version_format": "apk"
+      },
+      "fixInfo": {
+        "fix_available": 0,
+        "fixed_version": ""
+      },
+      "imageId": "sha256:7652596622b05043763f962cff30edf01f6ea1ba29374f1703dda759dc9ff3a1",
+      "riskInfo": {
+        "factors": [
+          "cve",
+          "reachability",
+          "activeExploits",
+          "knownExploits"
+        ],
+        "factors_breakdown": {
+          "active_containers": 0,
+          "cve_counts": {
+            "Critical": 2,
+            "High": 13,
+            "Medium": 14,
+            "Other": 20
+          },
+          "exploit_summary": {
+            "disclosure_in_wild": "Yes",
+            "exploit_public": "Yes",
+            "exploit_virus_malware": "No",
+            "exploit_wormified": "No"
+          },
+          "internet_reachability": "Unknown"
         }
-]
+      },
+      "startTime": "2022-11-21T19:21:57.765Z",
+      "status": "VULNERABLE",
+      "severity": "Critical",
+      "vulnId": "CVE-2020-12345"
+    },
+    {
+      "evalCtx": {
+        "cve_batch_info": [
+          {
+            "cve_created_time": "2022-11-21 19:05:48.075000000"
+          }
+        ],
+        "image_info": {
+          "created_time": 1588284823675,
+          "digest": "sha256:15b072fd2ce1732e4c2f0f601c2c12ea2ea657c9572d9ba477b1174d9159e123",
+          "id": "sha256:1252596622b05043763f962gff30adf01f6ea1ba29374f1703dda759dc9ab3a1",
+          "registry": "gcr.io",
+          "repo": "techally-test-4/exservice",
+          "scan_created_time": 1636768856,
+          "size": 14933503,
+          "status": "Success",
+          "tags": [
+            "v1.0.0"
+          ],
+          "type": "Docker"
+        },
+        "integration_props": {},
+        "is_reeval": true,
+        "request_source": "PLATFORM_SCANNER",
+        "scan_batch_id": "cd1d57ca-c018-4ffd-ac07-6664bc7c7a85-1636768857524097264",
+        "scan_request_props": {
+          "data_format_version": "1.0",
+          "props": {
+            "data_format_version": "1.0",
+            "scanner_version": "0.2.2"
+          },
+          "scanCompletionUtcTime": 1636768857,
+          "scan_start_time": 1636768856,
+          "scanner_version": "0.2.2"
+        },
+        "vuln_batch_id": "E1BA1053AB374E4C968C689F0F013C9A",
+        "vuln_created_time": "2022-11-21 19:05:48.075000000"
+      },
+      "evalGuid": "097464827bb2d34b6f62c5ebbdab3385",
+      "featureKey": {
+        "name": "example-4",
+        "namespace": "alpine:v3.11",
+        "version": "1.0.0"
+      },
+      "featureProps": {
+        "feed": "lacework",
+        "introduced_in": "apk add --no-cache ca-certificates",
+        "layer": "sha256:sha256:e3693d3358098cb60aed2d9820d583add96dec7313befcf714ffc4d9c464a275",
+        "src": "",
+        "version_format": "apk"
+      },
+      "fixInfo": {
+        "fix_available": 1,
+        "fixed_version": "1.31.1-r11"
+      },
+      "imageId": "sha256:1252596622b05043763f962gff30adf01f6ea1ba29374f1703dda759dc9ab3a1",
+      "riskInfo": {
+        "factors": [
+          "cve",
+          "reachability",
+          "activeExploits",
+          "knownExploits"
+        ],
+        "factors_breakdown": {
+          "active_containers": 0,
+          "cve_counts": {
+            "Critical": 2,
+            "High": 13,
+            "Medium": 14,
+            "Other": 20
+          },
+          "exploit_summary": {
+            "disclosure_in_wild": "Yes",
+            "exploit_public": "Yes",
+            "exploit_virus_malware": "No",
+            "exploit_wormified": "No"
+          },
+          "internet_reachability": "Unknown"
+        }
+      },
+      "severity": "High",
+      "startTime": "2022-11-21T19:21:57.765Z",
+      "status": "VULNERABLE",
+      "vulnId": "CVE-2020-12345"
+    }
+  ]
 }`
 
 var mockIntroducedInLayerResponse = `
 {
-    "paging": {
-        "rows": 2,
-        "totalRows": 2,
-        "urls": { }
-    },
-    "data": [
-        {
-            "evalCtx": {
-                "cve_batch_info": [
-                    {
-                        "cve_created_time": "2022-11-21 00:21:41.678000000"
-                    }
-                ],
-                "exception_props": [
-                    {
-                        "exception_guid": "VULN_C44BF2CBE09F0E705565BEA1A0C1D2A5D1534857F2C7CDF8381",
-                        "exception_name": "registry index.docker.io severity Low",
-                        "exception_reason": "Accepted Risk"
-                    }
-                ],
-                "image_info": {
-                    "created_time": 1605140985874,
-                    "digest": "sha256:77b2d2246518044ef95e3dbd029e51dd477788e5bf8e278e418685aabc3fe28a",
-                    "id": "sha256:a65572164cb78c4d04f57bd66201c775e2dab08fce394806a03a933c5daf9e48",
-                    "registry": "index.docker.io",
-                    "repo": "techally-test/test-cli",
-                    "scan_created_time": 1669055600,
-                    "size": 360608563,
-                    "status": "Success",
-                    "tags": [
-                        "latest"
-                    ],
-                    "type": "Docker"
-                },
-                "integration_props": {
-                    "INTG_GUID": "TECHALLY_FC5485B5ACFF3DAFE77E8C8A734C6C2FAD7CAAC9F01313C",
-                    "NAME": "Terraform-Dockerhub",
-                    "REGISTRY_TYPE": "DOCKERHUB"
-                },
-                "is_reeval": false,
-                "request_source": "PLATFORM_SCANNER",
-                "scan_batch_id": "467a274c-f847-456b-b62d-13f9d88988cc-1669055607923432004",
-                "scan_request_props": {
-                    "data_format_version": "1.0",
-                    "props": {
-                        "data_format_version": "1.0",
-                        "scanner_version": "10.0.155"
-                    },
-                    "reqId": "2ac494a9-b7be-453a-81b9-7a2f1f9e2113",
-                    "reqSource": "ondemand",
-                    "scanCompletionUtcTime": 1669055607,
-                    "scan_start_time": 1669055600,
-                    "scanner_version": "10.0.155"
-                },
-                "vuln_batch_id": "7B2EDDD2D2D140ECA6B85001FC62AE45",
-                "vuln_created_time": "2022-11-21 00:21:41.678000000"
-            },
-            "evalGuid": "781865fdff984def2587b5f05065f0db",
-            "featureKey": {
-                "name": "example-1",
-                "namespace": "debian:9",
-                "version": "1.0.0"
-            },
-            "featureProps": {
-                "feed": "lacework",
-                "introduced_in": "example introduced in layer 1",
-                "layer": "sha256:sha256:572866ab72a68759e23b071fbbdce6341137c9606936b4fff9846f74997bbaac",
-                "src": "var/lib/dpkg/status",
-                "version_format": "dpkg"
-            },
-            "fixInfo": {
-                "fix_available": 1,
-                "fixed_version": "2.2.0-11+deb9u4"
-            },
-            "imageId": "sha256:a65572164cb78c4d04f57bd66201c775e2dab08fce394806a03a933c5daf9e48",
-            "severity": "Medium",
-            "startTime": "2022-11-21T18:33:28.076Z",
-            "status": "VULNERABLE",
-            "vulnId": "CVE-2029-21234"
+  "paging": {
+    "rows": 2,
+    "totalRows": 2,
+    "urls": {}
+  },
+  "data": [
+    {
+      "evalCtx": {
+        "cve_batch_info": [
+          {
+            "cve_created_time": "2022-11-21 00:21:41.678000000"
+          }
+        ],
+        "exception_props": [
+          {
+            "exception_guid": "VULN_C44BF2CBE09F0E705565BEA1A0C1D2A5D1534857F2C7CDF8381",
+            "exception_name": "registry index.docker.io severity Low",
+            "exception_reason": "Accepted Risk"
+          }
+        ],
+        "image_info": {
+          "created_time": 1605140985874,
+          "digest": "sha256:77b2d2246518044ef95e3dbd029e51dd477788e5bf8e278e418685aabc3fe28a",
+          "id": "sha256:a65572164cb78c4d04f57bd66201c775e2dab08fce394806a03a933c5daf9e48",
+          "registry": "index.docker.io",
+          "repo": "techally-test/test-cli",
+          "scan_created_time": 1669055600,
+          "size": 360608563,
+          "status": "Success",
+          "tags": [
+            "latest"
+          ],
+          "type": "Docker"
         },
-				{
-            "evalCtx": {
-                "cve_batch_info": [
-                    {
-                        "cve_created_time": "2022-11-21 00:21:41.678000000"
-                    }
-                ],
-                "exception_props": [
-                    {
-                        "exception_guid": "VULN_C44BF2CBE09F0E705565BEA1A0C1D2A5D1534857F2C7CDF8381",
-                        "exception_name": "registry index.docker.io severity Low",
-                        "exception_reason": "Accepted Risk"
-                    }
-                ],
-                "image_info": {
-                    "created_time": 1605140985874,
-                    "digest": "sha256:77b2d2246518044ef95e3dbd029e51dd477788e5bf8e278e418685aabc3fe28a",
-                    "id": "sha256:a65572164cb78c4d04f57bd66201c775e2dab08fce394806a03a933c5daf9e48",
-                    "registry": "index.docker.io",
-                    "repo": "techally-test/test-cli",
-                    "scan_created_time": 1669055600,
-                    "size": 360608563,
-                    "status": "Success",
-                    "tags": [
-                        "latest"
-                    ],
-                    "type": "Docker"
-                },
-                "integration_props": {
-                    "INTG_GUID": "TECHALLY_FC5485B5ACFF3DAFE77E8C8A734C6C2FAD7CAAC9F01313C",
-                    "NAME": "Terraform-Dockerhub",
-                    "REGISTRY_TYPE": "DOCKERHUB"
-                },
-                "is_reeval": false,
-                "request_source": "PLATFORM_SCANNER",
-                "scan_batch_id": "467a274c-f847-456b-b62d-13f9d88988cc-1669055607923432004",
-                "scan_request_props": {
-                    "data_format_version": "1.0",
-                    "props": {
-                        "data_format_version": "1.0",
-                        "scanner_version": "10.0.155"
-                    },
-                    "reqId": "2ac494a9-b7be-453a-81b9-7a2f1f9e2113",
-                    "reqSource": "ondemand",
-                    "scanCompletionUtcTime": 1669055607,
-                    "scan_start_time": 1669055600,
-                    "scanner_version": "10.0.155"
-                },
-                "vuln_batch_id": "7B2EDDD2D2D140ECA6B85001FC62AE45",
-                "vuln_created_time": "2022-11-21 00:21:41.678000000"
-            },
-            "evalGuid": "781865fdff984def2587b5f05065f0db",
-            "featureKey": {
-                "name": "example-1",
-                "namespace": "debian:9",
-                "version": "1.0.0"
-            },
-            "featureProps": {
-                "feed": "lacework",
-                "introduced_in": "example introduced in layer 2",
-                "layer": "sha256:sha256:572866ab72a68759e23b071fbbdce6341137c9606936b4fff9846f74997bbaaa",
-                "src": "var/lib/dpkg/status",
-                "version_format": "dpkg"
-            },
-            "fixInfo": {
-                "fix_available": 1,
-                "fixed_version": "2.2.0-11+deb9u4"
-            },
-            "imageId": "sha256:a65572164cb78c4d04f57bd66201c775e2dab08fce394806a03a933c5daf9e48",
-            "severity": "Medium",
-            "startTime": "2022-11-21T18:33:28.076Z",
-            "status": "VULNERABLE",
-            "vulnId": "CVE-2029-21234"
+        "integration_props": {
+          "INTG_GUID": "TECHALLY_FC5485B5ACFF3DAFE77E8C8A734C6C2FAD7CAAC9F01313C",
+          "NAME": "Terraform-Dockerhub",
+          "REGISTRY_TYPE": "DOCKERHUB"
+        },
+        "is_reeval": false,
+        "request_source": "PLATFORM_SCANNER",
+        "scan_batch_id": "467a274c-f847-456b-b62d-13f9d88988cc-1669055607923432004",
+        "scan_request_props": {
+          "data_format_version": "1.0",
+          "props": {
+            "data_format_version": "1.0",
+            "scanner_version": "10.0.155"
+          },
+          "reqId": "2ac494a9-b7be-453a-81b9-7a2f1f9e2113",
+          "reqSource": "ondemand",
+          "scanCompletionUtcTime": 1669055607,
+          "scan_start_time": 1669055600,
+          "scanner_version": "10.0.155"
+        },
+        "vuln_batch_id": "7B2EDDD2D2D140ECA6B85001FC62AE45",
+        "vuln_created_time": "2022-11-21 00:21:41.678000000"
+      },
+      "evalGuid": "781865fdff984def2587b5f05065f0db",
+      "featureKey": {
+        "name": "example-1",
+        "namespace": "debian:9",
+        "version": "1.0.0"
+      },
+      "featureProps": {
+        "feed": "lacework",
+        "introduced_in": "example introduced in layer 1",
+        "layer": "sha256:sha256:572866ab72a68759e23b071fbbdce6341137c9606936b4fff9846f74997bbaac",
+        "src": "var/lib/dpkg/status",
+        "version_format": "dpkg"
+      },
+      "fixInfo": {
+        "fix_available": 1,
+        "fixed_version": "2.2.0-11+deb9u4"
+      },
+      "imageId": "sha256:a65572164cb78c4d04f57bd66201c775e2dab08fce394806a03a933c5daf9e48",
+      "riskInfo": {
+        "factors": [
+          "cve",
+          "reachability",
+          "activeExploits",
+          "knownExploits"
+        ],
+        "factors_breakdown": {
+          "active_containers": 0,
+          "cve_counts": {
+            "Critical": 2,
+            "High": 13,
+            "Medium": 14,
+            "Other": 20
+          },
+          "exploit_summary": {
+            "disclosure_in_wild": "Yes",
+            "exploit_public": "Yes",
+            "exploit_virus_malware": "No",
+            "exploit_wormified": "No"
+          },
+          "internet_reachability": "Unknown"
         }
-
-]
+      },
+      "severity": "Medium",
+      "startTime": "2022-11-21T18:33:28.076Z",
+      "status": "VULNERABLE",
+      "vulnId": "CVE-2029-21234"
+    },
+    {
+      "evalCtx": {
+        "cve_batch_info": [
+          {
+            "cve_created_time": "2022-11-21 00:21:41.678000000"
+          }
+        ],
+        "exception_props": [
+          {
+            "exception_guid": "VULN_C44BF2CBE09F0E705565BEA1A0C1D2A5D1534857F2C7CDF8381",
+            "exception_name": "registry index.docker.io severity Low",
+            "exception_reason": "Accepted Risk"
+          }
+        ],
+        "image_info": {
+          "created_time": 1605140985874,
+          "digest": "sha256:77b2d2246518044ef95e3dbd029e51dd477788e5bf8e278e418685aabc3fe28a",
+          "id": "sha256:a65572164cb78c4d04f57bd66201c775e2dab08fce394806a03a933c5daf9e48",
+          "registry": "index.docker.io",
+          "repo": "techally-test/test-cli",
+          "scan_created_time": 1669055600,
+          "size": 360608563,
+          "status": "Success",
+          "tags": [
+            "latest"
+          ],
+          "type": "Docker"
+        },
+        "integration_props": {
+          "INTG_GUID": "TECHALLY_FC5485B5ACFF3DAFE77E8C8A734C6C2FAD7CAAC9F01313C",
+          "NAME": "Terraform-Dockerhub",
+          "REGISTRY_TYPE": "DOCKERHUB"
+        },
+        "is_reeval": false,
+        "request_source": "PLATFORM_SCANNER",
+        "scan_batch_id": "467a274c-f847-456b-b62d-13f9d88988cc-1669055607923432004",
+        "scan_request_props": {
+          "data_format_version": "1.0",
+          "props": {
+            "data_format_version": "1.0",
+            "scanner_version": "10.0.155"
+          },
+          "reqId": "2ac494a9-b7be-453a-81b9-7a2f1f9e2113",
+          "reqSource": "ondemand",
+          "scanCompletionUtcTime": 1669055607,
+          "scan_start_time": 1669055600,
+          "scanner_version": "10.0.155"
+        },
+        "vuln_batch_id": "7B2EDDD2D2D140ECA6B85001FC62AE45",
+        "vuln_created_time": "2022-11-21 00:21:41.678000000"
+      },
+      "evalGuid": "781865fdff984def2587b5f05065f0db",
+      "featureKey": {
+        "name": "example-1",
+        "namespace": "debian:9",
+        "version": "1.0.0"
+      },
+      "featureProps": {
+        "feed": "lacework",
+        "introduced_in": "example introduced in layer 2",
+        "layer": "sha256:sha256:572866ab72a68759e23b071fbbdce6341137c9606936b4fff9846f74997bbaaa",
+        "src": "var/lib/dpkg/status",
+        "version_format": "dpkg"
+      },
+      "fixInfo": {
+        "fix_available": 1,
+        "fixed_version": "2.2.0-11+deb9u4"
+      },
+      "imageId": "sha256:a65572164cb78c4d04f57bd66201c775e2dab08fce394806a03a933c5daf9e48",
+      "riskInfo": {
+        "factors": [
+          "cve",
+          "reachability",
+          "activeExploits",
+          "knownExploits"
+        ],
+        "factors_breakdown": {
+          "active_containers": 0,
+          "cve_counts": {
+            "Critical": 2,
+            "High": 13,
+            "Medium": 14,
+            "Other": 20
+          },
+          "exploit_summary": {
+            "disclosure_in_wild": "Yes",
+            "exploit_public": "Yes",
+            "exploit_virus_malware": "No",
+            "exploit_wormified": "No"
+          },
+          "internet_reachability": "Unknown"
+        }
+      },
+      "severity": "Medium",
+      "startTime": "2022-11-21T18:33:28.076Z",
+      "status": "VULNERABLE",
+      "vulnId": "CVE-2029-21234"
+    }
+  ]
 }`

--- a/cli/cmd/vulnerability_test.go
+++ b/cli/cmd/vulnerability_test.go
@@ -45,7 +45,7 @@ func TestOutputContainerVulnerabilityAssessmentNoVulnerabilities(t *testing.T) {
 		})
 		expectedJSON := `[]
 `
-		assert.Equal(t, expectedJSON, cliJSONOutput)
+		assert.JSONEq(t, expectedJSON, cliJSONOutput)
 	})
 }
 
@@ -294,6 +294,30 @@ func TestOutputContainerVulnerabilityAssessmentWithSingleCveFilterJson(t *testin
       "fixed_version": "1.20.00-r0"
     },
     "imageId": "sha256:123d67f5861237689554fa4a2121441e1230dbab9416fccd7d675cfb34476abcd",
+    "riskInfo": {
+      "factors": [
+        "cve",
+		"reachability",
+		"activeExploits",
+		"knownExploits"
+	  ],
+	  "factors_breakdown": {
+	    "active_containers": 0,
+		"cve_counts": {
+		  "Critical": 2,
+		  "High": 13,
+		  "Medium": 14,
+		  "Other": 20
+		},
+		"exploit_summary": {
+		  "disclosure_in_wild": "Yes",
+		  "exploit_public": "Yes",
+		  "exploit_virus_malware": "No",
+		  "exploit_wormified": "No"
+		},
+	    "internet_reachability": "Unknown"
+	  }
+    },
     "severity": "Medium",
     "startTime": "2022-11-14T00:20:57.367Z",
     "status": "VULNERABLE",
@@ -301,7 +325,7 @@ func TestOutputContainerVulnerabilityAssessmentWithSingleCveFilterJson(t *testin
   }
 ]`
 	out := strings.TrimSpace(cliOutput)
-	assert.Equal(t, expectedJson, out)
+	assert.JSONEq(t, expectedJson, out)
 }
 
 func TestOutputContainerVulnerabilityAssessmentWithVulnerabilitiesWithoutCritical(t *testing.T) {
@@ -416,6 +440,30 @@ func TestOutputContainerVulnerabilityAssessmentWithVulnerabilitiesPackagesViewWi
       "fixed_version": "1.20.00-r0"
     },
     "imageId": "sha256:123d67f5861237689554fa4a2121441e1230dbab9416fccd7d675cfb34476abcd",
+    "riskInfo": {
+      "factors": [
+        "cve",
+		"reachability",
+		"activeExploits",
+		"knownExploits"
+	  ],
+	  "factors_breakdown": {
+	    "active_containers": 0,
+		"cve_counts": {
+		  "Critical": 2,
+		  "High": 13,
+		  "Medium": 14,
+		  "Other": 20
+		},
+		"exploit_summary": {
+		  "disclosure_in_wild": "Yes",
+		  "exploit_public": "Yes",
+		  "exploit_virus_malware": "No",
+		  "exploit_wormified": "No"
+		},
+	    "internet_reachability": "Unknown"
+	  }
+    },
     "severity": "Critical",
     "startTime": "2022-11-14T00:20:57.367Z",
     "status": "VULNERABLE",
@@ -423,7 +471,7 @@ func TestOutputContainerVulnerabilityAssessmentWithVulnerabilitiesPackagesViewWi
   }
 ]
 `
-		assert.Equal(t, expectedJSON, cliJSONOutput)
+		assert.JSONEq(t, expectedJSON, cliJSONOutput)
 	})
 }
 func mockVulnerabilityAssessmentWithoutCriticalSeverity() api.VulnerabilitiesContainersResponse {
@@ -509,137 +557,185 @@ func mockVulnerabilityAssessmentWithoutCriticalSeverity() api.VulnerabilitiesCon
 func mockVulnerabilityAssessment() api.VulnerabilitiesContainersResponse {
 	var assessment api.VulnerabilitiesContainersResponse
 	err := json.Unmarshal([]byte(`{
-    "paging": {
-        "rows": 1,
-        "totalRows": 1,
-        "urls": {
-            "nextPage": null
-        }
-    },
-    "data": [
-        {
-            "evalCtx": {
-                "cve_batch_info": [
-                    {
-                        "cve_created_time": "2022-11-14 00:07:45.736000000"
-                    }
-                ],
-                "image_info": {
-                    "created_time": 1588285120631,
-                    "digest": "sha256:1234ab1cd12345ab91d8cf9848682b12c5ce64c208e8f796542410d1abcderg",
-                    "id": "sha256:123d12a1238613e123456ab1c1141441e6850dbab1416abcd7d675cfb34412abc",
-                    "registry": "gcr.io",
-                    "repo": "techally-test-123/test",
-                    "scan_created_time": 1636768865,
-                    "size": 20853835,
-                    "status": "Success",
-                    "tags": [
-                        "v0.1.0-00-abc"
-                    ],
-                    "type": "Docker"
-                },
-                "integration_props": {},
-                "is_reeval": true,
-                "request_source": "PLATFORM_SCANNER",
-                "scan_batch_id": "a1234546-a6a3-4509-a1e9-123283a1020e-1636768866551654123",
-                "scan_request_props": {
-                    "data_format_version": "1.0",
-                    "props": {
-                        "data_format_version": "1.0",
-                        "scanner_version": "0.1.0"
-                    },
-                    "scanCompletionUtcTime": 1636768866,
-                    "scan_start_time": 1636768865,
-                    "scanner_version": "0.2.2"
-                },
-                "vuln_batch_id": "ABCD1A1234AB123A1AB12AB1BD867B123",
-                "vuln_created_time": "2022-11-14 00:07:45.736000000"
-            },
-            "evalGuid": "0a1234567891a1230f2a12a0a12b12ab",
-            "featureKey": {
-                "name": "example",
-                "namespace": "alpine:test",
-                "version": "1.00.0-r1"
-            },
-            "featureProps": {
-                "feed": "lacework",
-                "introduced_in": "example",
-                "layer": "sha256:sha256:1234d8c89e19b4b4abcdd4af13d64150ba3d482445d820ae1f6ba71ed6812345",
-                "src": "",
-                "version_format": "apk"
-            },
-            "fixInfo": {
-                "fix_available": 1,
-                "fixed_version": "1.20.00-r0"
-            },
-            "imageId": "sha256:123d67f5861237689554fa4a2121441e1230dbab9416fccd7d675cfb34476abcd",
-            "severity": "Medium",
-            "startTime": "2022-11-14T00:20:57.367Z",
-            "status": "VULNERABLE",
-            "vulnId": "CVE-2021-24215"
+  "paging": {
+    "rows": 1,
+    "totalRows": 1,
+    "urls": {
+      "nextPage": null
+    }
+  },
+  "data": [
+    {
+      "evalCtx": {
+        "cve_batch_info": [
+          {
+            "cve_created_time": "2022-11-14 00:07:45.736000000"
+          }
+        ],
+        "image_info": {
+          "created_time": 1588285120631,
+          "digest": "sha256:1234ab1cd12345ab91d8cf9848682b12c5ce64c208e8f796542410d1abcderg",
+          "id": "sha256:123d12a1238613e123456ab1c1141441e6850dbab1416abcd7d675cfb34412abc",
+          "registry": "gcr.io",
+          "repo": "techally-test-123/test",
+          "scan_created_time": 1636768865,
+          "size": 20853835,
+          "status": "Success",
+          "tags": [
+            "v0.1.0-00-abc"
+          ],
+          "type": "Docker"
         },
-        {
-            "evalCtx": {
-                "cve_batch_info": [
-                    {
-                        "cve_created_time": "2022-11-14 00:07:45.736000000"
-                    }
-                ],
-                "image_info": {
-                    "created_time": 1588285120631,
-                    "digest": "sha256:1234ab1cd12345ab91d8cf9848682b12c5ce64c208e8f796542410d1abcderg",
-                    "id": "sha256:123d12a1238613e123456ab1c1141441e6850dbab1416abcd7d675cfb34412abc",
-                    "registry": "gcr.io",
-                    "repo": "techally-test-123/test",
-                    "scan_created_time": 1636768865,
-                    "size": 20853835,
-                    "status": "Success",
-                    "tags": [
-                        "v0.1.0-00-abc"
-                    ],
-                    "type": "Docker"
-                },
-                "integration_props": {},
-                "is_reeval": true,
-                "request_source": "PLATFORM_SCANNER",
-                "scan_batch_id": "a1234546-a6a3-4509-a1e9-123283a1020e-1636768866551654123",
-                "scan_request_props": {
-                    "data_format_version": "1.0",
-                    "props": {
-                        "data_format_version": "1.0",
-                        "scanner_version": "0.1.0"
-                    },
-                    "scanCompletionUtcTime": 1636768866,
-                    "scan_start_time": 1636768865,
-                    "scanner_version": "0.2.2"
-                },
-                "vuln_batch_id": "ABCD1A1234AB123A1AB12AB1BD867B123",
-                "vuln_created_time": "2022-11-14 00:07:45.736000000"
-            },
-            "evalGuid": "0a1234567891a1230f2a12a0a12b12ab",
-            "featureKey": {
-                "name": "example-2",
-                "namespace": "alpine:test",
-                "version": "1.00.0-r1"
-            },
-            "featureProps": {
-                "feed": "lacework",
-                "introduced_in": "example introduced",
-                "layer": "sha256:sha256:1234d8c89e19b4b4abcdd4af13d64150ba3d482445d820ae1f6ba71ed6812345",
-                "src": "",
-                "version_format": "apk"
-            },
-            "fixInfo": {
-                "fix_available": 1,
-                "fixed_version": "1.20.00-r0"
-            },
-            "imageId": "sha256:123d67f5861237689554fa4a2121441e1230dbab9416fccd7d675cfb34476abcd",
-            "severity": "Critical",
-            "startTime": "2022-11-14T00:20:57.367Z",
-            "status": "VULNERABLE",
-            "vulnId": "CVE-2020-24215"
+        "integration_props": {},
+        "is_reeval": true,
+        "request_source": "PLATFORM_SCANNER",
+        "scan_batch_id": "a1234546-a6a3-4509-a1e9-123283a1020e-1636768866551654123",
+        "scan_request_props": {
+          "data_format_version": "1.0",
+          "props": {
+            "data_format_version": "1.0",
+            "scanner_version": "0.1.0"
+          },
+          "scanCompletionUtcTime": 1636768866,
+          "scan_start_time": 1636768865,
+          "scanner_version": "0.2.2"
+        },
+        "vuln_batch_id": "ABCD1A1234AB123A1AB12AB1BD867B123",
+        "vuln_created_time": "2022-11-14 00:07:45.736000000"
+      },
+      "evalGuid": "0a1234567891a1230f2a12a0a12b12ab",
+      "featureKey": {
+        "name": "example",
+        "namespace": "alpine:test",
+        "version": "1.00.0-r1"
+      },
+      "featureProps": {
+        "feed": "lacework",
+        "introduced_in": "example",
+        "layer": "sha256:sha256:1234d8c89e19b4b4abcdd4af13d64150ba3d482445d820ae1f6ba71ed6812345",
+        "src": "",
+        "version_format": "apk"
+      },
+      "fixInfo": {
+        "fix_available": 1,
+        "fixed_version": "1.20.00-r0"
+      },
+      "riskInfo": {
+        "factors": [
+          "cve",
+          "reachability",
+          "activeExploits",
+          "knownExploits"
+        ],
+        "factors_breakdown": {
+          "active_containers": 0,
+          "cve_counts": {
+            "Critical": 2,
+            "High": 13,
+            "Medium": 14,
+            "Other": 20
+          },
+          "exploit_summary": {
+            "disclosure_in_wild": "Yes",
+            "exploit_public": "Yes",
+            "exploit_virus_malware": "No",
+            "exploit_wormified": "No"
+          },
+          "internet_reachability": "Unknown"
         }
-    ]
+      },
+      "imageId": "sha256:123d67f5861237689554fa4a2121441e1230dbab9416fccd7d675cfb34476abcd",
+      "severity": "Medium",
+      "startTime": "2022-11-14T00:20:57.367Z",
+      "status": "VULNERABLE",
+      "vulnId": "CVE-2021-24215"
+    },
+    {
+      "evalCtx": {
+        "cve_batch_info": [
+          {
+            "cve_created_time": "2022-11-14 00:07:45.736000000"
+          }
+        ],
+        "image_info": {
+          "created_time": 1588285120631,
+          "digest": "sha256:1234ab1cd12345ab91d8cf9848682b12c5ce64c208e8f796542410d1abcderg",
+          "id": "sha256:123d12a1238613e123456ab1c1141441e6850dbab1416abcd7d675cfb34412abc",
+          "registry": "gcr.io",
+          "repo": "techally-test-123/test",
+          "scan_created_time": 1636768865,
+          "size": 20853835,
+          "status": "Success",
+          "tags": [
+            "v0.1.0-00-abc"
+          ],
+          "type": "Docker"
+        },
+        "integration_props": {},
+        "is_reeval": true,
+        "request_source": "PLATFORM_SCANNER",
+        "scan_batch_id": "a1234546-a6a3-4509-a1e9-123283a1020e-1636768866551654123",
+        "scan_request_props": {
+          "data_format_version": "1.0",
+          "props": {
+            "data_format_version": "1.0",
+            "scanner_version": "0.1.0"
+          },
+          "scanCompletionUtcTime": 1636768866,
+          "scan_start_time": 1636768865,
+          "scanner_version": "0.2.2"
+        },
+        "vuln_batch_id": "ABCD1A1234AB123A1AB12AB1BD867B123",
+        "vuln_created_time": "2022-11-14 00:07:45.736000000"
+      },
+      "evalGuid": "0a1234567891a1230f2a12a0a12b12ab",
+      "featureKey": {
+        "name": "example-2",
+        "namespace": "alpine:test",
+        "version": "1.00.0-r1"
+      },
+      "featureProps": {
+        "feed": "lacework",
+        "introduced_in": "example introduced",
+        "layer": "sha256:sha256:1234d8c89e19b4b4abcdd4af13d64150ba3d482445d820ae1f6ba71ed6812345",
+        "src": "",
+        "version_format": "apk"
+      },
+      "fixInfo": {
+        "fix_available": 1,
+        "fixed_version": "1.20.00-r0"
+      },
+      "imageId": "sha256:123d67f5861237689554fa4a2121441e1230dbab9416fccd7d675cfb34476abcd",
+      "riskInfo": {
+        "factors": [
+          "cve",
+          "reachability",
+          "activeExploits",
+          "knownExploits"
+        ],
+        "factors_breakdown": {
+          "active_containers": 0,
+          "cve_counts": {
+            "Critical": 2,
+            "High": 13,
+            "Medium": 14,
+            "Other": 20
+          },
+          "exploit_summary": {
+            "disclosure_in_wild": "Yes",
+            "exploit_public": "Yes",
+            "exploit_virus_malware": "No",
+            "exploit_wormified": "No"
+          },
+          "internet_reachability": "Unknown"
+        }
+      },
+      "severity": "Critical",
+      "startTime": "2022-11-14T00:20:57.367Z",
+      "status": "VULNERABLE",
+      "vulnId": "CVE-2020-24215"
+    }
+  ]
 }`), &assessment)
 	if err != nil {
 		log.Fatal(err)
@@ -714,6 +810,30 @@ func mockVulnerabilityAssessmentSameCves() api.VulnerabilitiesContainersResponse
                 "fixed_version": "1.20.00-r0"
             },
             "imageId": "sha256:123d67f5861237689554fa4a2121441e1230dbab9416fccd7d675cfb34476abcd",
+			"riskInfo": {
+				"factors": [
+					"cve",
+					"reachability",
+					"activeExploits",
+					"knownExploits"
+				],
+				"factors_breakdown": {
+					"active_containers": 0,
+					"cve_counts": {
+						"Critical": 2,
+						"High": 13,
+						"Medium": 14,
+						"Other": 20
+					},
+					"exploit_summary": {
+						"disclosure_in_wild": "Yes",
+						"exploit_public": "Yes",
+						"exploit_virus_malware": "No",
+						"exploit_wormified": "No"
+					},
+					"internet_reachability": "Unknown"
+				}
+			},
             "severity": "Medium",
             "startTime": "2022-11-14T00:20:57.367Z",
             "status": "VULNERABLE",
@@ -775,6 +895,30 @@ func mockVulnerabilityAssessmentSameCves() api.VulnerabilitiesContainersResponse
                 "fixed_version": "1.20.00-r0"
             },
             "imageId": "sha256:123d67f5861237689554fa4a2121441e1230dbab9416fccd7d675cfb34476abcd",
+			"riskInfo": {
+				"factors": [
+					"cve",
+					"reachability",
+					"activeExploits",
+					"knownExploits"
+				],
+				"factors_breakdown": {
+					"active_containers": 0,
+					"cve_counts": {
+						"Critical": 2,
+						"High": 13,
+						"Medium": 14,
+						"Other": 20
+					},
+					"exploit_summary": {
+						"disclosure_in_wild": "Yes",
+						"exploit_public": "Yes",
+						"exploit_virus_malware": "No",
+						"exploit_wormified": "No"
+					},
+					"internet_reachability": "Unknown"
+				}
+			},
             "severity": "Critical",
             "startTime": "2022-11-14T00:20:57.367Z",
             "status": "VULNERABLE",


### PR DESCRIPTION
## Summary

The client did not have the information related to active_containers and I needed that information 😄 

## How did you test this change?

Added the missing struct for RiskInfo and updated the tests JSON.

## Issue

No Issue. New feature.
