### PR TITLE
feat(cli): add cloud-account repair command for org-onboarded AwsCfg accounts

### DIFF
--- a/cli/cmd/cloud_account_repair.go
+++ b/cli/cmd/cloud_account_repair.go
@@ -86,11 +86,17 @@ template's own setup Lambda, which registers the integration first. In that case
 "already onboarded" and the integration keeps the Lambda's name - the account is still fully
 recovered, just registered by the Lambda rather than directly.
 
+With --all instead of --account-id, the command sweeps every ACTIVE account under the StackSet's
+targeted OUs (recursively, excluding the organization management account), finds the ones missing
+their member stack and/or integration, rebuilds all missing stack instances in one StackSet
+operation, and registers every unregistered account. With --dry-run it only reports the diff.
+
 Run it with credentials for your AWS Organizations management account (the account that owns the
 management stack):
 
     lacework cloud-account repair --account-id 123456789012 --stack-name lacework-aws-cfg-org
     lacework cloud-account repair --account-id 123456789012 --stack-name lacework-aws-cfg-org --dry-run
+    lacework cloud-account repair --all --stack-name lacework-aws-cfg-org --dry-run
 
 Creating a stack instance only works when the account already belongs to an OU the StackSet targets.
 If it does not, add the account to a targeted OU (or add its OU to the stack's OrganizationalUnits

--- a/cli/cmd/cloud_account_repair.go
+++ b/cli/cmd/cloud_account_repair.go
@@ -1,0 +1,110 @@
+//
+// Author:: Fortinet
+// Copyright:: Copyright 2026, Fortinet
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cmd
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+// repairMethodFunc recovers a missing cloud-account integration for one onboarding method.
+type repairMethodFunc func() error
+
+// repairMethods maps a --method value to its handler. To add a new onboarding method, drop a
+// cloud_account_repair_<method>.go file that implements the handler and registers its own flags,
+// then add one entry here. Method values are named <cloud>-<template>.
+var repairMethods = map[string]repairMethodFunc{
+	repairMethodAwsCfgOrg: repairAwsCfgOrg,
+}
+
+func supportedRepairMethods() []string {
+	names := make([]string, 0, len(repairMethods))
+	for n := range repairMethods {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// repairMethod is the --method flag; the method-specific flags live in each method's own file.
+var repairMethod string
+
+func init() {
+	cloudAccountCommand.AddCommand(cloudAccountRepairCmd)
+
+	cloudAccountRepairCmd.Flags().StringVar(&repairMethod, "method", repairMethodAwsCfgOrg,
+		"onboarding template to repair (supported: "+strings.Join(supportedRepairMethods(), ", ")+")")
+}
+
+var cloudAccountRepairCmd = &cobra.Command{
+	Use:   "repair",
+	Short: "Re-register a missing cloud-account integration from its onboarding template",
+	Long: `Re-register a missing Lacework cloud-account integration for one account onboarded through a
+Lacework onboarding template, when the integration is missing - whether the underlying IAM role is
+still healthy or was dropped (in which case it is rebuilt first).
+
+The template is selected with --method, named <cloud>-<template>. Only "aws-cfg-org" (AWS Config
+organization onboarding) is implemented today; more AWS templates and other clouds (gcp, azure) are
+planned and will be added as additional --method values. The rest of this help describes the
+aws-cfg-org method.
+
+The org-config setup Lambda registers each member account with Lacework but does NOT reconcile: if a
+registration (or the member stack) is dropped, replaying is the only recovery. For aws-cfg-org this
+command is state-aware and does the minimum needed for the account:
+
+  - member stack instance present, integration missing -> re-register the integration only
+  - member stack instance missing (role gone) but the account is in a targeted OU -> re-create the
+    stack instance (which rebuilds the IAM role), wait for it, then register the integration
+  - integration already present -> nothing to do
+  - account not in any targeted OU, or the management StackSet is gone -> report and do nothing
+
+It registers directly against the Lacework API (deriving the member role ARN and external id from
+the stack instance), so you get the result synchronously instead of the setup Lambda's 5-minute
+fire-and-forget. When it registers directly the integration is named "<LaceworkAccount>-Config".
+
+Naming note: in the rebuild path (member stack instance missing), re-creating the instance fires the
+template's own setup Lambda, which registers the integration first. In that case this command reports
+"already onboarded" and the integration keeps the Lambda's name - the account is still fully
+recovered, just registered by the Lambda rather than directly.
+
+Run it with credentials for your AWS Organizations management account (the account that owns the
+management stack):
+
+    lacework cloud-account repair --account-id 123456789012 --stack-name lacework-aws-cfg-org
+    lacework cloud-account repair --account-id 123456789012 --stack-name lacework-aws-cfg-org --dry-run
+
+Creating a stack instance only works when the account already belongs to an OU the StackSet targets.
+If it does not, add the account to a targeted OU (or add its OU to the stack's OrganizationalUnits
+parameter) first - this command reports that case and does nothing.`,
+	Args: cobra.NoArgs,
+	RunE: cloudAccountRepair,
+}
+
+// cloudAccountRepair dispatches to the handler registered for the selected --method.
+func cloudAccountRepair(_ *cobra.Command, _ []string) error {
+	run, ok := repairMethods[repairMethod]
+	if !ok {
+		return errors.Errorf("unsupported --method %q; supported: %s",
+			repairMethod, strings.Join(supportedRepairMethods(), ", "))
+	}
+	return run()
+}

--- a/cli/cmd/cloud_account_repair_aws_cfg_org.go
+++ b/cli/cmd/cloud_account_repair_aws_cfg_org.go
@@ -21,6 +21,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -28,6 +29,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/cloudformation"
 	cfntypes "github.com/aws/aws-sdk-go-v2/service/cloudformation/types"
+	"github.com/aws/aws-sdk-go-v2/service/organizations"
+	orgtypes "github.com/aws/aws-sdk-go-v2/service/organizations/types"
 	"github.com/pkg/errors"
 
 	"github.com/lacework/go-sdk/v2/api"
@@ -39,6 +42,7 @@ const repairMethodAwsCfgOrg = "aws-cfg-org"
 // aws-cfg-org flags.
 var (
 	repairAccountID  string // --account-id
+	repairAll        bool   // --all
 	repairStackName  string // --stack-name (the AWS Config org management stack)
 	repairAwsProfile string // --aws-profile
 	repairAwsRegion  string // --aws-region
@@ -48,7 +52,9 @@ var (
 func init() {
 	f := cloudAccountRepairCmd.Flags()
 	f.StringVar(&repairAccountID,
-		"account-id", "", "AWS account id whose AwsCfg integration is missing (required)")
+		"account-id", "", "AWS account id whose AwsCfg integration is missing (required unless --all)")
+	f.BoolVar(&repairAll,
+		"all", false, "find and repair every account in the targeted OUs that is missing its member stack or integration")
 	f.StringVar(&repairStackName,
 		"stack-name", "", "name of the Lacework AWS Config org management CloudFormation stack (required)")
 	f.StringVar(&repairAwsProfile,
@@ -63,8 +69,11 @@ func init() {
 // AWS Config organization CloudFormation template. It runs with AWS Organizations management-account
 // credentials and reads the member StackSet instance to derive the role ARN and external id.
 func repairAwsCfgOrg() error {
-	if repairAccountID == "" {
-		return errors.New("--account-id is required")
+	if repairAll && repairAccountID != "" {
+		return errors.New("--account-id and --all are mutually exclusive")
+	}
+	if !repairAll && repairAccountID == "" {
+		return errors.New("--account-id is required (or use --all)")
 	}
 	if repairStackName == "" {
 		return errors.New("--stack-name is required")
@@ -100,6 +109,10 @@ func repairAwsCfgOrg() error {
 		return err
 	}
 
+	if repairAll {
+		return repairAwsCfgOrgAll(ctx, cfg, cfn, laceworkAccount, stackSetName)
+	}
+
 	// 3. The member account's stack instance carries the StackId we derive the role UID from.
 	cli.StartProgress(fmt.Sprintf(" Locating the stack instance for %s...", repairAccountID))
 	stackID, found, err := memberStackID(ctx, cfn, stackSetName, repairAccountID)
@@ -132,7 +145,7 @@ func repairAwsCfgOrg() error {
 				"stack %s has no OrganizationalUnits parameter; cannot create a stack instance", repairStackName)
 		}
 		cli.StartProgress(fmt.Sprintf(" Creating the stack instance for %s (rebuilding the IAM role)...", repairAccountID))
-		err = createMemberInstance(ctx, cfn, stackSetName, cfg.Region, targetOUs, repairAccountID)
+		err = createMemberInstances(ctx, cfn, stackSetName, cfg.Region, targetOUs, []string{repairAccountID})
 		cli.StopProgress()
 		if err != nil {
 			return err
@@ -150,16 +163,10 @@ func repairAwsCfgOrg() error {
 		cli.OutputHuman("Stack instance created for %s.\n", repairAccountID)
 	}
 
-	uid := stackUID(stackID)
-	if uid == "" {
-		return errors.Errorf("could not derive the role UID from stack id %q", stackID)
+	name, roleArn, externalID, err := awsCfgRegistration(laceworkAccount, repairAccountID, stackID)
+	if err != nil {
+		return err
 	}
-
-	// Role name and external id are both keyed off the same UID by the config_org member template
-	// (role: lacework-config-role-<UID>; externalId: lweid:aws:v2:<tenant>:<acct>:LW<UID>).
-	roleArn := fmt.Sprintf("arn:aws:iam::%s:role/lacework-config-role-%s", repairAccountID, uid)
-	externalID := fmt.Sprintf("lweid:aws:v2:%s:%s:LW%s", laceworkAccount, repairAccountID, uid)
-	name := fmt.Sprintf("%s-Config", laceworkAccount)
 
 	cli.OutputHuman("Re-registering AwsCfg integration:\n")
 	cli.OutputHuman("  account-id:  %s\n", repairAccountID)
@@ -175,39 +182,66 @@ func repairAwsCfgOrg() error {
 		return nil
 	}
 
+	cli.StartProgress(" Creating integration...")
+	intgGuid, alreadyOnboarded, err := createAwsCfgIntegration(name, roleArn, externalID, repairAccountID)
+	cli.StopProgress()
+	if err != nil {
+		return err
+	}
+	if alreadyOnboarded {
+		if cli.JSONOutput() {
+			return cli.OutputJSON(map[string]interface{}{
+				"accountId": repairAccountID,
+				"action":    "none",
+				"status":    "already-onboarded",
+			})
+		}
+		cli.OutputHuman("\nAccount %s is already onboarded; nothing to do.\n", repairAccountID)
+		return nil
+	}
+
+	if cli.JSONOutput() {
+		return cli.OutputJSON(
+			repairRegisterResult("registered", repairAccountID, name, roleArn, externalID, intgGuid))
+	}
+	cli.OutputHuman("\nThe cloud account integration was created with GUID %s.\n", intgGuid)
+	return nil
+}
+
+// awsCfgRegistration derives the integration name, role ARN and external id for one member account
+// from its stack instance id, exactly as the config_org member template builds them
+// (role: lacework-config-role-<UID>; externalId: lweid:aws:v2:<tenant>:<acct>:LW<UID>).
+func awsCfgRegistration(laceworkAccount, accountID, stackID string) (name, roleArn, externalID string, err error) {
+	uid := stackUID(stackID)
+	if uid == "" {
+		return "", "", "", errors.Errorf("could not derive the role UID from stack id %q", stackID)
+	}
+	name = fmt.Sprintf("%s-Config", laceworkAccount)
+	roleArn = fmt.Sprintf("arn:aws:iam::%s:role/lacework-config-role-%s", accountID, uid)
+	externalID = fmt.Sprintf("lweid:aws:v2:%s:%s:LW%s", laceworkAccount, accountID, uid)
+	return name, roleArn, externalID, nil
+}
+
+// createAwsCfgIntegration registers the AwsCfg integration with the Lacework API. Mirroring the
+// setup Lambda, an already-registered account is success (alreadyOnboarded), not an error.
+func createAwsCfgIntegration(name, roleArn, externalID, accountID string) (
+	intgGuid string, alreadyOnboarded bool, err error,
+) {
 	awsCfg := api.NewCloudAccount(name, api.AwsCfgCloudAccount, api.AwsCfgData{
-		AwsAccountID: repairAccountID,
+		AwsAccountID: accountID,
 		Credentials: api.AwsCfgCredentials{
 			RoleArn:    roleArn,
 			ExternalID: externalID,
 		},
 	})
-
-	cli.StartProgress(" Creating integration...")
 	resp, err := cli.LwApi.V2.CloudAccounts.Create(awsCfg)
-	cli.StopProgress()
 	if err != nil {
-		// Mirror the setup Lambda: an already-registered account is success, not an error.
 		if strings.Contains(strings.ToLower(err.Error()), "aws account is already used") {
-			if cli.JSONOutput() {
-				return cli.OutputJSON(map[string]interface{}{
-					"accountId": repairAccountID,
-					"action":    "none",
-					"status":    "already-onboarded",
-				})
-			}
-			cli.OutputHuman("\nAccount %s is already onboarded; nothing to do.\n", repairAccountID)
-			return nil
+			return "", true, nil
 		}
-		return errors.Wrap(err, "unable to create cloud account integration")
+		return "", false, errors.Wrap(err, "unable to create cloud account integration")
 	}
-
-	if cli.JSONOutput() {
-		return cli.OutputJSON(
-			repairRegisterResult("registered", repairAccountID, name, roleArn, externalID, resp.Data.IntgGuid))
-	}
-	cli.OutputHuman("\nThe cloud account integration was created with GUID %s.\n", resp.Data.IntgGuid)
-	return nil
+	return resp.Data.IntgGuid, false, nil
 }
 
 // repairRegisterResult builds the --json payload for the register path. The dry-run ("register") and
@@ -302,11 +336,13 @@ func targetOUsParam(ctx context.Context, cfn *cloudformation.Client) []string {
 	return ous
 }
 
-// createMemberInstance re-deploys the member stack into one account by creating a stack instance
-// scoped to that account within the targeted OUs, and waits for the operation to finish. INTERSECTION
-// with a single account means nothing is deployed if the account is not under a targeted OU.
-func createMemberInstance(
-	ctx context.Context, cfn *cloudformation.Client, stackSetName, region string, ous []string, accountID string,
+// createMemberInstances re-deploys the member stack into the given accounts by creating stack
+// instances scoped to those accounts within the targeted OUs, and waits for the operation to finish.
+// INTERSECTION means nothing is deployed to an account that is not under a targeted OU.
+// ponytail: FailureToleranceCount 0 / MaxConcurrentCount 1 aborts the whole batch on the first bad
+// account (re-run friendly); raise both if fleets get large enough to hurt.
+func createMemberInstances(
+	ctx context.Context, cfn *cloudformation.Client, stackSetName, region string, ous, accountIDs []string,
 ) error {
 	out, err := cfn.CreateStackInstances(ctx, &cloudformation.CreateStackInstancesInput{
 		StackSetName: aws.String(stackSetName),
@@ -314,7 +350,7 @@ func createMemberInstance(
 		CallAs:       cfntypes.CallAsSelf,
 		DeploymentTargets: &cfntypes.DeploymentTargets{
 			OrganizationalUnitIds: ous,
-			Accounts:              []string{accountID},
+			Accounts:              accountIDs,
 			AccountFilterType:     cfntypes.AccountFilterTypeIntersection,
 		},
 		OperationPreferences: &cfntypes.StackSetOperationPreferences{
@@ -323,7 +359,7 @@ func createMemberInstance(
 		},
 	})
 	if err != nil {
-		return errors.Wrapf(err, "unable to create stack instance for %s", accountID)
+		return errors.Wrapf(err, "unable to create stack instances for %s", strings.Join(accountIDs, ", "))
 	}
 	return pollStackSetOperation(ctx, cfn, stackSetName, aws.ToString(out.OperationId))
 }
@@ -364,4 +400,261 @@ func stackUID(stackID string) string {
 		return ""
 	}
 	return strings.Split(guid, "-")[0]
+}
+
+// repairAwsCfgOrgAll (--all) sweeps every ACTIVE account under the StackSet's targeted OUs, finds
+// the ones missing their member stack instance and/or AwsCfg integration, rebuilds the missing
+// instances in one StackSet operation, and registers every unregistered account.
+func repairAwsCfgOrgAll(
+	ctx context.Context, cfg aws.Config, cfn *cloudformation.Client, laceworkAccount, stackSetName string,
+) error {
+	targetOUs := targetOUsParam(ctx, cfn)
+	if len(targetOUs) == 0 {
+		return errors.Errorf(
+			"stack %s has no OrganizationalUnits parameter; there are no targeted OUs to sweep", repairStackName)
+	}
+
+	org := organizations.NewFromConfig(cfg)
+
+	cli.StartProgress(" Enumerating accounts in the targeted OUs...")
+	expected, err := accountsInOUs(ctx, org, targetOUs)
+	cli.StopProgress()
+	if err != nil {
+		return err
+	}
+
+	cli.StartProgress(" Listing member stack instances and existing integrations...")
+	instances, err := stackInstanceIDs(ctx, cfn, stackSetName)
+	var registered map[string]bool
+	if err == nil {
+		registered, err = registeredAwsCfgAccounts()
+	}
+	cli.StopProgress()
+	if err != nil {
+		return err
+	}
+
+	missingInstance, missingIntegration := diffRepairTargets(expected, instances, registered)
+
+	if len(missingInstance) == 0 && len(missingIntegration) == 0 {
+		if cli.JSONOutput() {
+			return cli.OutputJSON(map[string]interface{}{
+				"targetOUs":        targetOUs,
+				"expectedAccounts": len(expected),
+				"repaired":         []interface{}{},
+			})
+		}
+		cli.OutputHuman("All %d accounts in the targeted OUs are onboarded; nothing to do.\n", len(expected))
+		return nil
+	}
+
+	if repairDryRun {
+		if cli.JSONOutput() {
+			return cli.OutputJSON(map[string]interface{}{
+				"targetOUs":            targetOUs,
+				"expectedAccounts":     len(expected),
+				"missingStackInstance": missingInstance,
+				"missingIntegration":   missingIntegration,
+				"dryRun":               true,
+			})
+		}
+		cli.OutputHuman("Found %d accounts in the targeted OUs (%s):\n", len(expected), strings.Join(targetOUs, ","))
+		cli.OutputHuman("  missing stack instance (role gone): %s\n", orNone(missingInstance))
+		cli.OutputHuman("  missing integration only:           %s\n", orNone(missingIntegration))
+		cli.OutputHuman("\nDry-run: nothing was created. Re-run without --dry-run to repair.\n")
+		return nil
+	}
+
+	if len(missingInstance) > 0 {
+		cli.OutputHuman("Rebuilding %d member stack instance(s): %s\n",
+			len(missingInstance), strings.Join(missingInstance, ", "))
+		cli.StartProgress(" Waiting for the stack instances (rebuilding IAM roles)...")
+		err = createMemberInstances(ctx, cfn, stackSetName, cfg.Region, targetOUs, missingInstance)
+		cli.StopProgress()
+		if err != nil {
+			return err
+		}
+		instances, err = stackInstanceIDs(ctx, cfn, stackSetName)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Register everything unregistered. For just-rebuilt accounts the template's setup Lambda
+	// usually wins the race, which surfaces here as already-onboarded - still a full recovery.
+	var results []map[string]interface{}
+	failed := 0
+	for _, accountID := range append(missingInstance, missingIntegration...) {
+		stackID, ok := instances[accountID]
+		if !ok {
+			results = append(results, map[string]interface{}{
+				"accountId": accountID, "action": "error",
+				"error": "no stack instance was created; is the account still in a targeted OU?",
+			})
+			failed++
+			continue
+		}
+		result := repairOneRegistration(laceworkAccount, accountID, stackID)
+		if result["action"] == "error" {
+			failed++
+		}
+		results = append(results, result)
+	}
+
+	if cli.JSONOutput() {
+		err = cli.OutputJSON(map[string]interface{}{
+			"targetOUs":        targetOUs,
+			"expectedAccounts": len(expected),
+			"repaired":         results,
+		})
+		if err != nil {
+			return err
+		}
+	} else {
+		cli.OutputHuman("\n")
+		for _, r := range results {
+			switch r["action"] {
+			case "registered":
+				cli.OutputHuman("  %s: registered (GUID %s)\n", r["accountId"], r["intgGuid"])
+			case "already-onboarded":
+				cli.OutputHuman("  %s: already onboarded\n", r["accountId"])
+			default:
+				cli.OutputHuman("  %s: FAILED - %s\n", r["accountId"], r["error"])
+			}
+		}
+		cli.OutputHuman("\nRepaired %d of %d account(s).\n", len(results)-failed, len(results))
+	}
+	if failed > 0 {
+		return errors.Errorf("%d of %d repairs failed", failed, len(results))
+	}
+	return nil
+}
+
+// repairOneRegistration derives the registration for one account and creates the integration,
+// returning a result map for the summary (never an error - bulk repair reports and moves on).
+func repairOneRegistration(laceworkAccount, accountID, stackID string) map[string]interface{} {
+	name, roleArn, externalID, err := awsCfgRegistration(laceworkAccount, accountID, stackID)
+	if err != nil {
+		return map[string]interface{}{"accountId": accountID, "action": "error", "error": err.Error()}
+	}
+	intgGuid, alreadyOnboarded, err := createAwsCfgIntegration(name, roleArn, externalID, accountID)
+	if err != nil {
+		return map[string]interface{}{"accountId": accountID, "action": "error", "error": err.Error()}
+	}
+	if alreadyOnboarded {
+		return map[string]interface{}{"accountId": accountID, "action": "already-onboarded"}
+	}
+	return repairRegisterResult("registered", accountID, name, roleArn, externalID, intgGuid)
+}
+
+// diffRepairTargets classifies the expected accounts against the current stack instances and
+// Lacework integrations: no instance means the IAM role is gone (rebuild + register); an instance
+// without an integration means register only.
+func diffRepairTargets(
+	expected []string, instances map[string]string, registered map[string]bool,
+) (missingInstance, missingIntegration []string) {
+	for _, accountID := range expected {
+		if _, ok := instances[accountID]; !ok {
+			missingInstance = append(missingInstance, accountID)
+		} else if !registered[accountID] {
+			missingIntegration = append(missingIntegration, accountID)
+		}
+	}
+	return missingInstance, missingIntegration
+}
+
+// accountsInOUs returns every ACTIVE account id under the given OUs, recursing into child OUs to
+// mirror StackSets' recursive OU targeting. The organization management account is excluded:
+// service-managed StackSets never deploy to it, so it can never have a member instance.
+func accountsInOUs(ctx context.Context, org *organizations.Client, ous []string) ([]string, error) {
+	mgmtOut, err := org.DescribeOrganization(ctx, &organizations.DescribeOrganizationInput{})
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to describe the organization")
+	}
+	mgmtAccountID := aws.ToString(mgmtOut.Organization.MasterAccountId)
+
+	seen := map[string]bool{}
+	var accounts []string
+	queue := append([]string{}, ous...)
+	for len(queue) > 0 {
+		parent := queue[0]
+		queue = queue[1:]
+
+		accPag := organizations.NewListAccountsForParentPaginator(org,
+			&organizations.ListAccountsForParentInput{ParentId: aws.String(parent)})
+		for accPag.HasMorePages() {
+			page, err := accPag.NextPage(ctx)
+			if err != nil {
+				return nil, errors.Wrapf(err, "unable to list accounts under %s", parent)
+			}
+			for _, a := range page.Accounts {
+				id := aws.ToString(a.Id)
+				if a.Status == orgtypes.AccountStatusActive && id != mgmtAccountID && !seen[id] {
+					seen[id] = true
+					accounts = append(accounts, id)
+				}
+			}
+		}
+
+		ouPag := organizations.NewListOrganizationalUnitsForParentPaginator(org,
+			&organizations.ListOrganizationalUnitsForParentInput{ParentId: aws.String(parent)})
+		for ouPag.HasMorePages() {
+			page, err := ouPag.NextPage(ctx)
+			if err != nil {
+				return nil, errors.Wrapf(err, "unable to list child OUs under %s", parent)
+			}
+			for _, child := range page.OrganizationalUnits {
+				queue = append(queue, aws.ToString(child.Id))
+			}
+		}
+	}
+	sort.Strings(accounts)
+	return accounts, nil
+}
+
+// stackInstanceIDs maps member account id -> stack id for every instance in the StackSet.
+func stackInstanceIDs(
+	ctx context.Context, cfn *cloudformation.Client, stackSetName string,
+) (map[string]string, error) {
+	instances := map[string]string{}
+	pag := cloudformation.NewListStackInstancesPaginator(cfn, &cloudformation.ListStackInstancesInput{
+		StackSetName: aws.String(stackSetName),
+		CallAs:       cfntypes.CallAsSelf,
+	})
+	for pag.HasMorePages() {
+		page, err := pag.NextPage(ctx)
+		if err != nil {
+			return nil, errors.Wrapf(err, "unable to list stack instances for %s", stackSetName)
+		}
+		for _, s := range page.Summaries {
+			if id := aws.ToString(s.StackId); id != "" {
+				instances[aws.ToString(s.Account)] = id
+			}
+		}
+	}
+	return instances, nil
+}
+
+// registeredAwsCfgAccounts returns the AWS account ids that already have an AwsCfg integration,
+// derived from each integration's cross-account role ARN.
+func registeredAwsCfgAccounts() (map[string]bool, error) {
+	res, err := cli.LwApi.V2.CloudAccounts.ListByType(api.AwsCfgCloudAccount)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to list AwsCfg cloud accounts")
+	}
+	registered := map[string]bool{}
+	for _, raw := range res.Data {
+		if accountID, _, ok := deriveAwsAccountAndRole(raw); ok {
+			registered[accountID] = true
+		}
+	}
+	return registered, nil
+}
+
+// orNone renders an account list for human output, with an explicit marker when empty.
+func orNone(accounts []string) string {
+	if len(accounts) == 0 {
+		return "(none)"
+	}
+	return strings.Join(accounts, ", ")
 }

--- a/cli/cmd/cloud_account_repair_aws_cfg_org.go
+++ b/cli/cmd/cloud_account_repair_aws_cfg_org.go
@@ -96,7 +96,10 @@ func repairAwsCfgOrg() error {
 
 	// 1. LaceworkAccount (tenant) from the management stack parameters.
 	cli.StartProgress(" Reading the management stack...")
-	laceworkAccount, err := stackParameter(ctx, cfn, repairStackName, "LaceworkAccount")
+	laceworkAccount, found, err := stackParameter(ctx, cfn, repairStackName, "LaceworkAccount")
+	if err == nil && !found {
+		err = errors.Errorf("stack %s has no LaceworkAccount parameter; is it the management stack?", repairStackName)
+	}
 	if err != nil {
 		cli.StopProgress()
 		return err
@@ -124,7 +127,10 @@ func repairAwsCfgOrg() error {
 	// No stack instance means the IAM role does not exist; re-create the instance (which rebuilds the
 	// role) before registering. This only lands the account if it is under an OU the StackSet targets.
 	if !found {
-		targetOUs := targetOUsParam(ctx, cfn)
+		targetOUs, err := targetOUsParam(ctx, cfn)
+		if err != nil {
+			return err
+		}
 		if repairDryRun {
 			if cli.JSONOutput() {
 				return cli.OutputJSON(map[string]interface{}{
@@ -190,10 +196,10 @@ func repairAwsCfgOrg() error {
 	}
 	if alreadyOnboarded {
 		if cli.JSONOutput() {
+			// Same shape --all reports per account, so consumers parse one contract.
 			return cli.OutputJSON(map[string]interface{}{
 				"accountId": repairAccountID,
-				"action":    "none",
-				"status":    "already-onboarded",
+				"action":    "already-onboarded",
 			})
 		}
 		cli.OutputHuman("\nAccount %s is already onboarded; nothing to do.\n", repairAccountID)
@@ -263,21 +269,25 @@ func repairRegisterResult(action, accountID, name, roleArn, externalID, intgGuid
 	return r
 }
 
-// stackParameter returns the value of a named parameter on a CloudFormation stack.
-func stackParameter(ctx context.Context, cfn *cloudformation.Client, stackName, key string) (string, error) {
+// stackParameter returns the value of a named parameter on a CloudFormation stack, with
+// found=false (and no error) when the stack exists but has no such parameter - the caller
+// decides whether that is fatal.
+func stackParameter(
+	ctx context.Context, cfn *cloudformation.Client, stackName, key string,
+) (value string, found bool, err error) {
 	out, err := cfn.DescribeStacks(ctx, &cloudformation.DescribeStacksInput{StackName: aws.String(stackName)})
 	if err != nil {
-		return "", errors.Wrapf(err, "unable to describe stack %s", stackName)
+		return "", false, errors.Wrapf(err, "unable to describe stack %s", stackName)
 	}
 	if len(out.Stacks) == 0 {
-		return "", errors.Errorf("stack %s not found", stackName)
+		return "", false, errors.Errorf("stack %s not found", stackName)
 	}
 	for _, p := range out.Stacks[0].Parameters {
 		if aws.ToString(p.ParameterKey) == key {
-			return aws.ToString(p.ParameterValue), nil
+			return aws.ToString(p.ParameterValue), true, nil
 		}
 	}
-	return "", errors.Errorf("stack %s has no %s parameter", stackName, key)
+	return "", false, nil
 }
 
 // stackResourcePhysicalID returns the physical resource id for a logical resource on a stack.
@@ -321,11 +331,11 @@ func memberStackID(
 }
 
 // targetOUsParam returns the OU ids the StackSet targets, from the management stack's
-// OrganizationalUnits parameter. Returns nil if the parameter is absent.
-func targetOUsParam(ctx context.Context, cfn *cloudformation.Client) []string {
-	raw, err := stackParameter(ctx, cfn, repairStackName, "OrganizationalUnits")
+// OrganizationalUnits parameter. Returns nil (no error) if the parameter is absent.
+func targetOUsParam(ctx context.Context, cfn *cloudformation.Client) ([]string, error) {
+	raw, _, err := stackParameter(ctx, cfn, repairStackName, "OrganizationalUnits")
 	if err != nil {
-		return nil
+		return nil, err
 	}
 	var ous []string
 	for _, ou := range strings.Split(raw, ",") {
@@ -333,7 +343,7 @@ func targetOUsParam(ctx context.Context, cfn *cloudformation.Client) []string {
 			ous = append(ous, ou)
 		}
 	}
-	return ous
+	return ous, nil
 }
 
 // createMemberInstances re-deploys the member stack into the given accounts by creating stack
@@ -408,7 +418,10 @@ func stackUID(stackID string) string {
 func repairAwsCfgOrgAll(
 	ctx context.Context, cfg aws.Config, cfn *cloudformation.Client, laceworkAccount, stackSetName string,
 ) error {
-	targetOUs := targetOUsParam(ctx, cfn)
+	targetOUs, err := targetOUsParam(ctx, cfn)
+	if err != nil {
+		return err
+	}
 	if len(targetOUs) == 0 {
 		return errors.Errorf(
 			"stack %s has no OrganizationalUnits parameter; there are no targeted OUs to sweep", repairStackName)
@@ -436,13 +449,25 @@ func repairAwsCfgOrgAll(
 
 	missingInstance, missingIntegration := diffRepairTargets(expected, instances, registered)
 
+	// repairAllJSON is the single --json envelope for every --all outcome (healthy, dry-run,
+	// repaired), so consumers parse one shape and key off dryRun / the array contents.
+	repairAllJSON := func(repaired []map[string]interface{}) error {
+		out := map[string]interface{}{
+			"targetOUs":            targetOUs,
+			"expectedAccounts":     len(expected),
+			"missingStackInstance": missingInstance,
+			"missingIntegration":   missingIntegration,
+			"repaired":             repaired,
+		}
+		if repairDryRun {
+			out["dryRun"] = true
+		}
+		return cli.OutputJSON(out)
+	}
+
 	if len(missingInstance) == 0 && len(missingIntegration) == 0 {
 		if cli.JSONOutput() {
-			return cli.OutputJSON(map[string]interface{}{
-				"targetOUs":        targetOUs,
-				"expectedAccounts": len(expected),
-				"repaired":         []interface{}{},
-			})
+			return repairAllJSON([]map[string]interface{}{})
 		}
 		cli.OutputHuman("All %d accounts in the targeted OUs are onboarded; nothing to do.\n", len(expected))
 		return nil
@@ -450,13 +475,7 @@ func repairAwsCfgOrgAll(
 
 	if repairDryRun {
 		if cli.JSONOutput() {
-			return cli.OutputJSON(map[string]interface{}{
-				"targetOUs":            targetOUs,
-				"expectedAccounts":     len(expected),
-				"missingStackInstance": missingInstance,
-				"missingIntegration":   missingIntegration,
-				"dryRun":               true,
-			})
+			return repairAllJSON([]map[string]interface{}{})
 		}
 		cli.OutputHuman("Found %d accounts in the targeted OUs (%s):\n", len(expected), strings.Join(targetOUs, ","))
 		cli.OutputHuman("  missing stack instance (role gone): %s\n", orNone(missingInstance))
@@ -482,7 +501,7 @@ func repairAwsCfgOrgAll(
 
 	// Register everything unregistered. For just-rebuilt accounts the template's setup Lambda
 	// usually wins the race, which surfaces here as already-onboarded - still a full recovery.
-	var results []map[string]interface{}
+	results := []map[string]interface{}{}
 	failed := 0
 	for _, accountID := range append(missingInstance, missingIntegration...) {
 		stackID, ok := instances[accountID]
@@ -502,12 +521,7 @@ func repairAwsCfgOrgAll(
 	}
 
 	if cli.JSONOutput() {
-		err = cli.OutputJSON(map[string]interface{}{
-			"targetOUs":        targetOUs,
-			"expectedAccounts": len(expected),
-			"repaired":         results,
-		})
-		if err != nil {
+		if err := repairAllJSON(results); err != nil {
 			return err
 		}
 	} else {
@@ -553,6 +567,8 @@ func repairOneRegistration(laceworkAccount, accountID, stackID string) map[strin
 func diffRepairTargets(
 	expected []string, instances map[string]string, registered map[string]bool,
 ) (missingInstance, missingIntegration []string) {
+	// non-nil so the --json envelope renders [] instead of null
+	missingInstance, missingIntegration = []string{}, []string{}
 	for _, accountID := range expected {
 		if _, ok := instances[accountID]; !ok {
 			missingInstance = append(missingInstance, accountID)

--- a/cli/cmd/cloud_account_repair_aws_cfg_org.go
+++ b/cli/cmd/cloud_account_repair_aws_cfg_org.go
@@ -1,0 +1,367 @@
+//
+// Author:: Fortinet
+// Copyright:: Copyright 2026, Fortinet
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/cloudformation"
+	cfntypes "github.com/aws/aws-sdk-go-v2/service/cloudformation/types"
+	"github.com/pkg/errors"
+
+	"github.com/lacework/go-sdk/v2/api"
+)
+
+// repairMethodAwsCfgOrg repairs an account onboarded via the AWS Config organization template.
+const repairMethodAwsCfgOrg = "aws-cfg-org"
+
+// aws-cfg-org flags.
+var (
+	repairAccountID  string // --account-id
+	repairStackName  string // --stack-name (the AWS Config org management stack)
+	repairAwsProfile string // --aws-profile
+	repairAwsRegion  string // --aws-region
+	repairDryRun     bool   // --dry-run
+)
+
+func init() {
+	f := cloudAccountRepairCmd.Flags()
+	f.StringVar(&repairAccountID,
+		"account-id", "", "AWS account id whose AwsCfg integration is missing (required)")
+	f.StringVar(&repairStackName,
+		"stack-name", "", "name of the Lacework AWS Config org management CloudFormation stack (required)")
+	f.StringVar(&repairAwsProfile,
+		"aws-profile", "", "AWS profile for the org management account credentials")
+	f.StringVar(&repairAwsRegion,
+		"aws-region", "", "AWS region the management stack/stackset live in (default us-east-1)")
+	f.BoolVar(&repairDryRun,
+		"dry-run", false, "show what would be re-registered without calling the Lacework API")
+}
+
+// repairAwsCfgOrg re-registers a missing AwsCfg integration for one AWS account onboarded through the
+// AWS Config organization CloudFormation template. It runs with AWS Organizations management-account
+// credentials and reads the member StackSet instance to derive the role ARN and external id.
+func repairAwsCfgOrg() error {
+	if repairAccountID == "" {
+		return errors.New("--account-id is required")
+	}
+	if repairStackName == "" {
+		return errors.New("--stack-name is required")
+	}
+
+	ctx := context.Background()
+	region := repairAwsRegion
+	if region == "" {
+		region = "us-east-1"
+	}
+	opts := []func(*config.LoadOptions) error{config.WithRegion(region)}
+	if repairAwsProfile != "" {
+		opts = append(opts, config.WithSharedConfigProfile(repairAwsProfile))
+	}
+	cfg, err := config.LoadDefaultConfig(ctx, opts...)
+	if err != nil {
+		return errors.Wrap(err, "unable to load AWS credentials")
+	}
+	cfn := cloudformation.NewFromConfig(cfg)
+
+	// 1. LaceworkAccount (tenant) from the management stack parameters.
+	cli.StartProgress(" Reading the management stack...")
+	laceworkAccount, err := stackParameter(ctx, cfn, repairStackName, "LaceworkAccount")
+	if err != nil {
+		cli.StopProgress()
+		return err
+	}
+
+	// 2. The StackSet name is the physical id of the management stack's LaceworkStackset resource.
+	stackSetName, err := stackResourcePhysicalID(ctx, cfn, repairStackName, "LaceworkStackset")
+	cli.StopProgress()
+	if err != nil {
+		return err
+	}
+
+	// 3. The member account's stack instance carries the StackId we derive the role UID from.
+	cli.StartProgress(fmt.Sprintf(" Locating the stack instance for %s...", repairAccountID))
+	stackID, found, err := memberStackID(ctx, cfn, stackSetName, repairAccountID)
+	cli.StopProgress()
+	if err != nil {
+		return err
+	}
+
+	// No stack instance means the IAM role does not exist; re-create the instance (which rebuilds the
+	// role) before registering. This only lands the account if it is under an OU the StackSet targets.
+	if !found {
+		targetOUs := targetOUsParam(ctx, cfn)
+		if repairDryRun {
+			if cli.JSONOutput() {
+				return cli.OutputJSON(map[string]interface{}{
+					"accountId": repairAccountID,
+					"action":    "create-stack-instance-and-register",
+					"stackSet":  stackSetName,
+					"targetOUs": targetOUs,
+					"dryRun":    true,
+				})
+			}
+			cli.OutputHuman("Account %s has no stack instance in stackset %s.\n", repairAccountID, stackSetName)
+			cli.OutputHuman("Dry-run: would create-stack-instances (targeting OUs %s) to rebuild the "+
+				"role, then register the integration. Re-run without --dry-run.\n", strings.Join(targetOUs, ","))
+			return nil
+		}
+		if len(targetOUs) == 0 {
+			return errors.Errorf(
+				"stack %s has no OrganizationalUnits parameter; cannot create a stack instance", repairStackName)
+		}
+		cli.StartProgress(fmt.Sprintf(" Creating the stack instance for %s (rebuilding the IAM role)...", repairAccountID))
+		err = createMemberInstance(ctx, cfn, stackSetName, cfg.Region, targetOUs, repairAccountID)
+		cli.StopProgress()
+		if err != nil {
+			return err
+		}
+		stackID, found, err = memberStackID(ctx, cfn, stackSetName, repairAccountID)
+		if err != nil {
+			return err
+		}
+		if !found {
+			return errors.Errorf(
+				"no stack instance was created for %s: the account is not under any OU the stackset "+
+					"targets (%s). Add the account to a targeted OU (or add its OU to the stack's "+
+					"OrganizationalUnits parameter), then retry", repairAccountID, strings.Join(targetOUs, ","))
+		}
+		cli.OutputHuman("Stack instance created for %s.\n", repairAccountID)
+	}
+
+	uid := stackUID(stackID)
+	if uid == "" {
+		return errors.Errorf("could not derive the role UID from stack id %q", stackID)
+	}
+
+	// Role name and external id are both keyed off the same UID by the config_org member template
+	// (role: lacework-config-role-<UID>; externalId: lweid:aws:v2:<tenant>:<acct>:LW<UID>).
+	roleArn := fmt.Sprintf("arn:aws:iam::%s:role/lacework-config-role-%s", repairAccountID, uid)
+	externalID := fmt.Sprintf("lweid:aws:v2:%s:%s:LW%s", laceworkAccount, repairAccountID, uid)
+	name := fmt.Sprintf("%s-Config", laceworkAccount)
+
+	cli.OutputHuman("Re-registering AwsCfg integration:\n")
+	cli.OutputHuman("  account-id:  %s\n", repairAccountID)
+	cli.OutputHuman("  name:        %s\n", name)
+	cli.OutputHuman("  role-arn:    %s\n", roleArn)
+	cli.OutputHuman("  external-id: %s\n", externalID)
+
+	if repairDryRun {
+		if cli.JSONOutput() {
+			return cli.OutputJSON(repairRegisterResult("register", repairAccountID, name, roleArn, externalID, ""))
+		}
+		cli.OutputHuman("\nDry-run: nothing was created. Re-run without --dry-run to register.\n")
+		return nil
+	}
+
+	awsCfg := api.NewCloudAccount(name, api.AwsCfgCloudAccount, api.AwsCfgData{
+		AwsAccountID: repairAccountID,
+		Credentials: api.AwsCfgCredentials{
+			RoleArn:    roleArn,
+			ExternalID: externalID,
+		},
+	})
+
+	cli.StartProgress(" Creating integration...")
+	resp, err := cli.LwApi.V2.CloudAccounts.Create(awsCfg)
+	cli.StopProgress()
+	if err != nil {
+		// Mirror the setup Lambda: an already-registered account is success, not an error.
+		if strings.Contains(strings.ToLower(err.Error()), "aws account is already used") {
+			if cli.JSONOutput() {
+				return cli.OutputJSON(map[string]interface{}{
+					"accountId": repairAccountID,
+					"action":    "none",
+					"status":    "already-onboarded",
+				})
+			}
+			cli.OutputHuman("\nAccount %s is already onboarded; nothing to do.\n", repairAccountID)
+			return nil
+		}
+		return errors.Wrap(err, "unable to create cloud account integration")
+	}
+
+	if cli.JSONOutput() {
+		return cli.OutputJSON(
+			repairRegisterResult("registered", repairAccountID, name, roleArn, externalID, resp.Data.IntgGuid))
+	}
+	cli.OutputHuman("\nThe cloud account integration was created with GUID %s.\n", resp.Data.IntgGuid)
+	return nil
+}
+
+// repairRegisterResult builds the --json payload for the register path. The dry-run ("register") and
+// applied ("registered") outcomes share the derived role/external id; the applied one also carries
+// the server-assigned integration guid.
+func repairRegisterResult(action, accountID, name, roleArn, externalID, intgGuid string) map[string]interface{} {
+	r := map[string]interface{}{
+		"accountId":  accountID,
+		"action":     action,
+		"name":       name,
+		"roleArn":    roleArn,
+		"externalId": externalID,
+	}
+	if intgGuid != "" {
+		r["intgGuid"] = intgGuid
+	} else {
+		r["dryRun"] = true
+	}
+	return r
+}
+
+// stackParameter returns the value of a named parameter on a CloudFormation stack.
+func stackParameter(ctx context.Context, cfn *cloudformation.Client, stackName, key string) (string, error) {
+	out, err := cfn.DescribeStacks(ctx, &cloudformation.DescribeStacksInput{StackName: aws.String(stackName)})
+	if err != nil {
+		return "", errors.Wrapf(err, "unable to describe stack %s", stackName)
+	}
+	if len(out.Stacks) == 0 {
+		return "", errors.Errorf("stack %s not found", stackName)
+	}
+	for _, p := range out.Stacks[0].Parameters {
+		if aws.ToString(p.ParameterKey) == key {
+			return aws.ToString(p.ParameterValue), nil
+		}
+	}
+	return "", errors.Errorf("stack %s has no %s parameter", stackName, key)
+}
+
+// stackResourcePhysicalID returns the physical resource id for a logical resource on a stack.
+func stackResourcePhysicalID(
+	ctx context.Context, cfn *cloudformation.Client, stackName, logicalID string,
+) (string, error) {
+	out, err := cfn.DescribeStackResources(ctx, &cloudformation.DescribeStackResourcesInput{
+		StackName:         aws.String(stackName),
+		LogicalResourceId: aws.String(logicalID),
+	})
+	if err != nil {
+		return "", errors.Wrapf(err, "unable to read %s from stack %s", logicalID, stackName)
+	}
+	if len(out.StackResources) == 0 {
+		return "", errors.Errorf("stack %s has no %s resource", stackName, logicalID)
+	}
+	return aws.ToString(out.StackResources[0].PhysicalResourceId), nil
+}
+
+// memberStackID returns the StackId of the StackSet instance for the given account. found is false
+// (with no error) when the account has no instance yet - the caller decides whether to create one.
+func memberStackID(
+	ctx context.Context, cfn *cloudformation.Client, stackSetName, accountID string,
+) (stackID string, found bool, err error) {
+	out, err := cfn.ListStackInstances(ctx, &cloudformation.ListStackInstancesInput{
+		StackSetName:         aws.String(stackSetName),
+		StackInstanceAccount: aws.String(accountID),
+		CallAs:               cfntypes.CallAsSelf,
+	})
+	if err != nil {
+		return "", false, errors.Wrapf(err, "unable to list stack instances for %s", stackSetName)
+	}
+	// ponytail: a present-but-FAILED instance can carry a StackId without a live role; we still try to
+	// register (backend AssumeRole validation surfaces a clear error if the role is truly absent).
+	for _, s := range out.Summaries {
+		if id := aws.ToString(s.StackId); id != "" {
+			return id, true, nil
+		}
+	}
+	return "", false, nil
+}
+
+// targetOUsParam returns the OU ids the StackSet targets, from the management stack's
+// OrganizationalUnits parameter. Returns nil if the parameter is absent.
+func targetOUsParam(ctx context.Context, cfn *cloudformation.Client) []string {
+	raw, err := stackParameter(ctx, cfn, repairStackName, "OrganizationalUnits")
+	if err != nil {
+		return nil
+	}
+	var ous []string
+	for _, ou := range strings.Split(raw, ",") {
+		if ou = strings.TrimSpace(ou); ou != "" {
+			ous = append(ous, ou)
+		}
+	}
+	return ous
+}
+
+// createMemberInstance re-deploys the member stack into one account by creating a stack instance
+// scoped to that account within the targeted OUs, and waits for the operation to finish. INTERSECTION
+// with a single account means nothing is deployed if the account is not under a targeted OU.
+func createMemberInstance(
+	ctx context.Context, cfn *cloudformation.Client, stackSetName, region string, ous []string, accountID string,
+) error {
+	out, err := cfn.CreateStackInstances(ctx, &cloudformation.CreateStackInstancesInput{
+		StackSetName: aws.String(stackSetName),
+		Regions:      []string{region},
+		CallAs:       cfntypes.CallAsSelf,
+		DeploymentTargets: &cfntypes.DeploymentTargets{
+			OrganizationalUnitIds: ous,
+			Accounts:              []string{accountID},
+			AccountFilterType:     cfntypes.AccountFilterTypeIntersection,
+		},
+		OperationPreferences: &cfntypes.StackSetOperationPreferences{
+			FailureToleranceCount: aws.Int32(0),
+			MaxConcurrentCount:    aws.Int32(1),
+		},
+	})
+	if err != nil {
+		return errors.Wrapf(err, "unable to create stack instance for %s", accountID)
+	}
+	return pollStackSetOperation(ctx, cfn, stackSetName, aws.ToString(out.OperationId))
+}
+
+// pollStackSetOperation blocks until a StackSet operation finishes, returning an error on any
+// non-SUCCEEDED terminal status.
+func pollStackSetOperation(ctx context.Context, cfn *cloudformation.Client, stackSetName, operationID string) error {
+	for {
+		out, err := cfn.DescribeStackSetOperation(ctx, &cloudformation.DescribeStackSetOperationInput{
+			StackSetName: aws.String(stackSetName),
+			OperationId:  aws.String(operationID),
+			CallAs:       cfntypes.CallAsSelf,
+		})
+		if err != nil {
+			return errors.Wrap(err, "unable to poll stack instance operation")
+		}
+		switch out.StackSetOperation.Status {
+		case cfntypes.StackSetOperationStatusRunning,
+			cfntypes.StackSetOperationStatusQueued,
+			cfntypes.StackSetOperationStatusStopping:
+			time.Sleep(15 * time.Second)
+		case cfntypes.StackSetOperationStatusSucceeded:
+			return nil
+		default:
+			return errors.Errorf("stack instance operation %s ended with status %s: %s",
+				operationID, out.StackSetOperation.Status, aws.ToString(out.StackSetOperation.StatusReason))
+		}
+	}
+}
+
+// stackUID extracts the role UID the config_org template derives from a stack id: the first
+// hyphen-delimited segment of the stack's GUID (the last "/"-delimited segment of the stack id).
+// e.g. arn:aws:cloudformation:us-west-2:123:stack/foo/abcd1234-ef56-... -> "abcd1234".
+func stackUID(stackID string) string {
+	slash := strings.Split(stackID, "/")
+	guid := slash[len(slash)-1]
+	if guid == "" {
+		return ""
+	}
+	return strings.Split(guid, "-")[0]
+}

--- a/cli/cmd/cloud_account_repair_aws_cfg_org_test.go
+++ b/cli/cmd/cloud_account_repair_aws_cfg_org_test.go
@@ -94,3 +94,23 @@ func TestRepairRegisterResult(t *testing.T) {
 		assert.False(t, hasDryRun, "applied outcome must not report dryRun")
 	})
 }
+
+// --all classifies each expected account into exactly one bucket: no stack instance means rebuild
+// then register; an instance without an integration means register only; fully onboarded means skip.
+func TestDiffRepairTargets(t *testing.T) {
+	expected := []string{"111111111111", "222222222222", "333333333333", "444444444444"}
+	instances := map[string]string{
+		"111111111111": "arn:aws:cloudformation:us-east-1:111111111111:stack/s/aaaa1111-x",
+		"222222222222": "arn:aws:cloudformation:us-east-1:222222222222:stack/s/bbbb2222-x",
+		// 333333333333 and 444444444444 have no instance
+	}
+	registered := map[string]bool{
+		"111111111111": true, // healthy: instance + integration
+		// 222222222222 has an instance but no integration
+	}
+
+	missingInstance, missingIntegration := diffRepairTargets(expected, instances, registered)
+
+	assert.Equal(t, []string{"333333333333", "444444444444"}, missingInstance)
+	assert.Equal(t, []string{"222222222222"}, missingIntegration)
+}

--- a/cli/cmd/cloud_account_repair_aws_cfg_org_test.go
+++ b/cli/cmd/cloud_account_repair_aws_cfg_org_test.go
@@ -113,4 +113,11 @@ func TestDiffRepairTargets(t *testing.T) {
 
 	assert.Equal(t, []string{"333333333333", "444444444444"}, missingInstance)
 	assert.Equal(t, []string{"222222222222"}, missingIntegration)
+
+	// healthy fleet: both buckets empty but non-nil, so the --json envelope renders [] not null
+	missingInstance, missingIntegration = diffRepairTargets([]string{"111111111111"}, instances, registered)
+	assert.NotNil(t, missingInstance)
+	assert.NotNil(t, missingIntegration)
+	assert.Empty(t, missingInstance)
+	assert.Empty(t, missingIntegration)
 }

--- a/cli/cmd/cloud_account_repair_aws_cfg_org_test.go
+++ b/cli/cmd/cloud_account_repair_aws_cfg_org_test.go
@@ -1,0 +1,96 @@
+//
+// Author:: Fortinet
+// Copyright:: Copyright 2026, Fortinet
+// License:: Apache License, Version 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cmd
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStackUID(t *testing.T) {
+	cases := []struct {
+		name    string
+		stackID string
+		want    string
+	}{
+		{
+			name:    "standard stack arn",
+			stackID: "arn:aws:cloudformation:us-west-2:123456789012:stack/lacework-cfg/abcd1234-ef56-7890-abcd-ef1234567890",
+			want:    "abcd1234",
+		},
+		{
+			name: "eu region member stack",
+			stackID: "arn:aws:cloudformation:eu-west-1:210987654321:stack/StackSet-lacework-x/" +
+				"deadbeef-0000-1111-2222-333344445555",
+			want: "deadbeef",
+		},
+		{
+			name:    "empty",
+			stackID: "",
+			want:    "",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			assert.Equal(t, c.want, stackUID(c.stackID))
+		})
+	}
+}
+
+// The role name and external id must key off the same UID, exactly as the config_org member
+// template builds them, or the backend AssumeRole validation rejects the re-registration.
+func TestRepairDerivationMatchesTemplate(t *testing.T) {
+	stackID := "arn:aws:cloudformation:us-east-1:123456789012:stack/StackSet-lw/abcd1234-ef56-7890-abcd-ef1234567890"
+	uid := stackUID(stackID)
+
+	roleArn := fmt.Sprintf("arn:aws:iam::%s:role/lacework-config-role-%s", "123456789012", uid)
+	externalID := fmt.Sprintf("lweid:aws:v2:%s:%s:LW%s", "TENANT", "123456789012", uid)
+
+	assert.Equal(t, "arn:aws:iam::123456789012:role/lacework-config-role-abcd1234", roleArn)
+	assert.Equal(t, "lweid:aws:v2:TENANT:123456789012:LWabcd1234", externalID)
+}
+
+// The --json payload for the register path must carry the derived role/external id, and only the
+// applied outcome should include the server-assigned guid (dry-run has none).
+func TestRepairRegisterResult(t *testing.T) {
+	roleArn := "arn:aws:iam::123456789012:role/lacework-config-role-abcd1234"
+	externalID := "lweid:aws:v2:TENANT:123456789012:LWabcd1234"
+
+	t.Run("dry-run has no guid and dryRun true", func(t *testing.T) {
+		r := repairRegisterResult("register", "123456789012", "TENANT-Config", roleArn, externalID, "")
+		assert.Equal(t, "123456789012", r["accountId"])
+		assert.Equal(t, "register", r["action"])
+		assert.Equal(t, "TENANT-Config", r["name"])
+		assert.Equal(t, roleArn, r["roleArn"])
+		assert.Equal(t, externalID, r["externalId"])
+		assert.Equal(t, true, r["dryRun"])
+		_, hasGuid := r["intgGuid"]
+		assert.False(t, hasGuid, "dry-run must not report a guid")
+	})
+
+	t.Run("applied carries guid and dryRun false", func(t *testing.T) {
+		r := repairRegisterResult("registered", "123456789012", "TENANT-Config", roleArn, externalID, "LWINTG-GUID")
+		assert.Equal(t, "registered", r["action"])
+		assert.Equal(t, "LWINTG-GUID", r["intgGuid"])
+		_, hasDryRun := r["dryRun"]
+		assert.False(t, hasDryRun, "applied outcome must not report dryRun")
+	})
+}

--- a/integration/test_resources/help/cloud-account
+++ b/integration/test_resources/help/cloud-account
@@ -13,6 +13,7 @@ Available Commands:
   delete       Delete a cloud account integration
   list         List all available cloud account integrations
   migrate      Mark a GCPv1 (storage-based) cloud account integration for migration
+  repair       Re-register a missing cloud-account integration from its onboarding template
   restore      Re-create cloud account integrations from a backup file
   show         Show a single cloud account integration
 

--- a/integration/test_resources/help/cloud-account_repair
+++ b/integration/test_resources/help/cloud-account_repair
@@ -1,0 +1,63 @@
+Re-register a missing Lacework cloud-account integration for one account onboarded through a
+Lacework onboarding template, when the integration is missing - whether the underlying IAM role is
+still healthy or was dropped (in which case it is rebuilt first).
+
+The template is selected with --method, named <cloud>-<template>. Only "aws-cfg-org" (AWS Config
+organization onboarding) is implemented today; more AWS templates and other clouds (gcp, azure) are
+planned and will be added as additional --method values. The rest of this help describes the
+aws-cfg-org method.
+
+The org-config setup Lambda registers each member account with Lacework but does NOT reconcile: if a
+registration (or the member stack) is dropped, replaying is the only recovery. For aws-cfg-org this
+command is state-aware and does the minimum needed for the account:
+
+  - member stack instance present, integration missing -> re-register the integration only
+  - member stack instance missing (role gone) but the account is in a targeted OU -> re-create the
+    stack instance (which rebuilds the IAM role), wait for it, then register the integration
+  - integration already present -> nothing to do
+  - account not in any targeted OU, or the management StackSet is gone -> report and do nothing
+
+It registers directly against the Lacework API (deriving the member role ARN and external id from
+the stack instance), so you get the result synchronously instead of the setup Lambda's 5-minute
+fire-and-forget. When it registers directly the integration is named "<LaceworkAccount>-Config".
+
+Naming note: in the rebuild path (member stack instance missing), re-creating the instance fires the
+template's own setup Lambda, which registers the integration first. In that case this command reports
+"already onboarded" and the integration keeps the Lambda's name - the account is still fully
+recovered, just registered by the Lambda rather than directly.
+
+Run it with credentials for your AWS Organizations management account (the account that owns the
+management stack):
+
+    lacework cloud-account repair --account-id 123456789012 --stack-name lacework-aws-cfg-org
+    lacework cloud-account repair --account-id 123456789012 --stack-name lacework-aws-cfg-org --dry-run
+
+Creating a stack instance only works when the account already belongs to an OU the StackSet targets.
+If it does not, add the account to a targeted OU (or add its OU to the stack's OrganizationalUnits
+parameter) first - this command reports that case and does nothing.
+
+Usage:
+  lacework cloud-account repair [flags]
+
+Flags:
+      --account-id string    AWS account id whose AwsCfg integration is missing (required)
+      --aws-profile string   AWS profile for the org management account credentials
+      --aws-region string    AWS region the management stack/stackset live in (default us-east-1)
+      --dry-run              show what would be re-registered without calling the Lacework API
+  -h, --help                 help for repair
+      --method string        onboarding template to repair (supported: aws-cfg-org) (default "aws-cfg-org")
+      --stack-name string    name of the Lacework AWS Config org management CloudFormation stack (required)
+
+Global Flags:
+  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
+  -k, --api_key string      access key id
+  -s, --api_secret string   secret access key
+      --api_token string    access token (replaces the use of api_key and api_secret)
+      --debug               turn on debug logging
+      --json                switch commands output from human-readable to json format
+      --nocache             turn off caching
+      --nocolor             turn off colors
+      --noninteractive      turn off interactive mode (disable spinners, prompts, etc.)
+      --organization        access organization level data sets (org admins only)
+  -p, --profile string      switch between profiles configured at ~/.lacework.toml
+      --subaccount string   sub-account name inside your organization (org admins only)

--- a/integration/test_resources/help/cloud-account_repair
+++ b/integration/test_resources/help/cloud-account_repair
@@ -26,11 +26,17 @@ template's own setup Lambda, which registers the integration first. In that case
 "already onboarded" and the integration keeps the Lambda's name - the account is still fully
 recovered, just registered by the Lambda rather than directly.
 
+With --all instead of --account-id, the command sweeps every ACTIVE account under the StackSet's
+targeted OUs (recursively, excluding the organization management account), finds the ones missing
+their member stack and/or integration, rebuilds all missing stack instances in one StackSet
+operation, and registers every unregistered account. With --dry-run it only reports the diff.
+
 Run it with credentials for your AWS Organizations management account (the account that owns the
 management stack):
 
     lacework cloud-account repair --account-id 123456789012 --stack-name lacework-aws-cfg-org
     lacework cloud-account repair --account-id 123456789012 --stack-name lacework-aws-cfg-org --dry-run
+    lacework cloud-account repair --all --stack-name lacework-aws-cfg-org --dry-run
 
 Creating a stack instance only works when the account already belongs to an OU the StackSet targets.
 If it does not, add the account to a targeted OU (or add its OU to the stack's OrganizationalUnits
@@ -40,7 +46,8 @@ Usage:
   lacework cloud-account repair [flags]
 
 Flags:
-      --account-id string    AWS account id whose AwsCfg integration is missing (required)
+      --account-id string    AWS account id whose AwsCfg integration is missing (required unless --all)
+      --all                  find and repair every account in the targeted OUs that is missing its member stack or integration
       --aws-profile string   AWS profile for the org management account credentials
       --aws-region string    AWS region the management stack/stackset live in (default us-east-1)
       --dry-run              show what would be re-registered without calling the Lacework API


### PR DESCRIPTION
## Jira/Github ticket

https://lacework.atlassian.net/browse/LINK-4430

## Summary

Adds `lacework cloud-account repair` to re-register a missing cloud-account integration for an account onboarded through a Lacework onboarding template — one account with `--account-id`, or every broken account in the fleet with `--all`.

The onboarding template is selected with `--method`, named `<cloud>-<template>`. Only `aws-cfg-org` (AWS Config organization onboarding) is implemented today; more AWS templates and other clouds (gcp, azure) are planned as additional `--method` values. The code is modular: each method lives in its own file (`cloud_account_repair_aws_cfg_org.go`) behind a small dispatch registry in `cloud_account_repair.go`, so adding a method is a new file plus one registry entry.

For `aws-cfg-org`: the org-config setup Lambda registers each member account with Lacework but does not reconcile — if a registration (or the member stack) is dropped, replaying is the only recovery. This command does the recovery synchronously and is state-aware:

- member stack instance present, integration missing → re-register the integration only
- member stack instance missing (role gone) but the account is in a targeted OU → re-create the stack instance (rebuilds the IAM role), wait for it, then register
- integration already present → nothing to do
- account not in any targeted OU, or the management StackSet is gone → report and do nothing

It derives the member role ARN and external id from the StackSet instance's stack id (matching how the config-org member template builds them), so it registers directly against the Lacework API. Supports `--dry-run` and `--json`.

With `--all` (mutually exclusive with `--account-id`), the command sweeps the whole fleet instead: it enumerates every ACTIVE account under the StackSet's targeted OUs (recursively, via AWS Organizations; the org management account is excluded since service-managed StackSets never deploy to it), diffs them against the existing stack instances and AwsCfg integrations, rebuilds **all** missing member instances in a single StackSet operation, then registers every unregistered account. Per-account registration failures are reported in the summary and exit non-zero rather than aborting the sweep. `--dry-run` reports the classified diff without changing anything.

### Output contract (`--json`)

Per-account results use one shape in both modes: `{"accountId", "action"}` plus `name`/`roleArn`/`externalId`/`intgGuid` when a registration happened, or `error` when it failed. `action` is one of `register` (dry-run), `registered`, `already-onboarded`, `create-stack-instance-and-register` (dry-run, rebuild pending), `error`.

`--all` always emits a single envelope regardless of outcome — healthy, dry-run, or repaired — so consumers parse one shape:

```json
{
  "targetOUs": ["..."],
  "expectedAccounts": 2,
  "missingStackInstance": ["..."],
  "missingIntegration": [],
  "repaired": [ { "accountId": "...", "action": "registered", "intgGuid": "..." } ],
  "dryRun": true
}
```

(`dryRun` present only on dry-runs; `repaired` empty on dry-run and healthy outcomes.)

<details>
<summary><code>lacework cloud-account repair --help</code> (byte-exact, from the committed help fixture CI verifies)</summary>

```
Re-register a missing Lacework cloud-account integration for one account onboarded through a
Lacework onboarding template, when the integration is missing - whether the underlying IAM role is
still healthy or was dropped (in which case it is rebuilt first).

The template is selected with --method, named <cloud>-<template>. Only "aws-cfg-org" (AWS Config
organization onboarding) is implemented today; more AWS templates and other clouds (gcp, azure) are
planned and will be added as additional --method values. The rest of this help describes the
aws-cfg-org method.

The org-config setup Lambda registers each member account with Lacework but does NOT reconcile: if a
registration (or the member stack) is dropped, replaying is the only recovery. For aws-cfg-org this
command is state-aware and does the minimum needed for the account:

  - member stack instance present, integration missing -> re-register the integration only
  - member stack instance missing (role gone) but the account is in a targeted OU -> re-create the
    stack instance (which rebuilds the IAM role), wait for it, then register the integration
  - integration already present -> nothing to do
  - account not in any targeted OU, or the management StackSet is gone -> report and do nothing

It registers directly against the Lacework API (deriving the member role ARN and external id from
the stack instance), so you get the result synchronously instead of the setup Lambda's 5-minute
fire-and-forget. When it registers directly the integration is named "<LaceworkAccount>-Config".

Naming note: in the rebuild path (member stack instance missing), re-creating the instance fires the
template's own setup Lambda, which registers the integration first. In that case this command reports
"already onboarded" and the integration keeps the Lambda's name - the account is still fully
recovered, just registered by the Lambda rather than directly.

With --all instead of --account-id, the command sweeps every ACTIVE account under the StackSet's
targeted OUs (recursively, excluding the organization management account), finds the ones missing
their member stack and/or integration, rebuilds all missing stack instances in one StackSet
operation, and registers every unregistered account. With --dry-run it only reports the diff.

Run it with credentials for your AWS Organizations management account (the account that owns the
management stack):

    lacework cloud-account repair --account-id 123456789012 --stack-name lacework-aws-cfg-org
    lacework cloud-account repair --account-id 123456789012 --stack-name lacework-aws-cfg-org --dry-run
    lacework cloud-account repair --all --stack-name lacework-aws-cfg-org --dry-run

Creating a stack instance only works when the account already belongs to an OU the StackSet targets.
If it does not, add the account to a targeted OU (or add its OU to the stack's OrganizationalUnits
parameter) first - this command reports that case and does nothing.

Usage:
  lacework cloud-account repair [flags]

Flags:
      --account-id string    AWS account id whose AwsCfg integration is missing (required unless --all)
      --all                  find and repair every account in the targeted OUs that is missing its member stack or integration
      --aws-profile string   AWS profile for the org management account credentials
      --aws-region string    AWS region the management stack/stackset live in (default us-east-1)
      --dry-run              show what would be re-registered without calling the Lacework API
  -h, --help                 help for repair
      --method string        onboarding template to repair (supported: aws-cfg-org) (default "aws-cfg-org")
      --stack-name string    name of the Lacework AWS Config org management CloudFormation stack (required)

Global Flags:
  -a, --account string      account subdomain of URL (i.e. <ACCOUNT>.lacework.net)
  -k, --api_key string      access key id
  -s, --api_secret string   secret access key
      --api_token string    access token (replaces the use of api_key and api_secret)
      --debug               turn on debug logging
      --json                switch commands output from human-readable to json format
      --nocache             turn off caching
      --nocolor             turn off colors
      --noninteractive      turn off interactive mode (disable spinners, prompts, etc.)
      --organization        access organization level data sets (org admins only)
  -p, --profile string      switch between profiles configured at ~/.lacework.toml
      --subaccount string   sub-account name inside your organization (org admins only)
```

</details>

## How did you test this change?

Unit tests (`TestStackUID`, `TestRepairDerivationMatchesTemplate`, `TestRepairRegisterResult`, `TestDiffRepairTargets`) plus flag/dispatch checks — `--method` defaults to `aws-cfg-org`, and unsupported values fail fast listing what's supported:

```
$ lacework cloud-account repair --method aws-ct-org --account-id <member> --stack-name <mgmt-stack>
ERROR unsupported --method "aws-ct-org"; supported: aws-cfg-org
```

Verified end-to-end against a real AWS Config organization onboarding (twice — before and after the modular refactor, identical behavior): deployed the config-org template into an AWS Organizations management account, onboarding two member accounts to a Lacework tenant, then exercised both recovery paths.

**Scenario 1 — instance present, integration missing** (deleted the integration, left the IAM role):

```
$ lacework cloud-account repair --account-id <member> --stack-name <mgmt-stack> --aws-region us-west-2 --dry-run
Re-registering AwsCfg integration:
  account-id:  <member>
  name:        <tenant>-Config
  role-arn:    arn:aws:iam::<member>:role/lacework-config-role-d051baf0
  external-id: lweid:aws:v2:<tenant>:<member>:LWd051baf0
Dry-run: nothing was created. Re-run without --dry-run to register.

$ lacework --json cloud-account repair --account-id <member> --stack-name <mgmt-stack> --aws-region us-west-2
{ "accountId": "<member>", "action": "registered", "intgGuid": "...", "roleArn": "...", "externalId": "..." }
```

Derived role/external id matched the original onboarding exactly; integration came back `state: Ok`. Re-running is idempotent (`action: already-onboarded`).

**Scenario 2 — member stack instance + role gone** (deleted the StackSet instance with `--no-retain-stacks`; this also deregisters the integration via the member stack's custom resource):

```
$ lacework --json cloud-account repair --account-id <member> --stack-name <mgmt-stack> --aws-region us-west-2 --dry-run
{ "accountId": "<member>", "action": "create-stack-instance-and-register", "dryRun": true, "stackSet": "...", "targetOUs": ["..."] }
```

The real run rebuilt the member StackSet instance and the account recovered healthy (stack instance CURRENT, integration `state: Ok`). Note: re-creating the instance fires the template's own setup Lambda, which registers first — so `repair` reports `already-onboarded` in this path (the account is still fully recovered, just registered by the Lambda rather than directly). This is documented in the command help.

### `--all` sweep mode

Verified end-to-end against a fresh config-org deployment (management account, two member accounts under the targeted OUs — one targeted OU intentionally left empty to exercise the recursive enumeration — onboarding to a Lacework tenant). Unit test `TestDiffRepairTargets` covers the diff classification.

**Healthy baseline** — enumeration, management-account exclusion, and diff report nothing to fix; the `--json` envelope carries the same keys as every other outcome, and the single-account mode reports the shared already-onboarded shape:

```
$ lacework cloud-account repair --all --stack-name <mgmt-stack> --aws-region us-west-2 --dry-run
All 2 accounts in the targeted OUs are onboarded; nothing to do.

$ lacework --json cloud-account repair --all --stack-name <mgmt-stack> --aws-region us-west-2 --dry-run
{
  "dryRun": true,
  "expectedAccounts": 2,
  "missingIntegration": [],
  "missingStackInstance": [],
  "repaired": [],
  "targetOUs": [ "<ou-1>", "<ou-2>" ]
}

$ lacework --json cloud-account repair --account-id <member-1> --stack-name <mgmt-stack> --aws-region us-west-2
{
  "accountId": "<member-1>",
  "action": "already-onboarded"
}
```

**Register-only path** — deleted one integration (instances left intact); the diff classifies it and the sweep registers it directly, synchronously:

```
$ lacework --json cloud-account repair --all --stack-name <mgmt-stack> --aws-region us-west-2 --dry-run
{
  "dryRun": true,
  "expectedAccounts": 2,
  "missingIntegration": [ "<member-1>" ],
  "missingStackInstance": [],
  "repaired": [],
  "targetOUs": [ "<ou-1>", "<ou-2>" ]
}

$ lacework --json cloud-account repair --all --stack-name <mgmt-stack> --aws-region us-west-2
{
  "expectedAccounts": 2,
  "missingIntegration": [ "<member-1>" ],
  "missingStackInstance": [],
  "repaired": [
    {
      "accountId": "<member-1>",
      "action": "registered",
      "externalId": "lweid:aws:v2:<tenant>:<member-1>:LW08b703c0",
      "intgGuid": "<tenant-guid>_B34F4E2E...",
      "name": "<tenant>-Config",
      "roleArn": "arn:aws:iam::<member-1>:role/lacework-config-role-08b703c0"
    }
  ],
  "targetOUs": [ "<ou-1>", "<ou-2>" ]
}
```

The integration came up `Enabled/Ok` — the role ARN and external id derived from the existing stack instance matched what the member template built.

**Broken fleet / batch rebuild** — deleted both member stack instances (`--no-retain-stacks`, which also deregisters both integrations via the member stacks' custom resource), then:

```
$ lacework --json cloud-account repair --all --stack-name <mgmt-stack> --aws-region us-west-2 --dry-run
{
  "dryRun": true,
  "expectedAccounts": 2,
  "missingIntegration": [],
  "missingStackInstance": [ "<member-1>", "<member-2>" ],
  "repaired": [],
  "targetOUs": [ "<ou-1>", "<ou-2>" ]
}

$ lacework cloud-account repair --all --stack-name <mgmt-stack> --aws-region us-west-2
Rebuilding 2 member stack instance(s): <member-1>, <member-2>

  <member-1>: already onboarded
  <member-2>: already onboarded

Repaired 2 of 2 account(s).
```

Both instances were created in one StackSet operation and came back CURRENT; both integrations recovered `Enabled/Ok` ("already onboarded" because re-creating the member stacks fires the template's setup Lambda, which registers first — the documented race). A follow-up `--all` run converged to "All 2 accounts in the targeted OUs are onboarded; nothing to do" (idempotent). Note the rebuild is a long operation (~10+ minutes for two accounts — each member deploy provisions the role and blocks on the Lambda registration round-trip, serialized by `MaxConcurrentCount: 1`).

**Field note:** the config-org template ships its StackSet with `AutoDeployment: Enabled`, so an instance deleted while the account is still in a targeted OU is re-created by AWS reconciliation within minutes (and the Lambda re-registers it). The `--all` rebuild path matters for the cases auto-deployment can't see: integration deleted on the Lacework side only, the account was outside the OU when the instance was lost, or the StackSet/management stack was replaced. (For the E2E rebuild test above, auto-deployment was temporarily disabled on the test StackSet to keep it from racing the repair.)

