### PR TITLE
fix(lwpreflight): correct GCP and AWS required-permission lists

### DIFF
--- a/lwpreflight/aws/constants.go
+++ b/lwpreflight/aws/constants.go
@@ -247,6 +247,7 @@ var RequiredPermissions = map[IntegrationType][]string{
 	},
 	EksAuditLog: {
 		"ec2:DescribeRegions",
+		"eks:ListClusters",
 		"s3:CreateBucket",
 		"s3:DeleteBucket",
 		"s3:ListBucket",
@@ -676,6 +677,7 @@ var RequiredPermissionsForOrg = map[IntegrationType][]string{
 	},
 	EksAuditLog: {
 		"ec2:DescribeRegions",
+		"eks:ListClusters",
 		"organizations:DescribeAccount",
 		"organizations:DescribeOrganization",
 		"organizations:ListAccounts",

--- a/lwpreflight/gcp/constants.go
+++ b/lwpreflight/gcp/constants.go
@@ -64,6 +64,7 @@ var RequiredPermissions = map[IntegrationType][]string{
 		"storage.buckets.list",
 		"storage.buckets.setIamPolicy",
 		"storage.objects.delete",
+		"storage.objects.list",
 	},
 	AuditLog: {
 		"cloudscheduler.locations.list",
@@ -253,6 +254,7 @@ var RequiredPermissionsForOrg = map[IntegrationType][]string{
 		"storage.buckets.list",
 		"storage.buckets.setIamPolicy",
 		"storage.objects.delete",
+		"storage.objects.list",
 	},
 	AuditLog: {
 		"billing.accounts.get",

--- a/lwpreflight/gcp/constants.go
+++ b/lwpreflight/gcp/constants.go
@@ -133,7 +133,6 @@ var RequiredPermissions = map[IntegrationType][]string{
 		"monitoring.timeSeries.list",
 		"resourcemanager.projects.get",
 		"resourcemanager.projects.getIamPolicy",
-		"resourcemanager.projects.list",
 		"resourcemanager.projects.setIamPolicy",
 		"serviceusage.quotas.get",
 		"serviceusage.quotas.update",


### PR DESCRIPTION
Three permission-list corrections, each one line of data. All share a shape: the required-permission list did not match what the operation actually needs, so onboarding or teardown failed with no way for the customer to satisfy it.

## `resourcemanager.projects.list` removed from project-level GCP Config

Google marks this permission "Not applicable for project-level custom roles", so it cannot be granted there at all. `CheckPermissions` selects `RequiredPermissions` whenever `orgID` is empty, so every project-scope Config onboarding demanded it and died at Discovery with "Required permission missing", unsatisfiably.

It was a copy from the org list. Preflight never calls `projects.list`, the project-level `terraform-gcp-config` custom role does not use it, and it was the only project-level list carrying it. `RequiredPermissionsForOrg` keeps it, so org validation is unchanged.

CAD-2292

## `storage.objects.list` added to GCP Agentless

Terraform force-destroys the Agentless scanning bucket, which enumerates the objects before deleting them. The lists granted `storage.objects.delete` without `storage.objects.list`, so `destroy` died partway with "Permission 'storage.objects.list' denied".

The partial destroy is what orphans resources: the Lacework integration is itself a Terraform-managed resource depending on the GCP ones, so it is torn down first and the account disappears from Cloud Accounts while the GCP resources survive.

The AWS Agentless lists already pair `s3:ListBucket` with `s3:DeleteObject` for this same path.

CAD-2294
CAD-2295

## `eks:ListClusters` added to AWS EKS Audit Log

`FetchEKSClusters` calls `eks:ListClusters` once per region to enumerate the clusters to onboard. Neither EksAuditLog list required it, so preflight passed and Discovery then failed with a 403. The task is added only under `params.EksAuditLog`, so the permission belongs on these two lists alone.

CAD-2296