### PR TITLE
fix:(PLTI-599) Tab escape issue in resourceTags

### DIFF
--- a/cli/cmd/outputs.go
+++ b/cli/cmd/outputs.go
@@ -36,7 +36,10 @@ func (c *cliState) OutputJSON(v interface{}) error {
 		c.Log.Debugw("unable to pretty print JSON object", "raw", v)
 		return err
 	}
-	fmt.Fprintln(color.Output, string(pretty))
+
+	formatted := strings.ReplaceAll(string(pretty), "\t", "\\t")
+
+	fmt.Fprintln(color.Output, formatted)
 	return nil
 }
 


### PR DESCRIPTION
https://lacework.atlassian.net/browse/PLTI-599

The response from http.go already has tab escaped "\\t" however after the decoder process the escaped character is converted to a literal tab for resourceTags.
 
"Tags" is unaffected because it's an array.