### PR TITLE
chore(lwpreflight): add verbose writer to show preflight progress messages

### DIFF
--- a/lwpreflight/aws/caller.go
+++ b/lwpreflight/aws/caller.go
@@ -21,6 +21,8 @@ func (c *Caller) IsAssumedRole() bool {
 }
 
 func FetchCaller(p *Preflight) error {
+	p.verboseWriter.Write("Discovering caller information")
+
 	stsSvc := sts.NewFromConfig(p.awsConfig)
 
 	caller, err := stsSvc.GetCallerIdentity(context.Background(), nil)

--- a/lwpreflight/aws/permission.go
+++ b/lwpreflight/aws/permission.go
@@ -11,6 +11,8 @@ func CheckPermissions(p *Preflight) error {
 	}
 
 	for _, integrationType := range p.integrationTypes {
+		p.verboseWriter.Write(fmt.Sprintf("Checking permissions for %s", integrationType))
+
 		requiredPermissions := RequiredPermissions[integrationType]
 		for _, permission := range requiredPermissions {
 			// First check plain permission strings

--- a/lwpreflight/azure/azure.go
+++ b/lwpreflight/azure/azure.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/lacework/go-sdk/v2/lwpreflight/verbosewriter"
 )
 
 type Preflight struct {
@@ -18,6 +19,8 @@ type Preflight struct {
 	caller  Caller
 	details Details
 	errors  map[IntegrationType][]string
+
+	verboseWriter verbosewriter.WriteCloser
 }
 
 type Result struct {
@@ -85,9 +88,15 @@ func New(params Params) (*Preflight, error) {
 		tasks:            tasks,
 		details:          Details{},
 		errors:           map[IntegrationType][]string{},
+		verboseWriter:    verbosewriter.New(),
 	}
 
 	return preflight, nil
+}
+
+// Overwrite the default verbose writer
+func (p *Preflight) SetVerboseWriter(vw verbosewriter.WriteCloser) {
+	p.verboseWriter = vw
 }
 
 func (p *Preflight) Run() (*Result, error) {

--- a/lwpreflight/azure/caller.go
+++ b/lwpreflight/azure/caller.go
@@ -23,6 +23,8 @@ type Caller struct {
 }
 
 func FetchCaller(p *Preflight) error {
+	p.verboseWriter.Write("Discovering caller information")
+
 	// Get caller identity
 	token, err := p.cred.GetToken(context.Background(), policy.TokenRequestOptions{
 		Scopes: []string{"https://management.azure.com/.default"},

--- a/lwpreflight/azure/detail.go
+++ b/lwpreflight/azure/detail.go
@@ -17,6 +17,8 @@ func FetchDetails(p *Preflight) error {
 		return fmt.Errorf("failed to create subscriptions client: %v", err)
 	}
 
+	p.verboseWriter.Write("Discovering available regions")
+
 	// Get available locations using the pager
 	pager := client.NewListLocationsPager(p.subscriptionID, nil)
 	regions := make([]string, 0)

--- a/lwpreflight/azure/permission.go
+++ b/lwpreflight/azure/permission.go
@@ -10,6 +10,8 @@ func CheckPermissions(p *Preflight) error {
 	}
 
 	for _, integrationType := range p.integrationTypes {
+		p.verboseWriter.Write(fmt.Sprintf("Checking permissions for %s", integrationType))
+
 		requiredPermissions := RequiredPermissions[integrationType]
 		for _, permission := range requiredPermissions {
 			if !p.permissions[permission] {

--- a/lwpreflight/azure/policy.go
+++ b/lwpreflight/azure/policy.go
@@ -19,6 +19,8 @@ func FetchPolicies(p *Preflight) error {
 		return fmt.Errorf("failed to create credential: %v", err)
 	}
 
+	p.verboseWriter.Write(fmt.Sprintf("Discovering role assigments for subscription %s", p.subscriptionID))
+
 	// Get role assignments for the caller
 	client, err := armauthorization.NewRoleAssignmentsClient(p.subscriptionID, cred, nil)
 	if err != nil {

--- a/lwpreflight/gcp/caller.go
+++ b/lwpreflight/gcp/caller.go
@@ -12,6 +12,8 @@ type Caller struct {
 }
 
 func FetchCaller(p *Preflight) error {
+	p.verboseWriter.Write("Discovering caller information")
+
 	oauth2Svc, err := oauth2.NewService(context.Background(), p.gcpClientOption)
 	if err != nil {
 		return err

--- a/lwpreflight/gcp/detail.go
+++ b/lwpreflight/gcp/detail.go
@@ -25,6 +25,8 @@ func FetchDetails(p *Preflight) error {
 }
 
 func fetchSchedulerRegions(p *Preflight) error {
+	p.verboseWriter.Write("Discovering scheduler regions")
+
 	schedulerSvc, err := scheduler.NewService(context.Background(), p.gcpClientOption)
 	if err != nil {
 		return err

--- a/lwpreflight/gcp/gcp.go
+++ b/lwpreflight/gcp/gcp.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/lacework/go-sdk/v2/lwpreflight/verbosewriter"
 	"golang.org/x/oauth2"
 	"google.golang.org/api/option"
 )
@@ -20,6 +21,8 @@ type Preflight struct {
 	caller  Caller
 	details Details
 	errors  map[IntegrationType][]string
+
+	verboseWriter verbosewriter.WriteCloser
 }
 
 type Result struct {
@@ -71,6 +74,7 @@ func New(params Params) (*Preflight, error) {
 		tasks:            tasks,
 		details:          Details{},
 		errors:           map[IntegrationType][]string{},
+		verboseWriter:    verbosewriter.New(),
 	}
 
 	if params.AccessToken != "" {
@@ -95,6 +99,11 @@ func New(params Params) (*Preflight, error) {
 	}
 
 	return preflight, nil
+}
+
+// Overwrite the default verbose writer
+func (p *Preflight) SetVerboseWriter(vw verbosewriter.WriteCloser) {
+	p.verboseWriter = vw
 }
 
 func (p *Preflight) Run() (*Result, error) {

--- a/lwpreflight/gcp/permission.go
+++ b/lwpreflight/gcp/permission.go
@@ -6,6 +6,8 @@ import (
 
 func CheckPermissions(p *Preflight) error {
 	for _, integrationType := range p.integrationTypes {
+		p.verboseWriter.Write(fmt.Sprintf("Checking permissions for %s", integrationType))
+
 		for _, permission := range RequiredPermissions[integrationType] {
 			if !p.permissions[permission] {
 				p.errors[integrationType] = append(

--- a/lwpreflight/gcp/policy.go
+++ b/lwpreflight/gcp/policy.go
@@ -18,8 +18,10 @@ func FetchPolicies(p *Preflight) error {
 	var policies []*cloudresourcemanagerV3.Policy
 
 	if p.orgID != "" {
+		p.verboseWriter.Write(fmt.Sprintf("Discovering IAM policies for organization %s", p.orgID))
 		policies, err = fetchOrgPolicies(p)
 	} else {
+		p.verboseWriter.Write(fmt.Sprintf("Discovering IAM policies for project %s", p.projectID))
 		policies, err = fetchProjectPolicies(p)
 	}
 	if err != nil {

--- a/lwpreflight/verbosewriter/verbosewriter.go
+++ b/lwpreflight/verbosewriter/verbosewriter.go
@@ -1,0 +1,31 @@
+package verbosewriter
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/abiosoft/colima/util/terminal"
+)
+
+type WriteCloser interface {
+	Write(s string)
+	Close()
+}
+
+type VerboseWriter struct {
+	vw io.WriteCloser
+}
+
+func New() *VerboseWriter {
+	return &VerboseWriter{
+		vw: terminal.NewVerboseWriter(10),
+	}
+}
+
+func (v *VerboseWriter) Write(s string) {
+	v.vw.Write(fmt.Appendf(nil, "%s\n", s))
+}
+
+func (v *VerboseWriter) Close() {
+	v.vw.Close()
+}


### PR DESCRIPTION
## Summary

Add `verbosewriter` to print preflight progress messages. It can be overwritten so that the consumer of `lwpreflight` can relay the progress messages to another writer.

## How did you test this change?

<img width="424" alt="Screenshot 2025-06-19 at 6 06 10 PM" src="https://github.com/user-attachments/assets/30499d13-3615-46ad-b975-3fa4f231fce0" />

