### PR TITLE
ci: retire dead deploy-cli-docs Netlify job

### DIFF
--- a/.github/workflows/update-cli-docs.yml
+++ b/.github/workflows/update-cli-docs.yml
@@ -61,24 +61,8 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_DOC_PULL_REQUESTS }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
-  deploy-cli-docs:
-    runs-on: ubuntu-latest
-    needs: update-cli-docs
-    environment: cli-docs
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          repository: lacework/docs_lw
-          token: ${{ secrets.TOKEN }}
-          path: docs_lw
-      - name: Deploy CLI docs
-        working-directory: "docs_lw/docusaurus"
-        env:
-          GIT_SHA: ${{ needs.update-cli-docs.outputs.git-sha }}
-          NETLIFY_API_KEY: ${{ secrets.NETLIFY_API_KEY }}
-          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y jq
-          scripts/codefresh/netlify-site-deploy.sh
+  # NOTE: the former `deploy-cli-docs` job was removed. It published the docs to
+  # the legacy Netlify site behind docs.lacework.net, which now 301-redirects to
+  # docs.fortinet.com/product/lacework-forticnapp. The Netlify site was
+  # decommissioned, so the job failed on every run (Netlify API 404). CLI docs
+  # are now published through Fortinet's docs pipeline.

--- a/.github/workflows/update-cli-docs.yml
+++ b/.github/workflows/update-cli-docs.yml
@@ -61,8 +61,3 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_DOC_PULL_REQUESTS }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
-  # NOTE: the former `deploy-cli-docs` job was removed. It published the docs to
-  # the legacy Netlify site behind docs.lacework.net, which now 301-redirects to
-  # docs.fortinet.com/product/lacework-forticnapp. The Netlify site was
-  # decommissioned, so the job failed on every run (Netlify API 404). CLI docs
-  # are now published through Fortinet's docs pipeline.


### PR DESCRIPTION
## What

Removes the `deploy-cli-docs` job from the **Update CLI Docs** workflow.

## Why

That job published the CLI docs to the legacy Netlify site behind `docs.lacework.net`, which since the FortiCNAPP migration only **301-redirects** to `docs.fortinet.com/product/lacework-forticnapp`. The Netlify site itself was decommissioned, so the job failed on **every** run:

```
GET https://api.netlify.com/api/v1/sites/$NETLIFY_SITE_ID/deploys
--> {"code":404,"message":"Not Found"}
jq: error (at <stdin>:1): Cannot index number with string "commit_ref"
Process completed with exit code 5
```

The 404 (site no longer resolves for the configured `NETLIFY_SITE_ID`) leaves the response as a `{code,message}` object, which the deploy script then fails to `jq`-parse. Example failing run: https://github.com/lacework/go-sdk/actions/runs/29549635816

CLI docs are now maintained on Fortinet's docs platform, so this deploy step has no valid target.

## Scope

- Only the `deploy-cli-docs` job is removed (+ an explanatory comment left in its place).
- The `update-cli-docs` job is **unchanged** — it still generates the docs and commits them to `lacework/docs_lw`, which continues to feed the reader-redirect map (`fortinet_redirects.py`).
