### PR TITLE
feat(lwpreflight): add CloudTrail org trusted service check

### DIFF
--- a/lwpreflight/aws/aws.go
+++ b/lwpreflight/aws/aws.go
@@ -85,6 +85,9 @@ func New(params Params) (*Preflight, error) {
 	}
 	if params.CloudTrail {
 		integrationTypes = append(integrationTypes, CloudTrail)
+		if params.IsOrg {
+			tasks = append(tasks, CheckCloudTrailOrgServiceEnabled)
+		}
 	}
 	if params.EksAuditLog {
 		integrationTypes = append(integrationTypes, EksAuditLog)

--- a/lwpreflight/aws/detail.go
+++ b/lwpreflight/aws/detail.go
@@ -21,14 +21,15 @@ type Details struct {
 	EKSClusters   []EKSCluster
 
 	// Fields for org-level
-	OrgAccess           bool
-	OrgID               string
-	IsManagementAccount bool
-	ManagementAccountID string
-	OrgAccountIDs       []string
-	OrgUnitIDs          []string
-	RootOrgUnitID       string
-	ControlTowerAccess  bool
+	OrgAccess                   bool
+	OrgID                       string
+	IsManagementAccount         bool
+	ManagementAccountID         string
+	OrgAccountIDs               []string
+	OrgUnitIDs                  []string
+	RootOrgUnitID               string
+	ControlTowerAccess          bool
+	CloudTrailOrgServiceEnabled bool
 }
 
 type Trail struct {
@@ -168,10 +169,29 @@ func fetchOrg(p *Preflight) error {
 		return nil
 	}
 	for _, service := range servicesOutput.EnabledServicePrincipals {
-		if *service.ServicePrincipal == "controltower.amazonaws.com" {
+		switch *service.ServicePrincipal {
+		case "controltower.amazonaws.com":
 			p.details.ControlTowerAccess = true
+		case "cloudtrail.amazonaws.com":
+			p.details.CloudTrailOrgServiceEnabled = true
 		}
 	}
+
+	return nil
+}
+
+func CheckCloudTrailOrgServiceEnabled(p *Preflight) error {
+	if p.details.ControlTowerAccess || p.details.CloudTrailOrgServiceEnabled {
+		return nil
+	}
+
+	p.verboseWriter.Write("Verifying CloudTrail is enabled as a trusted service in the organization")
+	p.errors[CloudTrail] = append(
+		p.errors[CloudTrail],
+		"CloudTrail is not enabled as a trusted service in the AWS Organization. "+
+			"Enable it from the management account: "+
+			"aws organizations enable-aws-service-access --service-principal cloudtrail.amazonaws.com",
+	)
 
 	return nil
 }


### PR DESCRIPTION
## Summary

Adds a preflight check that verifies cloudtrail.amazonaws.com is enabled as a trusted service in the AWS Organization when running org-level CloudTrail integration preflight.       
                                                                                                                                                                                       
Previously, org-level preflight only tracked whether Control Tower was enabled. For customers who run a plain AWS Organization without Control Tower, CloudTrail integration requires cloudtrail.amazonaws.com to be enabled as a trusted service (aws organizations enable-aws-service-access). Without this, preflight passed but the integration failed later at apply time with a less actionable error.                                                                                                                                                   
                                                                                
 Changes:                                                      
  - lwpreflight/aws/detail.go: detect the cloudtrail.amazonaws.com service principal in fetchOrg and store it on Details.CloudTrailOrgServiceEnabled. Add CheckCloudTrailOrgServiceEnabled, which short-circuits if Control Tower is present (CT manages its own trail) and otherwise surfaces an actionable error with the exact remediation command.                                                                                                                                                                           
  - lwpreflight/aws/aws.go: register the check when params.CloudTrail && params.IsOrg. 
  
## How did you test this change?

Tested on devspace and qan. 

## Issue
https://lacework.atlassian.net/browse/CAD-2035

## Screenshots
<img width="1449" height="360" alt="Screenshot 2026-04-21 at 1 57 02 PM" src="https://github.com/user-attachments/assets/52f904fe-631d-4118-97fc-16463abf16ae" />

<img width="1449" height="360" alt="Screenshot 2026-04-21 at 1 59 49 PM" src="https://github.com/user-attachments/assets/5ff58250-6e53-46cd-b574-e3a40d3c2380" />

