### PR TITLE
feat(GROW-2949): Provide organization_id for project level agentless integration

### DIFF
--- a/cli/cdk/go/proto/v1/cdk.pb.go
+++ b/cli/cdk/go/proto/v1/cdk.pb.go
@@ -25,11 +25,12 @@
 package cdk
 
 import (
+	reflect "reflect"
+	sync "sync"
+
 	timestamp "github.com/golang/protobuf/ptypes/timestamp"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
-	reflect "reflect"
-	sync "sync"
 )
 
 const (

--- a/cli/cdk/go/proto/v1/cdk_grpc.pb.go
+++ b/cli/cdk/go/proto/v1/cdk_grpc.pb.go
@@ -8,6 +8,7 @@ package cdk
 
 import (
 	context "context"
+
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"

--- a/cli/cmd/generate_gcp.go
+++ b/cli/cmd/generate_gcp.go
@@ -315,7 +315,7 @@ func initGenerateGcpTfCommandFlags() {
 		&GenerateGcpCommandState.GcpOrganizationId,
 		"organization_id",
 		"",
-		"specify the organization id (only set if organization_integration is set)")
+		"specify the organization id (only set if agentless integration or organization_integration is set)")
 	generateGcpTfCommand.PersistentFlags().StringVar(
 		&GenerateGcpCommandState.GcpProjectId,
 		"project_id",
@@ -736,9 +736,17 @@ func promptGcpGenerate(
 				Prompt:   &survey.Confirm{Message: QuestionGcpOrganizationIntegration, Default: config.OrganizationIntegration},
 				Response: &config.OrganizationIntegration,
 			},
+		}); err != nil {
+		return err
+	}
+
+	organizationIdRequired := config.Agentless || config.OrganizationIntegration
+
+	if err := SurveyMultipleQuestionWithValidation(
+		[]SurveyQuestionWithValidationArgs{
 			{
 				Prompt:   &survey.Input{Message: QuestionGcpOrganizationID, Default: config.GcpOrganizationId},
-				Checks:   []*bool{&config.OrganizationIntegration},
+				Checks:   []*bool{&organizationIdRequired},
 				Required: true,
 				Response: &config.GcpOrganizationId,
 			},

--- a/cli/docs/lacework_generate_cloud-account_gcp.md
+++ b/cli/docs/lacework_generate_cloud-account_gcp.md
@@ -58,7 +58,7 @@ lacework generate cloud-account gcp [flags]
   -h, --help                                          help for gcp
       --include_root_projects                         Disables logic that includes root-level projects if excluding folders (default true)
       --k8s_filter                                    filter out GKE logs from GCP Audit Log sinks (default true)
-      --organization_id string                        specify the organization id (only set if organization_integration is set)
+      --organization_id string                        specify the organization id (only set if agentless integration or organization_integration is set)
       --organization_integration                      enable organization integration
       --output string                                 location to write generated content (default is ~/lacework/gcp)
       --prefix string                                 prefix that will be used at the beginning of every generated resource

--- a/integration/test_resources/help/generate_cloud-account_gcp
+++ b/integration/test_resources/help/generate_cloud-account_gcp
@@ -37,7 +37,7 @@ Flags:
   -h, --help                                          help for gcp
       --include_root_projects                         Disables logic that includes root-level projects if excluding folders (default true)
       --k8s_filter                                    filter out GKE logs from GCP Audit Log sinks (default true)
-      --organization_id string                        specify the organization id (only set if organization_integration is set)
+      --organization_id string                        specify the organization id (only set if agentless integration or organization_integration is set)
       --organization_integration                      enable organization integration
       --output string                                 location to write generated content (default is ~/lacework/gcp)
       --prefix string                                 prefix that will be used at the beginning of every generated resource

--- a/lwgenerate/gcp/gcp.go
+++ b/lwgenerate/gcp/gcp.go
@@ -141,10 +141,6 @@ type GenerateGcpTfConfigurationArgs struct {
 
 	Projects []string
 
-	// GCP organization id for agentless integration. Agentless integration requires an organization id
-	// even for project level integration
-	AgentlessOrganizationId string
-
 	// Default GCP Provider labels
 	ProviderDefaultLabels map[string]interface{}
 
@@ -175,11 +171,6 @@ func (args *GenerateGcpTfConfigurationArgs) validate() error {
 	// Validate if this is an organization integration, verify that the organization id has been provided
 	if args.OrganizationIntegration && args.GcpOrganizationId == "" {
 		return errors.New("an Organization ID must be provided for an Organization Integration")
-	}
-
-	// Validate if an organization id has been provided that this is and organization integration
-	if !args.OrganizationIntegration && args.GcpOrganizationId != "" {
-		return errors.New("to provide an Organization ID, Organization Integration must be true")
 	}
 
 	// Validate existing Service Account values, if set
@@ -232,13 +223,6 @@ func NewTerraform(
 func WithUsePubSubAudit(usePubSub bool) GcpTerraformModifier {
 	return func(c *GenerateGcpTfConfigurationArgs) {
 		c.UsePubSubAudit = usePubSub
-	}
-}
-
-// WithAgentlessOrganizationId Set the agentless organization id for GCP provider
-func WithAgentlessOrganizationId(organizationId string) GcpTerraformModifier {
-	return func(c *GenerateGcpTfConfigurationArgs) {
-		c.AgentlessOrganizationId = organizationId
 	}
 }
 
@@ -642,9 +626,9 @@ func createAgentless(args *GenerateGcpTfConfigurationArgs) ([]*hclwrite.Block, e
 			}
 			if args.OrganizationIntegration {
 				attributes["integration_type"] = "ORGANIZATION"
+			}
+			if len(args.GcpOrganizationId) > 0 {
 				attributes["organization_id"] = args.GcpOrganizationId
-			} else if len(args.AgentlessOrganizationId) > 0 {
-				attributes["organization_id"] = args.AgentlessOrganizationId
 			}
 		}
 		if i > 0 {

--- a/lwgenerate/gcp/gcp.go
+++ b/lwgenerate/gcp/gcp.go
@@ -141,6 +141,10 @@ type GenerateGcpTfConfigurationArgs struct {
 
 	Projects []string
 
+	// GCP organization id for agentless integration. Agentless integration requires an organization id
+	// even for project level integration
+	AgentlessOrganizationId string
+
 	// Default GCP Provider labels
 	ProviderDefaultLabels map[string]interface{}
 
@@ -228,6 +232,13 @@ func NewTerraform(
 func WithUsePubSubAudit(usePubSub bool) GcpTerraformModifier {
 	return func(c *GenerateGcpTfConfigurationArgs) {
 		c.UsePubSubAudit = usePubSub
+	}
+}
+
+// WithAgentlessOrganizationId Set the agentless organization id for GCP provider
+func WithAgentlessOrganizationId(organizationId string) GcpTerraformModifier {
+	return func(c *GenerateGcpTfConfigurationArgs) {
+		c.AgentlessOrganizationId = organizationId
 	}
 }
 
@@ -632,6 +643,8 @@ func createAgentless(args *GenerateGcpTfConfigurationArgs) ([]*hclwrite.Block, e
 			if args.OrganizationIntegration {
 				attributes["integration_type"] = "ORGANIZATION"
 				attributes["organization_id"] = args.GcpOrganizationId
+			} else if len(args.AgentlessOrganizationId) > 0 {
+				attributes["organization_id"] = args.AgentlessOrganizationId
 			}
 		}
 		if i > 0 {

--- a/lwgenerate/gcp/gcp_test.go
+++ b/lwgenerate/gcp/gcp_test.go
@@ -45,6 +45,17 @@ func TestGenerateGcpTfConfigurationArgs_Generate_AuditLog(t *testing.T) {
 			ReqProvider(projectName, moduleImportProjectLevelPubSubAuditLogWithoutConfiguration),
 		},
 		{
+			"TestGenerationProjectLevelPubSubAuditLogWithoutConfigWithOrgId",
+			gcp.NewTerraform(
+				false,
+				false,
+				true,
+				true,
+				gcp.WithGcpServiceAccountCredentials("/path/to/credentials"),
+				gcp.WithProjectId(projectName), gcp.WithOrganizationId("123456789")),
+			ReqProvider(projectName, moduleImportProjectLevelPubSubAuditLogWithoutConfiguration),
+		},
+		{
 			"TestGenerationProjectLevelAuditLogWithoutCredentialsAndProject",
 			gcp.NewTerraform(false, false, true, false),
 			fmt.Sprintf("%s\n%s\n%s", RequiredProviders, gcpProviderWithoutCredentialsAndProject, moduleImportProjectLevelAuditLogWithoutConfiguration),
@@ -514,6 +525,16 @@ func TestGenerateGcpTfConfigurationArgs_Generate_Configuration(t *testing.T) {
 			ReqProvider(projectName, moduleImportProjectLevelConfigurationExistingSA),
 		},
 		{
+			"TestGenerationProjectLevelConfigurationExistingSAWithOrgId",
+			gcp.NewTerraform(false, true, false, false,
+				gcp.WithGcpServiceAccountCredentials("/path/to/credentials"),
+				gcp.WithProjectId(projectName),
+				gcp.WithOrganizationId("123456789"),
+				gcp.WithExistingServiceAccount(gcp.NewExistingServiceAccountDetails("foo", "123456789")),
+			),
+			ReqProvider(projectName, moduleImportProjectLevelConfigurationExistingSA),
+		},
+		{
 			"TestGenerationProjectLevelConfigurationCustomIntegrationName",
 			gcp.NewTerraform(false, true, false, false,
 				gcp.WithGcpServiceAccountCredentials("/path/to/credentials"),
@@ -720,7 +741,7 @@ func TestGenerateGcpTfConfigurationArgs_Generate_Agentless(t *testing.T) {
 			"TestGenerationProjectLevelAgentless",
 			gcp.NewTerraform(true, false, false, false,
 				gcp.WithProjectId(projectName),
-				gcp.WithAgentlessOrganizationId("123456789"),
+				gcp.WithOrganizationId("123456789"),
 				gcp.WithRegions([]string{"us-east1"}),
 			),
 			fmt.Sprintf("%s\n%s", RequiredProviders, moduleImportProjectLevelAgentless),
@@ -730,7 +751,6 @@ func TestGenerateGcpTfConfigurationArgs_Generate_Agentless(t *testing.T) {
 			gcp.NewTerraform(true, false, false, false,
 				gcp.WithProjectId(projectName),
 				gcp.WithRegions([]string{"us-east1"}),
-				gcp.WithAgentlessOrganizationId("123456789"),
 				gcp.WithProjectFilterList([]string{"p1", "p2"}),
 			),
 			fmt.Sprintf("%s\n%s", RequiredProviders, moduleImportProjectLevelAgentlessWithProjectFilterList),
@@ -769,16 +789,6 @@ func TestGenerationOrganizationLevelAuditLogNoOrgId(t *testing.T) {
 	).Generate()
 	assert.Empty(t, hcl)
 	assert.EqualError(t, err, "invalid inputs: an Organization ID must be provided for an Organization Integration")
-}
-
-func TestGenerationOrganizationLevelAuditLogNoOrgIntegrationFlag(t *testing.T) {
-	hcl, err := gcp.NewTerraform(false, false, true, false,
-		gcp.WithGcpServiceAccountCredentials("/path/to/credentials"),
-		gcp.WithProjectId(projectName),
-		gcp.WithOrganizationId("123456789"),
-	).Generate()
-	assert.Empty(t, hcl)
-	assert.EqualError(t, err, "invalid inputs: to provide an Organization ID, Organization Integration must be true")
 }
 
 func TestGenerationNoIntegration(t *testing.T) {
@@ -1205,7 +1215,6 @@ module "lacework_gcp_agentless_scanning_global" {
   source              = "lacework/agentless-scanning/gcp"
   version             = "~> 2.0"
   global              = true
-  organization_id     = "123456789"
   project_filter_list = ["p1", "p2"]
   regional            = true
 

--- a/lwgenerate/gcp/gcp_test.go
+++ b/lwgenerate/gcp/gcp_test.go
@@ -720,6 +720,7 @@ func TestGenerateGcpTfConfigurationArgs_Generate_Agentless(t *testing.T) {
 			"TestGenerationProjectLevelAgentless",
 			gcp.NewTerraform(true, false, false, false,
 				gcp.WithProjectId(projectName),
+				gcp.WithAgentlessOrganizationId("123456789"),
 				gcp.WithRegions([]string{"us-east1"}),
 			),
 			fmt.Sprintf("%s\n%s", RequiredProviders, moduleImportProjectLevelAgentless),
@@ -729,6 +730,7 @@ func TestGenerateGcpTfConfigurationArgs_Generate_Agentless(t *testing.T) {
 			gcp.NewTerraform(true, false, false, false,
 				gcp.WithProjectId(projectName),
 				gcp.WithRegions([]string{"us-east1"}),
+				gcp.WithAgentlessOrganizationId("123456789"),
 				gcp.WithProjectFilterList([]string{"p1", "p2"}),
 			),
 			fmt.Sprintf("%s\n%s", RequiredProviders, moduleImportProjectLevelAgentlessWithProjectFilterList),
@@ -1181,10 +1183,11 @@ var moduleImportProjectLevelAgentless = `provider "google" {
 }
 
 module "lacework_gcp_agentless_scanning_global" {
-  source   = "lacework/agentless-scanning/gcp"
-  version  = "~> 2.0"
-  global   = true
-  regional = true
+  source          = "lacework/agentless-scanning/gcp"
+  version         = "~> 2.0"
+  global          = true
+  organization_id = "123456789"
+  regional        = true
 
   providers = {
     google = google.us-east1
@@ -1202,6 +1205,7 @@ module "lacework_gcp_agentless_scanning_global" {
   source              = "lacework/agentless-scanning/gcp"
   version             = "~> 2.0"
   global              = true
+  organization_id     = "123456789"
   project_filter_list = ["p1", "p2"]
   regional            = true
 


### PR DESCRIPTION
Provide organization_id for project level agentless integration.

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/lacework/go-sdk) and create your branch from `main`
  2. Run `make prepare` in the repository root
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`make test`)
  5. Format your code (`make fmt`)
  6. Make sure your code lints (`make lint`)
  7. If you are updating the Lacework CLI, make sure it compiles (`make build-cli-cross-platform`)
  8. Follow the commit message standard (`type(scope): subject`) documented in [DEVELOPER_GUIDELINES.md](https://github.com/lacework/go-sdk/blob/main/DEVELOPER_GUIDELINES.md#commit-message-standard)
  9. If you haven't already, configure signed commits by [telling git about your signing key](https://docs.github.com/en/github/authenticating-to-github/managing-commit-signature-verification/telling-git-about-your-signing-key) and [signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)

  Learn more about contributing: https://github.com/lacework/go-sdk/blob/main/CONTRIBUTING.md
-->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## How did you test this change?

Tested using `lacework generate cloud-account gcp` command line to generate agentless terraform.

<!--
  How exactly did you verify that your PR solves the issue you wanted to solve?
  Include any other relevant information such as how to use the new functionality, screenshots, etc.
-->

## Issue

<!--
  Include the link to a Jira/Github issue
-->
