### PR TITLE
feat(cli): Add new scope "ObservationTimeline" to alert show command

### DIFF
--- a/api/alerts_details.go
+++ b/api/alerts_details.go
@@ -34,15 +34,17 @@ const (
 	AlertRelatedAlertsScope
 	AlertIntegrationsScope
 	AlertTimelineScope
+	AlertObservationTimelineScope
 )
 
 var AlertScopes = map[alertScope]string{
-	AlertDetailsScope:       "Details",
-	AlertInvestigationScope: "Investigation",
-	AlertEventsScope:        "Events",
-	AlertRelatedAlertsScope: "RelatedAlerts",
-	AlertIntegrationsScope:  "Integrations",
-	AlertTimelineScope:      "Timeline",
+	AlertDetailsScope:             "Details",
+	AlertInvestigationScope:       "Investigation",
+	AlertEventsScope:              "Events",
+	AlertRelatedAlertsScope:       "RelatedAlerts",
+	AlertIntegrationsScope:        "Integrations",
+	AlertTimelineScope:            "Timeline",
+	AlertObservationTimelineScope: "ObservationTimeline",
 }
 
 func (i alertScope) String() string {
@@ -72,6 +74,8 @@ func (svc *AlertsService) Get(id int, scope alertScope) (interface{}, error) {
 		return svc.GetIntegrations(id)
 	case AlertTimelineScope:
 		return svc.GetTimeline(id)
+	case AlertObservationTimelineScope:
+		return svc.GetObservationTimeline(id)
 	default:
 		return nil, errors.New(fmt.Sprintf("alert scope (%s) not recognized", scope))
 	}

--- a/api/alerts_details_observationtimeline.go
+++ b/api/alerts_details_observationtimeline.go
@@ -1,0 +1,42 @@
+//
+// Author:: Lokesh Vadlamudi (<lvadlamudi@fortinet.com>)
+// Copyright:: Copyright 2025, Fortinet Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package api
+
+import (
+	"fmt"
+)
+
+type AlertObservationTimeline map[string]interface{}
+
+type AlertObservationTimelineResponse struct {
+	Data []AlertObservationTimeline `json:"data"`
+}
+
+func (svc *AlertsService) GetObservationTimeline(id int) (
+	response AlertObservationTimelineResponse,
+	err error,
+) {
+	err = svc.client.RequestDecoder(
+		"GET",
+		fmt.Sprintf(apiV2AlertsDetails, id, AlertObservationTimelineScope),
+		nil,
+		&response,
+	)
+	return
+}

--- a/api/alerts_details_observationtimeline_test.go
+++ b/api/alerts_details_observationtimeline_test.go
@@ -1,0 +1,213 @@
+//
+// Author:: Lokesh Vadlamudi (<lvadlamudi@fortinet.com>)
+// Copyright:: Copyright 2025, Fortinet Inc.
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package api_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/lacework/go-sdk/v2/api"
+	"github.com/lacework/go-sdk/v2/internal/lacework"
+	"github.com/stretchr/testify/assert"
+)
+
+var alertObservationTimelineJSON = `{
+  "data": [
+    {
+      "description": "Remote system discovery using Ping or ARP observed",
+      "endEpoch": 1750692691,
+      "entities": [
+        {
+          "entity_key": {
+            "repo": "docker.io/example/ecommerce-website"
+          },
+          "entity_text": "docker.io/example/ecommerce-website",
+          "entity_type": "container_repo",
+          "entity_uuid": "gt6LFSoHsasqSBfQpJncoj",
+          "is_detail": false,
+          "is_subject": false
+        },
+        {
+          "entity_key": {
+            "mid": "4325415338702892297",
+            "pid_hash": "-5106375999317139109"
+          },
+          "entity_props": "{\"cmdline\": \"ping -c 1 -t 1 10.0.3.6\"}",
+          "entity_text": "ping -c 1 -t 1 10.0.3.6",
+          "entity_type": "process",
+          "entity_uuid": "TL4dYNpFrFxZRhrT2ZqNRJ",
+          "is_detail": true,
+          "is_subject": false
+        },
+        {
+          "entity_key": {
+            "account": "123456789012",
+            "principal_id": "AROAEXAMPLE:example-instance",
+            "username": "AssumedRole/123456789012:ExampleRole"
+          },
+          "entity_text": "AssumedRole/123456789012:ExampleRole",
+          "entity_type": "ct_user",
+          "entity_uuid": "ZXXdzywqQCCRz97n9Q57Mw",
+          "is_detail": false,
+          "is_subject": true
+        },
+        {
+          "entity_key": {
+            "hostname": "host-1.example.com",
+            "mid": "4325415338702892297"
+          },
+          "entity_props": "{\"internal_ip_addr\": \"10.0.3.226\", \"os_type\": \"linux\"}",
+          "entity_text": "host-1.example.com",
+          "entity_type": "machine",
+          "entity_uuid": "muupdPVN2nZWokr8HkooLK",
+          "is_detail": false,
+          "is_subject": true
+        },
+        {
+          "entity_key": {
+            "cluster_id": "example-cluster",
+            "pod_name": "ecommerce-website-58dc7b54f9-ctp2n",
+            "pod_namespace": "default"
+          },
+          "entity_text": "ecommerce-website-58dc7b54f9-ctp2n",
+          "entity_type": "k8_pod",
+          "entity_uuid": "WWJksiQgq2zBnronZquHzN",
+          "is_detail": true,
+          "is_subject": false
+        }
+      ],
+      "formalTags": [
+        {
+          "customer_facing_id": "T1018",
+          "id": "T1018",
+          "name": "Remote System Discovery",
+          "order_index": 25,
+          "parent_id": "TA0007",
+          "url": "https://attack.mitre.org/techniques/T1018"
+        },
+        {
+          "customer_facing_id": "TA0007",
+          "id": "TA0007",
+          "name": "Discovery",
+          "order_index": 6,
+          "url": "https://attack.mitre.org/tactics/TA0007"
+        }
+      ],
+      "observationPivotEntityUuids": [
+        "muupdPVN2nZWokr8HkooLK"
+      ],
+      "observationType": "linux_discovery_remote_system_discovery",
+      "recordUuid": "2e034bf4-683f-56f0-a91b-bc8c4510d2b3",
+      "relationships": [
+        {
+          "dstEntityKey": {
+            "mid": "4325415338702892297",
+            "pid_hash": "-5161409754333993982"
+          },
+          "dstEntityText": "sh -x ./deepce.sh",
+          "dstEntityType": "process",
+          "dstEntityUuid": "CExjyKEFbc3ngP5GFeNja4",
+          "relationshipDescriptor": "is a child process of process",
+          "relationshipId": "c8a6fb3e23fa89ab3b977dc8de815204fe738c87",
+          "srcEntityKey": {
+            "mid": "4325415338702892297",
+            "pid_hash": "-5112041715404371368"
+          },
+          "srcEntityText": "ping -c 1 127.0.0.1",
+          "srcEntityType": "process",
+          "srcEntityUuid": "EHnMTz74eJmgfb2iLpzkcx"
+        }
+      ],
+      "startEpoch": 1750692691
+    }
+  ]
+}`
+
+func TestAlertsGetObservationTimelineMethod(t *testing.T) {
+	fakeServer := lacework.MockServer()
+	fakeServer.MockAPI(
+		fmt.Sprintf("Alerts/%d", alertID),
+		func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "GET", r.Method, "GetObservationTimeline should be a GET method")
+			fmt.Fprint(w, "{}")
+		},
+	)
+	defer fakeServer.Close()
+
+	c, err := api.NewClient("test",
+		api.WithToken("TOKEN"),
+		api.WithURL(fakeServer.URL()),
+	)
+	assert.Nil(t, err)
+
+	_, err = c.V2.Alerts.GetObservationTimeline(alertID)
+	assert.Nil(t, err)
+}
+
+func TestAlertsGetObservationTimelineOK(t *testing.T) {
+	mockResponse := alertObservationTimelineJSON
+
+	fakeServer := lacework.MockServer()
+	fakeServer.MockAPI(
+		fmt.Sprintf("Alerts/%d", alertID),
+		func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprint(w, mockResponse)
+		},
+	)
+	defer fakeServer.Close()
+
+	c, err := api.NewClient("test",
+		api.WithToken("TOKEN"),
+		api.WithURL(fakeServer.URL()),
+	)
+	assert.Nil(t, err)
+	// Get actual response from SDK method
+	resp, err := c.V2.Alerts.GetObservationTimeline(alertID)
+	assert.Nil(t, err)
+
+	// Marshal actual output back to JSON
+	actualJSON, err := json.Marshal(resp)
+	assert.Nil(t, err)
+
+	// Compare JSON using assert.JSONEq
+	assert.JSONEq(t, mockResponse, string(actualJSON))
+
+}
+
+func TestAlertsGetObservationTimelineError(t *testing.T) {
+	fakeServer := lacework.MockServer()
+	fakeServer.MockAPI(
+		fmt.Sprintf("Alerts/%d", alertID),
+		func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, lqlErrorReponse, http.StatusInternalServerError)
+		},
+	)
+	defer fakeServer.Close()
+
+	c, err := api.NewClient("test",
+		api.WithToken("TOKEN"),
+		api.WithURL(fakeServer.URL()),
+	)
+	assert.Nil(t, err)
+
+	_, err = c.V2.Alerts.GetObservationTimeline(alertID)
+	assert.NotNil(t, err)
+}

--- a/cli/cmd/alert_show.go
+++ b/cli/cmd/alert_show.go
@@ -45,6 +45,7 @@ The following alert detail scopes are available:
   * RelatedAlerts
   * Integrations
   * Timeline
+  * ObservationTimeline
 
 View an alert's timeline details:
 
@@ -88,6 +89,8 @@ func showAlert(_ *cobra.Command, args []string) error {
 		err = showAlertIntegrations(id)
 	case api.AlertTimelineScope.String():
 		err = showAlertTimeline(id)
+	case api.AlertObservationTimelineScope.String():
+		err = showAlertObservationTimeline(id)
 	default:
 		err = errors.New(fmt.Sprintf("scope (%s) is not recognized", alertCmdState.Scope))
 	}

--- a/cli/cmd/alert_show_observationtimeline.go
+++ b/cli/cmd/alert_show_observationtimeline.go
@@ -1,0 +1,16 @@
+package cmd
+
+import (
+	"github.com/pkg/errors"
+)
+
+func showAlertObservationTimeline(id int) error {
+	cli.StartProgress(" Fetching alert observation timeline...")
+	observationtimelineResponse, err := cli.LwApi.V2.Alerts.GetObservationTimeline(id)
+	cli.StopProgress()
+	if err != nil {
+		return errors.Wrap(err, "unable to show alert")
+	}
+
+	return cli.OutputJSON(observationtimelineResponse.Data)
+}

--- a/cli/docs/lacework_alert_show.md
+++ b/cli/docs/lacework_alert_show.md
@@ -23,6 +23,7 @@ The following alert detail scopes are available:
   * RelatedAlerts
   * Integrations
   * Timeline
+  * ObservationTimeline
 
 View an alert's timeline details:
 

--- a/integration/alert_show_test.go
+++ b/integration/alert_show_test.go
@@ -160,3 +160,20 @@ func TestAlertShowTimeline(t *testing.T) {
 	assert.Empty(t, err.String(), "STDERR should be empty")
 	assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
 }
+
+func TestAlertShowObservationTimeline(t *testing.T) {
+	out, err, exitcode := LaceworkCLIWithTOMLConfig("alert", "show", alertShowID, "--scope", "ObservationTimeline")
+
+	if strings.Contains(err.String(), "[404] Not found") {
+		return
+	}
+	assert.Contains(t, out.String(), `"entities"`)
+	assert.Contains(t, out.String(), "For further investigation")
+	assert.Empty(t, err.String(), "STDERR should be empty")
+	assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
+
+	out, err, exitcode = LaceworkCLIWithTOMLConfig("alert", "show", alertShowID, "--scope", "ObservationTimeline", "--json")
+	assert.Contains(t, out.String(), `"description"`)
+	assert.Empty(t, err.String(), "STDERR should be empty")
+	assert.Equal(t, 0, exitcode, "EXITCODE is not the expected one")
+}

--- a/integration/test_resources/help/alert_show
+++ b/integration/test_resources/help/alert_show
@@ -11,6 +11,7 @@ The following alert detail scopes are available:
   * RelatedAlerts
   * Integrations
   * Timeline
+  * ObservationTimeline
 
 View an alert's timeline details:
 


### PR DESCRIPTION
## Summary

Add a new scope for alerts show command in cli to match the below api. 

GET https://YourLacework.lacework.net/api/v2/Alerts/{alertId}?scope=ObservationTimeline

**Example CLI command**:
lacework alert show 126275 --scope ObservationTimeline

## How did you test this change?

Tested on local cli.

Able to fetch the right data. 

<img width="1237" height="527" alt="Screenshot 2025-07-17 at 3 14 08 PM" src="https://github.com/user-attachments/assets/3cb9b47d-b672-4b11-8a0c-80ffa5fccbb0" />
 

Help text:
<img width="912" height="527" alt="Screenshot 2025-07-17 at 3 23 52 PM" src="https://github.com/user-attachments/assets/e0a6a9be-0f7a-4ffd-8a3b-bd563775c18d" />



## Issue

(https://lacework.atlassian.net/browse/CAD-1300?atlOrigin=eyJpIjoiOTJkMTc3Yjc3OGFiNGY0OWFlZWY4NmY3MTA0YzIxYzQiLCJwIjoiaiJ9)