### PR TITLE
chore: support existing IAM role for standalone AWS Config integration

### DIFF
--- a/lwgenerate/aws/aws.go
+++ b/lwgenerate/aws/aws.go
@@ -1021,13 +1021,18 @@ func createConfig(args *GenerateAwsTfConfigurationArgs) ([]*hclwrite.Block, erro
 		lwgenerate.HclModuleWithVersion(lwgenerate.AwsConfigVersion),
 		lwgenerate.HclModuleWithProviderDetails(map[string]string{"aws": "aws.main"}),
 	}
+	attributes := map[string]interface{}{}
 	if args.LaceworkAccountID != "" {
-		moduleDetails = append(
-			moduleDetails,
-			lwgenerate.HclModuleWithAttributes(
-				map[string]interface{}{"lacework_aws_account_id": args.LaceworkAccountID},
-			),
-		)
+		attributes["lacework_aws_account_id"] = args.LaceworkAccountID
+	}
+	if !args.ExistingIamRole.IsEmpty() {
+		attributes["use_existing_iam_role"] = true
+		attributes["iam_role_name"] = args.ExistingIamRole.Name
+		attributes["iam_role_arn"] = args.ExistingIamRole.Arn
+		attributes["iam_role_external_id"] = args.ExistingIamRole.ExternalId
+	}
+	if len(attributes) > 0 {
+		moduleDetails = append(moduleDetails, lwgenerate.HclModuleWithAttributes(attributes))
 	}
 
 	moduleBlock, err := lwgenerate.NewModule(

--- a/lwgenerate/aws/aws_test.go
+++ b/lwgenerate/aws/aws_test.go
@@ -92,6 +92,32 @@ func TestGenerationConfig(t *testing.T) {
 	assert.Equal(t, reqProviderAndRegion(moduleImportConfig), hcl)
 }
 
+func TestGenerationConfigExistingRole(t *testing.T) {
+	iamRoleArn := "arn:aws:iam::123456789012:role/test-role"
+	iamRoleName := "test-role"
+	extId := "1234567890123456"
+
+	data, err := createConfig(&GenerateAwsTfConfigurationArgs{
+		Config:          true,
+		ExistingIamRole: NewExistingIamRoleDetails(iamRoleName, iamRoleArn, extId),
+	})
+
+	assert.Nil(t, err)
+	assert.Len(t, data, 1)
+	assert.Equal(t,
+		"use_existing_iam_role=true\n",
+		string(data[0].Body().GetAttribute("use_existing_iam_role").BuildTokens(nil).Bytes()))
+	assert.Equal(t,
+		fmt.Sprintf("iam_role_name=\"%s\"\n", iamRoleName),
+		string(data[0].Body().GetAttribute("iam_role_name").BuildTokens(nil).Bytes()))
+	assert.Equal(t,
+		fmt.Sprintf("iam_role_arn=\"%s\"\n", iamRoleArn),
+		string(data[0].Body().GetAttribute("iam_role_arn").BuildTokens(nil).Bytes()))
+	assert.Equal(t,
+		fmt.Sprintf("iam_role_external_id=\"%s\"\n", extId),
+		string(data[0].Body().GetAttribute("iam_role_external_id").BuildTokens(nil).Bytes()))
+}
+
 func TestGenerationConfigWithExtraBlocks(t *testing.T) {
 	extraBlock, err := lwgenerate.HclCreateGenericBlock("variable", []string{"var_name"}, nil)
 	assert.NoError(t, err)


### PR DESCRIPTION
## Jira/Github ticket
https://lacework.atlassian.net/browse/CAD-1921

## Summary
If support of existing IAM role is missing for AWS config. This PR adds it.

## How did you test this change?

Manually test the integration end-to-end
