### PR TITLE
chore: specify go 1.24.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/lacework/go-sdk/v2
 
-go 1.24
+go 1.24.0
 
 require (
 	aead.dev/minisign v0.2.0


### PR DESCRIPTION
Need to specify 1.24.0 instead of 1.24
Reference: https://github.com/golang/go/issues/62278#issuecomment-1693538776