### PR TITLE
chore(CAD-2190): use OICD instead of MFA token + static keys for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,12 +40,20 @@ jobs:
           make prepare
           scripts/release.sh build
 
-      - name: Notify Slack to Sign Artifacts
+      - name: Trigger Windows Signing
+        env:
+          GH_TOKEN: ${{ secrets.TOKEN }}
+        run: |
+          gh workflow run windows-signing.yml \
+            --repo lacework-dev/lacework-cli-signing \
+            --field branch_or_tag=${{ github.ref_name }}
+
+      - name: Notify Slack of Signing
         uses: slackapi/slack-github-action@v1.25.0
         with:
           payload: |
             {
-              "text": "<@U0279A42HV0> sign_cli ${{ github.ref_name }} https://github.com/lacework/go-sdk/actions/runs/${{ github.run_id }}"
+              "text": "Windows signing triggered for Lacework CLI ${{ github.ref_name }} https://github.com/lacework/go-sdk/actions/runs/${{ github.run_id }}"
             }
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_GROWTH_ENG_ALERTS }}

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -157,9 +157,19 @@ download_artifacts() {
   log "downloading signed artifacts for v$VERSION"
   aws s3 sync "s3://lacework-cli/builds/v${VERSION}/signed" bin/signed
 
+  # Bound the wait so a stalled/failed signing job fails the release loudly
+  # instead of hanging forever. SIGN_WAIT_TIMEOUT_SECONDS defaults to 45m.
+  local wait_timeout=${SIGN_WAIT_TIMEOUT_SECONDS:-2700}
+  local waited=0
   while [ ! -n "$(ls -1 bin/signed/.completed 2>/dev/null)"  ]; do
-    log "waiting for signed artifacts..."
+    if [ "$waited" -ge "$wait_timeout" ]; then
+      log "ERROR: timed out after ${waited}s waiting for signed artifacts (s3://lacework-cli/builds/v${VERSION}/signed/.completed)"
+      log "check the 'Windows Sign and Release' workflow in lacework-dev/lacework-cli-signing"
+      exit 1
+    fi
+    log "waiting for signed artifacts... (${waited}s/${wait_timeout}s)"
     sleep 5
+    waited=$((waited + 5))
     aws s3 sync "s3://lacework-cli/builds/v${VERSION}/signed" bin/signed
   done
 


### PR DESCRIPTION
## Jira/Github ticket
https://lacework.atlassian.net/browse/CAD-2190

## Summary

As title

## How did you test this change?

Merge then test.
