### PR TITLE
fix: report missing secretsmanager:TagResource in agentless preflight (CAD-2093)

### DIFF
--- a/lwpreflight/aws/constants.go
+++ b/lwpreflight/aws/constants.go
@@ -130,6 +130,7 @@ var RequiredPermissions = map[IntegrationType][]string{
 		"secretsmanager:GetResourcePolicy",
 		"secretsmanager:GetSecretValue",
 		"secretsmanager:PutSecretValue",
+		"secretsmanager:TagResource",
 		"servicequotas:GetServiceQuota",
 	},
 	Config: {


### PR DESCRIPTION
## Jira/Github ticket

https://lacework.atlassian.net/browse/CAD-2093

## Summary

During AWS agentless self-deployment discovery, a role missing `secretsmanager:TagResource` passed the preflight permission check silently, and the deployment later failed when Terraform tried to tag the secret.

The single-account `RequiredPermissions[Agentless]` list in `lwpreflight/aws/constants.go` was missing `secretsmanager:TagResource`, while the org-level `RequiredPermissionsForOrg[Agentless]` list already included it. Both the policy-evaluation path (`permission.go`) and the IAM simulation path (`permission_simulate.go`) consume this list, so the permission was never checked for single-account onboarding.

This adds `secretsmanager:TagResource` to the single-account agentless list so discovery reports it as missing.

## How did you test this change?

- `go build ./lwpreflight/...`
- `go test ./lwpreflight/aws/` — passes