### PR TITLE
fix(LINK-2046: stop using integrations for get registries

### DIFF
--- a/api/v2_vulnerabilities.go
+++ b/api/v2_vulnerabilities.go
@@ -100,6 +100,7 @@ func (svc *v2ContainerVulnerabilityService) SearchAllPages(filters SearchFilter)
 		}
 		break
 	}
+	fmt.Println("finished all length: ", len(all))
 
 	response.ResetPaging()
 	response.Data = all

--- a/cli/cmd/vuln_container_scan.go
+++ b/cli/cmd/vuln_container_scan.go
@@ -109,7 +109,7 @@ func userFriendlyErrorForOnDemandCtrVulnScan(err error, registry, repo, tag stri
 		"Could not find vulnerability integrations",
 	) {
 
-		registries, errReg := getContainerRegistries()
+		registries, errReg := getPlatformScannerIntegrationContainerRegistries()
 		if errReg != nil {
 			cli.Log.Debugw("error trying to retrieve configured registries", "error", errReg)
 			return errors.Errorf("container registry '%s' not found", registry)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/lacework/go-sdk/v2
 
-go 1.24
+go 1.24.0
 
 require (
 	aead.dev/minisign v0.2.0


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/lacework/go-sdk) and create your branch from `main`
  2. Run `make prepare` in the repository root
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`make test`)
  5. Format your code (`make fmt`)
  6. Make sure your code lints (`make lint`)
  7. If you are updating the Lacework CLI, make sure it compiles (`make build-cli-cross-platform`)
  8. Follow the commit message standard (`type(scope): subject`) documented in [DEVELOPER_GUIDELINES.md](https://github.com/lacework/go-sdk/blob/main/DEVELOPER_GUIDELINES.md#commit-message-standard)
  9. If you haven't already, configure signed commits by [telling git about your signing key](https://docs.github.com/en/github/authenticating-to-github/managing-commit-signature-verification/telling-git-about-your-signing-key) and [signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)

  Learn more about contributing: https://github.com/lacework/go-sdk/blob/main/CONTRIBUTING.md
-->

## Summary
The vulnerability container list-registries command is currently missing data. It relies on container registry integration data to get a list of scanned registries. However, proxy scanner and inline scanner integrations don't contain the registry domain, and we are only able to get this data by looking at the container assessment. We can use the container assessment API here to get a full list of scanned registries in the last 7 days

The vulnerability container list-assessments command is also missing data. It calls the container assessment API while filtering for registry domains coming from the integration information. This only include platform scans, and would also consistently hit the API 500,000 total row limitation. We can improve this by breaking up the API requests further by scanner type. Breaking it up into four separate requests by scanner type prevents us from missing non-platform scan assessments. However, we are still hitting the API row limitation.

## How did you test this change?

Tested list-registries, list-assessments, and container scan commands with local built CLI

## Issue
https://lacework.atlassian.net/browse/LINK-2046
