### PR TITLE
ci: fix post-release homebrew formula and docs update jobs

### DIFF
--- a/.github/workflows/update-cli-docs.yml
+++ b/.github/workflows/update-cli-docs.yml
@@ -27,7 +27,9 @@ jobs:
           GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
         working-directory: "docs_lw/docusaurus"
         run: |
-          git remote set-url origin git@github.com:lacework/docs_lw.git
+          # Keep the token-authenticated HTTPS remote configured by actions/checkout
+          # above. Switching origin to SSH (git@github.com) fails the docs push with
+          # "Permission denied (publickey)" because no SSH key is loaded in CI.
           sudo apt-get update -y
           sudo apt-get install gpg-agent -y
           echo "$GPG_SECRET_KEY" | base64 --decode | gpg --import --no-tty --batch --yes

--- a/.github/workflows/update-homebrew-formula.yml
+++ b/.github/workflows/update-homebrew-formula.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Set up Homebrew
         id: set-up-homebrew
-        uses: Homebrew/actions/setup-homebrew@master
+        uses: Homebrew/actions/setup-homebrew@main
 
       - name: Create local Homebrew tap
         working-directory: homebrew-tap
@@ -39,6 +39,9 @@ jobs:
           sudo chmod -R 777 $(brew --repository)/Library/Taps/lacework/homebrew-lacework-cli/.git
           cd $(brew --repository)/Library/Taps/lacework/homebrew-lacework-cli/
           echo "$GPG_SECRET_KEY" | base64 --decode | gpg --import --no-tty --batch --yes
+          # Recent Homebrew refuses to load formulae from third-party taps unless
+          # they are explicitly trusted; this is a locally-created tap so trust it.
+          brew trust lacework/lacework-cli
           make update-cli-version
 
       - name: Notify Slack on Failure


### PR DESCRIPTION
## Summary

The two automation jobs that fire after a `Release` completes both broke on the v2.14.1 release. Neither is a code/test failure — they're release-time infra breakages, fixed independently here.

## Update Homebrew Formula (`update-homebrew-formula.yml`)

Failed at the **Update CLI Version** step:

```
Refusing to load formula lacework/lacework-cli/lacework-cli from untrusted tap lacework/lacework-cli.
make: *** [Makefile:12: update-cli-version] Error 1
```

Recent Homebrew refuses to load a formula from a third-party tap unless it's explicitly trusted. The failure surfaces inside the homebrew-tap script's `lint()` → `brew audit --formula lacework-cli --strict`. Since the tap is created locally in this workflow, the fix belongs here:

- Add `brew trust lacework/lacework-cli` before `make update-cli-version`.
- Bump `Homebrew/actions/setup-homebrew@master` → `@main` (`master` is deprecated and becomes a hard error in Homebrew 5.2.0).

## Update CLI Docs (`update-cli-docs.yml`)

Docs generated and committed fine; only the push died:

```
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.
```

The step forced `origin` to the SSH URL (`git@github.com:lacework/docs_lw.git`), but CI only has the HTTPS token from `actions/checkout` — no SSH key is loaded. Removed the `set-url` override so the push reuses the token-authenticated HTTPS remote.

## Notes

- No change needed in `lacework/homebrew-tap`; the `brew trust` step covers the audit call without coupling the tap script to CI-only setup.
- The Node 20 deprecation annotations are warnings only (jobs force-run on Node 24) and are left untouched.