### PR TITLE
fix: Fix casing during reading of resource group

### DIFF
--- a/api/resource_groups.go
+++ b/api/resource_groups.go
@@ -22,6 +22,7 @@ import (
 	_ "embed"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -95,14 +96,52 @@ func (svc *ResourceGroupsService) List() (response ResourceGroupsResponse, err e
 		return rawResponse, err
 	}
 
+	err = sanitizeFieldsInRawResponseList(&rawResponse, &response)
+	if err != nil {
+		return rawResponse, err
+	}
+
 	return rawResponse, nil
+}
+
+func sanitizeFieldsInRawResponse(rawResponse *ResourceGroupResponse, response interface{}) error {
+	// update filters keys to match the query template
+	updateFiltersKeys(&rawResponse.Data)
+
+	j, err := json.Marshal(rawResponse)
+	if err != nil {
+		return err
+	}
+
+	return json.Unmarshal(j, &response)
+}
+
+func sanitizeFieldsInRawResponseList(rawResponse *ResourceGroupsResponse, response interface{}) error {
+	for i := range rawResponse.Data {
+		// update filters keys to match the query template
+		updateFiltersKeys(&rawResponse.Data[i])
+	}
+
+	j, err := json.Marshal(rawResponse)
+	if err != nil {
+		return err
+	}
+
+	return json.Unmarshal(j, &response)
 }
 
 func (svc *ResourceGroupsService) Create(group ResourceGroupData) (
 	response ResourceGroupResponse,
 	err error,
 ) {
-	err = svc.create(group, &response)
+	var rawResponse ResourceGroupResponse
+	err = svc.create(group, &rawResponse)
+	if err != nil {
+		return
+	}
+
+	err = sanitizeFieldsInRawResponse(&rawResponse, &response)
+
 	return
 }
 
@@ -117,12 +156,52 @@ func (svc *ResourceGroupsService) Update(data *ResourceGroupData) (
 	guid := data.ID()
 	data.ResetResourceGUID()
 
-	err = svc.update(guid, data, &response)
+	var rawResponse ResourceGroupResponse
+	err = svc.update(guid, data, &rawResponse)
+
 	if err != nil {
 		return
 	}
 
+	err = sanitizeFieldsInRawResponse(&rawResponse, &response)
+
 	return
+}
+
+func collectFilterNames(children []*RGChild, filterNames map[string]string) {
+	for _, child := range children {
+		if child.FilterName != "" {
+			normalizedKey := strings.ReplaceAll(strings.ToLower(child.FilterName), "_", "")
+			filterNames[normalizedKey] = child.FilterName
+		}
+		if len(child.Children) > 0 {
+			collectFilterNames(child.Children, filterNames)
+		}
+	}
+}
+
+/*
+updateFiltersKeys updates the keys in the Filters map of ResourceGroupData to ensure they match the filter names
+defined in the nested children of the query expression. This is necessary because JSON decoding/encoding can
+convert keys to camel case, causing mismatches. The function normalizes the keys by removing underscores and
+converting them to lower case, then compares them with the filter names. If a mismatch is found, the key is
+updated to the value in RGExpression.Children
+*/
+func updateFiltersKeys(data *ResourceGroupData) {
+	filterNames := make(map[string]string)
+	collectFilterNames(data.Query.Expression.Children, filterNames)
+
+	updatedFilters := make(map[string]*RGFilter)
+	for key, value := range data.Query.Filters {
+		normalizedKey := strings.ReplaceAll(strings.ToLower(key), "_", "")
+		if _, exists := filterNames[normalizedKey]; exists {
+			updatedFilters[filterNames[normalizedKey]] = value
+		} else {
+			updatedFilters[key] = value
+		}
+	}
+
+	data.Query.Filters = updatedFilters
 }
 
 func (group *ResourceGroupData) ResetResourceGUID() {
@@ -149,20 +228,17 @@ func (svc *ResourceGroupsService) Delete(guid string) error {
 
 func (svc *ResourceGroupsService) Get(guid string, response interface{}) error {
 	var rawResponse ResourceGroupResponse
+
 	err := svc.get(guid, &rawResponse)
 	if err != nil {
 		return err
 	}
 
-	j, err := json.Marshal(rawResponse)
+	err = sanitizeFieldsInRawResponse(&rawResponse, response)
 	if err != nil {
 		return err
 	}
 
-	err = json.Unmarshal(j, &response)
-	if err != nil {
-		return err
-	}
 	return nil
 }
 

--- a/api/resource_groups.go
+++ b/api/resource_groups.go
@@ -188,6 +188,10 @@ converting them to lower case, then compares them with the filter names. If a mi
 updated to the value in RGExpression.Children
 */
 func updateFiltersKeys(data *ResourceGroupData) {
+	if data.Query == nil || data.Query.Expression == nil {
+		return
+	}
+
 	filterNames := make(map[string]string)
 	collectFilterNames(data.Query.Expression.Children, filterNames)
 

--- a/cli/cmd/resource_groups.go
+++ b/cli/cmd/resource_groups.go
@@ -208,24 +208,7 @@ func promptCreateResourceGroup() error {
 		return err
 	}
 
-	switch group {
-	case "AWS":
-		return createResourceGroup("AWS")
-	case "AZURE":
-		return createResourceGroup("AZURE")
-	case "GCP":
-		return createResourceGroup("GCP")
-	case "CONTAINER":
-		return createResourceGroup("CONTAINER")
-	case "MACHINE":
-		return createResourceGroup("MACHINE")
-	case "OCI":
-		return createResourceGroup("OCI")
-	case "KUBERNETES":
-		return createResourceGroup("KUBERNETES")
-	default:
-		return errors.New("unknown resource group type")
-	}
+	return createResourceGroup(group)
 }
 
 func init() {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/lacework/go-sdk) and create your branch from `main`
  2. Run `make prepare` in the repository root
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`make test`)
  5. Format your code (`make fmt`)
  6. Make sure your code lints (`make lint`)
  7. If you are updating the Lacework CLI, make sure it compiles (`make build-cli-cross-platform`)
  8. Follow the commit message standard (`type(scope): subject`) documented in [DEVELOPER_GUIDELINES.md](https://github.com/lacework/go-sdk/blob/main/DEVELOPER_GUIDELINES.md#commit-message-standard)
  9. If you haven't already, configure signed commits by [telling git about your signing key](https://docs.github.com/en/github/authenticating-to-github/managing-commit-signature-verification/telling-git-about-your-signing-key) and [signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)

  Learn more about contributing: https://github.com/lacework/go-sdk/blob/main/CONTRIBUTING.md
-->

## Summary

Bug in CLI causing us to output wrong casing for filter names.

## How did you test this change?

Added a unit test. Also ran cli locally to visually confirm that the filter names where not getting changed when a camel case filter name is provided.

## Issue

<!--
  Include the link to a Jira/Github issue
-->
