### PR TITLE
fix: Disable aws_vpc_log creation in go-sdk

### DIFF
--- a/lwgenerate/aws/aws.go
+++ b/lwgenerate/aws/aws.go
@@ -1368,7 +1368,8 @@ func createAgentless(args *GenerateAwsTfConfigurationArgs) ([]*hclwrite.Block, e
 			"lacework_aws_agentless_scanning_global",
 			lwgenerate.AwsAgentlessSource,
 			lwgenerate.HclModuleWithVersion(lwgenerate.AwsAgentlessVersion),
-			lwgenerate.HclModuleWithAttributes(map[string]interface{}{"global": true, "regional": true, "use_aws_flow_log": false}),
+			lwgenerate.HclModuleWithAttributes(map[string]interface{}{"global": true,
+				"regional": true, "use_aws_flow_log": false}),
 			lwgenerate.HclModuleWithProviderDetails(
 				map[string]string{"aws": "aws.main"},
 			),

--- a/lwgenerate/aws/aws.go
+++ b/lwgenerate/aws/aws.go
@@ -1368,7 +1368,7 @@ func createAgentless(args *GenerateAwsTfConfigurationArgs) ([]*hclwrite.Block, e
 			"lacework_aws_agentless_scanning_global",
 			lwgenerate.AwsAgentlessSource,
 			lwgenerate.HclModuleWithVersion(lwgenerate.AwsAgentlessVersion),
-			lwgenerate.HclModuleWithAttributes(map[string]interface{}{"global": true, "regional": true}),
+			lwgenerate.HclModuleWithAttributes(map[string]interface{}{"global": true, "regional": true, "use_aws_flow_log": false}),
 			lwgenerate.HclModuleWithProviderDetails(
 				map[string]string{"aws": "aws.main"},
 			),
@@ -1389,6 +1389,8 @@ func createAgentless(args *GenerateAwsTfConfigurationArgs) ([]*hclwrite.Block, e
 				lwgenerate.HclModuleWithAttributes(
 					map[string]interface{}{
 						"regional": true,
+						// Disable aws_flow_log creation due to https://lacework.atlassian.net/browse/GROW-3001
+						"use_aws_flow_log": false,
 						"global_module_reference": lwgenerate.CreateSimpleTraversal(
 							[]string{"module", "lacework_aws_agentless_scanning_global"},
 						),

--- a/lwgenerate/aws/aws_test.go
+++ b/lwgenerate/aws/aws_test.go
@@ -587,10 +587,11 @@ provider "aws" {
 }
 
 module "lacework_aws_agentless_scanning_global" {
-  source   = "lacework/agentless-scanning/aws"
-  version  = "~> 0.6"
-  global   = true
-  regional = true
+  source           = "lacework/agentless-scanning/aws"
+  version          = "~> 0.6"
+  global           = true
+  regional         = true
+  use_aws_flow_log = false
 
   providers = {
     aws = aws.main
@@ -602,6 +603,7 @@ module "lacework_aws_agentless_scanning_region_scanning-1-us-east-1" {
   version                 = "~> 0.6"
   global_module_reference = module.lacework_aws_agentless_scanning_global
   regional                = true
+  use_aws_flow_log        = false
 
   providers = {
     aws = aws.scanning-1-us-east-1


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/lacework/go-sdk) and create your branch from `main`
  2. Run `make prepare` in the repository root
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`make test`)
  5. Format your code (`make fmt`)
  6. Make sure your code lints (`make lint`)
  7. If you are updating the Lacework CLI, make sure it compiles (`make build-cli-cross-platform`)
  8. Follow the commit message standard (`type(scope): subject`) documented in [DEVELOPER_GUIDELINES.md](https://github.com/lacework/go-sdk/blob/main/DEVELOPER_GUIDELINES.md#commit-message-standard)
  9. If you haven't already, configure signed commits by [telling git about your signing key](https://docs.github.com/en/github/authenticating-to-github/managing-commit-signature-verification/telling-git-about-your-signing-key) and [signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)

  Learn more about contributing: https://github.com/lacework/go-sdk/blob/main/CONTRIBUTING.md
-->

## Summary

Disable aws_flow_log creation in go-sdk.

## How did you test this change?


Tested in dev5

## Issue

[GROW-3001](https://lacework.atlassian.net/browse/GROW-3001)


[GROW-3001]: https://lacework.atlassian.net/browse/GROW-3001?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ