### PR TITLE
feat(AWLS2-1027): tenant level support for Azure DSPM

### DIFF
--- a/api/cloud_accounts_aws_dspm.go
+++ b/api/cloud_accounts_aws_dspm.go
@@ -67,12 +67,8 @@ type AwsDspmData struct {
 	BucketArn         string                         `json:"bucketArn,omitempty"`
 	CrossAccountCreds AwsDspmCrossAccountCredentials `json:"crossAccountCredentials"`
 	Regions           []string                       `json:"regions,omitempty"`
-	// IntegrationLevel is ACCOUNT (single account) or ORG (whole organization),
-	// mirroring AzureDspmData.IntegrationLevel (SUBSCRIPTION/TENANT).
-	IntegrationLevel string `json:"integrationLevel,omitempty"`
-	// ManagementAccount is the AWS organization's management account ID; set only
-	// for ORG-level integrations.
-	ManagementAccount string `json:"managementAccount,omitempty"`
+	IntegrationLevel  string                         `json:"integrationLevel,omitempty"`
+	ManagementAccount string                         `json:"managementAccount,omitempty"`
 }
 
 type AwsDspmCrossAccountCredentials struct {

--- a/api/cloud_accounts_aws_dspm.go
+++ b/api/cloud_accounts_aws_dspm.go
@@ -67,6 +67,12 @@ type AwsDspmData struct {
 	BucketArn         string                         `json:"bucketArn,omitempty"`
 	CrossAccountCreds AwsDspmCrossAccountCredentials `json:"crossAccountCredentials"`
 	Regions           []string                       `json:"regions,omitempty"`
+	// IntegrationLevel is ACCOUNT (single account) or ORG (whole organization),
+	// mirroring AzureDspmData.IntegrationLevel (SUBSCRIPTION/TENANT).
+	IntegrationLevel string `json:"integrationLevel,omitempty"`
+	// ManagementAccount is the AWS organization's management account ID; set only
+	// for ORG-level integrations.
+	ManagementAccount string `json:"managementAccount,omitempty"`
 }
 
 type AwsDspmCrossAccountCredentials struct {

--- a/api/cloud_accounts_aws_dspm.go
+++ b/api/cloud_accounts_aws_dspm.go
@@ -18,6 +18,11 @@
 
 package api
 
+const (
+	AwsAccountIntegration string = "ACCOUNT"
+	AwsOrgIntegration     string = "ORG"
+)
+
 // GetAwsDspm gets a single AwsDspm integration matching the provided integration guid
 func (svc *CloudAccountsService) GetAwsDspm(guid string) (
 	response AwsDspmResponse,

--- a/api/cloud_accounts_azure_dspm.go
+++ b/api/cloud_accounts_azure_dspm.go
@@ -63,7 +63,13 @@ type azureDspmToken struct {
 
 // AzureDspmData contains the data needed by Lacework platform services.
 type AzureDspmData struct {
-	TenantID          string               `json:"tenantId,omitempty"`
+	TenantID string `json:"tenantId,omitempty"`
+	// IntegrationLevel is either SUBSCRIPTION (scan a single subscription) or
+	// TENANT (scan every subscription in the tenant). Reuses the constants
+	// AzureSubscriptionIntegration / AzureTenantIntegration. This lives on the
+	// integration data (not props) so it surfaces on the Cloud Accounts page,
+	// mirroring the Azure agentless integration.
+	IntegrationLevel  string               `json:"integrationLevel,omitempty"`
 	StorageAccountUrl string               `json:"storageAccountUrl,omitempty"`
 	BlobContainerName string               `json:"blobContainerName,omitempty"`
 	Credentials       AzureDspmCredentials `json:"credentials"`

--- a/api/cloud_accounts_azure_dspm.go
+++ b/api/cloud_accounts_azure_dspm.go
@@ -63,12 +63,7 @@ type azureDspmToken struct {
 
 // AzureDspmData contains the data needed by Lacework platform services.
 type AzureDspmData struct {
-	TenantID string `json:"tenantId,omitempty"`
-	// IntegrationLevel is either SUBSCRIPTION (scan a single subscription) or
-	// TENANT (scan every subscription in the tenant). Reuses the constants
-	// AzureSubscriptionIntegration / AzureTenantIntegration. This lives on the
-	// integration data (not props) so it surfaces on the Cloud Accounts page,
-	// mirroring the Azure agentless integration.
+	TenantID          string               `json:"tenantId,omitempty"`
 	IntegrationLevel  string               `json:"integrationLevel,omitempty"`
 	StorageAccountUrl string               `json:"storageAccountUrl,omitempty"`
 	BlobContainerName string               `json:"blobContainerName,omitempty"`

--- a/api/cloud_accounts_dspm_props.go
+++ b/api/cloud_accounts_dspm_props.go
@@ -54,9 +54,10 @@ func (p *DspmProps) UnmarshalJSON(data []byte) error {
 
 // DspmPropsConfig contains DSPM-specific configuration
 type DspmPropsConfig struct {
-	ScanIntervalHours *int                  `json:"scanIntervalHours,omitempty"`
-	MaxDownloadBytes  *int                  `json:"maxDownloadBytes,omitempty"`
-	DatastoreFilters  *DspmDatastoreFilters `json:"datastoreFilters,omitempty"`
+	ScanIntervalHours   *int                     `json:"scanIntervalHours,omitempty"`
+	MaxDownloadBytes    *int                     `json:"maxDownloadBytes,omitempty"`
+	DatastoreFilters    *DspmDatastoreFilters    `json:"datastoreFilters,omitempty"`
+	SubscriptionFilters *DspmSubscriptionFilters `json:"subscriptionFilters,omitempty"`
 }
 
 // DspmDatastoreFilters configures which datastores to include/exclude from scanning
@@ -65,17 +66,30 @@ type DspmDatastoreFilters struct {
 	DatastoreNames []string `json:"datastoreNames"`
 }
 
+// DspmSubscriptionFilters configures which subscriptions to include/exclude from a
+// TENANT-level Azure scan, mirroring DspmDatastoreFilters.
+type DspmSubscriptionFilters struct {
+	FilterMode      string   `json:"filterMode"`
+	SubscriptionIds []string `json:"subscriptionIds"`
+}
+
 // dspmPropsConfigUpper mirrors DspmPropsConfig with UPPER_SNAKE_CASE JSON tags
 // for deserializing PATCH responses.
 type dspmPropsConfigUpper struct {
-	ScanIntervalHours *int                       `json:"SCAN_INTERVAL_HOURS,omitempty"`
-	MaxDownloadBytes  *int                       `json:"MAX_DOWNLOAD_BYTES,omitempty"`
-	DatastoreFilters  *dspmDatastoreFiltersUpper `json:"DATASTORE_FILTERS,omitempty"`
+	ScanIntervalHours   *int                          `json:"SCAN_INTERVAL_HOURS,omitempty"`
+	MaxDownloadBytes    *int                          `json:"MAX_DOWNLOAD_BYTES,omitempty"`
+	DatastoreFilters    *dspmDatastoreFiltersUpper    `json:"DATASTORE_FILTERS,omitempty"`
+	SubscriptionFilters *dspmSubscriptionFiltersUpper `json:"SUBSCRIPTION_FILTERS,omitempty"`
 }
 
 type dspmDatastoreFiltersUpper struct {
 	FilterMode     string   `json:"FILTER_MODE"`
 	DatastoreNames []string `json:"DATASTORE_NAMES"`
+}
+
+type dspmSubscriptionFiltersUpper struct {
+	FilterMode      string   `json:"FILTER_MODE"`
+	SubscriptionIds []string `json:"SUBSCRIPTION_IDS"`
 }
 
 func (u *dspmPropsConfigUpper) toConfig() *DspmPropsConfig {
@@ -87,6 +101,12 @@ func (u *dspmPropsConfigUpper) toConfig() *DspmPropsConfig {
 		cfg.DatastoreFilters = &DspmDatastoreFilters{
 			FilterMode:     u.DatastoreFilters.FilterMode,
 			DatastoreNames: u.DatastoreFilters.DatastoreNames,
+		}
+	}
+	if u.SubscriptionFilters != nil {
+		cfg.SubscriptionFilters = &DspmSubscriptionFilters{
+			FilterMode:      u.SubscriptionFilters.FilterMode,
+			SubscriptionIds: u.SubscriptionFilters.SubscriptionIds,
 		}
 	}
 	return cfg

--- a/api/cloud_accounts_dspm_props.go
+++ b/api/cloud_accounts_dspm_props.go
@@ -54,10 +54,10 @@ func (p *DspmProps) UnmarshalJSON(data []byte) error {
 
 // DspmPropsConfig contains DSPM-specific configuration
 type DspmPropsConfig struct {
-	ScanIntervalHours   *int                     `json:"scanIntervalHours,omitempty"`
-	MaxDownloadBytes    *int                     `json:"maxDownloadBytes,omitempty"`
-	DatastoreFilters    *DspmDatastoreFilters    `json:"datastoreFilters,omitempty"`
-	SubscriptionFilters *DspmSubscriptionFilters `json:"subscriptionFilters,omitempty"`
+	ScanIntervalHours *int                  `json:"scanIntervalHours,omitempty"`
+	MaxDownloadBytes  *int                  `json:"maxDownloadBytes,omitempty"`
+	DatastoreFilters  *DspmDatastoreFilters `json:"datastoreFilters,omitempty"`
+	AccountFilters    *DspmAccountFilters   `json:"accountFilters,omitempty"`
 }
 
 // DspmDatastoreFilters configures which datastores to include/exclude from scanning
@@ -66,20 +66,21 @@ type DspmDatastoreFilters struct {
 	DatastoreNames []string `json:"datastoreNames"`
 }
 
-// DspmSubscriptionFilters configures which subscriptions to include/exclude from a
-// TENANT-level Azure scan, mirroring DspmDatastoreFilters.
-type DspmSubscriptionFilters struct {
-	FilterMode      string   `json:"filterMode"`
-	SubscriptionIds []string `json:"subscriptionIds"`
+// DspmAccountFilters configures which accounts to include/exclude from an
+// organization/tenant-level scan (AWS accounts or Azure subscriptions), mirroring
+// DspmDatastoreFilters. Cloud-agnostic: "account" == an Azure subscription too.
+type DspmAccountFilters struct {
+	FilterMode string   `json:"filterMode"`
+	AccountIds []string `json:"accountIds"`
 }
 
 // dspmPropsConfigUpper mirrors DspmPropsConfig with UPPER_SNAKE_CASE JSON tags
 // for deserializing PATCH responses.
 type dspmPropsConfigUpper struct {
-	ScanIntervalHours   *int                          `json:"SCAN_INTERVAL_HOURS,omitempty"`
-	MaxDownloadBytes    *int                          `json:"MAX_DOWNLOAD_BYTES,omitempty"`
-	DatastoreFilters    *dspmDatastoreFiltersUpper    `json:"DATASTORE_FILTERS,omitempty"`
-	SubscriptionFilters *dspmSubscriptionFiltersUpper `json:"SUBSCRIPTION_FILTERS,omitempty"`
+	ScanIntervalHours *int                       `json:"SCAN_INTERVAL_HOURS,omitempty"`
+	MaxDownloadBytes  *int                       `json:"MAX_DOWNLOAD_BYTES,omitempty"`
+	DatastoreFilters  *dspmDatastoreFiltersUpper `json:"DATASTORE_FILTERS,omitempty"`
+	AccountFilters    *dspmAccountFiltersUpper   `json:"ACCOUNT_FILTERS,omitempty"`
 }
 
 type dspmDatastoreFiltersUpper struct {
@@ -87,9 +88,9 @@ type dspmDatastoreFiltersUpper struct {
 	DatastoreNames []string `json:"DATASTORE_NAMES"`
 }
 
-type dspmSubscriptionFiltersUpper struct {
-	FilterMode      string   `json:"FILTER_MODE"`
-	SubscriptionIds []string `json:"SUBSCRIPTION_IDS"`
+type dspmAccountFiltersUpper struct {
+	FilterMode string   `json:"FILTER_MODE"`
+	AccountIds []string `json:"ACCOUNT_IDS"`
 }
 
 func (u *dspmPropsConfigUpper) toConfig() *DspmPropsConfig {
@@ -103,10 +104,10 @@ func (u *dspmPropsConfigUpper) toConfig() *DspmPropsConfig {
 			DatastoreNames: u.DatastoreFilters.DatastoreNames,
 		}
 	}
-	if u.SubscriptionFilters != nil {
-		cfg.SubscriptionFilters = &DspmSubscriptionFilters{
-			FilterMode:      u.SubscriptionFilters.FilterMode,
-			SubscriptionIds: u.SubscriptionFilters.SubscriptionIds,
+	if u.AccountFilters != nil {
+		cfg.AccountFilters = &DspmAccountFilters{
+			FilterMode: u.AccountFilters.FilterMode,
+			AccountIds: u.AccountFilters.AccountIds,
 		}
 	}
 	return cfg


### PR DESCRIPTION
## Jira Ticket
https://lacework.atlassian.net/browse/AWLS2-1027

## Summary
This PR is part of our initiative to add tenant (Azure) and organization (AWS) level support to DSPM, as already exists in other features like AWLS. Right now DSPM is only supported at the account/subscription level.

Accomplishing this requires us to add several fields to the DSPM integration objects, which in turn requires modifications to the various components that use/create those objects. The two fields of note are:
* an `INTEGRATION_LEVEL` constant that is either `TENANT` or `SUBSCRIPTION` for Azure and `ORGANIZATION` or `ACCOUNT` for AWS
* an `ACCOUNT_FILTERS` property that specifies which subscriptions/accounts in the tenant/org should be scanned. The format and usage of this property is identical to the existing `DATASTORE_FILTERS`.

## Testing Performed
These changes were tested alongside companion PRs for:

* the DSPM scanner itself (https://github.com/lacework-dev/dspm-scanner/pull/138)
* the Terraform module that creates Azure DSPM integrations (https://github.com/lacework/terraform-azure-dspm/pull/13)
* the corresponding `terraform-provider-lacework` code that actually creates the integration objects via API call (https://github.com/lacework/terraform-provider-lacework/pull/726 and https://github.com/lacework/go-sdk/pull/1835)
* the backend changes to actually display this information on the UI (https://github.com/lacework/rainbow/pull/22886 and https://github.com/lacework/services/pull/33199)

.... after creating a tenant level integration and bringing up a development environment in Tilt, I confirmed that these fields were visible and functioning correctly in the UI:
<img width="500" height="484" alt="sub-filter" src="https://github.com/user-attachments/assets/26bd0078-4cfe-430a-8850-f5969e72df20" />
<img width="500" height="484" alt="sub-filter" src="https://github.com/user-attachments/assets/41e18cb2-2aa2-4fa7-8060-05b7236ff7eb" />

