### PR TITLE
feat(GROW-2908): lwgenerate enable custom root terraform blocks and provider arguments

### DIFF
--- a/lwgenerate/aws/aws.go
+++ b/lwgenerate/aws/aws.go
@@ -300,8 +300,11 @@ type GenerateAwsTfConfigurationArgs struct {
 	// Add custom blocks to the root `terraform{}` block. Can be used for advanced configuration. Things like backend, etc
 	ExtraBlocksRootTerraform []*hclwrite.Block
 
-	// ExtraProviderArguments  allows adding more arguments to the provider block as needed (custom use cases)
+	// ExtraProviderArguments allows adding more arguments to the provider block as needed (custom use cases)
 	ExtraProviderArguments map[string]interface{}
+
+	// ExtraBlocks allows adding more hclwrite.Block to the root terraform document (advanced use cases)
+	ExtraBlocks []*hclwrite.Block
 }
 
 func (args *GenerateAwsTfConfigurationArgs) IsEmpty() bool {
@@ -754,6 +757,13 @@ func WithExtraProviderArguments(arguments map[string]interface{}) AwsTerraformMo
 	}
 }
 
+// WithExtraBlocks enables adding additional arbitrary blocks to the root hcl document
+func WithExtraBlocks(blocks []*hclwrite.Block) AwsTerraformModifier {
+	return func(c *GenerateAwsTfConfigurationArgs) {
+		c.ExtraBlocks = blocks
+	}
+}
+
 // Generate new Terraform code based on the supplied args.
 func (args *GenerateAwsTfConfigurationArgs) Generate() (string, error) {
 	// Validate inputs
@@ -810,7 +820,9 @@ func (args *GenerateAwsTfConfigurationArgs) Generate() (string, error) {
 			configModule,
 			cloudTrailModule,
 			agentlessModule,
-			outputBlocks),
+			outputBlocks,
+			args.ExtraBlocks,
+		),
 	)
 	return hclBlocks, nil
 }

--- a/lwgenerate/aws/aws_test.go
+++ b/lwgenerate/aws/aws_test.go
@@ -102,6 +102,14 @@ func TestGenerationConfigWithCustomBackendBlock(t *testing.T) {
 	assert.Equal(t, requiredProvidersWithCustomBlock+"\n"+awsProvider+"\n"+moduleImportConfig, hcl)
 }
 
+func TestGenerationConfigWithCustomProviderAttributes(t *testing.T) {
+	hcl, err := NewTerraform(false, false, true, false, WithAwsRegion("us-east-2"),
+		WithExtraProviderArguments(map[string]interface{}{"foo": "bar"})).Generate()
+	assert.Nil(t, err)
+	assert.NotNil(t, hcl)
+	assert.Equal(t, requiredProviders+"\n"+awsProviderExtraArguments+"\n"+moduleImportConfig, hcl)
+}
+
 func TestGenerationConfigWithOutputs(t *testing.T) {
 	hcl, err := NewTerraform(
 		false, false, true, false, WithAwsRegion("us-east-2"),
@@ -420,6 +428,12 @@ var requiredProviders = `terraform {
       version = "~> 1.0"
     }
   }
+}
+`
+var awsProviderExtraArguments = `provider "aws" {
+  alias  = "main"
+  foo    = "bar"
+  region = "us-east-2"
 }
 `
 

--- a/lwgenerate/aws/aws_test.go
+++ b/lwgenerate/aws/aws_test.go
@@ -92,6 +92,17 @@ func TestGenerationConfig(t *testing.T) {
 	assert.Equal(t, reqProviderAndRegion(moduleImportConfig), hcl)
 }
 
+func TestGenerationConfigWithExtraBlocks(t *testing.T) {
+	extraBlock, err := lwgenerate.HclCreateGenericBlock("variable", []string{"var_name"}, nil)
+	assert.NoError(t, err)
+
+	hcl, err := NewTerraform(false, false, true, false,
+		WithAwsRegion("us-east-2"), WithExtraBlocks([]*hclwrite.Block{extraBlock})).Generate()
+	assert.Nil(t, err)
+	assert.NotNil(t, hcl)
+	assert.Equal(t, requiredProviders+"\n"+awsProvider+"\n"+moduleImportConfig+"\n"+testVariable, hcl)
+}
+
 func TestGenerationConfigWithCustomBackendBlock(t *testing.T) {
 	customBlock, err := lwgenerate.HclCreateGenericBlock("backend", []string{"s3"}, nil)
 	assert.NoError(t, err)
@@ -861,5 +872,9 @@ var moduleImportCtWithS3BucketNotification = `module "main_cloudtrail" {
   providers = {
     aws = aws.main
   }
+}
+`
+
+var testVariable = `variable "var_name" {
 }
 `

--- a/lwgenerate/hcl_test.go
+++ b/lwgenerate/hcl_test.go
@@ -149,6 +149,22 @@ func TestRequiredProvidersBlock(t *testing.T) {
 	assert.Equal(t, testRequiredProvider, lwgenerate.CreateHclStringOutput([]*hclwrite.Block{data}))
 }
 
+func TestRequiredProvidersBlockWithCustomBlocks(t *testing.T) {
+	provider1 := lwgenerate.NewRequiredProvider("foo",
+		lwgenerate.HclRequiredProviderWithSource("test/test"))
+	provider2 := lwgenerate.NewRequiredProvider("bar",
+		lwgenerate.HclRequiredProviderWithVersion("~> 0.1"))
+	provider3 := lwgenerate.NewRequiredProvider("lacework",
+		lwgenerate.HclRequiredProviderWithSource("lacework/lacework"),
+		lwgenerate.HclRequiredProviderWithVersion("~> 0.1"))
+
+	customBlock, err := lwgenerate.HclCreateGenericBlock("backend", []string{"s3"}, nil)
+	assert.NoError(t, err)
+	data, err := lwgenerate.CreateRequiredProvidersWithCustomBlocks([]*hclwrite.Block{customBlock}, provider1, provider2, provider3)
+	assert.Nil(t, err)
+	assert.Equal(t, testRequiredProviderWithCustomBlocks, lwgenerate.CreateHclStringOutput([]*hclwrite.Block{data}))
+}
+
 func TestModuleBlockWithComplexAttributes(t *testing.T) {
 	data, err := lwgenerate.NewModule("foo",
 		"mycorp/mycloud",
@@ -191,6 +207,24 @@ func TestOutputBlockCreation(t *testing.T) {
 		assert.Equal(t, "output \"test\" {\n  description = \"test description\"\n  value       = test.one.two\n}\n", str)
 	})
 }
+
+var testRequiredProviderWithCustomBlocks = `terraform {
+  required_providers {
+    bar = {
+      version = "~> 0.1"
+    }
+    foo = {
+      source = "test/test"
+    }
+    lacework = {
+      source  = "lacework/lacework"
+      version = "~> 0.1"
+    }
+  }
+  backend "s3" {
+  }
+}
+`
 
 var testRequiredProvider = `terraform {
   required_providers {


### PR DESCRIPTION
## Summary
Enable some advanced use cases for AWS lwgenerate that require adding custom hclwrite blocks to the root terraform block, the base hcl document, as well as being able to set provider arguments.

## How did you test this change?

See unit tests.

## Issue

https://lacework.atlassian.net/browse/GROW-2908