### PR TITLE
chore: specify aws tf provider version

### DIFF
--- a/lwgenerate/aws/aws.go
+++ b/lwgenerate/aws/aws.go
@@ -839,11 +839,18 @@ func (args *GenerateAwsTfConfigurationArgs) Generate() (string, error) {
 }
 
 func createRequiredProviders(extraBlocks []*hclwrite.Block) (*hclwrite.Block, error) {
-	return lwgenerate.CreateRequiredProvidersWithCustomBlocks(
-		extraBlocks,
-		lwgenerate.NewRequiredProvider("lacework",
-			lwgenerate.HclRequiredProviderWithSource(lwgenerate.LaceworkProviderSource),
-			lwgenerate.HclRequiredProviderWithVersion(lwgenerate.LaceworkProviderVersion)))
+	providers := []*lwgenerate.HclRequiredProvider{
+		lwgenerate.NewRequiredProvider("aws",
+			lwgenerate.HclRequiredProviderWithSource(lwgenerate.AwsProviderSource),
+			lwgenerate.HclRequiredProviderWithVersion(lwgenerate.AwsProviderVersion)),
+	}
+
+	providers = append(providers, lwgenerate.NewRequiredProvider("lacework",
+		lwgenerate.HclRequiredProviderWithSource(lwgenerate.LaceworkProviderSource),
+		lwgenerate.HclRequiredProviderWithVersion(lwgenerate.LaceworkProviderVersion),
+	))
+
+	return lwgenerate.CreateRequiredProvidersWithCustomBlocks(extraBlocks, providers...)
 }
 
 func createAwsProvider(args *GenerateAwsTfConfigurationArgs) ([]*hclwrite.Block, error) {

--- a/lwgenerate/aws/aws_test.go
+++ b/lwgenerate/aws/aws_test.go
@@ -422,6 +422,10 @@ func TestGenerationCloudTrailS3BucketNotification(t *testing.T) {
 
 var requiredProvidersWithCustomBlock = `terraform {
   required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
     lacework = {
       source  = "lacework/lacework"
       version = "~> 2.0"
@@ -434,6 +438,10 @@ var requiredProvidersWithCustomBlock = `terraform {
 
 var requiredProviders = `terraform {
   required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
     lacework = {
       source  = "lacework/lacework"
       version = "~> 2.0"
@@ -567,6 +575,10 @@ var moduleImportCtWithAllEncryptionSet = `module "main_cloudtrail" {
 
 var moduleImportAgentless = `terraform {
   required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
     lacework = {
       source  = "lacework/lacework"
       version = "~> 2.0"
@@ -613,6 +625,10 @@ module "lacework_aws_agentless_scanning_region_scanning-1-us-east-1" {
 
 var moduleImportAgentlessOrganization = `terraform {
   required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
     lacework = {
       source  = "lacework/lacework"
       version = "~> 2.0"
@@ -740,6 +756,10 @@ var moduleImportCloudtrail = `module "main_cloudtrail" {
 
 var moduleImportConfigWithProviderTags = `terraform {
   required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
     lacework = {
       source  = "lacework/lacework"
       version = "~> 2.0"
@@ -787,6 +807,10 @@ var customOutput = `output "test" {
 
 var moduleImportConfigWithMultipleAccounts = `terraform {
   required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
     lacework = {
       source  = "lacework/lacework"
       version = "~> 2.0"

--- a/lwgenerate/constants.go
+++ b/lwgenerate/constants.go
@@ -5,6 +5,8 @@ const (
 	LaceworkProviderSource  = "lacework/lacework"
 	LaceworkProviderVersion = "~> 2.0"
 
+	AwsProviderSource                = "hashicorp/aws"
+	AwsProviderVersion               = "~> 5.0"
 	AwsAgentlessSource               = "lacework/agentless-scanning/aws"
 	AwsAgentlessVersion              = "~> 0.6"
 	AwsConfigSource                  = "lacework/config/aws"


### PR DESCRIPTION
## Summary

Adding AWS terraform version to tf files makes it consistent across different environments. 


## How did you test this change?

Tested on dev space. 
Generated terraform file contains the right aws provider version. 
<img width="596" height="583" alt="Screenshot 2025-08-15 at 8 43 05 AM" src="https://github.com/user-attachments/assets/161ac8cb-9d10-4889-a947-1c72163b8227" />

## Issue

https://lacework.atlassian.net/browse/LINK-4096
