### PR TITLE
feat(GROW-2819): enable custom blocks with azure generate

### DIFF
--- a/lwgenerate/azure/azure_test.go
+++ b/lwgenerate/azure/azure_test.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/lacework/go-sdk/lwgenerate"
 	"github.com/lacework/go-sdk/lwgenerate/azure"
 	"github.com/stretchr/testify/assert"
 )
@@ -30,6 +32,38 @@ func TestGenerationActivityLogWithConfig(t *testing.T) {
 	var ActivityLogWithConfig, fileErr = getFileContent("test-data/activity_log_with_config.tf")
 	assert.Nil(t, fileErr)
 	hcl, err := azure.NewTerraform(true, true, true).Generate()
+	assert.Nil(t, err)
+	assert.NotNil(t, hcl)
+	assert.Equal(t, ActivityLogWithConfig, hcl)
+
+}
+
+func TestGenerationActivityLogWithConfigAndExtraBlocks(t *testing.T) {
+	var ActivityLogWithConfig, fileErr = getFileContent("test-data/activity_log_with_config_extra.tf")
+	assert.Nil(t, fileErr)
+	extraBlock, err := lwgenerate.HclCreateGenericBlock("variable", []string{"var_name"}, nil)
+	assert.NoError(t, err)
+	hcl, err := azure.NewTerraform(true, true, true, azure.WithExtraBlocks([]*hclwrite.Block{extraBlock})).Generate()
+	assert.Nil(t, err)
+	assert.NotNil(t, hcl)
+	assert.Equal(t, ActivityLogWithConfig, hcl)
+}
+
+func TestGenerationActivityLogWithConfigAndExtraProviderBlocks(t *testing.T) {
+	var ActivityLogWithConfig, fileErr = getFileContent("test-data/activity_log_with_config_provider_args.tf")
+	assert.Nil(t, fileErr)
+	hcl, err := azure.NewTerraform(true, true, true, azure.WithExtraProviderArguments(map[string]interface{}{"foo": "bar"})).Generate()
+	assert.Nil(t, err)
+	assert.NotNil(t, hcl)
+	assert.Equal(t, ActivityLogWithConfig, hcl)
+}
+
+func TestGenerationActivityLogWithConfigAndCustomBackendBlock(t *testing.T) {
+	customBlock, err := lwgenerate.HclCreateGenericBlock("backend", []string{"s3"}, nil)
+	assert.NoError(t, err)
+	var ActivityLogWithConfig, fileErr = getFileContent("test-data/activity_log_with_config_root_blocks.tf")
+	assert.Nil(t, fileErr)
+	hcl, err := azure.NewTerraform(true, true, true, azure.WithExtraRootBlocks([]*hclwrite.Block{customBlock})).Generate()
 	assert.Nil(t, err)
 	assert.NotNil(t, hcl)
 	assert.Equal(t, ActivityLogWithConfig, hcl)

--- a/lwgenerate/azure/test-data/activity_log_with_config_extra.tf
+++ b/lwgenerate/azure/test-data/activity_log_with_config_extra.tf
@@ -1,0 +1,43 @@
+terraform {
+  required_providers {
+    lacework = {
+      source  = "lacework/lacework"
+      version = "~> 1.0"
+    }
+  }
+}
+
+provider "azuread" {
+}
+
+provider "azurerm" {
+  features {
+  }
+}
+
+module "az_ad_application" {
+  source  = "lacework/ad-application/azure"
+  version = "~> 1.0"
+}
+
+module "az_config" {
+  source                      = "lacework/config/azure"
+  version                     = "~> 2.0"
+  application_id              = module.az_ad_application.application_id
+  application_password        = module.az_ad_application.application_password
+  service_principal_id        = module.az_ad_application.service_principal_id
+  use_existing_ad_application = true
+}
+
+module "az_activity_log" {
+  source                            = "lacework/activity-log/azure"
+  version                           = "~> 2.0"
+  application_id                    = module.az_ad_application.application_id
+  application_password              = module.az_ad_application.application_password
+  infrastructure_encryption_enabled = true
+  service_principal_id              = module.az_ad_application.service_principal_id
+  use_existing_ad_application       = true
+}
+
+variable "var_name" {
+}

--- a/lwgenerate/azure/test-data/activity_log_with_config_provider_args.tf
+++ b/lwgenerate/azure/test-data/activity_log_with_config_provider_args.tf
@@ -1,0 +1,42 @@
+terraform {
+  required_providers {
+    lacework = {
+      source  = "lacework/lacework"
+      version = "~> 1.0"
+    }
+  }
+}
+
+provider "azuread" {
+  foo = "bar"
+}
+
+provider "azurerm" {
+  foo = "bar"
+  features {
+  }
+}
+
+module "az_ad_application" {
+  source  = "lacework/ad-application/azure"
+  version = "~> 1.0"
+}
+
+module "az_config" {
+  source                      = "lacework/config/azure"
+  version                     = "~> 2.0"
+  application_id              = module.az_ad_application.application_id
+  application_password        = module.az_ad_application.application_password
+  service_principal_id        = module.az_ad_application.service_principal_id
+  use_existing_ad_application = true
+}
+
+module "az_activity_log" {
+  source                            = "lacework/activity-log/azure"
+  version                           = "~> 2.0"
+  application_id                    = module.az_ad_application.application_id
+  application_password              = module.az_ad_application.application_password
+  infrastructure_encryption_enabled = true
+  service_principal_id              = module.az_ad_application.service_principal_id
+  use_existing_ad_application       = true
+}

--- a/lwgenerate/azure/test-data/activity_log_with_config_root_blocks.tf
+++ b/lwgenerate/azure/test-data/activity_log_with_config_root_blocks.tf
@@ -1,0 +1,42 @@
+terraform {
+  required_providers {
+    lacework = {
+      source  = "lacework/lacework"
+      version = "~> 1.0"
+    }
+  }
+  backend "s3" {
+  }
+}
+
+provider "azuread" {
+}
+
+provider "azurerm" {
+  features {
+  }
+}
+
+module "az_ad_application" {
+  source  = "lacework/ad-application/azure"
+  version = "~> 1.0"
+}
+
+module "az_config" {
+  source                      = "lacework/config/azure"
+  version                     = "~> 2.0"
+  application_id              = module.az_ad_application.application_id
+  application_password        = module.az_ad_application.application_password
+  service_principal_id        = module.az_ad_application.service_principal_id
+  use_existing_ad_application = true
+}
+
+module "az_activity_log" {
+  source                            = "lacework/activity-log/azure"
+  version                           = "~> 2.0"
+  application_id                    = module.az_ad_application.application_id
+  application_password              = module.az_ad_application.application_password
+  infrastructure_encryption_enabled = true
+  service_principal_id              = module.az_ad_application.service_principal_id
+  use_existing_ad_application       = true
+}


### PR DESCRIPTION
## Summary

Add ability to add root terraform blocks, top-level document blocks, as well as provider arguments to the lwgenerate package for Azure


## How did you test this change?

See unit tests; also was executed via examples.


## Issue

GROW-2919