### PR TITLE
chore: add Jira ticket section at top of PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,6 +18,12 @@
   Learn more about contributing: https://github.com/lacework/go-sdk/blob/main/CONTRIBUTING.md
 -->
 
+## Jira Ticket
+
+<!--
+  Link to the Jira ticket (e.g., https://lacework.atlassian.net/browse/XXX-1234)
+-->
+
 ## Summary
 
 <!--

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -36,9 +36,3 @@
   How exactly did you verify that your PR solves the issue you wanted to solve?
   Include any other relevant information such as how to use the new functionality, screenshots, etc.
 -->
-
-## Issue
-
-<!--
-  Include the link to a Jira/Github issue
--->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,10 +18,10 @@
   Learn more about contributing: https://github.com/lacework/go-sdk/blob/main/CONTRIBUTING.md
 -->
 
-## Jira Ticket
+## Jira/Github ticket
 
 <!--
-  Link to the Jira ticket (e.g., https://lacework.atlassian.net/browse/XXX-1234)
+  Link to the Jira ticket (e.g., https://lacework.atlassian.net/browse/XXX-1234) or GitHub issue
 -->
 
 ## Summary


### PR DESCRIPTION
## Jira/Github ticket

N/A — repo tooling change.

## Summary

Updates `.github/pull_request_template.md`:

- Adds a **Jira/Github ticket** section at the top so contributors surface the associated ticket immediately, above Summary / How did you test.
- Removes the old bottom **Issue** section (now redundant with the top section).

## How did you test this change?

- [x] Markdown renders correctly (visible in this PR's description preview)
- [x] No code/build impact — template-only change