### PR TITLE
feat: prosast component data upload

### DIFF
--- a/api/component_data.go
+++ b/api/component_data.go
@@ -17,8 +17,9 @@ type ComponentDataService struct {
 
 const URL_TYPE_DEFAULT = "Default"
 const URL_TYPE_SAST_TABLES = "SastTables"
+const URL_TYPE_PROSAST = "ProSast"
 
-var URL_TYPES = []string{URL_TYPE_DEFAULT, URL_TYPE_SAST_TABLES}
+var URL_TYPES = []string{URL_TYPE_DEFAULT, URL_TYPE_SAST_TABLES, URL_TYPE_PROSAST}
 
 type ComponentDataInitialRequest struct {
 	Name             string          `json:"name"`
@@ -68,6 +69,10 @@ func (svc *ComponentDataService) UploadFiles(
 func (svc *ComponentDataService) UploadSastTables(
 	name string, paths []string) (string, error) {
 	return svc.doUploadFiles(name, []string{"sast"}, paths, URL_TYPE_SAST_TABLES)
+}
+
+func (svc *ComponentDataService) UploadProSast(name string, paths []string) (string, error) {
+	return svc.doUploadFiles(name, []string{"sast"}, paths, URL_TYPE_PROSAST)
 }
 
 func (svc *ComponentDataService) doUploadFiles(

--- a/api/component_data_test.go
+++ b/api/component_data_test.go
@@ -102,6 +102,36 @@ func TestSastTablesUrlType(t *testing.T) {
 	assert.Equal(t, "SOME-GUID", guid)
 }
 
+func TestProSastUrlType(t *testing.T) {
+	fakeServer := lacework.MockServer()
+	fakeServer.MockToken("TOKEN")
+	defer fakeServer.Close()
+	fakeServer.MockAPI("ComponentData/requestUpload", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+		assert.NotNil(t, r.Body)
+		body := httpBodySniffer(r)
+		assert.Contains(t, body, api.URL_TYPE_PROSAST)
+		_, err := fmt.Fprint(w, generateInitialResponse())
+		assert.Nil(t, err)
+	})
+	fakeServer.MockAPI("ComponentData/completeUpload", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+		assert.NotNil(t, r.Body)
+		body := httpBodySniffer(r)
+		assert.Contains(t, body, api.URL_TYPE_PROSAST)
+		_, err := fmt.Fprint(w, generateCompleteResponse())
+		assert.Nil(t, err)
+	})
+	c, err := api.NewClient("test",
+		api.WithToken("TOKEN"),
+		api.WithURL(fakeServer.URL()),
+	)
+	assert.Nil(t, err)
+	guid, err := c.V2.ComponentData.UploadProSast("doc-set", []string{})
+	assert.Nil(t, err)
+	assert.Equal(t, "SOME-GUID", guid)
+}
+
 func TestDoWithExponentialBackoffAlwaysFailing(t *testing.T) {
 	waited := 0
 	err := api.DoWithExponentialBackoff(func() error {

--- a/integration/resource_groups_test.go
+++ b/integration/resource_groups_test.go
@@ -20,7 +20,6 @@ package integration
 import (
 	"encoding/json"
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/lacework/go-sdk/api"
@@ -169,16 +168,13 @@ func TestResourceGroupDelete(t *testing.T) {
 		case api.NoneResourceGroup, api.LwAccountResourceGroup:
 			// these resource groups are not applicable
 			continue
-		case api.OciResourceGroup, api.GcpResourceGroup:
-			// broken integration test
-			continue
 		default:
 			// skip lw_account
 			t.Run(i.String(), func(t *testing.T) {
 				// setup resource group
 				resourceGroupID, err := createResourceGroup(i.String())
-				if err != nil && !strings.Contains(err.Error(), "already exists in the account") {
-					assert.FailNow(t, err.Error())
+				if err != nil {
+					assert.FailNow(t, err.Error(), fmt.Sprintf("Manually delete resourceGroup CLI_TestCreateResourceGroup_%s", i.String()))
 				}
 
 				// delete resource group

--- a/integration/resource_groups_test.go
+++ b/integration/resource_groups_test.go
@@ -169,6 +169,9 @@ func TestResourceGroupDelete(t *testing.T) {
 		case api.NoneResourceGroup, api.LwAccountResourceGroup:
 			// these resource groups are not applicable
 			continue
+		case api.OciResourceGroup, api.GcpResourceGroup:
+			// broken integration test
+			continue
 		default:
 			// skip lw_account
 			t.Run(i.String(), func(t *testing.T) {


### PR DESCRIPTION
## Summary

ProSAST must upload with the `UrlType` of `ProSast`.

Improved resourceGroup integration test by telling user how to recover.

## How did you test this change?

Unit test

## Issue

https://lacework.atlassian.net/browse/COD-3355