### PR TITLE
fix(lwpreflight): require storage.objects.list for GCP Agentless

### DIFF
--- a/lwpreflight/gcp/constants.go
+++ b/lwpreflight/gcp/constants.go
@@ -64,6 +64,7 @@ var RequiredPermissions = map[IntegrationType][]string{
 		"storage.buckets.list",
 		"storage.buckets.setIamPolicy",
 		"storage.objects.delete",
+		"storage.objects.list",
 	},
 	AuditLog: {
 		"cloudscheduler.locations.list",
@@ -254,6 +255,7 @@ var RequiredPermissionsForOrg = map[IntegrationType][]string{
 		"storage.buckets.list",
 		"storage.buckets.setIamPolicy",
 		"storage.objects.delete",
+		"storage.objects.list",
 	},
 	AuditLog: {
 		"billing.accounts.get",


### PR DESCRIPTION
## Problem

Deleting a GCP Agentless Workload Scanning integration that was onboarded with the provided custom IAM role fails during `terraform destroy`:

```
Permission 'storage.objects.list' denied
```

The integration still disappears from Cloud Accounts, and the GCP resources it was supposed to clean up survive as orphans the customer has to remove by hand.

## Root cause

The Agentless permission lists granted `storage.objects.delete` but not `storage.objects.list`. Terraform force-destroys the scanning bucket, and that enumerates the objects before deleting them, so delete without list cannot complete. The AWS Agentless lists already pair `s3:ListBucket` / `s3:ListBucketVersions` with `s3:DeleteObject` for exactly this path. GCP was missing the equivalent.

The orphaning is a consequence rather than a separate defect. The Lacework integration is itself a Terraform-managed resource that depends on the GCP resources, so `destroy` tears it down first and then dies on the bucket. Any partial destroy leaves that same shape.

## Change

Adds `storage.objects.list` to `RequiredPermissions[Agentless]` and `RequiredPermissionsForOrg[Agentless]`. The permission is valid in both project- and org-level custom roles.

Adds a test asserting that any list granting `storage.objects.delete` also grants `storage.objects.list`. Verified it fails on both lists before the fix and passes after.

CAD-2294
CAD-2295
