### PR TITLE
chore: run go mod tidy to mark golang.org/x/sync as a direct dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -79,6 +79,7 @@ require (
 	github.com/spf13/cast v1.7.1
 	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56
 	golang.org/x/oauth2 v0.30.0
+	golang.org/x/sync v0.14.0
 	google.golang.org/api v0.235.0
 )
 
@@ -154,7 +155,6 @@ require (
 	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/multierr v1.9.0 // indirect
 	golang.org/x/mod v0.19.0 // indirect
-	golang.org/x/sync v0.14.0 // indirect
 	golang.org/x/sys v0.33.0 // indirect
 	golang.org/x/term v0.32.0 // indirect
 	golang.org/x/time v0.11.0 // indirect


### PR DESCRIPTION
## Summary

The **Prepare Release** workflow is failing ([run 27363999599](https://github.com/lacework/go-sdk/actions/runs/27363999599)) with:

```
xxx go-sdk: You have unsaved changes in the main branch. Are you resuming a release?
make: *** [Makefile:250: release] Error 127
```

The "unsaved changes" are produced by the release flow itself: `make release` runs `go mod tidy` (via the `prepare` target) before `scripts/release.sh prepare`, and tidy currently modifies `go.mod` on main, tripping the dirty-tree guard in `release.sh`.

Root cause: #1831 added a direct import of `golang.org/x/sync/errgroup` in `lwpreflight/aws/detail.go`, but `go.mod` was not re-tidied, so `x/sync` is still listed as `// indirect`.

## Changes

- `go mod tidy`: moves `golang.org/x/sync v0.14.0` from the indirect block to the direct `require` block. No version changes, no vendor changes.

## How I tested

- Ran `go mod tidy && go mod vendor && go mod verify` at main (bdf7c23) and confirmed this is the only resulting diff; the tree is clean afterwards, so the release guard passes.

After this merges, re-dispatching Prepare Release should succeed.