### PR TITLE
fix: stop filtering out non-Recommended Azure regions in region discovery (CAD-2132)

### DIFF
--- a/lwpreflight/azure/detail.go
+++ b/lwpreflight/azure/detail.go
@@ -3,6 +3,7 @@ package azure
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions"
 )
@@ -45,11 +46,11 @@ func FetchDetails(p *Preflight) error {
 				}
 			}
 
-			//Filter for Recommmended (GA) regions
-			if location.Metadata != nil && location.Metadata.RegionCategory != nil {
-				if *location.Metadata.RegionCategory != armsubscriptions.RegionCategoryRecommended {
-					continue
-				}
+			// filter out Microsoft-internal staging/canary regions (e.g. eastusstg, centraluseuap).
+			// Note: we intentionally do NOT filter on RegionCategoryRecommended — Azure marks
+			// fully functional regions like westus, eastus2 and westus3 as "Other" (CAD-2132).
+			if strings.HasSuffix(*location.Name, "stg") || strings.HasSuffix(*location.Name, "euap") {
+				continue
 			}
 
 			// add to available regions


### PR DESCRIPTION
## Jira/Github ticket

https://lacework.atlassian.net/browse/CAD-2132

## Summary

The Azure Agentless onboarding UI only offered "West US 2" (and other `regionCategory == Recommended` regions) in its region dropdown, even though onboarding into "West US" works fine via Terraform. The dropdown is populated from `lwpreflight/azure.FetchDetails`, which filtered `ListLocations` results to `RegionCategoryRecommended` only.

That category is not a reliable "deployable" signal:

- Azure marks fully functional physical regions as `Other` — including `westus`, and (per current subscription metadata) even `eastus2`, `southcentralus`, and `westus3`.
- Meanwhile `eastus2euap` (a Microsoft canary region) is marked `Recommended` and leaked into the dropdown.

This change removes the category filter and instead excludes Microsoft-internal regions by their documented name suffixes: `*stg` (staging) and `*euap` (Early Updates Access Program/canary). The existing edge-zone and physical-region filters are unchanged.

## How did you test this change?

- `go build`, `go vet`, `gofmt` on `lwpreflight/...` — clean.
- Replicated the new filter against a live `az account list-locations` response (102 locations): result is 58 regions — `westus`, `eastus2`, `westus3`, `southcentralus` now included; `eastusstg`, `southcentralusstg`, `centraluseuap`, and `eastus2euap` excluded.
- Verified the only locations matching the `*stg`/`*euap` suffixes are the Microsoft-internal staging/canary entries — no false positives.