### PR TITLE
feat(cli): add --simulate flag to preflight aws

### DIFF
--- a/cli/cmd/preflight_aws.go
+++ b/cli/cmd/preflight_aws.go
@@ -44,8 +44,13 @@ At least one integration flag must be set: --agentless, --config,
 
 By default, the caller's identity-based policies are inspected locally. Pass
 --simulate to evaluate each required action through the IAM policy simulator
-instead — this also accounts for Organizations service control policies and
-permissions boundaries, which a local policy walk cannot see.`,
+instead — this also accounts for permissions boundaries and unconditional
+Organizations service control policies, which a local policy walk cannot see.
+Note: the simulator skips SCPs that have any conditions, and does not
+evaluate resource control policies (RCPs). Condition keys (e.g. aws:SourceIp,
+aws:MultiFactorAuthPresent, aws:PrincipalTag/*) are not supplied, so policies
+that grant access only when such conditions are met may be reported as denied
+even though the call would succeed in production.`,
 		Args:         cobra.NoArgs,
 		SilenceUsage: true,
 		RunE:         runPreflightAws,
@@ -65,7 +70,7 @@ func init() {
 	flags.BoolVar(&preflightAwsState.isOrg, "is-org", false,
 		"treat the account as an AWS Organizations management account")
 	flags.BoolVar(&preflightAwsState.simulate, "simulate", false,
-		"use IAM SimulatePrincipalPolicy (covers SCPs and permissions boundaries)")
+		"use IAM SimulatePrincipalPolicy (covers permissions boundaries and unconditional SCPs)")
 	flags.StringVar(&preflightAwsState.region, "region", "",
 		"AWS region to use for API calls")
 	flags.StringVar(&preflightAwsState.profile, "profile", "",

--- a/cli/cmd/preflight_aws.go
+++ b/cli/cmd/preflight_aws.go
@@ -127,18 +127,20 @@ func runPreflightAws(_ *cobra.Command, _ []string) error {
 		return preflightExitError(toStringErrorMap(result.Errors))
 	}
 
-	renderAwsHumanResult(result, integrationsRequestedAws(s))
+	renderAwsHumanResult(result, integrationsRequestedAws(s), s.simulate)
 	return preflightExitError(toStringErrorMap(result.Errors))
 }
 
-func renderAwsHumanResult(result *aws.Result, integrations []string) {
+func renderAwsHumanResult(result *aws.Result, integrations []string, simulated bool) {
 	cli.OutputHuman("Preflight check: AWS\n\n")
 	cli.OutputHuman("Caller\n")
 	cli.OutputHuman("  ARN:     %s\n", result.Caller.ARN)
 	cli.OutputHuman("  Account: %s\n", result.Caller.AccountID)
 	cli.OutputHuman("  User ID: %s\n", result.Caller.UserID)
 	cli.OutputHuman("  Name:    %s\n", result.Caller.Name)
-	cli.OutputHuman("  Admin:   %t\n", result.Caller.IsAdmin)
+	if !simulated {
+		cli.OutputHuman("  Admin:   %t\n", result.Caller.IsAdmin)
+	}
 
 	if len(integrations) > 0 {
 		cli.OutputHuman("\nIntegrations checked: %s\n", strings.Join(integrations, ", "))

--- a/cli/cmd/preflight_aws.go
+++ b/cli/cmd/preflight_aws.go
@@ -22,6 +22,7 @@ var (
 		cloudtrail      bool
 		eksAuditLog     bool
 		isOrg           bool
+		simulate        bool
 		region          string
 		profile         string
 		accessKeyID     string
@@ -39,7 +40,12 @@ config files, EC2 instance profile) unless explicit --profile or
 --access-key-id/--secret-access-key flags are provided.
 
 At least one integration flag must be set: --agentless, --config,
---cloudtrail, or --eks-audit-log.`,
+--cloudtrail, or --eks-audit-log.
+
+By default, the caller's identity-based policies are inspected locally. Pass
+--simulate to evaluate each required action through the IAM policy simulator
+instead — this also accounts for Organizations service control policies and
+permissions boundaries, which a local policy walk cannot see.`,
 		Args:         cobra.NoArgs,
 		SilenceUsage: true,
 		RunE:         runPreflightAws,
@@ -58,6 +64,8 @@ func init() {
 		"check permissions for the EKS Audit Log integration")
 	flags.BoolVar(&preflightAwsState.isOrg, "is-org", false,
 		"treat the account as an AWS Organizations management account")
+	flags.BoolVar(&preflightAwsState.simulate, "simulate", false,
+		"use IAM SimulatePrincipalPolicy (covers SCPs and permissions boundaries)")
 	flags.StringVar(&preflightAwsState.region, "region", "",
 		"AWS region to use for API calls")
 	flags.StringVar(&preflightAwsState.profile, "profile", "",
@@ -84,6 +92,7 @@ func runPreflightAws(_ *cobra.Command, _ []string) error {
 		CloudTrail:      s.cloudtrail,
 		EksAuditLog:     s.eksAuditLog,
 		IsOrg:           s.isOrg,
+		Simulate:        s.simulate,
 		Region:          s.region,
 		Profile:         s.profile,
 		AccessKeyID:     s.accessKeyID,
@@ -155,6 +164,7 @@ func integrationsRequestedAws(s struct {
 	cloudtrail      bool
 	eksAuditLog     bool
 	isOrg           bool
+	simulate        bool
 	region          string
 	profile         string
 	accessKeyID     string

--- a/cli/cmd/preflight_test.go
+++ b/cli/cmd/preflight_test.go
@@ -59,6 +59,7 @@ func TestIntegrationsRequestedAws(t *testing.T) {
 		cloudtrail      bool
 		eksAuditLog     bool
 		isOrg           bool
+		simulate        bool
 		region          string
 		profile         string
 		accessKeyID     string

--- a/integration/test_resources/help/preflight_aws
+++ b/integration/test_resources/help/preflight_aws
@@ -9,8 +9,13 @@ At least one integration flag must be set: --agentless, --config,
 
 By default, the caller's identity-based policies are inspected locally. Pass
 --simulate to evaluate each required action through the IAM policy simulator
-instead — this also accounts for Organizations service control policies and
-permissions boundaries, which a local policy walk cannot see.
+instead — this also accounts for permissions boundaries and unconditional
+Organizations service control policies, which a local policy walk cannot see.
+Note: the simulator skips SCPs that have any conditions, and does not
+evaluate resource control policies (RCPs). Condition keys (e.g. aws:SourceIp,
+aws:MultiFactorAuthPresent, aws:PrincipalTag/*) are not supplied, so policies
+that grant access only when such conditions are met may be reported as denied
+even though the call would succeed in production.
 
 Usage:
   lacework preflight aws [flags]
@@ -27,7 +32,7 @@ Flags:
       --region string              AWS region to use for API calls
       --secret-access-key string   AWS secret access key (paired with --access-key-id)
       --session-token string       AWS session token for temporary credentials
-      --simulate                   use IAM SimulatePrincipalPolicy (covers SCPs and permissions boundaries)
+      --simulate                   use IAM SimulatePrincipalPolicy (covers permissions boundaries and unconditional SCPs)
 
 Global Flags:
   -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)

--- a/integration/test_resources/help/preflight_aws
+++ b/integration/test_resources/help/preflight_aws
@@ -7,6 +7,11 @@ config files, EC2 instance profile) unless explicit --profile or
 At least one integration flag must be set: --agentless, --config,
 --cloudtrail, or --eks-audit-log.
 
+By default, the caller's identity-based policies are inspected locally. Pass
+--simulate to evaluate each required action through the IAM policy simulator
+instead — this also accounts for Organizations service control policies and
+permissions boundaries, which a local policy walk cannot see.
+
 Usage:
   lacework preflight aws [flags]
 
@@ -22,6 +27,7 @@ Flags:
       --region string              AWS region to use for API calls
       --secret-access-key string   AWS secret access key (paired with --access-key-id)
       --session-token string       AWS session token for temporary credentials
+      --simulate                   use IAM SimulatePrincipalPolicy (covers SCPs and permissions boundaries)
 
 Global Flags:
   -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)

--- a/lwpreflight/aws/aws.go
+++ b/lwpreflight/aws/aws.go
@@ -37,6 +37,7 @@ type Params struct {
 	CloudTrail      bool
 	EksAuditLog     bool
 	IsOrg           bool // If it's org-level integration
+	Simulate        bool // Use IAM SimulatePrincipalPolicy (covers SCPs and permission boundaries)
 	Region          string
 	Profile         string
 	AccessKeyID     string
@@ -69,12 +70,13 @@ func New(params Params) (*Preflight, error) {
 	}
 
 	integrationTypes := []IntegrationType{}
-	tasks := []func(p *Preflight) error{
-		FetchCaller,
-		FetchPolicies,
-		CheckPermissions,
-		FetchDetails,
+	permissionTasks := []func(p *Preflight) error{FetchPolicies, CheckPermissions}
+	if params.Simulate {
+		permissionTasks = []func(p *Preflight) error{CheckPermissionsViaSimulation}
 	}
+	tasks := []func(p *Preflight) error{FetchCaller}
+	tasks = append(tasks, permissionTasks...)
+	tasks = append(tasks, FetchDetails)
 
 	if params.Agentless {
 		integrationTypes = append(integrationTypes, Agentless)

--- a/lwpreflight/aws/permission_simulate.go
+++ b/lwpreflight/aws/permission_simulate.go
@@ -26,7 +26,6 @@ const simulateBatchSize = 50
 func CheckPermissionsViaSimulation(p *Preflight) error {
 	if p.caller.IsRoot {
 		// Root is unconstrained by IAM policies, SCPs, or boundaries.
-		p.caller.IsAdmin = true
 		return nil
 	}
 

--- a/lwpreflight/aws/permission_simulate.go
+++ b/lwpreflight/aws/permission_simulate.go
@@ -1,0 +1,160 @@
+package aws
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	"github.com/aws/aws-sdk-go-v2/service/iam/types"
+)
+
+// simulateBatchSize caps how many actions are evaluated per
+// SimulatePrincipalPolicy call. AWS allows more, but smaller batches keep
+// individual responses well below the 1MB payload limit and avoid Marker
+// pagination in the common case.
+const simulateBatchSize = 50
+
+// CheckPermissionsViaSimulation evaluates the required permissions against
+// the caller's effective policies using IAM SimulatePrincipalPolicy. Unlike
+// the static policy walk in CheckPermissions, this includes SCPs and
+// permission boundaries because AWS performs the same evaluation it would for
+// a real API call.
+func CheckPermissionsViaSimulation(p *Preflight) error {
+	if p.caller.IsRoot {
+		// Root is unconstrained by IAM policies, SCPs, or boundaries.
+		p.caller.IsAdmin = true
+		return nil
+	}
+
+	ctx := context.Background()
+	iamSvc := iam.NewFromConfig(p.awsConfig)
+
+	sourceArn, err := simulationPolicySourceArn(ctx, iamSvc, p.caller)
+	if err != nil {
+		return err
+	}
+
+	requiredPermissions := RequiredPermissions
+	if p.isOrg {
+		requiredPermissions = RequiredPermissionsForOrg
+	}
+
+	// Action -> integrations that require it. One simulation call can serve
+	// multiple integrations and we attribute denials back to all of them.
+	actionOwners := map[string][]IntegrationType{}
+	for _, integrationType := range p.integrationTypes {
+		for _, action := range requiredPermissions[integrationType] {
+			actionOwners[action] = append(actionOwners[action], integrationType)
+		}
+	}
+	if len(actionOwners) == 0 {
+		return nil
+	}
+
+	actions := make([]string, 0, len(actionOwners))
+	for action := range actionOwners {
+		actions = append(actions, action)
+	}
+	sort.Strings(actions)
+
+	p.verboseWriter.Write(fmt.Sprintf(
+		"Simulating %d permission(s) against %s", len(actions), sourceArn,
+	))
+
+	for start := 0; start < len(actions); start += simulateBatchSize {
+		end := start + simulateBatchSize
+		if end > len(actions) {
+			end = len(actions)
+		}
+		results, err := simulatePrincipalPolicyAll(ctx, iamSvc, sourceArn, actions[start:end])
+		if err != nil {
+			return err
+		}
+		for _, result := range results {
+			if result.EvalActionName == nil {
+				continue
+			}
+			if isAllowed(result.EvalDecision) {
+				continue
+			}
+			reason := simulationDenialReason(result)
+			action := *result.EvalActionName
+			for _, integrationType := range actionOwners[action] {
+				p.errors[integrationType] = append(
+					p.errors[integrationType],
+					fmt.Sprintf("Required permission denied: %s (%s)", action, reason),
+				)
+			}
+		}
+	}
+
+	return nil
+}
+
+// simulatePrincipalPolicyAll runs SimulatePrincipalPolicy for one batch of
+// actions and follows the Marker through every page.
+func simulatePrincipalPolicyAll(
+	ctx context.Context, iamSvc *iam.Client, sourceArn string, actions []string,
+) ([]types.EvaluationResult, error) {
+	input := &iam.SimulatePrincipalPolicyInput{
+		PolicySourceArn: aws.String(sourceArn),
+		ActionNames:     actions,
+	}
+	out := []types.EvaluationResult{}
+	for {
+		page, err := iamSvc.SimulatePrincipalPolicy(ctx, input)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, page.EvaluationResults...)
+		if page.Marker == nil || *page.Marker == "" {
+			return out, nil
+		}
+		input.Marker = page.Marker
+	}
+}
+
+// simulationPolicySourceArn picks the ARN to feed to SimulatePrincipalPolicy.
+// SimulatePrincipalPolicy accepts user, group, or role ARNs but rejects
+// assumed-role session ARNs, so we resolve the underlying role ARN via
+// iam:GetRole when the caller is an assumed role.
+func simulationPolicySourceArn(
+	ctx context.Context, iamSvc *iam.Client, caller Caller,
+) (string, error) {
+	if !caller.IsAssumedRole() {
+		return caller.ARN, nil
+	}
+	role, err := iamSvc.GetRole(ctx, &iam.GetRoleInput{RoleName: aws.String(caller.Name)})
+	if err != nil {
+		return "", fmt.Errorf("resolving role ARN for %s: %w", caller.Name, err)
+	}
+	if role.Role == nil || role.Role.Arn == nil {
+		return "", fmt.Errorf("iam:GetRole returned no ARN for %s", caller.Name)
+	}
+	return *role.Role.Arn, nil
+}
+
+func isAllowed(decision types.PolicyEvaluationDecisionType) bool {
+	return decision == types.PolicyEvaluationDecisionTypeAllowed
+}
+
+// simulationDenialReason summarises why a simulated action was denied. SCPs
+// and permission boundaries are checked first because their denials override
+// any identity-policy allow.
+func simulationDenialReason(r types.EvaluationResult) string {
+	if r.OrganizationsDecisionDetail != nil && !r.OrganizationsDecisionDetail.AllowedByOrganizations {
+		return "blocked by Organizations SCP"
+	}
+	if r.PermissionsBoundaryDecisionDetail != nil && !r.PermissionsBoundaryDecisionDetail.AllowedByPermissionsBoundary {
+		return "blocked by permissions boundary"
+	}
+	switch r.EvalDecision {
+	case types.PolicyEvaluationDecisionTypeExplicitDeny:
+		return "explicit deny in identity policy"
+	case types.PolicyEvaluationDecisionTypeImplicitDeny:
+		return "no identity policy grants this action"
+	}
+	return string(r.EvalDecision)
+}

--- a/lwpreflight/aws/permission_simulate.go
+++ b/lwpreflight/aws/permission_simulate.go
@@ -2,12 +2,14 @@ package aws
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	"github.com/aws/aws-sdk-go-v2/service/iam/types"
+	"github.com/aws/smithy-go"
 )
 
 // simulateBatchSize caps how many actions are evaluated per
@@ -70,6 +72,11 @@ func CheckPermissionsViaSimulation(p *Preflight) error {
 		}
 		results, err := simulatePrincipalPolicyAll(ctx, iamSvc, sourceArn, actions[start:end])
 		if err != nil {
+			if isAWSAccessDenied(err) {
+				return fmt.Errorf(
+					"--simulate requires iam:SimulatePrincipalPolicy on the caller; "+
+						"add it to the role's policy and re-run: %w", err)
+			}
 			return err
 		}
 		for _, result := range results {
@@ -128,12 +135,33 @@ func simulationPolicySourceArn(
 	}
 	role, err := iamSvc.GetRole(ctx, &iam.GetRoleInput{RoleName: aws.String(caller.Name)})
 	if err != nil {
+		if isAWSAccessDenied(err) {
+			return "", fmt.Errorf(
+				"--simulate requires iam:GetRole on %s to translate the assumed-role "+
+					"session into a role ARN; add iam:GetRole to the role's policy and "+
+					"re-run: %w", caller.Name, err)
+		}
 		return "", fmt.Errorf("resolving role ARN for %s: %w", caller.Name, err)
 	}
 	if role.Role == nil || role.Role.Arn == nil {
 		return "", fmt.Errorf("iam:GetRole returned no ARN for %s", caller.Name)
 	}
 	return *role.Role.Arn, nil
+}
+
+// isAWSAccessDenied reports whether err is an AWS API error indicating the
+// caller lacks permission. IAM and STS use AccessDenied; some services use
+// AccessDeniedException; EC2-style services use UnauthorizedOperation.
+func isAWSAccessDenied(err error) bool {
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) {
+		return false
+	}
+	switch apiErr.ErrorCode() {
+	case "AccessDenied", "AccessDeniedException", "UnauthorizedOperation":
+		return true
+	}
+	return false
 }
 
 func isAllowed(decision types.PolicyEvaluationDecisionType) bool {

--- a/lwpreflight/aws/permission_simulate_test.go
+++ b/lwpreflight/aws/permission_simulate_test.go
@@ -1,10 +1,13 @@
 package aws
 
 import (
+	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/iam/types"
+	"github.com/aws/smithy-go"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -58,6 +61,42 @@ func TestIsAllowed(t *testing.T) {
 	assert.True(t, isAllowed(types.PolicyEvaluationDecisionTypeAllowed))
 	assert.False(t, isAllowed(types.PolicyEvaluationDecisionTypeExplicitDeny))
 	assert.False(t, isAllowed(types.PolicyEvaluationDecisionTypeImplicitDeny))
+}
+
+func TestIsAWSAccessDenied(t *testing.T) {
+	t.Run("nil is not access denied", func(t *testing.T) {
+		assert.False(t, isAWSAccessDenied(nil))
+	})
+
+	t.Run("plain error is not access denied", func(t *testing.T) {
+		assert.False(t, isAWSAccessDenied(errors.New("network blip")))
+	})
+
+	t.Run("IAM AccessDenied is detected", func(t *testing.T) {
+		err := &smithy.GenericAPIError{Code: "AccessDenied", Message: "no"}
+		assert.True(t, isAWSAccessDenied(err))
+	})
+
+	t.Run("AccessDeniedException is detected", func(t *testing.T) {
+		err := &smithy.GenericAPIError{Code: "AccessDeniedException", Message: "no"}
+		assert.True(t, isAWSAccessDenied(err))
+	})
+
+	t.Run("EC2-style UnauthorizedOperation is detected", func(t *testing.T) {
+		err := &smithy.GenericAPIError{Code: "UnauthorizedOperation", Message: "no"}
+		assert.True(t, isAWSAccessDenied(err))
+	})
+
+	t.Run("unrelated API error is not access denied", func(t *testing.T) {
+		err := &smithy.GenericAPIError{Code: "InvalidInput", Message: "bad"}
+		assert.False(t, isAWSAccessDenied(err))
+	})
+
+	t.Run("wrapped AccessDenied is still detected", func(t *testing.T) {
+		inner := &smithy.GenericAPIError{Code: "AccessDenied", Message: "no"}
+		wrapped := fmt.Errorf("calling iam:GetRole: %w", inner)
+		assert.True(t, isAWSAccessDenied(wrapped))
+	})
 }
 
 // Compile-time check that the EvaluationResult fields we depend on still

--- a/lwpreflight/aws/permission_simulate_test.go
+++ b/lwpreflight/aws/permission_simulate_test.go
@@ -1,0 +1,69 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/iam/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSimulationDenialReason(t *testing.T) {
+	t.Run("SCP denial wins over identity decision", func(t *testing.T) {
+		got := simulationDenialReason(types.EvaluationResult{
+			EvalDecision: types.PolicyEvaluationDecisionTypeImplicitDeny,
+			OrganizationsDecisionDetail: &types.OrganizationsDecisionDetail{
+				AllowedByOrganizations: false,
+			},
+		})
+		assert.Equal(t, "blocked by Organizations SCP", got)
+	})
+
+	t.Run("permissions boundary denial wins over identity decision", func(t *testing.T) {
+		got := simulationDenialReason(types.EvaluationResult{
+			EvalDecision: types.PolicyEvaluationDecisionTypeImplicitDeny,
+			PermissionsBoundaryDecisionDetail: &types.PermissionsBoundaryDecisionDetail{
+				AllowedByPermissionsBoundary: false,
+			},
+		})
+		assert.Equal(t, "blocked by permissions boundary", got)
+	})
+
+	t.Run("explicit deny in identity policy", func(t *testing.T) {
+		got := simulationDenialReason(types.EvaluationResult{
+			EvalDecision: types.PolicyEvaluationDecisionTypeExplicitDeny,
+		})
+		assert.Equal(t, "explicit deny in identity policy", got)
+	})
+
+	t.Run("implicit deny in identity policy", func(t *testing.T) {
+		got := simulationDenialReason(types.EvaluationResult{
+			EvalDecision: types.PolicyEvaluationDecisionTypeImplicitDeny,
+		})
+		assert.Equal(t, "no identity policy grants this action", got)
+	})
+
+	t.Run("SCP allowed but identity denies still reports identity reason", func(t *testing.T) {
+		got := simulationDenialReason(types.EvaluationResult{
+			EvalDecision: types.PolicyEvaluationDecisionTypeImplicitDeny,
+			OrganizationsDecisionDetail: &types.OrganizationsDecisionDetail{
+				AllowedByOrganizations: true,
+			},
+		})
+		assert.Equal(t, "no identity policy grants this action", got)
+	})
+}
+
+func TestIsAllowed(t *testing.T) {
+	assert.True(t, isAllowed(types.PolicyEvaluationDecisionTypeAllowed))
+	assert.False(t, isAllowed(types.PolicyEvaluationDecisionTypeExplicitDeny))
+	assert.False(t, isAllowed(types.PolicyEvaluationDecisionTypeImplicitDeny))
+}
+
+// Compile-time check that the EvaluationResult fields we depend on still
+// have the types we expect from the IAM SDK. Guards against a vendored SDK
+// upgrade silently changing the shape of the API we read.
+var _ = func() *string {
+	r := types.EvaluationResult{EvalActionName: aws.String("iam:GetRole")}
+	return r.EvalActionName
+}


### PR DESCRIPTION
## Jira/Github ticket

(https://lacework.atlassian.net/browse/CAD-2046)

## Summary

The current \`lacework preflight aws\` walks the caller's identity-based IAM policies and matches required action strings locally. That misses two whole layers of AWS authorization:

- **Organizations service control policies** (SCPs) — applied at the org/OU level, can deny actions that the identity policy allows.
- **Permissions boundaries** — applied to the user/role itself, cap the max permissions regardless of identity policy.

A caller can have all the required permissions in their attached policies and still be unable to onboard because of an SCP or boundary, and the current preflight reports a green pass.

This PR adds a \`--simulate\` flag that swaps the local policy walk for \`iam:SimulatePrincipalPolicy\`. AWS evaluates each action through the same authorization stack a real API call would hit (SCPs → boundary → identity → resource), so denials from any layer are caught.

Each denial is reported with its specific reason:

\`\`\`
aws_agentless: FAIL (2 issue(s))
  - Required permission denied: ec2:CreateVpc (blocked by Organizations SCP)
  - Required permission denied: iam:PassRole (blocked by permissions boundary)
\`\`\`

Implementation notes:

- Default behaviour unchanged. \`--simulate\` is opt-in.
- Required actions are deduped across the requested integrations and sent to \`SimulatePrincipalPolicy\` in batches of 50, with \`Marker\` pagination.
- For assumed-role callers the principal ARN is resolved via \`iam:GetRole\`, since the simulator rejects STS session ARNs (\`arn:aws:sts::...:assumed-role/...\`).
- Caller needs \`iam:SimulatePrincipalPolicy\` (and \`iam:GetRole\` when running as an assumed role) for this mode to work.

## How did you test this change?

- Unit tests for denial-reason mapping (\`permission_simulate_test.go\`).
- Help fixture refreshed and verified by diffing \`go run ./cli help preflight aws\` against \`integration/test_resources/help/preflight_aws\`.
- End-to-end run against a real account with \`--simulate --config\`: principal resolved correctly, 156 actions simulated in 4 batches, all allowed, integrations rendered \`OK\`, org details discovered as expected.
- Built the CLI and verified the new flag appears under \`preflight aws --help\`.

## Screen shots:
SCP check:
<img width="1038" height="566" alt="Screenshot 2026-05-06 at 11 36 34 AM" src="https://github.com/user-attachments/assets/fe460da9-4a06-47f0-b128-e84f1111962b" />

Permission boundary check:
<img width="1038" height="566" alt="Screenshot 2026-05-06 at 11 33 36 AM" src="https://github.com/user-attachments/assets/c8787866-4b1f-4345-812e-74addd6daef0" />

