### PR TITLE
chore: update metrics service to use v2/telemetry/OtelMetrics

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Build Artifacts
         env:
-          HONEYDATASET: ${{ secrets.PROD_HONEYDATASET }}
+          METRIC_DATASET: ${{ secrets.METRIC_DATASET }}
         run: |
           make prepare
           scripts/release.sh build

--- a/.github/workflows/windows-integration.yml
+++ b/.github/workflows/windows-integration.yml
@@ -28,7 +28,6 @@ jobs:
           CI_SUBACCOUNT: ${{ secrets.CI_SUBACCOUNT }}
           CI_API_KEY: ${{ secrets.CI_API_KEY }}
           CI_API_SECRET: ${{ secrets.CI_API_SECRET }}
-          HONEYDATASET: ${{ secrets.HONEYDATASET }}
           LW_INT_TEST_AWS_ACC: ${{ secrets.LW_INT_TEST_AWS_ACC }}
         run: |
           Set-ExecutionPolicy Bypass -Scope Process -Force

--- a/Makefile
+++ b/Makefile
@@ -17,11 +17,10 @@ COVERAGEHTML?=coverage.html
 GOJUNITOUT?=go-junit.xml
 PACKAGENAME?=lacework-cli
 CLINAME?=lacework
-# Honeycomb variables
-HONEYDATASET?=lacework-cli-dev
+METRIC_DATASET?=lacework-cli-dev
 GO_LDFLAGS="-X github.com/lacework/go-sdk/v2/cli/cmd.Version=$(shell cat VERSION) \
             -X github.com/lacework/go-sdk/v2/cli/cmd.GitSHA=$(shell git rev-parse HEAD) \
-            -X github.com/lacework/go-sdk/v2/cli/cmd.HoneyDataset=$(HONEYDATASET) \
+            -X github.com/lacework/go-sdk/v2/cli/cmd.MetricDataset=$(METRIC_DATASET) \
             -X github.com/lacework/go-sdk/v2/cli/cmd.BuildTime=$(shell date +%Y%m%d%H%M%S)"
 GOFLAGS=-mod=vendor
 CGO_ENABLED?=0

--- a/api/api.go
+++ b/api/api.go
@@ -27,7 +27,7 @@ const (
 	// API v2 Endpoints
 	apiTokens = "v2/access/tokens" // Auth
 
-	apiV2HoneyMetrics = "v2/metrics/honeycomb"
+	apiV2OtelMetrics = "v2/telemetry/OtelMetrics?dataset=%s"
 
 	apiV2UserProfile = "v2/UserProfile"
 

--- a/api/metrics_test.go
+++ b/api/metrics_test.go
@@ -21,7 +21,7 @@ func TestDisableTelemetry(t *testing.T) {
 
 	assert.Nil(t, err)
 
-	res, err := c.V2.Metrics.Send(api.Honeyvent{})
+	res, err := c.V2.Metrics.Send(api.MetricEvent{})
 
 	assert.Nil(t, err)
 	assert.Equal(t, res.Data[0].TraceID, "Telemetry Disabled")

--- a/api/metrics_test.go
+++ b/api/metrics_test.go
@@ -21,8 +21,7 @@ func TestDisableTelemetry(t *testing.T) {
 
 	assert.Nil(t, err)
 
-	res, err := c.V2.Metrics.Send(api.MetricEvent{})
+	err = c.V2.Metrics.Send(api.MetricEvent{})
 
 	assert.Nil(t, err)
-	assert.Equal(t, res.Data[0].TraceID, "Telemetry Disabled")
 }

--- a/cli/cmd/cdk.go
+++ b/cli/cmd/cdk.go
@@ -121,7 +121,7 @@ func (c *cliState) Honeyvent(ctx context.Context, in *cdk.HoneyventRequest) (*cd
 	}
 
 	// Send the Honeyvent
-	c.SendHoneyvent()
+	c.SendMetricEvent()
 
 	return &cdk.Reply{}, nil
 }

--- a/cli/cmd/cli_state.go
+++ b/cli/cmd/cli_state.go
@@ -61,7 +61,7 @@ type cliState struct {
 	LwApi        *api.Client
 	JsonF        *prettyjson.Formatter
 	Log          *zap.SugaredLogger
-	Event        *api.Honeyvent
+	Event        *api.MetricEvent
 	Cache        *diskv.Diskv
 	LwComponents *lwcomponent.State
 
@@ -108,8 +108,8 @@ func NewDefaultState() *cliState {
 		cdkServerPort:  defaultGrpcPort,
 	}
 
-	// initialize honeycomb library and honeyvent
-	c.InitHoneyvent()
+	// initialize MetricEvent
+	c.InitMetricEvent()
 
 	return c
 }
@@ -135,7 +135,7 @@ func (c *cliState) SetProfile(profile string) error {
 // this function verifies parameters and env variables coming from viper
 func (c *cliState) LoadState() error {
 	defer func() {
-		// update global honeyvent with loaded state
+		// update global MetricEvent with loaded state
 		c.Event.Account = c.Account
 		c.Event.Subaccount = c.Subaccount
 		c.Event.Profile = c.Profile

--- a/cli/cmd/component.go
+++ b/cli/cmd/component.go
@@ -419,7 +419,7 @@ func installComponent(args []string) (err error) {
 
 	cli.Event.Component = componentName
 	cli.Event.Feature = "install_component"
-	defer cli.SendHoneyvent()
+	defer cli.SendMetricEvent()
 
 	catalog, err := LoadCatalog(componentName, false)
 	if err != nil {
@@ -896,7 +896,7 @@ func prototypeRunComponentsInstall(_ *cobra.Command, args []string) (err error) 
 
 	cli.Event.Component = componentName
 	cli.Event.Feature = "install_component"
-	defer cli.SendHoneyvent()
+	defer cli.SendMetricEvent()
 
 	cli.StartProgress("Loading components state...")
 	// @afiune maybe move the state to the cache and fetch if it if has expired

--- a/cli/cmd/metricevent.go
+++ b/cli/cmd/metricevent.go
@@ -25,22 +25,21 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/honeycombio/libhoney-go"
 	"github.com/lacework/go-sdk/v2/api"
 	"github.com/lacework/go-sdk/v2/lwdomain"
 )
 
 var (
-	// HoneyDataset is the dataset in Honeycomb that we send tracing
+	// MetricDataset is the dataset in Elastic that we send tracing
 	// data this variable will be set depending on the environment we
 	// are running on. During development, we send all events and
 	// tracing data to a default dataset.
-	HoneyDataset = "lacework-cli-dev"
+	MetricDataset = "lacework-cli-dev"
 )
 
 const (
 	// DisableTelemetry is an environment variable that can be used to
-	// disable telemetry sent to Honeycomb
+	// disable telemetry sent to Elastic
 	DisableTelemetry = "LW_TELEMETRY_DISABLE"
 
 	// HomebrewInstall is an environment variable that denotes the
@@ -54,13 +53,13 @@ const (
 	// List of Features
 	//
 	// A feature within the Lacework CLI is any functionality that
-	// can't be traced or tracked by the default event sent to Honeycomb,
+	// can't be traced or tracked by the default event sent to Elastic,
 	// it is a behavior that we, Lacework engineers, would like to
 	// trace and understand its usage and adoption.
 	//
-	// By default the Feature field within the Honeyvent is empty,
+	// By default the Feature field within the MetricEvent is empty,
 	// define a new feature below and set it before sending a new
-	// Honeyvent. Additionally, there is a FeatureData field that
+	// MetricEvent. Additionally, there is a FeatureData field that
 	// any feature can use to inject any specific information
 	// related to that feature.
 	//
@@ -69,7 +68,7 @@ const (
 	// ```go
 	// cli.Event.Feature = featPollCtrScan
 	// cli.Event.AddFeatureField("key", "value")
-	// cli.SendHoneyvent()
+	// cli.SendMetricEvent()
 	// ```
 	//
 	// Polling mechanism feature
@@ -91,11 +90,11 @@ const (
 	featMigrateConfigV2 = "migrate_config_v2"
 )
 
-// InitHoneyvent initialize honeycomb library and main Honeyvent, such event
+// InitMetricEvent initialize Elastic library and main MetricEvent, such event
 // could be modified during a command execution to add extra parameters such
 // as error message, feature data, etc.
-func (c *cliState) InitHoneyvent() {
-	c.Event = &api.Honeyvent{
+func (c *cliState) InitMetricEvent() {
+	c.Event = &api.MetricEvent{
 		Os:            runtime.GOOS,
 		Arch:          runtime.GOARCH,
 		Version:       Version,
@@ -106,36 +105,33 @@ func (c *cliState) InitHoneyvent() {
 		CfgVersion:    c.CfgVersion,
 		TraceID:       newID(),
 		InstallMethod: installMethod(),
-		Dataset:       HoneyDataset,
+		Dataset:       MetricDataset,
 	}
 }
 
 // Wait should be called before finishing the execution of any CLI command,
-// it waits for pending workers (a.k.a. honeyvents) to be transmitted
+// it waits for pending workers (a.k.a. MetricEvents) to be transmitted
 func (c *cliState) Wait() {
 	// wait for any missing worker
 	c.workers.Wait()
-
-	// flush any pending calls to Honeycomb
-	libhoney.Close()
 
 	// stop gRPC server gracefully
 	c.Stop()
 }
 
-// SendHoneyvent is used throughout the CLI to send Honeyvents, these events
+// SendMetricEvent is used throughout the CLI to send metric events, these events
 // have tracing data to understand how the commands are being executed, what
 // features are used and the overall command flow. This function sends the
 // events via goroutines so that we don't block the execution of the main process
 //
 // NOTE: the CLI will send at least one event per command execution
-func (c *cliState) SendHoneyvent() {
+func (c *cliState) SendMetricEvent() {
 	if disabled := os.Getenv(DisableTelemetry); disabled != "" {
 		return
 	}
 
 	if c.LwApi == nil {
-		c.Log.Debug("unable to send honeyvent", "error")
+		c.Log.Debug("unable to send MetricEvent", "error")
 		return
 	}
 
@@ -154,8 +150,7 @@ func (c *cliState) SendHoneyvent() {
 
 	// Lacework accounts are NOT case-sensitive but some users configure them
 	// in uppercase and others in lowercase, therefore we will normalize all
-	// account to be lowercase so that we don't see different accounts in
-	// Honeycomb.
+	// account to be lowercase so that we don't see different accounts in metrics.
 	c.Event.Account = strings.ToLower(c.Event.Account)
 
 	// Detect if the account has the full domain, if so, subtract the account
@@ -166,31 +161,30 @@ func (c *cliState) SendHoneyvent() {
 		}
 	}
 
-	c.Log.Debugw("new honeyvent", "dataset", HoneyDataset,
+	c.Log.Debugw("new metric event", "dataset", MetricDataset,
 		"trace_id", c.Event.TraceID,
 		"span_id", c.Event.SpanID,
 		"parent_id", c.Event.ParentID,
 		"context_id", c.Event.ContextID,
 	)
-	honeyvent := libhoney.NewEvent()
-	_ = honeyvent.Add(c.Event)
-	honeycombEvent := *c.Event
-	honeycombEvent.Dataset = c.Event.Dataset
+
+	event := *c.Event
+	event.Dataset = c.Event.Dataset
 
 	c.workers.Add(1)
-	go func(wg *sync.WaitGroup, event *libhoney.Event, honeycombEvent api.Honeyvent) {
+	go func(wg *sync.WaitGroup, event api.MetricEvent) {
 		defer wg.Done()
 
-		c.Log.Debugw("sending honeyvent", "dataset", HoneyDataset)
+		c.Log.Debugw("sending MetricEvent", "dataset", MetricDataset)
 
-		_, err := c.LwApi.V2.Metrics.Send(honeycombEvent)
+		_, err := c.LwApi.V2.Metrics.Send(event)
 		if err != nil {
-			c.Log.Debugw("unable to send honeyvent", "error", err)
+			c.Log.Debugw("unable to send MetricEvent", "error", err)
 		}
 
-	}(&c.workers, honeyvent, honeycombEvent)
+	}(&c.workers, event)
 
-	// after adding a worker to submit a honeyvent, we remove
+	// after adding a worker to submit a metric event, we remove
 	// all temporal fields such as feature, feature.data, error
 	c.Event.DurationMs = 0
 	c.Event.Error = ""

--- a/cli/cmd/metricevent.go
+++ b/cli/cmd/metricevent.go
@@ -177,7 +177,7 @@ func (c *cliState) SendMetricEvent() {
 
 		c.Log.Debugw("sending MetricEvent", "dataset", MetricDataset)
 
-		_, err := c.LwApi.V2.Metrics.Send(event)
+		err := c.LwApi.V2.Metrics.Send(event)
 		if err != nil {
 			c.Log.Debugw("unable to send MetricEvent", "error", err)
 		}

--- a/cli/cmd/metricevent_test.go
+++ b/cli/cmd/metricevent_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestHoneyventDefaultParameters(t *testing.T) {
+func TestMetricEventDefaultParameters(t *testing.T) {
 	assert.NotNil(t, cli.Event)
 	assert.Equal(t, Version, cli.Event.Version)
 	assert.Equal(t, runtime.GOOS, cli.Event.Os)
@@ -43,7 +43,7 @@ func TestHoneyventDefaultParameters(t *testing.T) {
 	assert.Empty(t, cli.Event.InstallMethod)
 }
 
-func TestSendHoneyventTracingFields(t *testing.T) {
+func TestSendMetricEventTracingFields(t *testing.T) {
 	// by default, the span_id must be empty
 	assert.Empty(t, cli.Event.SpanID)
 	assert.Empty(t, cli.Event.ParentID)
@@ -57,8 +57,8 @@ func TestSendHoneyventTracingFields(t *testing.T) {
 
 	cli.LwApi = client
 
-	// mocking sending first honeyvent
-	cli.SendHoneyvent()
+	// mocking sending first MetricEvent
+	cli.SendMetricEvent()
 
 	// the span_id should be set to the cli id
 	// but the parent_id must continue to be empty
@@ -66,9 +66,9 @@ func TestSendHoneyventTracingFields(t *testing.T) {
 	assert.Empty(t, cli.Event.ParentID)
 	assert.Empty(t, cli.Event.ContextID)
 
-	// mocking sending second honeyvent after setting a context ID
+	// mocking sending second MetricEvent after setting a context ID
 	os.Setenv("LACEWORK_CONTEXT_ID", "test-id")
-	cli.SendHoneyvent()
+	cli.SendMetricEvent()
 
 	// any further event should set the parent_id as the cli id
 	// and generate a new id for the span_id
@@ -79,7 +79,7 @@ func TestSendHoneyventTracingFields(t *testing.T) {
 	assert.Equal(t, "test-id", cli.Event.ContextID)
 }
 
-func TestSendHoneyventFeatureFields(t *testing.T) {
+func TestSendMetricEventFeatureFields(t *testing.T) {
 	// by default, the feature, feature.data and duration_ms should be empty
 	assert.Empty(t, cli.Event.DurationMs)
 	assert.Empty(t, cli.Event.Error)
@@ -101,10 +101,10 @@ func TestSendHoneyventFeatureFields(t *testing.T) {
 	cli.Event.DurationMs = 639023
 	cli.Event.Error = "something happened"
 
-	// mocking sending honeyvent
-	cli.SendHoneyvent()
+	// mocking sending MetricEvent
+	cli.SendMetricEvent()
 
-	// after submitting the honeyvent, the global
+	// after submitting the MetricEvent, the global
 	// event struct should be resetted
 	assert.Empty(t, cli.Event.DurationMs)
 	assert.Empty(t, cli.Event.Error)
@@ -112,8 +112,8 @@ func TestSendHoneyventFeatureFields(t *testing.T) {
 	assert.Empty(t, cli.Event.FeatureData)
 }
 
-func TestSendHoneyventDisableTelemetry(t *testing.T) {
-	// testing that the func SendHoneyvent won't run when the
+func TestSendMetricEventDisableTelemetry(t *testing.T) {
+	// testing that the func SendMetricEvent won't run when the
 	// environment variable 'DisableTelemetry'  is set
 	os.Setenv(DisableTelemetry, "1")
 	defer os.Setenv(DisableTelemetry, "")
@@ -128,8 +128,8 @@ func TestSendHoneyventDisableTelemetry(t *testing.T) {
 	// setting up a test feature
 	cli.Event.Feature = "test_feature"
 
-	// mocking sending honeyvent
-	cli.SendHoneyvent()
+	// mocking sending MetricEvent
+	cli.SendMetricEvent()
 
 	// all these fields should not be empty after sending the event
 	assert.Equal(t, "test_feature", cli.Event.Feature)
@@ -137,7 +137,7 @@ func TestSendHoneyventDisableTelemetry(t *testing.T) {
 	// events when it is set (disabled)
 }
 
-func TestSendHoneyventHomebrewInstall(t *testing.T) {
+func TestSendMetricEventHomebrewInstall(t *testing.T) {
 	// testing that the install method will be "Homebrew"
 	// environment variable 'LW_HOMEBREW_INSTALL'  is set
 	os.Setenv(HomebrewInstall, "1")
@@ -150,17 +150,17 @@ func TestSendHoneyventHomebrewInstall(t *testing.T) {
 	)
 	cli.LwApi = client
 
-	// init honeyvent as InstallMethod is set on init
-	cli.InitHoneyvent()
+	// init MetricEvent as InstallMethod is set on init
+	cli.InitMetricEvent()
 
-	// mocking sending honeyvent
-	cli.SendHoneyvent()
+	// mocking sending MetricEvent
+	cli.SendMetricEvent()
 
 	assert.NotEmpty(t, cli.Event.InstallMethod)
 	assert.Equal(t, "HOMEBREW", cli.Event.InstallMethod)
 }
 
-func TestSendHoneyventAccountToLower(t *testing.T) {
+func TestSendMetricEventAccountToLower(t *testing.T) {
 	cli.Event.Account = "all-lower-OR-ALL-UPPER"
 
 	fakeServer := lacework.MockServer()
@@ -170,10 +170,10 @@ func TestSendHoneyventAccountToLower(t *testing.T) {
 	)
 	cli.LwApi = client
 
-	// mocking sending honeyvent
-	cli.SendHoneyvent()
+	// mocking sending MetricEvent
+	cli.SendMetricEvent()
 
-	// after submitting the honeyvent, the global
+	// after submitting the MetricEvent, the global
 	// event struct should be resetted
 	assert.Equal(t, "all-lower-or-all-upper", cli.Event.Account)
 }

--- a/cli/cmd/migration.go
+++ b/cli/cmd/migration.go
@@ -46,12 +46,12 @@ func (c *cliState) Migrations() (err error) {
 
 	defer func() {
 		if err == nil {
-			c.SendHoneyvent()
+			c.SendMetricEvent()
 		} else {
 			err = errors.Wrap(err, "during v2 migration")
 		}
 
-		// update global honeyvent with updated state
+		// update global MetricEvent with updated state
 		c.Event.Account = c.Account
 		c.Event.Subaccount = c.Subaccount
 		c.Event.CfgVersion = c.CfgVersion

--- a/cli/cmd/package_manifest.go
+++ b/cli/cmd/package_manifest.go
@@ -61,10 +61,10 @@ func (c *cliState) GeneratePackageManifest() (*api.VulnerabilitiesPackageManifes
 		c.Event.DurationMs = time.Since(start).Milliseconds()
 		if err == nil {
 			// if this function returns an error, most likely,
-			// the command will send a honeyvent with that error,
+			// the command will send a MetricEvent with that error,
 			// therefore we should duplicate events and only send
 			// one here if there is NO error
-			c.SendHoneyvent()
+			c.SendMetricEvent()
 		}
 	}()
 
@@ -497,7 +497,7 @@ func fanOutHostScans(manifests ...*api.VulnerabilitiesPackageManifest) (
 		cli.Event.DurationMs = time.Since(start).Milliseconds()
 		// avoid duplicating events
 		if err == nil {
-			cli.SendHoneyvent()
+			cli.SendMetricEvent()
 		}
 	}()
 

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -78,7 +78,7 @@ This will prompt you for your Lacework account and a set of API access keys.`,
 )
 
 func cliPersistentPreRun(cmd *cobra.Command, args []string) error {
-	cli.Log.Debugw("updating honeyvent", "dataset", HoneyDataset)
+	cli.Log.Debugw("updating MetricEvent", "dataset", MetricDataset)
 	cli.Event.Command = cmd.CommandPath()
 	cli.Event.Args = args
 	cli.Event.Flags = parseFlags(os.Args[1:])
@@ -105,7 +105,7 @@ func cliPersistentPreRun(cmd *cobra.Command, args []string) error {
 			}
 		}
 	}
-	cli.SendHoneyvent()
+	cli.SendMetricEvent()
 	return nil
 }
 
@@ -113,7 +113,7 @@ func componentPersistentPreRun(cmd *cobra.Command, args []string) error {
 	cli.Event.Command = cmd.CommandPath()
 	cli.Event.Component = cmd.Use
 	cli.Event.Flags = parseFlags(os.Args[1:])
-	defer cli.SendHoneyvent()
+	defer cli.SendMetricEvent()
 
 	// For components, we disable flag parsing, therefore we
 	// split args into those handled by the CLI and those
@@ -131,7 +131,7 @@ func componentPersistentPreRun(cmd *cobra.Command, args []string) error {
 			"provided_flags", cli.componentParser.cliArgs)
 	}
 
-	cli.Log.Debugw("honeyvent updated", "dataset", HoneyDataset)
+	cli.Log.Debugw("MetricEvent updated", "dataset", MetricDataset)
 
 	return cli.NewClient()
 }
@@ -164,9 +164,9 @@ func Execute() (err error) {
 	}
 
 	if err = rootCmd.Execute(); err != nil {
-		// send a new error event to Honeycomb
+		// send a new error event to Elastic
 		cli.Event.Error = err.Error()
-		cli.SendHoneyvent()
+		cli.SendMetricEvent()
 	}
 
 	return

--- a/cli/cmd/version.go
+++ b/cli/cmd/version.go
@@ -174,7 +174,7 @@ func dailyComponentUpdateAvailable(componentName string) (bool, error) {
 
 	if versionCache.CheckComponentBefore(componentName, checkTime) {
 		cli.Event.Feature = featDailyCompVerCheck
-		defer cli.SendHoneyvent()
+		defer cli.SendMetricEvent()
 
 		versionCache.ComponentsLastCheck[componentName] = nowTime
 		cli.Log.Debugw("storing new version cache", "content", versionCache)
@@ -203,7 +203,7 @@ func firstTimeVersionCheck(dir, file string) error {
 		if err != nil {
 			cli.Event.FeatureData = map[string]interface{}{"silent_error": err.Error()}
 		}
-		cli.SendHoneyvent()
+		cli.SendMetricEvent()
 	}()
 
 	if err = os.MkdirAll(dir, 0755); err != nil {
@@ -254,7 +254,7 @@ func dailyVersionCheck() error {
 
 	if versionCache.LastCheckTime.Before(checkTime) {
 		cli.Event.Feature = featDailyVerCheck
-		defer cli.SendHoneyvent()
+		defer cli.SendMetricEvent()
 
 		versionCache.LastCheckTime = nowTime
 		cli.Log.Debugw("storing new version cache", "content", versionCache)

--- a/cli/cmd/vuln_container_scan.go
+++ b/cli/cmd/vuln_container_scan.go
@@ -190,13 +190,13 @@ func pollScanStatus(requestID string, args []string) error {
 		evalGUID, err := checkScanStatus(requestID)
 		if err != nil {
 			cli.Event.Error = err.Error()
-			cli.SendHoneyvent()
+			cli.SendMetricEvent()
 			return err
 		}
 
 		if evalGUID == "" {
 			cli.Log.Debugw("waiting for a retry", "request_id", requestID, "sleep", expPollTime)
-			cli.SendHoneyvent()
+			cli.SendMetricEvent()
 			time.Sleep(expPollTime)
 			expPollTime = time.Duration(retries*retries) * time.Second
 			continue
@@ -206,7 +206,7 @@ func pollScanStatus(requestID string, args []string) error {
 		params["total_duration_ms"] = time.Since(start).Milliseconds()
 		params["eval_guid"] = evalGUID
 		cli.Event.FeatureData = params
-		cli.SendHoneyvent()
+		cli.SendMetricEvent()
 
 		// reset event fields
 		cli.Event.DurationMs = 0

--- a/integration/test_resources/cdk/go-component/main.go
+++ b/integration/test_resources/cdk/go-component/main.go
@@ -78,7 +78,7 @@ func app() error {
 		).WithDuration(time.Since(now).Milliseconds()).Send()
 
 		if err != nil {
-			log.Error("unable to send honeyvent", "error", err)
+			log.Error("unable to send MetricEvent", "error", err)
 		}
 	}(highestSev)
 


### PR DESCRIPTION
## Summary

We are migrating from Honecomb to Elastic. This PR updates go-sdk to use the new endpoint `v2/telemetry/OtelMetrics`.

## How did you test this change?

Run a lacework command such as `lacework cloud-account list`, then verify the metric event is sent to Elastic succeffuly:

<img width="1185" alt="Screenshot 2025-06-06 at 4 02 41 PM" src="https://github.com/user-attachments/assets/9f2146d5-d458-47f2-b874-fc0f1ac5a374" />

