### PR TITLE
chore: make subscription_id required for Azure Activity Log and Config

### DIFF
--- a/cli/cmd/generate_azure.go
+++ b/cli/cmd/generate_azure.go
@@ -22,8 +22,7 @@ var (
 	QuestionEnableEntraIdActivityLog = "Enable Azure Entra ID Activity Log Integration?"
 	QuestionEntraIdActivityLogName   = "Specify custom EntraID Activity Log integration name: (optional)"
 	QuestionAddAzureSubscriptionID   = "Set Azure Subscription ID?"
-	QuestionAzureSubscriptionID      = "Specify the Azure Subscription ID to be used to provision " +
-		"Lacework resources: (optional)"
+	QuestionAzureSubscriptionID      = "Specify the Azure Subscription ID to be used to provision Lacework resources:"
 
 	QuestionAzureAnotherAdvancedOpt      = "Configure another advanced integration option"
 	QuestionAzureConfigAdvanced          = "Configure advanced integration options?"
@@ -160,7 +159,7 @@ var (
 
 By default, this command will function interactively, prompting for the required information to setup
 the new cloud account. In interactive mode, this command will:
-		
+
 * Prompt for the required information to setup the integration
 * Generate new Terraform code using the inputs
 * Optionally, run the generated Terraform code:

--- a/lwgenerate/azure/azure.go
+++ b/lwgenerate/azure/azure.go
@@ -97,6 +97,10 @@ func (args *GenerateAzureTfConfigurationArgs) validate() error {
 		return errors.New("audit log or config integration must be enabled")
 	}
 
+	if (args.ActivityLog || args.Config) && args.SubscriptionID == "" {
+		return errors.New("subscription_id must be provided for Audit Log and Config integration")
+	}
+
 	// Validate that active directory settings are correct
 	if !args.CreateAdIntegration && (args.AdApplicationId == "" ||
 		args.AdServicePrincipalId == "" || args.AdApplicationPassword == "") {


### PR DESCRIPTION
## Summary

- `subscription_id` is required for Azure Activity Log and Config

## How did you test this change?

Run `lacework generate cloud-account azure --noninteractive --activity_log`, get and error
<img width="935" alt="Screenshot 2024-12-03 at 4 16 59 PM" src="https://github.com/user-attachments/assets/b6fbbbdd-1e17-453e-a791-e59f9dba6918">

Run `lacework generate cloud-account azure --noninteractive --activity_log --subscription_id 123123`, terraform gets generated successfully
<img width="1047" alt="Screenshot 2024-12-03 at 4 36 02 PM" src="https://github.com/user-attachments/assets/01fc3384-924e-4ad1-b35e-a4688ca4582d">
