### PR TITLE
fix(GROW-2819): lwgenerate split azuread and azurerm provider arguments

### DIFF
--- a/lwgenerate/azure/azure.go
+++ b/lwgenerate/azure/azure.go
@@ -64,8 +64,11 @@ type GenerateAzureTfConfigurationArgs struct {
 	// Add custom blocks to the root `terraform{}` block. Can be used for advanced configuration. Things like backend, etc
 	ExtraBlocksRootTerraform []*hclwrite.Block
 
-	// ExtraProviderArguments allows adding more arguments to the provider block as needed (custom use cases)
-	ExtraProviderArguments map[string]interface{}
+	// ExtraAZRMArguments allows adding more arguments to the provider block as needed (custom use cases)
+	ExtraAZRMArguments map[string]interface{}
+
+	// ExtraAZReadArguments allows adding more arguments to the provider block as needed (custom use cases)
+	ExtraAZReadArguments map[string]interface{}
 
 	// ExtraBlocks allows adding more hclwrite.Block to the root terraform document (advanced use cases)
 	ExtraBlocks []*hclwrite.Block
@@ -142,11 +145,19 @@ func WithExtraRootBlocks(blocks []*hclwrite.Block) AzureTerraformModifier {
 	}
 }
 
-// WithExtraProviderArguments enables adding additional arguments into the `aws` provider block
+// WithExtraAZRMArguments enables adding additional arguments into the `azurerm` provider block
 // this enables custom use cases
-func WithExtraProviderArguments(arguments map[string]interface{}) AzureTerraformModifier {
+func WithExtraAZRMArguments(arguments map[string]interface{}) AzureTerraformModifier {
 	return func(c *GenerateAzureTfConfigurationArgs) {
-		c.ExtraProviderArguments = arguments
+		c.ExtraAZRMArguments = arguments
+	}
+}
+
+// WithExtraAZReadArguments enables adding additional arguments into the `azuread` provider block
+// this enables custom use cases
+func WithExtraAZReadArguments(arguments map[string]interface{}) AzureTerraformModifier {
+	return func(c *GenerateAzureTfConfigurationArgs) {
+		c.ExtraAZReadArguments = arguments
 	}
 }
 
@@ -349,7 +360,7 @@ func createAzureADProvider(args *GenerateAzureTfConfigurationArgs) ([]*hclwrite.
 	attrs := map[string]interface{}{}
 
 	// set custom args before the required ones below to ensure expected behavior (i.e., no overrides)
-	for k, v := range args.ExtraProviderArguments {
+	for k, v := range args.ExtraAZReadArguments {
 		attrs[k] = v
 	}
 
@@ -379,7 +390,7 @@ func createAzureRMProvider(args *GenerateAzureTfConfigurationArgs) ([]*hclwrite.
 	featureAttrs := map[string]interface{}{}
 
 	// set custom args before the required ones below to ensure expected behavior (i.e., no overrides)
-	for k, v := range args.ExtraProviderArguments {
+	for k, v := range args.ExtraAZRMArguments {
 		attrs[k] = v
 	}
 

--- a/lwgenerate/azure/azure_test.go
+++ b/lwgenerate/azure/azure_test.go
@@ -49,10 +49,19 @@ func TestGenerationActivityLogWithConfigAndExtraBlocks(t *testing.T) {
 	assert.Equal(t, ActivityLogWithConfig, hcl)
 }
 
-func TestGenerationActivityLogWithConfigAndExtraProviderBlocks(t *testing.T) {
+func TestGenerationActivityLogWithConfigAndExtraAzureRMProviderBlocks(t *testing.T) {
 	var ActivityLogWithConfig, fileErr = getFileContent("test-data/activity_log_with_config_provider_args.tf")
 	assert.Nil(t, fileErr)
-	hcl, err := azure.NewTerraform(true, true, true, azure.WithExtraProviderArguments(map[string]interface{}{"foo": "bar"})).Generate()
+	hcl, err := azure.NewTerraform(true, true, true, azure.WithExtraAZRMArguments(map[string]interface{}{"foo": "bar"})).Generate()
+	assert.Nil(t, err)
+	assert.NotNil(t, hcl)
+	assert.Equal(t, ActivityLogWithConfig, hcl)
+}
+
+func TestGenerationActivityLogWithConfigAndExtraAZUReadProviderBlocks(t *testing.T) {
+	var ActivityLogWithConfig, fileErr = getFileContent("test-data/activity_log_with_config_azureadprovider_args.tf")
+	assert.Nil(t, fileErr)
+	hcl, err := azure.NewTerraform(true, true, true, azure.WithExtraAZReadArguments(map[string]interface{}{"foo": "bar"})).Generate()
 	assert.Nil(t, err)
 	assert.NotNil(t, hcl)
 	assert.Equal(t, ActivityLogWithConfig, hcl)

--- a/lwgenerate/azure/test-data/activity_log_with_config_azureadprovider_args.tf
+++ b/lwgenerate/azure/test-data/activity_log_with_config_azureadprovider_args.tf
@@ -8,10 +8,10 @@ terraform {
 }
 
 provider "azuread" {
+  foo = "bar"
 }
 
 provider "azurerm" {
-  foo = "bar"
   features {
   }
 }


### PR DESCRIPTION
## Summary

Split arguments sent to azuread and azurerm providers since they need to be different.

## How did you test this change?

Unit tests

## Issue

GROW-2819