### PR TITLE
ci: allow manual dispatch of post-release homebrew and docs jobs

### DIFF
--- a/.github/workflows/update-cli-docs.yml
+++ b/.github/workflows/update-cli-docs.yml
@@ -9,7 +9,9 @@ on:
 
 jobs:
   update-cli-docs:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    # Run after a successful Release, or when dispatched manually (where
+    # github.event.workflow_run is absent and the conclusion check is false).
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     outputs:
       git-sha: ${{ steps.update.outputs.git-sha }}

--- a/.github/workflows/update-homebrew-formula.yml
+++ b/.github/workflows/update-homebrew-formula.yml
@@ -9,7 +9,9 @@ on:
 
 jobs:
   update-homefrew-formula:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    # Run after a successful Release, or when dispatched manually (where
+    # github.event.workflow_run is absent and the conclusion check is false).
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/update-homebrew-formula.yml
+++ b/.github/workflows/update-homebrew-formula.yml
@@ -8,7 +8,7 @@ on:
       - completed
 
 jobs:
-  update-homefrew-formula:
+  update-homebrew-formula:
     # Run after a successful Release, or when dispatched manually (where
     # github.event.workflow_run is absent and the conclusion check is false).
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}


### PR DESCRIPTION
## Summary

Both `Update Homebrew Formula` and `Update CLI Docs` declare a `workflow_dispatch` trigger, but their job-level guard only passed for `workflow_run` events:

```yaml
if: ${{ github.event.workflow_run.conclusion == 'success' }}
```

On a manual dispatch there is no `github.event.workflow_run`, so the expression evaluates to false and the job is **skipped** — making manual runs a no-op (observed: dispatched runs complete in ~3s with conclusion `skipped`).

This widens the guard to also accept manual dispatch:

```yaml
if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
```

## Why

These are the post-release automation jobs whose failures were just fixed in #1841. They only auto-run after a successful `Release`, so when one fails (or, as with v2.14.1, was failing before the fix landed) there was no way to re-run it by hand to catch a release up. Allowing `workflow_dispatch` makes them recoverable on demand.

Normal release behavior is unchanged — the `workflow_run` path still requires a successful Release.