### PR TITLE
feat(cli): add preflight command for cloud onboarding checks

### DIFF
--- a/cli/cmd/preflight.go
+++ b/cli/cmd/preflight.go
@@ -1,0 +1,90 @@
+//
+// Author:: Lacework Inc.
+// Copyright:: Copyright 2026, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+
+package cmd
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
+	"github.com/lacework/go-sdk/v2/lwpreflight/verbosewriter"
+)
+
+var (
+	preflightCmd = &cobra.Command{
+		Use:   "preflight",
+		Short: "Run preflight checks against a cloud account",
+		Long: `Run preflight checks against AWS, Azure, or GCP accounts to verify that the
+caller identity has the IAM permissions and access required to onboard the
+selected Lacework integrations. Any missing permissions are reported as
+errors keyed by integration type.`,
+	}
+)
+
+func init() {
+	rootCmd.AddCommand(preflightCmd)
+	preflightCmd.AddCommand(preflightAwsCmd)
+	preflightCmd.AddCommand(preflightAzureCmd)
+	preflightCmd.AddCommand(preflightGcpCmd)
+}
+
+// discardVerboseWriter satisfies verbosewriter.WriteCloser without writing
+// anything, so progress chatter does not corrupt machine-readable output.
+type discardVerboseWriter struct{}
+
+func (discardVerboseWriter) Write(string) {}
+func (discardVerboseWriter) Close()       {}
+
+// silentVerboseWriter returns a verbose writer that drops all output. We use
+// this whenever the user has opted out of human output (e.g. --json), so the
+// preflight package does not write progress lines to the terminal.
+func silentVerboseWriter() verbosewriter.WriteCloser {
+	return discardVerboseWriter{}
+}
+
+// renderIntegrationErrors prints a per-integration pass/fail summary derived
+// from the Errors map returned by every preflight provider. integrations is
+// the list of integrations the caller actually requested, so we can surface
+// "OK" for ones that ran without issues. errs is the raw map keyed by the
+// provider's IntegrationType (a string alias).
+func renderIntegrationErrors(integrations []string, errs map[string][]string) {
+	if len(integrations) == 0 {
+		cli.OutputHuman("No integrations selected.\n")
+		return
+	}
+
+	sort.Strings(integrations)
+
+	cli.OutputHuman("\nResults\n")
+	for _, integration := range integrations {
+		issues := errs[integration]
+		if len(issues) == 0 {
+			cli.OutputHuman("  %s: OK\n", integration)
+			continue
+		}
+		cli.OutputHuman("  %s: FAIL (%d issue(s))\n", integration, len(issues))
+		for _, issue := range issues {
+			cli.OutputHuman("    - %s\n", issue)
+		}
+	}
+}
+
+// preflightExitError returns a non-nil error when any integration reported
+// problems, so the CLI exits non-zero and scripts can branch on it. The
+// rendered output (human or JSON) has already been emitted by the caller.
+func preflightExitError(errs map[string][]string) error {
+	total := 0
+	for _, v := range errs {
+		total += len(v)
+	}
+	if total == 0 {
+		return nil
+	}
+	return errors.New(fmt.Sprintf("preflight reported %d issue(s)", total))
+}

--- a/cli/cmd/preflight.go
+++ b/cli/cmd/preflight.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	"github.com/lacework/go-sdk/v2/lwpreflight/verbosewriter"
@@ -86,5 +85,5 @@ func preflightExitError(errs map[string][]string) error {
 	if total == 0 {
 		return nil
 	}
-	return errors.New(fmt.Sprintf("preflight reported %d issue(s)", total))
+	return fmt.Errorf("preflight reported %d issue(s)", total)
 }

--- a/cli/cmd/preflight.go
+++ b/cli/cmd/preflight.go
@@ -1,6 +1,6 @@
 //
-// Author:: Lacework Inc.
-// Copyright:: Copyright 2026, Lacework Inc.
+// Author:: Fortinet
+// Copyright:: Copyright 2026, Fortinet
 // License:: Apache License, Version 2.0
 //
 

--- a/cli/cmd/preflight_aws.go
+++ b/cli/cmd/preflight_aws.go
@@ -38,8 +38,9 @@ config files, EC2 instance profile) unless explicit --profile or
 
 At least one integration flag must be set: --agentless, --config,
 --cloudtrail, or --eks-audit-log.`,
-		Args: cobra.NoArgs,
-		RunE: runPreflightAws,
+		Args:         cobra.NoArgs,
+		SilenceUsage: true,
+		RunE:         runPreflightAws,
 	}
 )
 
@@ -92,7 +93,7 @@ func runPreflightAws(_ *cobra.Command, _ []string) error {
 	if err != nil {
 		return errors.Wrap(err, "unable to initialize AWS preflight")
 	}
-	if !cli.HumanOutput() {
+	if !cli.HumanOutput() || !cli.InteractiveMode() {
 		pf.SetVerboseWriter(silentVerboseWriter())
 	}
 

--- a/cli/cmd/preflight_aws.go
+++ b/cli/cmd/preflight_aws.go
@@ -7,6 +7,8 @@
 package cmd
 
 import (
+	"strings"
+
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
@@ -125,14 +127,14 @@ func renderAwsHumanResult(result *aws.Result, integrations []string) {
 	cli.OutputHuman("  Admin:   %t\n", result.Caller.IsAdmin)
 
 	if len(integrations) > 0 {
-		cli.OutputHuman("\nIntegrations checked: %s\n", joinIntegrations(integrations))
+		cli.OutputHuman("\nIntegrations checked: %s\n", strings.Join(integrations, ", "))
 	}
 
 	renderIntegrationErrors(integrations, toStringErrorMap(result.Errors))
 
 	cli.OutputHuman("\nDetails\n")
 	if len(result.Details.Regions) > 0 {
-		cli.OutputHuman("  Enabled regions: %s\n", joinIntegrations(result.Details.Regions))
+		cli.OutputHuman("  Enabled regions: %s\n", strings.Join(result.Details.Regions, ", "))
 	}
 	if result.Details.OrgID != "" {
 		cli.OutputHuman("  Organization ID:        %s\n", result.Details.OrgID)
@@ -182,17 +184,6 @@ func toStringErrorMap[K ~string](in map[K][]string) map[string][]string {
 	out := make(map[string][]string, len(in))
 	for k, v := range in {
 		out[string(k)] = v
-	}
-	return out
-}
-
-func joinIntegrations(items []string) string {
-	out := ""
-	for i, s := range items {
-		if i > 0 {
-			out += ", "
-		}
-		out += s
 	}
 	return out
 }

--- a/cli/cmd/preflight_aws.go
+++ b/cli/cmd/preflight_aws.go
@@ -1,0 +1,197 @@
+//
+// Author:: Lacework Inc.
+// Copyright:: Copyright 2026, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+
+package cmd
+
+import (
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
+	"github.com/lacework/go-sdk/v2/lwpreflight/aws"
+)
+
+var (
+	preflightAwsState struct {
+		agentless       bool
+		config          bool
+		cloudtrail      bool
+		eksAuditLog     bool
+		isOrg           bool
+		region          string
+		profile         string
+		accessKeyID     string
+		secretAccessKey string
+		sessionToken    string
+	}
+
+	preflightAwsCmd = &cobra.Command{
+		Use:   "aws",
+		Short: "Run preflight checks against an AWS account",
+		Long: `Run preflight checks against an AWS account to verify the caller has the
+permissions required by the selected Lacework integrations. Credentials are
+resolved using the standard AWS SDK chain (environment variables, shared
+config files, EC2 instance profile) unless explicit --profile or
+--access-key-id/--secret-access-key flags are provided.
+
+At least one integration flag must be set: --agentless, --config,
+--cloudtrail, or --eks-audit-log.`,
+		Args: cobra.NoArgs,
+		RunE: runPreflightAws,
+	}
+)
+
+func init() {
+	flags := preflightAwsCmd.Flags()
+	flags.BoolVar(&preflightAwsState.agentless, "agentless", false,
+		"check permissions for the Agentless integration")
+	flags.BoolVar(&preflightAwsState.config, "config", false,
+		"check permissions for the Config integration")
+	flags.BoolVar(&preflightAwsState.cloudtrail, "cloudtrail", false,
+		"check permissions for the CloudTrail integration")
+	flags.BoolVar(&preflightAwsState.eksAuditLog, "eks-audit-log", false,
+		"check permissions for the EKS Audit Log integration")
+	flags.BoolVar(&preflightAwsState.isOrg, "is-org", false,
+		"treat the account as an AWS Organizations management account")
+	flags.StringVar(&preflightAwsState.region, "region", "",
+		"AWS region to use for API calls")
+	flags.StringVar(&preflightAwsState.profile, "profile", "",
+		"AWS shared config profile to load credentials from")
+	flags.StringVar(&preflightAwsState.accessKeyID, "access-key-id", "",
+		"AWS access key ID (paired with --secret-access-key)")
+	flags.StringVar(&preflightAwsState.secretAccessKey, "secret-access-key", "",
+		"AWS secret access key (paired with --access-key-id)")
+	flags.StringVar(&preflightAwsState.sessionToken, "session-token", "",
+		"AWS session token for temporary credentials")
+}
+
+func runPreflightAws(_ *cobra.Command, _ []string) error {
+	s := preflightAwsState
+	if !s.agentless && !s.config && !s.cloudtrail && !s.eksAuditLog {
+		return errors.New(
+			"at least one of --agentless, --config, --cloudtrail, --eks-audit-log must be set",
+		)
+	}
+
+	params := aws.Params{
+		Agentless:       s.agentless,
+		Config:          s.config,
+		CloudTrail:      s.cloudtrail,
+		EksAuditLog:     s.eksAuditLog,
+		IsOrg:           s.isOrg,
+		Region:          s.region,
+		Profile:         s.profile,
+		AccessKeyID:     s.accessKeyID,
+		SecretAccessKey: s.secretAccessKey,
+		SessionToken:    s.sessionToken,
+	}
+
+	pf, err := aws.New(params)
+	if err != nil {
+		return errors.Wrap(err, "unable to initialize AWS preflight")
+	}
+	if !cli.HumanOutput() {
+		pf.SetVerboseWriter(silentVerboseWriter())
+	}
+
+	cli.StartProgress("Running AWS preflight checks...")
+	result, err := pf.Run()
+	cli.StopProgress()
+	if err != nil {
+		return errors.Wrap(err, "AWS preflight failed")
+	}
+
+	if cli.JSONOutput() {
+		if err := cli.OutputJSON(result); err != nil {
+			return err
+		}
+		return preflightExitError(toStringErrorMap(result.Errors))
+	}
+
+	renderAwsHumanResult(result, integrationsRequestedAws(s))
+	return preflightExitError(toStringErrorMap(result.Errors))
+}
+
+func renderAwsHumanResult(result *aws.Result, integrations []string) {
+	cli.OutputHuman("Preflight check: AWS\n\n")
+	cli.OutputHuman("Caller\n")
+	cli.OutputHuman("  ARN:     %s\n", result.Caller.ARN)
+	cli.OutputHuman("  Account: %s\n", result.Caller.AccountID)
+	cli.OutputHuman("  User ID: %s\n", result.Caller.UserID)
+	cli.OutputHuman("  Name:    %s\n", result.Caller.Name)
+	cli.OutputHuman("  Admin:   %t\n", result.Caller.IsAdmin)
+
+	if len(integrations) > 0 {
+		cli.OutputHuman("\nIntegrations checked: %s\n", joinIntegrations(integrations))
+	}
+
+	renderIntegrationErrors(integrations, toStringErrorMap(result.Errors))
+
+	cli.OutputHuman("\nDetails\n")
+	if len(result.Details.Regions) > 0 {
+		cli.OutputHuman("  Enabled regions: %s\n", joinIntegrations(result.Details.Regions))
+	}
+	if result.Details.OrgID != "" {
+		cli.OutputHuman("  Organization ID:        %s\n", result.Details.OrgID)
+		cli.OutputHuman("  Management account ID:  %s\n", result.Details.ManagementAccountID)
+		cli.OutputHuman("  Caller is mgmt account: %t\n", result.Details.IsManagementAccount)
+	}
+	if result.Details.ExistingTrail.Name != "" {
+		cli.OutputHuman("  Eligible CloudTrail:    %s\n", result.Details.ExistingTrail.Name)
+	}
+	if len(result.Details.EKSClusters) > 0 {
+		cli.OutputHuman("  EKS clusters: %d\n", len(result.Details.EKSClusters))
+	}
+}
+
+func integrationsRequestedAws(s struct {
+	agentless       bool
+	config          bool
+	cloudtrail      bool
+	eksAuditLog     bool
+	isOrg           bool
+	region          string
+	profile         string
+	accessKeyID     string
+	secretAccessKey string
+	sessionToken    string
+}) []string {
+	out := []string{}
+	if s.agentless {
+		out = append(out, string(aws.Agentless))
+	}
+	if s.config {
+		out = append(out, string(aws.Config))
+	}
+	if s.cloudtrail {
+		out = append(out, string(aws.CloudTrail))
+	}
+	if s.eksAuditLog {
+		out = append(out, string(aws.EksAuditLog))
+	}
+	return out
+}
+
+// toStringErrorMap converts a provider's map[IntegrationType][]string into the
+// generic map[string][]string the shared renderer expects. The IntegrationType
+// type alias differs per provider, so we normalise once here.
+func toStringErrorMap[K ~string](in map[K][]string) map[string][]string {
+	out := make(map[string][]string, len(in))
+	for k, v := range in {
+		out[string(k)] = v
+	}
+	return out
+}
+
+func joinIntegrations(items []string) string {
+	out := ""
+	for i, s := range items {
+		if i > 0 {
+			out += ", "
+		}
+		out += s
+	}
+	return out
+}

--- a/cli/cmd/preflight_aws.go
+++ b/cli/cmd/preflight_aws.go
@@ -1,6 +1,6 @@
 //
-// Author:: Lacework Inc.
-// Copyright:: Copyright 2026, Lacework Inc.
+// Author:: Fortinet
+// Copyright:: Copyright 2026, Fortinet
 // License:: Apache License, Version 2.0
 //
 

--- a/cli/cmd/preflight_azure.go
+++ b/cli/cmd/preflight_azure.go
@@ -35,8 +35,9 @@ Credentials are resolved using DefaultAzureCredential unless --client-id and
 
 At least one integration flag must be set: --agentless, --config, or
 --activity-log.`,
-		Args: cobra.NoArgs,
-		RunE: runPreflightAzure,
+		Args:         cobra.NoArgs,
+		SilenceUsage: true,
+		RunE:         runPreflightAzure,
 	}
 )
 
@@ -86,7 +87,7 @@ func runPreflightAzure(_ *cobra.Command, _ []string) error {
 	if err != nil {
 		return errors.Wrap(err, "unable to initialize Azure preflight")
 	}
-	if !cli.HumanOutput() {
+	if !cli.HumanOutput() || !cli.InteractiveMode() {
 		pf.SetVerboseWriter(silentVerboseWriter())
 	}
 

--- a/cli/cmd/preflight_azure.go
+++ b/cli/cmd/preflight_azure.go
@@ -1,0 +1,152 @@
+//
+// Author:: Lacework Inc.
+// Copyright:: Copyright 2026, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+
+package cmd
+
+import (
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
+	"github.com/lacework/go-sdk/v2/lwpreflight/azure"
+)
+
+var (
+	preflightAzureState struct {
+		agentless      bool
+		config         bool
+		activityLog    bool
+		subscriptionID string
+		tenantID       string
+		clientID       string
+		clientSecret   string
+		region         string
+	}
+
+	preflightAzureCmd = &cobra.Command{
+		Use:   "azure",
+		Short: "Run preflight checks against an Azure subscription",
+		Long: `Run preflight checks against an Azure subscription to verify the caller has
+the role assignments required by the selected Lacework integrations.
+Credentials are resolved using DefaultAzureCredential unless --client-id and
+--client-secret are provided for a service principal.
+
+At least one integration flag must be set: --agentless, --config, or
+--activity-log.`,
+		Args: cobra.NoArgs,
+		RunE: runPreflightAzure,
+	}
+)
+
+func init() {
+	flags := preflightAzureCmd.Flags()
+	flags.BoolVar(&preflightAzureState.agentless, "agentless", false,
+		"check permissions for the Agentless integration")
+	flags.BoolVar(&preflightAzureState.config, "config", false,
+		"check permissions for the Config integration")
+	flags.BoolVar(&preflightAzureState.activityLog, "activity-log", false,
+		"check permissions for the Activity Log integration")
+	flags.StringVar(&preflightAzureState.subscriptionID, "subscription-id", "",
+		"Azure subscription ID (required)")
+	flags.StringVar(&preflightAzureState.tenantID, "tenant-id", "",
+		"Azure tenant ID (required when using --client-id/--client-secret)")
+	flags.StringVar(&preflightAzureState.clientID, "client-id", "",
+		"Azure service principal client ID")
+	flags.StringVar(&preflightAzureState.clientSecret, "client-secret", "",
+		"Azure service principal client secret")
+	flags.StringVar(&preflightAzureState.region, "region", "",
+		"Azure region to use for region-scoped checks")
+}
+
+func runPreflightAzure(_ *cobra.Command, _ []string) error {
+	s := preflightAzureState
+	if !s.agentless && !s.config && !s.activityLog {
+		return errors.New(
+			"at least one of --agentless, --config, --activity-log must be set",
+		)
+	}
+	if s.subscriptionID == "" {
+		return errors.New("--subscription-id is required")
+	}
+
+	params := azure.Params{
+		Agentless:      s.agentless,
+		Config:         s.config,
+		ActivityLog:    s.activityLog,
+		SubscriptionID: s.subscriptionID,
+		TenantID:       s.tenantID,
+		ClientID:       s.clientID,
+		ClientSecret:   s.clientSecret,
+		Region:         s.region,
+	}
+
+	pf, err := azure.New(params)
+	if err != nil {
+		return errors.Wrap(err, "unable to initialize Azure preflight")
+	}
+	if !cli.HumanOutput() {
+		pf.SetVerboseWriter(silentVerboseWriter())
+	}
+
+	cli.StartProgress("Running Azure preflight checks...")
+	result, err := pf.Run()
+	cli.StopProgress()
+	if err != nil {
+		return errors.Wrap(err, "Azure preflight failed")
+	}
+
+	if cli.JSONOutput() {
+		if err := cli.OutputJSON(result); err != nil {
+			return err
+		}
+		return preflightExitError(toStringErrorMap(result.Errors))
+	}
+
+	renderAzureHumanResult(result, integrationsRequestedAzure(s))
+	return preflightExitError(toStringErrorMap(result.Errors))
+}
+
+func renderAzureHumanResult(result *azure.Result, integrations []string) {
+	cli.OutputHuman("Preflight check: Azure\n\n")
+	cli.OutputHuman("Caller\n")
+	cli.OutputHuman("  Object ID:    %s\n", result.Caller.ObjectID)
+	cli.OutputHuman("  Display name: %s\n", result.Caller.DisplayName)
+	cli.OutputHuman("  Tenant ID:    %s\n", result.Caller.TenantID)
+	cli.OutputHuman("  Admin:        %t\n", result.Caller.IsAdmin)
+
+	if len(integrations) > 0 {
+		cli.OutputHuman("\nIntegrations checked: %s\n", joinIntegrations(integrations))
+	}
+
+	renderIntegrationErrors(integrations, toStringErrorMap(result.Errors))
+
+	if len(result.Details.Regions) > 0 {
+		cli.OutputHuman("\nDetails\n")
+		cli.OutputHuman("  Available regions: %d\n", len(result.Details.Regions))
+	}
+}
+
+func integrationsRequestedAzure(s struct {
+	agentless      bool
+	config         bool
+	activityLog    bool
+	subscriptionID string
+	tenantID       string
+	clientID       string
+	clientSecret   string
+	region         string
+}) []string {
+	out := []string{}
+	if s.agentless {
+		out = append(out, string(azure.Agentless))
+	}
+	if s.config {
+		out = append(out, string(azure.Config))
+	}
+	if s.activityLog {
+		out = append(out, string(azure.ActivityLog))
+	}
+	return out
+}

--- a/cli/cmd/preflight_azure.go
+++ b/cli/cmd/preflight_azure.go
@@ -7,6 +7,8 @@
 package cmd
 
 import (
+	"strings"
+
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
@@ -118,7 +120,7 @@ func renderAzureHumanResult(result *azure.Result, integrations []string) {
 	cli.OutputHuman("  Admin:        %t\n", result.Caller.IsAdmin)
 
 	if len(integrations) > 0 {
-		cli.OutputHuman("\nIntegrations checked: %s\n", joinIntegrations(integrations))
+		cli.OutputHuman("\nIntegrations checked: %s\n", strings.Join(integrations, ", "))
 	}
 
 	renderIntegrationErrors(integrations, toStringErrorMap(result.Errors))

--- a/cli/cmd/preflight_azure.go
+++ b/cli/cmd/preflight_azure.go
@@ -1,6 +1,6 @@
 //
-// Author:: Lacework Inc.
-// Copyright:: Copyright 2026, Lacework Inc.
+// Author:: Fortinet
+// Copyright:: Copyright 2026, Fortinet
 // License:: Apache License, Version 2.0
 //
 

--- a/cli/cmd/preflight_gcp.go
+++ b/cli/cmd/preflight_gcp.go
@@ -1,0 +1,158 @@
+//
+// Author:: Lacework Inc.
+// Copyright:: Copyright 2026, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+
+package cmd
+
+import (
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
+	"github.com/lacework/go-sdk/v2/lwpreflight/gcp"
+)
+
+var (
+	preflightGcpState struct {
+		agentless       bool
+		auditLog        bool
+		config          bool
+		gkeAuditLog     bool
+		region          string
+		orgID           string
+		projectID       string
+		accessToken     string
+		credentialsFile string
+	}
+
+	preflightGcpCmd = &cobra.Command{
+		Use:   "gcp",
+		Short: "Run preflight checks against a GCP project",
+		Long: `Run preflight checks against a GCP project to verify the caller has the IAM
+permissions required by the selected Lacework integrations. Credentials are
+resolved from --access-token, --credentials-file, or the
+GOOGLE_APPLICATION_CREDENTIALS environment variable.
+
+At least one integration flag must be set: --agentless, --audit-log,
+--config, or --gke-audit-log.`,
+		Args: cobra.NoArgs,
+		RunE: runPreflightGcp,
+	}
+)
+
+func init() {
+	flags := preflightGcpCmd.Flags()
+	flags.BoolVar(&preflightGcpState.agentless, "agentless", false,
+		"check permissions for the Agentless integration")
+	flags.BoolVar(&preflightGcpState.auditLog, "audit-log", false,
+		"check permissions for the Audit Log integration")
+	flags.BoolVar(&preflightGcpState.config, "config", false,
+		"check permissions for the Config integration")
+	flags.BoolVar(&preflightGcpState.gkeAuditLog, "gke-audit-log", false,
+		"check permissions for the GKE Audit Log integration")
+	flags.StringVar(&preflightGcpState.region, "region", "",
+		"GCP region to use for region-scoped checks")
+	flags.StringVar(&preflightGcpState.orgID, "org-id", "",
+		"GCP organization ID; sets the integration to org-level when non-empty")
+	flags.StringVar(&preflightGcpState.projectID, "project-id", "",
+		"GCP project ID (required)")
+	flags.StringVar(&preflightGcpState.accessToken, "access-token", "",
+		"GCP OAuth2 access token")
+	flags.StringVar(&preflightGcpState.credentialsFile, "credentials-file", "",
+		"Path to a GCP service account credentials JSON file")
+}
+
+func runPreflightGcp(_ *cobra.Command, _ []string) error {
+	s := preflightGcpState
+	if !s.agentless && !s.auditLog && !s.config && !s.gkeAuditLog {
+		return errors.New(
+			"at least one of --agentless, --audit-log, --config, --gke-audit-log must be set",
+		)
+	}
+	if s.projectID == "" {
+		return errors.New("--project-id is required")
+	}
+
+	params := gcp.Params{
+		Agentless:       s.agentless,
+		AuditLog:        s.auditLog,
+		Config:          s.config,
+		GkeAuditLog:     s.gkeAuditLog,
+		Region:          s.region,
+		OrgID:           s.orgID,
+		ProjectID:       s.projectID,
+		AccessToken:     s.accessToken,
+		CredentialsFile: s.credentialsFile,
+	}
+
+	pf, err := gcp.New(params)
+	if err != nil {
+		return errors.Wrap(err, "unable to initialize GCP preflight")
+	}
+	if !cli.HumanOutput() {
+		pf.SetVerboseWriter(silentVerboseWriter())
+	}
+
+	cli.StartProgress("Running GCP preflight checks...")
+	result, err := pf.Run()
+	cli.StopProgress()
+	if err != nil {
+		return errors.Wrap(err, "GCP preflight failed")
+	}
+
+	if cli.JSONOutput() {
+		if err := cli.OutputJSON(result); err != nil {
+			return err
+		}
+		return preflightExitError(toStringErrorMap(result.Errors))
+	}
+
+	renderGcpHumanResult(result, integrationsRequestedGcp(s))
+	return preflightExitError(toStringErrorMap(result.Errors))
+}
+
+func renderGcpHumanResult(result *gcp.Result, integrations []string) {
+	cli.OutputHuman("Preflight check: GCP\n\n")
+	cli.OutputHuman("Caller\n")
+	cli.OutputHuman("  Email:   %s\n", result.Caller.Email)
+	cli.OutputHuman("  User ID: %s\n", result.Caller.UserID)
+
+	if len(integrations) > 0 {
+		cli.OutputHuman("\nIntegrations checked: %s\n", joinIntegrations(integrations))
+	}
+
+	renderIntegrationErrors(integrations, toStringErrorMap(result.Errors))
+
+	if len(result.Details.SchedulerRegions) > 0 {
+		cli.OutputHuman("\nDetails\n")
+		cli.OutputHuman("  Cloud Scheduler regions: %d\n", len(result.Details.SchedulerRegions))
+	}
+}
+
+func integrationsRequestedGcp(s struct {
+	agentless       bool
+	auditLog        bool
+	config          bool
+	gkeAuditLog     bool
+	region          string
+	orgID           string
+	projectID       string
+	accessToken     string
+	credentialsFile string
+}) []string {
+	out := []string{}
+	if s.agentless {
+		out = append(out, string(gcp.Agentless))
+	}
+	if s.auditLog {
+		out = append(out, string(gcp.AuditLog))
+	}
+	if s.config {
+		out = append(out, string(gcp.Config))
+	}
+	if s.gkeAuditLog {
+		out = append(out, string(gcp.GkeAuditLog))
+	}
+	return out
+}

--- a/cli/cmd/preflight_gcp.go
+++ b/cli/cmd/preflight_gcp.go
@@ -36,8 +36,9 @@ GOOGLE_APPLICATION_CREDENTIALS environment variable.
 
 At least one integration flag must be set: --agentless, --audit-log,
 --config, or --gke-audit-log.`,
-		Args: cobra.NoArgs,
-		RunE: runPreflightGcp,
+		Args:         cobra.NoArgs,
+		SilenceUsage: true,
+		RunE:         runPreflightGcp,
 	}
 )
 
@@ -90,7 +91,7 @@ func runPreflightGcp(_ *cobra.Command, _ []string) error {
 	if err != nil {
 		return errors.Wrap(err, "unable to initialize GCP preflight")
 	}
-	if !cli.HumanOutput() {
+	if !cli.HumanOutput() || !cli.InteractiveMode() {
 		pf.SetVerboseWriter(silentVerboseWriter())
 	}
 

--- a/cli/cmd/preflight_gcp.go
+++ b/cli/cmd/preflight_gcp.go
@@ -7,6 +7,8 @@
 package cmd
 
 import (
+	"strings"
+
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
@@ -120,7 +122,7 @@ func renderGcpHumanResult(result *gcp.Result, integrations []string) {
 	cli.OutputHuman("  User ID: %s\n", result.Caller.UserID)
 
 	if len(integrations) > 0 {
-		cli.OutputHuman("\nIntegrations checked: %s\n", joinIntegrations(integrations))
+		cli.OutputHuman("\nIntegrations checked: %s\n", strings.Join(integrations, ", "))
 	}
 
 	renderIntegrationErrors(integrations, toStringErrorMap(result.Errors))

--- a/cli/cmd/preflight_gcp.go
+++ b/cli/cmd/preflight_gcp.go
@@ -1,6 +1,6 @@
 //
-// Author:: Lacework Inc.
-// Copyright:: Copyright 2026, Lacework Inc.
+// Author:: Fortinet
+// Copyright:: Copyright 2026, Fortinet
 // License:: Apache License, Version 2.0
 //
 

--- a/cli/cmd/preflight_test.go
+++ b/cli/cmd/preflight_test.go
@@ -1,0 +1,110 @@
+//
+// Author:: Lacework Inc.
+// Copyright:: Copyright 2026, Lacework Inc.
+// License:: Apache License, Version 2.0
+//
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/lacework/go-sdk/v2/lwpreflight/aws"
+	"github.com/lacework/go-sdk/v2/lwpreflight/azure"
+	"github.com/lacework/go-sdk/v2/lwpreflight/gcp"
+)
+
+func TestPreflightExitError(t *testing.T) {
+	t.Run("nil when no issues", func(t *testing.T) {
+		assert.NoError(t, preflightExitError(nil))
+		assert.NoError(t, preflightExitError(map[string][]string{}))
+		assert.NoError(t, preflightExitError(map[string][]string{"x": {}}))
+	})
+
+	t.Run("error when any issues", func(t *testing.T) {
+		err := preflightExitError(map[string][]string{
+			"aws_agentless":  {"a", "b"},
+			"aws_cloudtrail": {"c"},
+		})
+		assert.EqualError(t, err, "preflight reported 3 issue(s)")
+	})
+}
+
+func TestToStringErrorMapPerProvider(t *testing.T) {
+	awsErrs := map[aws.IntegrationType][]string{
+		aws.Agentless:  {"missing perm 1"},
+		aws.CloudTrail: {"missing perm 2", "missing perm 3"},
+	}
+	out := toStringErrorMap(awsErrs)
+	assert.Equal(t, []string{"missing perm 1"}, out["aws_agentless"])
+	assert.Equal(t, []string{"missing perm 2", "missing perm 3"}, out["aws_cloudtrail"])
+
+	azureErrs := map[azure.IntegrationType][]string{
+		azure.ActivityLog: {"missing role"},
+	}
+	assert.Equal(t, []string{"missing role"}, toStringErrorMap(azureErrs)["azure_activity_log"])
+
+	gcpErrs := map[gcp.IntegrationType][]string{
+		gcp.GkeAuditLog: {"missing iam"},
+	}
+	assert.Equal(t, []string{"missing iam"}, toStringErrorMap(gcpErrs)["gcp_gke_audit_log"])
+}
+
+func TestJoinIntegrations(t *testing.T) {
+	assert.Equal(t, "", joinIntegrations(nil))
+	assert.Equal(t, "a", joinIntegrations([]string{"a"}))
+	assert.Equal(t, "a, b, c", joinIntegrations([]string{"a", "b", "c"}))
+}
+
+func TestIntegrationsRequestedAws(t *testing.T) {
+	got := integrationsRequestedAws(struct {
+		agentless       bool
+		config          bool
+		cloudtrail      bool
+		eksAuditLog     bool
+		isOrg           bool
+		region          string
+		profile         string
+		accessKeyID     string
+		secretAccessKey string
+		sessionToken    string
+	}{agentless: true, cloudtrail: true})
+	assert.Equal(t, []string{"aws_agentless", "aws_cloudtrail"}, got)
+}
+
+func TestIntegrationsRequestedAzure(t *testing.T) {
+	got := integrationsRequestedAzure(struct {
+		agentless      bool
+		config         bool
+		activityLog    bool
+		subscriptionID string
+		tenantID       string
+		clientID       string
+		clientSecret   string
+		region         string
+	}{config: true, activityLog: true})
+	assert.Equal(t, []string{"azure_config", "azure_activity_log"}, got)
+}
+
+func TestIntegrationsRequestedGcp(t *testing.T) {
+	got := integrationsRequestedGcp(struct {
+		agentless       bool
+		auditLog        bool
+		config          bool
+		gkeAuditLog     bool
+		region          string
+		orgID           string
+		projectID       string
+		accessToken     string
+		credentialsFile string
+	}{auditLog: true, gkeAuditLog: true})
+	assert.Equal(t, []string{"gcp_audit_log", "gcp_gke_audit_log"}, got)
+}
+
+func TestSilentVerboseWriter(t *testing.T) {
+	w := silentVerboseWriter()
+	w.Write("anything")
+	w.Close()
+}

--- a/cli/cmd/preflight_test.go
+++ b/cli/cmd/preflight_test.go
@@ -52,12 +52,6 @@ func TestToStringErrorMapPerProvider(t *testing.T) {
 	assert.Equal(t, []string{"missing iam"}, toStringErrorMap(gcpErrs)["gcp_gke_audit_log"])
 }
 
-func TestJoinIntegrations(t *testing.T) {
-	assert.Equal(t, "", joinIntegrations(nil))
-	assert.Equal(t, "a", joinIntegrations([]string{"a"}))
-	assert.Equal(t, "a, b, c", joinIntegrations([]string{"a", "b", "c"}))
-}
-
 func TestIntegrationsRequestedAws(t *testing.T) {
 	got := integrationsRequestedAws(struct {
 		agentless       bool

--- a/cli/cmd/preflight_test.go
+++ b/cli/cmd/preflight_test.go
@@ -1,6 +1,6 @@
 //
-// Author:: Lacework Inc.
-// Copyright:: Copyright 2026, Lacework Inc.
+// Author:: Fortinet
+// Copyright:: Copyright 2026, Fortinet
 // License:: Apache License, Version 2.0
 //
 

--- a/integration/test_resources/help/no-command-provided
+++ b/integration/test_resources/help/no-command-provided
@@ -29,6 +29,7 @@ Available Commands:
   help                    Help about any command
   policy                  Manage policies
   policy-exception        Manage policy exceptions
+  preflight               Run preflight checks against a cloud account
   query                   Run and manage queries
   report-rule             Manage report rules
   resource-group          Manage resource groups

--- a/integration/test_resources/help/preflight
+++ b/integration/test_resources/help/preflight
@@ -1,0 +1,31 @@
+Run preflight checks against AWS, Azure, or GCP accounts to verify that the
+caller identity has the IAM permissions and access required to onboard the
+selected Lacework integrations. Any missing permissions are reported as
+errors keyed by integration type.
+
+Usage:
+  lacework preflight [command]
+
+Available Commands:
+  aws         Run preflight checks against an AWS account
+  azure       Run preflight checks against an Azure subscription
+  gcp         Run preflight checks against a GCP project
+
+Flags:
+  -h, --help   help for preflight
+
+Global Flags:
+  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -k, --api_key string      access key id
+  -s, --api_secret string   secret access key
+      --api_token string    access token (replaces the use of api_key and api_secret)
+      --debug               turn on debug logging
+      --json                switch commands output from human-readable to json format
+      --nocache             turn off caching
+      --nocolor             turn off colors
+      --noninteractive      turn off interactive mode (disable spinners, prompts, etc.)
+      --organization        access organization level data sets (org admins only)
+  -p, --profile string      switch between profiles configured at ~/.lacework.toml
+      --subaccount string   sub-account name inside your organization (org admins only)
+
+Use "lacework preflight [command] --help" for more information about a command.

--- a/integration/test_resources/help/preflight_aws
+++ b/integration/test_resources/help/preflight_aws
@@ -1,0 +1,37 @@
+Run preflight checks against an AWS account to verify the caller has the
+permissions required by the selected Lacework integrations. Credentials are
+resolved using the standard AWS SDK chain (environment variables, shared
+config files, EC2 instance profile) unless explicit --profile or
+--access-key-id/--secret-access-key flags are provided.
+
+At least one integration flag must be set: --agentless, --config,
+--cloudtrail, or --eks-audit-log.
+
+Usage:
+  lacework preflight aws [flags]
+
+Flags:
+      --access-key-id string       AWS access key ID (paired with --secret-access-key)
+      --agentless                  check permissions for the Agentless integration
+      --cloudtrail                 check permissions for the CloudTrail integration
+      --config                     check permissions for the Config integration
+      --eks-audit-log              check permissions for the EKS Audit Log integration
+  -h, --help                       help for aws
+      --is-org                     treat the account as an AWS Organizations management account
+      --profile string             AWS shared config profile to load credentials from
+      --region string              AWS region to use for API calls
+      --secret-access-key string   AWS secret access key (paired with --access-key-id)
+      --session-token string       AWS session token for temporary credentials
+
+Global Flags:
+  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -k, --api_key string      access key id
+  -s, --api_secret string   secret access key
+      --api_token string    access token (replaces the use of api_key and api_secret)
+      --debug               turn on debug logging
+      --json                switch commands output from human-readable to json format
+      --nocache             turn off caching
+      --nocolor             turn off colors
+      --noninteractive      turn off interactive mode (disable spinners, prompts, etc.)
+      --organization        access organization level data sets (org admins only)
+      --subaccount string   sub-account name inside your organization (org admins only)

--- a/integration/test_resources/help/preflight_azure
+++ b/integration/test_resources/help/preflight_azure
@@ -1,0 +1,35 @@
+Run preflight checks against an Azure subscription to verify the caller has
+the role assignments required by the selected Lacework integrations.
+Credentials are resolved using DefaultAzureCredential unless --client-id and
+--client-secret are provided for a service principal.
+
+At least one integration flag must be set: --agentless, --config, or
+--activity-log.
+
+Usage:
+  lacework preflight azure [flags]
+
+Flags:
+      --activity-log             check permissions for the Activity Log integration
+      --agentless                check permissions for the Agentless integration
+      --client-id string         Azure service principal client ID
+      --client-secret string     Azure service principal client secret
+      --config                   check permissions for the Config integration
+  -h, --help                     help for azure
+      --region string            Azure region to use for region-scoped checks
+      --subscription-id string   Azure subscription ID (required)
+      --tenant-id string         Azure tenant ID (required when using --client-id/--client-secret)
+
+Global Flags:
+  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -k, --api_key string      access key id
+  -s, --api_secret string   secret access key
+      --api_token string    access token (replaces the use of api_key and api_secret)
+      --debug               turn on debug logging
+      --json                switch commands output from human-readable to json format
+      --nocache             turn off caching
+      --nocolor             turn off colors
+      --noninteractive      turn off interactive mode (disable spinners, prompts, etc.)
+      --organization        access organization level data sets (org admins only)
+  -p, --profile string      switch between profiles configured at ~/.lacework.toml
+      --subaccount string   sub-account name inside your organization (org admins only)

--- a/integration/test_resources/help/preflight_gcp
+++ b/integration/test_resources/help/preflight_gcp
@@ -1,0 +1,36 @@
+Run preflight checks against a GCP project to verify the caller has the IAM
+permissions required by the selected Lacework integrations. Credentials are
+resolved from --access-token, --credentials-file, or the
+GOOGLE_APPLICATION_CREDENTIALS environment variable.
+
+At least one integration flag must be set: --agentless, --audit-log,
+--config, or --gke-audit-log.
+
+Usage:
+  lacework preflight gcp [flags]
+
+Flags:
+      --access-token string       GCP OAuth2 access token
+      --agentless                 check permissions for the Agentless integration
+      --audit-log                 check permissions for the Audit Log integration
+      --config                    check permissions for the Config integration
+      --credentials-file string   Path to a GCP service account credentials JSON file
+      --gke-audit-log             check permissions for the GKE Audit Log integration
+  -h, --help                      help for gcp
+      --org-id string             GCP organization ID; sets the integration to org-level when non-empty
+      --project-id string         GCP project ID (required)
+      --region string             GCP region to use for region-scoped checks
+
+Global Flags:
+  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -k, --api_key string      access key id
+  -s, --api_secret string   secret access key
+      --api_token string    access token (replaces the use of api_key and api_secret)
+      --debug               turn on debug logging
+      --json                switch commands output from human-readable to json format
+      --nocache             turn off caching
+      --nocolor             turn off colors
+      --noninteractive      turn off interactive mode (disable spinners, prompts, etc.)
+      --organization        access organization level data sets (org admins only)
+  -p, --profile string      switch between profiles configured at ~/.lacework.toml
+      --subaccount string   sub-account name inside your organization (org admins only)


### PR DESCRIPTION
## Jira/Github ticket

https://lacework.atlassian.net/browse/CAD-2046

## Summary

Adds a new top-level CLI command, `lacework preflight`, that wraps the existing `lwpreflight` package and exposes it from the command line for AWS, Azure, and GCP. Operators (and onboarding scripts) can now verify ahead of time whether the caller identity has the IAM permissions and access required to onboard a given Lacework integration, instead of discovering missing permissions during a `terraform apply` or first sync.

- `lacework preflight aws    [--agentless --config --cloudtrail --eks-audit-log --is-org --region ...]`
- `lacework preflight azure  [--agentless --config --activity-log --subscription-id ... --tenant-id ...]`
- `lacework preflight gcp    [--agentless --audit-log --config --gke-audit-log --project-id ... --org-id ...]`

Per-integration results render as `OK` or `FAIL (N issue(s))`; each missing permission appears on its own line (e.g. `Required permission missing: ec2:DescribeVpcs`). The global `--json` flag emits the raw `Result` from the SDK so the output can be consumed programmatically. The command exits non-zero if any integration has issues, so onboarding scripts can branch on it. When stdout is non-human (`--json` / `--noninteractive`), the `lwpreflight` verbose progress writer is silenced via `SetVerboseWriter` so it does not corrupt machine-readable output.

No SDK or API changes — the CLI is a thin wrapper over `lwpreflight/{aws,azure,gcp}`.

## Tests

### Build and unit tests

- `go build ./cli/...` and `go vet ./cli/cmd/preflight*.go` clean.
- `go test -vet=off ./cli/cmd/ -run TestPreflight...` — unit tests cover the exit-code logic, the generic `IntegrationType → string` mapping for all three providers, integration-list assembly, and the silent verbose writer.
- Help text verified for `preflight`, `preflight aws`, `preflight azure`, `preflight gcp`. Integration help golden files updated (`integration/test_resources/help/preflight*` and `no-command-provided`); `TestHelpAll` and `TestNoCommandProvided` pass in CI.

### AWS — live test matrix

Run against two accounts in the CAD org:
- **mgmt** — management account (`159****`), admin caller (`lvadlamudi`)
- **loki-test** — non-admin user in the same account

| # | Account | Flags | Exit | Result |
|---|---|---|---|---|
| 1 | mgmt | `--config` | 0 | `aws_config: OK` |
| 2 | mgmt | `--cloudtrail` | 0 | `aws_cloudtrail: OK` |
| 3 | mgmt | `--agentless` | 0 | `aws_agentless: OK` |
| 4 | mgmt | `--eks-audit-log` | 0 | `aws_eks_audit_log: OK` |
| 5 | mgmt | all four together | 0 | all OK |
| 6 | mgmt | all four + `--is-org` | 0 | all OK; org-only `CheckCloudTrailOrgServiceEnabled` task ran; org ID, OUs, member accounts, and `IsManagementAccount=true` populated correctly |
| 7 | mgmt | `--config --json --noninteractive` | 0 | clean JSON `Result` with `"Errors": {}`, no progress chatter on stderr, `python -m json.tool` validates |
| 8 | loki-test | `--config` | 1 | `aws_config: FAIL (132 issue(s))` — exercises missing-permission rendering across cloudformation/kms/lambda/s3/secretsmanager/sns |
| 9 | loki-test | `--cloudtrail` | 1 | `aws_cloudtrail: FAIL (86 issue(s))` |
| 10 | loki-test | `--eks-audit-log` | 1 | `aws_eks_audit_log: FAIL (62 issue(s))` |
| 11 | loki-test | `--config --is-org` | 1 | hard error: `Organizations:ListAccounts AccessDenied` — correct, loki-test is not a management-account principal |
| 12 | (no creds) | (no integration flag) | 1 | clean validation: `ERROR at least one of --agentless, --config, --cloudtrail, --eks-audit-log must be set` (no usage-block dump thanks to `SilenceUsage: true`) |
| 13 | (no creds) | `--help` | 0 | help renders |

### GCP — live test matrix

Run against project `abc-demo-project-123` with a `gcloud auth print-access-token` short-lived token. Caller resolved as `lvadlamudi@fortinet.com` with full project IAM bindings.

| # | Flags | Exit | Result |
|---|---|---|---|
| 1 | `--config` | 0 | `gcp_config: OK` |
| 2 | `--audit-log` | 0 | `gcp_audit_log: OK` |
| 3 | `--agentless` | 0 | `gcp_agentless: OK` |
| 4 | `--gke-audit-log` | 0 | `gcp_gke_audit_log: OK` |
| 5 | all four together | 0 | all OK; Cloud Scheduler regions populated (27) |
| 6 | `--config --json --noninteractive` | 0 | valid JSON, `Errors: {}` |
| 7 | (no integration flag) | 1 | clean validation error |
| 8 | `--config` without `--project-id` | 1 | `ERROR --project-id is required` |

Note: unlike the AWS package, the GCP `lwpreflight` package has no admin short-circuit — `OK` here means the caller actually holds every required permission on the project, not that the check was skipped.

### Azure — live test matrix

Run against the test subscription via service principal (`--client-id`/`--client-secret` flags). Caller resolved in tenant `a329d4bf-...` with `IsAdmin: true` (the package's admin short-circuit fires when the principal has Owner or Contributor at the subscription level).

| # | Flags | Exit | Result |
|---|---|---|---|
| 1 | `--config` | 0 | `azure_config: OK`, 36 available regions |
| 2 | `--activity-log` | 0 | `azure_activity_log: OK` |
| 3 | `--agentless` | 0 | `azure_agentless: OK` |
| 4 | all three together | 0 | all OK |
| 5 | `--config --json --noninteractive` | 0 | valid JSON, `Errors: {}` |
| 6 | (no integration flag) | 1 | clean validation error |
| 7 | `--config` without `--subscription-id` | 1 | `ERROR --subscription-id is required` |

### Output verification across all clouds

- Both human and `--json` rendering exercised; non-zero exit codes verified for every failure case so onboarding scripts can branch on `$?`.
- `--noninteractive` confirmed to silence the `lwpreflight` verbose progress writer (no progress chatter pollutes JSON output).