### PR TITLE
fix: Increase API timeout to 120 seconds

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -36,8 +36,8 @@ import (
 )
 
 const (
-	defaultTimeout    = 60 * time.Second
-	defaultTLSTimeout = 63 * time.Second
+	defaultTimeout    = 120 * time.Second
+	defaultTLSTimeout = 123 * time.Second
 )
 
 type Client struct {

--- a/integration/container_vulnerability_test.go
+++ b/integration/container_vulnerability_test.go
@@ -220,7 +220,9 @@ func _TestContainerVulnerabilityCommandScanFailOnSeverity(t *testing.T) {
 		"STDERR doesn't match")
 }
 
-func TestContainerVulnerabilityCommandScanFailOnFixable(t *testing.T) {
+// Disabled due to the api timeout issue
+// TODO: re-enable when timeout is fixed
+func _TestContainerVulnerabilityCommandScanFailOnFixable(t *testing.T) {
 	home := createTOMLConfigFromCIvars()
 	defer os.RemoveAll(home)
 	_, err, exitcode := LaceworkCLIWithHome(home,
@@ -233,7 +235,9 @@ func TestContainerVulnerabilityCommandScanFailOnFixable(t *testing.T) {
 		"STDERR doesn't match")
 }
 
-func TestContainerVulnerabilityCommandScanHumanReadablePollGenerateHtml(t *testing.T) {
+// Disabled due to the api timeout issue
+// TODO: re-enable when timeout is fixed
+func _TestContainerVulnerabilityCommandScanHumanReadablePollGenerateHtml(t *testing.T) {
 	// create a temporal directory to check that the HTML file is deployed
 	home := createTOMLConfigFromCIvars()
 	defer os.RemoveAll(home)

--- a/integration/container_vulnerability_test.go
+++ b/integration/container_vulnerability_test.go
@@ -205,9 +205,7 @@ func TestContainerVulnerabilityCommandScanErrorContainerImageNotFound(t *testing
 		"EXITCODE is not the expected one")
 }
 
-// Disabled due to the api timeout issue
-// TODO: re-enable when timeout is fixed
-func _TestContainerVulnerabilityCommandScanFailOnSeverity(t *testing.T) {
+func TestContainerVulnerabilityCommandScanFailOnSeverity(t *testing.T) {
 	home := createTOMLConfigFromCIvars()
 	defer os.RemoveAll(home)
 	_, err, exitcode := LaceworkCLIWithHome(home,
@@ -220,9 +218,7 @@ func _TestContainerVulnerabilityCommandScanFailOnSeverity(t *testing.T) {
 		"STDERR doesn't match")
 }
 
-// Disabled due to the api timeout issue
-// TODO: re-enable when timeout is fixed
-func _TestContainerVulnerabilityCommandScanFailOnFixable(t *testing.T) {
+func TestContainerVulnerabilityCommandScanFailOnFixable(t *testing.T) {
 	home := createTOMLConfigFromCIvars()
 	defer os.RemoveAll(home)
 	_, err, exitcode := LaceworkCLIWithHome(home,
@@ -235,9 +231,7 @@ func _TestContainerVulnerabilityCommandScanFailOnFixable(t *testing.T) {
 		"STDERR doesn't match")
 }
 
-// Disabled due to the api timeout issue
-// TODO: re-enable when timeout is fixed
-func _TestContainerVulnerabilityCommandScanHumanReadablePollGenerateHtml(t *testing.T) {
+func TestContainerVulnerabilityCommandScanHumanReadablePollGenerateHtml(t *testing.T) {
 	// create a temporal directory to check that the HTML file is deployed
 	home := createTOMLConfigFromCIvars()
 	defer os.RemoveAll(home)


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/lacework/go-sdk) and create your branch from `main`
  2. Run `make prepare` in the repository root
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`make test`)
  5. Format your code (`make fmt`)
  6. Make sure your code lints (`make lint`)
  7. If you are updating the Lacework CLI, make sure it compiles (`make build-cli-cross-platform`)
  8. Follow the commit message standard (`type(scope): subject`) documented in [DEVELOPER_GUIDELINES.md](https://github.com/lacework/go-sdk/blob/main/DEVELOPER_GUIDELINES.md#commit-message-standard)
  9. If you haven't already, configure signed commits by [telling git about your signing key](https://docs.github.com/en/github/authenticating-to-github/managing-commit-signature-verification/telling-git-about-your-signing-key) and [signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)

  Learn more about contributing: https://github.com/lacework/go-sdk/blob/main/CONTRIBUTING.md
-->

## Summary

Some integration tests take a long time to get response from API which may lead to timeout sometimes. Increase the APi timeout to 120s

## How did you test this change?

<!--
  How exactly did you verify that your PR solves the issue you wanted to solve?
  Include any other relevant information such as how to use the new functionality, screenshots, etc.
-->

## Issue

<!--
  Include the link to a Jira/Github issue
-->
