### PR TITLE
fix(lwgenerate/azure): use az_entra_id_activity_log module label

### DIFF
--- a/lwgenerate/azure/azure.go
+++ b/lwgenerate/azure/azure.go
@@ -889,7 +889,7 @@ func createEntraIdActivityLog(args *GenerateAzureTfConfigurationArgs) ([]*hclwri
 		)
 
 		moduleBlock, err := lwgenerate.NewModule(
-			"microsoft-entra-id-activity-log",
+			"az_entra_id_activity_log",
 			lwgenerate.LWAzureEntraIdActivityLogSource,
 			append(moduleDetails, lwgenerate.HclModuleWithVersion(lwgenerate.LWAzureEntraIdActivityLogVersion))...,
 		).ToBlock()

--- a/lwgenerate/azure/test-data/entra-id-activity-log-event-hub-location-and-partition.tf
+++ b/lwgenerate/azure/test-data/entra-id-activity-log-event-hub-location-and-partition.tf
@@ -21,7 +21,7 @@ module "az_ad_application" {
   version = "~> 2.0"
 }
 
-module "microsoft-entra-id-activity-log" {
+module "az_entra_id_activity_log" {
   source                      = "lacework/microsoft-entra-id-activity-log/azure"
   version                     = "~> 0.3"
   application_id              = module.az_ad_application.application_id

--- a/lwgenerate/azure/test-data/entra-id-activity-log-existing-ad-app.tf
+++ b/lwgenerate/azure/test-data/entra-id-activity-log-existing-ad-app.tf
@@ -16,7 +16,7 @@ provider "azurerm" {
   }
 }
 
-module "microsoft-entra-id-activity-log" {
+module "az_entra_id_activity_log" {
   source                      = "lacework/microsoft-entra-id-activity-log/azure"
   version                     = "~> 0.3"
   application_id              = "testID"

--- a/lwgenerate/azure/test-data/entra-id-activity-log-existing-event-hub-ns.tf
+++ b/lwgenerate/azure/test-data/entra-id-activity-log-existing-event-hub-ns.tf
@@ -21,7 +21,7 @@ module "az_ad_application" {
   version = "~> 2.0"
 }
 
-module "microsoft-entra-id-activity-log" {
+module "az_entra_id_activity_log" {
   source                      = "lacework/microsoft-entra-id-activity-log/azure"
   version                     = "~> 0.3"
   application_id              = module.az_ad_application.application_id

--- a/lwgenerate/azure/test-data/entra-id-activity-log-no-custom-input.tf
+++ b/lwgenerate/azure/test-data/entra-id-activity-log-no-custom-input.tf
@@ -21,7 +21,7 @@ module "az_ad_application" {
   version = "~> 2.0"
 }
 
-module "microsoft-entra-id-activity-log" {
+module "az_entra_id_activity_log" {
   source                      = "lacework/microsoft-entra-id-activity-log/azure"
   version                     = "~> 0.3"
   application_id              = module.az_ad_application.application_id


### PR DESCRIPTION
## Jira/Github ticket

https://lacework.atlassian.net/browse/CAD-1921 (related: self-deployment custom-options work)

## Summary

The Azure Terraform generator labels each module block with a short `az_` prefix — `az_config`, `az_activity_log`, `az_ad_application` — except the Entra ID Activity Log module, which is labeled after its Terraform Registry name, `microsoft-entra-id-activity-log`. That inconsistency means callers can't reference the Entra module's outputs following the same `module.az_<integration>.<output>` convention they use for every other Azure integration.

This relabels the generated block to `az_entra_id_activity_log`, matching its siblings. Only the **block label** changes — the module source (`lacework/microsoft-entra-id-activity-log/azure`) and all attributes are unchanged. Golden `test-data` fixtures updated to match.

Note: because this changes a module block label, anyone who has already applied a config generated with the old `microsoft-entra-id-activity-log` label would see Terraform treat it as a new module (destroy/recreate) on regeneration. The Entra ID module is new (`~> 0.3`), so real-world impact is expected to be minimal; a `moved {}` block could be added if needed.

## How did you test this change?

- `go test ./lwgenerate/azure/...` — passes (golden fixtures regenerated to the new label).
- Verified the only change in generated HCL is the block label line; `source` and attributes are identical.
