### PR TITLE
chore(GROW-2960): support access keys for AWS Agentless multiple scanning regions 

### DIFF
--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -18,7 +18,7 @@ jobs:
         run: |
           # python -m pip install gitlint
           sudo apt install pipx
-          pipx install install
+          pipx install gitlint
 
       - name: Run gitlint
         shell: bash

--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -16,7 +16,8 @@ jobs:
       - name: Install gitlint
         shell: bash
         run: |
-          python -m pip install gitlint
+          # python -m pip install gitlint
+          apt install python3-gitlint
 
       - name: Run gitlint
         shell: bash

--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -17,7 +17,7 @@ jobs:
         shell: bash
         run: |
           # python -m pip install gitlint
-          apt install python3-gitlint
+          sudo apt install python3-gitlint
 
       - name: Run gitlint
         shell: bash

--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -16,9 +16,7 @@ jobs:
       - name: Install gitlint
         shell: bash
         run: |
-          # python -m pip install gitlint
-          sudo apt install pipx
-          pipx install gitlint
+          python -m pip install gitlint --break-system-packages
 
       - name: Run gitlint
         shell: bash

--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -17,7 +17,8 @@ jobs:
         shell: bash
         run: |
           # python -m pip install gitlint
-          sudo apt install python3-gitlint
+          sudo apt install pipx
+          pipx install install
 
       - name: Run gitlint
         shell: bash

--- a/lwgenerate/aws/aws.go
+++ b/lwgenerate/aws/aws.go
@@ -909,22 +909,34 @@ func createAwsProvider(args *GenerateAwsTfConfigurationArgs) ([]*hclwrite.Block,
 	seenAccounts := []string{}
 
 	for _, account := range accounts {
-		alias := fmt.Sprintf("%s-%s", account.AwsProfile, account.AwsRegion)
+		alias := account.AwsRegion
 		if account.Alias != "" {
 			alias = account.Alias
+		} else if account.AwsProfile != "" {
+			alias = fmt.Sprintf("%s-%s", account.AwsProfile, account.AwsRegion)
 		}
 		// Skip duplicate account
 		if slices.Contains(seenAccounts, alias) {
 			continue
 		}
 		seenAccounts = append(seenAccounts, alias)
+
+		attributes := map[string]interface{}{}
+		// set `access_key`, `secret_key` and `token` for single-account multiple-region Agentless
+		if args.Agentless {
+			for k, v := range args.ExtraProviderArguments {
+				attributes[k] = v
+			}
+		}
+		attributes["alias"] = alias
+		attributes["region"] = account.AwsRegion
+		if args.AwsProfile != "" {
+			attributes["profile"] = account.AwsProfile
+		}
+
 		providerBlock, err := lwgenerate.NewProvider(
 			"aws",
-			lwgenerate.HclProviderWithAttributes(map[string]interface{}{
-				"alias":   alias,
-				"profile": account.AwsProfile,
-				"region":  account.AwsRegion,
-			}),
+			lwgenerate.HclProviderWithAttributes(attributes),
 		).ToBlock()
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
## Summary

For single-account, multi-region AWS Agentless integration, we need to support passing `access_key`, `secret_key` and `token` for multiple regions(AWS providers).

