### PR TITLE
chore: update support email

### DIFF
--- a/cli/cmd/agent_install.go
+++ b/cli/cmd/agent_install.go
@@ -250,7 +250,7 @@ func selectAgentAccessToken() (string, error) {
 	}
 
 	// @afiune this should never happen
-	return "", errors.New("something went pretty wrong here, contact support@lacework.net")
+	return "", errors.New("something went pretty wrong here, contact cs@fortinet.com")
 }
 
 // ask for the ssh username

--- a/cli/cmd/component.go
+++ b/cli/cmd/component.go
@@ -343,7 +343,7 @@ func (c *cliState) PrototypeLoadComponents() {
 						// We will land here only if we couldn't run the component, which is not
 						// possible since we are adding the components dynamically, still if it
 						// happens, let the user know that we would love to hear their feedback
-						return errors.New("something went pretty wrong here, contact support@lacework.net")
+						return errors.New("something went pretty wrong here, contact cs@fortinet.com")
 					},
 				}
 			rootCmd.AddCommand(componentCmd)
@@ -756,7 +756,7 @@ func deleteComponent(args []string) (err error) {
 	cli.OutputChecklist(successIcon, "Component %s deleted\n", color.HiYellowString(component.Name))
 	cli.OutputHuman("\n- We will do better next time.\n")
 	cli.OutputHuman("\nDo you want to provide feedback?\n")
-	cli.OutputHuman("Reach out to us at %s\n", color.HiCyanString("support@lacework.net"))
+	cli.OutputHuman("Reach out to us at %s\n", color.HiCyanString("cs@fortinet.com"))
 	return
 }
 
@@ -1129,7 +1129,7 @@ func prototypeRunComponentsDelete(args []string) (err error) {
 	cli.OutputChecklist(successIcon, "Component %s deleted\n", color.HiYellowString(component.Name))
 	cli.OutputHuman("\n- We will do better next time.\n")
 	cli.OutputHuman("\nDo you want to provide feedback?\n")
-	cli.OutputHuman("Reach out to us at %s\n", color.HiCyanString("support@lacework.net"))
+	cli.OutputHuman("Reach out to us at %s\n", color.HiCyanString("cs@fortinet.com"))
 	return
 }
 

--- a/cli/cmd/component_dev.go
+++ b/cli/cmd/component_dev.go
@@ -599,7 +599,7 @@ func cdkInitGitRepo(rootPath string) error {
 	_, err = w.Commit("example go-git commit", &git.CommitOptions{
 		Author: &object.Signature{
 			Name:  "Component Scaffolding",
-			Email: "support@lacework.net",
+			Email: "cs@fortinet.com",
 			When:  time.Now(),
 		},
 	})

--- a/cli/cmd/errors.go
+++ b/cli/cmd/errors.go
@@ -131,7 +131,7 @@ func (e *vulnerabilityPolicyError) validate() bool {
 
 func yikes(msg string) error {
 	return errors.Wrap(
-		errors.New("something went pretty wrong here, contact support@lacework.net"),
+		errors.New("something went pretty wrong here, contact cs@fortinet.com"),
 		msg,
 	)
 }


### PR DESCRIPTION
## Summary

Change support email from support@lacework.net to cs@fortinet.com

## How did you test this change?

Tested locally.

Before:
<img width="682" height="206" alt="Screenshot 2025-10-07 at 11 53 29 AM" src="https://github.com/user-attachments/assets/82329c4a-dede-4497-8c9b-3ab42879db78" />

After:
<img width="780" height="206" alt="Screenshot 2025-10-07 at 12 00 54 PM" src="https://github.com/user-attachments/assets/fc5f01a1-774e-4000-80f6-d9e4586dd88b" />
