### PR TITLE
chore: check wildcard permissions in Azure preflight package

### DIFF
--- a/lwpreflight/azure/azure.go
+++ b/lwpreflight/azure/azure.go
@@ -16,10 +16,11 @@ type azureConfig struct {
 }
 
 type Preflight struct {
-	azureConfig      azureConfig
-	integrationTypes []IntegrationType
-	tasks            []func(p *Preflight) error
-	permissions      map[string]bool
+	azureConfig             azureConfig
+	integrationTypes        []IntegrationType
+	tasks                   []func(p *Preflight) error
+	permissions             map[string]bool
+	permissionsWithWildcard []string
 
 	caller  Caller
 	details Details
@@ -94,13 +95,14 @@ func New(params Params) (*Preflight, error) {
 	}
 
 	preflight := &Preflight{
-		azureConfig:      cfg,
-		integrationTypes: integrationTypes,
-		permissions:      map[string]bool{},
-		tasks:            tasks,
-		details:          Details{},
-		errors:           map[IntegrationType][]string{},
-		verboseWriter:    verbosewriter.New(),
+		azureConfig:             cfg,
+		integrationTypes:        integrationTypes,
+		permissions:             map[string]bool{},
+		permissionsWithWildcard: []string{},
+		tasks:                   tasks,
+		details:                 Details{},
+		errors:                  map[IntegrationType][]string{},
+		verboseWriter:           verbosewriter.New(),
 	}
 
 	return preflight, nil

--- a/lwpreflight/azure/policy.go
+++ b/lwpreflight/azure/policy.go
@@ -3,6 +3,7 @@ package azure
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization"
@@ -47,7 +48,13 @@ func FetchPolicies(p *Preflight) error {
 				if roleDef.Properties != nil && roleDef.Properties.Permissions != nil {
 					for _, permission := range roleDef.Properties.Permissions {
 						for _, action := range permission.Actions {
-							if action != nil {
+							if action != nil && *action == "*" {
+								p.caller.IsAdmin = true
+								return nil
+							}
+							if strings.Contains(*action, "*") {
+								p.permissionsWithWildcard = append(p.permissionsWithWildcard, *action)
+							} else if action != nil {
 								p.permissions[*action] = true
 							}
 						}


### PR DESCRIPTION
## Summary

Adding wildcard permissions check in azure preflight package, also fine tuning admin check during initialization.

## How did you test this change?

Using multiple Service principles with different custom role and owner RBAC role. 

Test case 1:
SP with wildcard permissions in the custom role. - passed
 
Test case 2:
SP with owner role assigned - The IsAdmin is set to true. Passed
<img width="1441" alt="Screenshot 2025-07-01 at 2 44 16 PM" src="https://github.com/user-attachments/assets/d7213c7a-1cb3-4e29-8de3-fb65b5b136dd" />


Test case 3:
SP with regular permissions instead of wildcard permissions.  - Passed
