### PR TITLE
fix(lwpreflight): credit GCP basic roles with storage permissions

### DIFF
--- a/lwpreflight/gcp/policy.go
+++ b/lwpreflight/gcp/policy.go
@@ -153,7 +153,11 @@ func fetchOrgPolicies(p *Preflight) ([]*cloudresourcemanagerV3.Policy, error) {
 
 	policy, err := crmSvcV3.Organizations.GetIamPolicy(
 		fmt.Sprintf("organizations/%s", p.orgID),
-		&cloudresourcemanagerV3.GetIamPolicyRequest{},
+		&cloudresourcemanagerV3.GetIamPolicyRequest{
+			Options: &cloudresourcemanagerV3.GetPolicyOptions{
+				RequestedPolicyVersion: 3,
+			},
+		},
 	).Do()
 	if err != nil {
 		return nil, err

--- a/lwpreflight/gcp/policy.go
+++ b/lwpreflight/gcp/policy.go
@@ -13,6 +13,18 @@ import (
 	"google.golang.org/api/iam/v1"
 )
 
+// The basic roles (owner/editor/viewer) do not list the bucket- and
+// object-scoped Cloud Storage permissions in their includedPermissions, so
+// expanding them via roles.get under-reports what the caller can actually do.
+// Cloud Storage grants those separately: every bucket created in a project
+// gets default IAM bindings for the projectOwner/projectEditor/projectViewer
+// convenience values, which map to the legacy storage roles below.
+var basicRoleStorageRoles = map[string]string{
+	"roles/owner":  "roles/storage.legacyBucketOwner",
+	"roles/editor": "roles/storage.legacyBucketOwner",
+	"roles/viewer": "roles/storage.legacyBucketReader",
+}
+
 func FetchPolicies(p *Preflight) error {
 	var err error
 	var policies []*cloudresourcemanagerV3.Policy
@@ -30,31 +42,20 @@ func FetchPolicies(p *Preflight) error {
 
 	// Loop through polices and fetch permissions
 	permissions := []string{}
-	roles := make(map[string]bool)
 
 	iamSvc, err := iam.NewService(context.Background(), p.gcpClientOption)
 	if err != nil {
 		return err
 	}
 
-	for _, policy := range policies {
-		for _, b := range policy.Bindings {
-			// Continue if already processed
-			if roles[b.Role] {
-				continue
-			}
-			for _, m := range b.Members {
-				if strings.Contains(strings.ToLower(m), strings.ToLower(p.caller.Email)) {
-					role, err := iamSvc.Roles.Get(b.Role).Do()
-					if err != nil {
-						return err
-					}
-					permissions = append(permissions, role.IncludedPermissions...)
-					roles[b.Role] = true
-					break
-				}
-			}
+	roles := rolesForCaller(policies, p.caller.Email)
+
+	for role := range roles {
+		r, err := iamSvc.Roles.Get(role).Do()
+		if err != nil {
+			return err
 		}
+		permissions = append(permissions, r.IncludedPermissions...)
 	}
 
 	for _, permission := range permissions {
@@ -62,6 +63,29 @@ func FetchPolicies(p *Preflight) error {
 	}
 
 	return nil
+}
+
+// rolesForCaller returns the set of roles bound to the caller across the given
+// policies, plus the legacy Cloud Storage role implied by any basic role.
+func rolesForCaller(policies []*cloudresourcemanagerV3.Policy, email string) map[string]bool {
+	roles := make(map[string]bool)
+	for _, policy := range policies {
+		for _, b := range policy.Bindings {
+			if roles[b.Role] {
+				continue
+			}
+			for _, m := range b.Members {
+				if strings.Contains(strings.ToLower(m), strings.ToLower(email)) {
+					roles[b.Role] = true
+					if legacyRole, ok := basicRoleStorageRoles[b.Role]; ok {
+						roles[legacyRole] = true
+					}
+					break
+				}
+			}
+		}
+	}
+	return roles
 }
 
 func fetchProjectPolicies(p *Preflight) ([]*cloudresourcemanagerV3.Policy, error) {

--- a/lwpreflight/gcp/policy_test.go
+++ b/lwpreflight/gcp/policy_test.go
@@ -1,0 +1,89 @@
+package gcp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	cloudresourcemanagerV3 "google.golang.org/api/cloudresourcemanager/v3"
+)
+
+func policy(bindings ...*cloudresourcemanagerV3.Binding) []*cloudresourcemanagerV3.Policy {
+	return []*cloudresourcemanagerV3.Policy{{Bindings: bindings}}
+}
+
+func TestRolesForCaller(t *testing.T) {
+	cases := []struct {
+		name     string
+		policies []*cloudresourcemanagerV3.Policy
+		email    string
+		expected []string
+	}{
+		{
+			// CAD-2290: roles/owner does not include storage.buckets.get,
+			// storage.buckets.{get,set}IamPolicy, storage.objects.{delete,list}.
+			// Those come from the legacy bucket role bound to projectOwner.
+			name: "owner also gets the legacy bucket role",
+			policies: policy(&cloudresourcemanagerV3.Binding{
+				Role: "roles/owner", Members: []string{"user:MPan@fortinet.com"},
+			}),
+			email:    "mpan@fortinet.com",
+			expected: []string{"roles/owner", "roles/storage.legacyBucketOwner"},
+		},
+		{
+			name: "editor also gets the legacy bucket role",
+			policies: policy(&cloudresourcemanagerV3.Binding{
+				Role: "roles/editor", Members: []string{"user:mpan@fortinet.com"},
+			}),
+			email:    "mpan@fortinet.com",
+			expected: []string{"roles/editor", "roles/storage.legacyBucketOwner"},
+		},
+		{
+			name: "a role bound in more than one policy is only returned once",
+			policies: []*cloudresourcemanagerV3.Policy{
+				{Bindings: []*cloudresourcemanagerV3.Binding{{
+					Role: "roles/owner", Members: []string{"user:mpan@fortinet.com"},
+				}}},
+				{Bindings: []*cloudresourcemanagerV3.Binding{{
+					Role: "roles/owner", Members: []string{"user:mpan@fortinet.com"},
+				}}},
+			},
+			email:    "mpan@fortinet.com",
+			expected: []string{"roles/owner", "roles/storage.legacyBucketOwner"},
+		},
+		{
+			name: "viewer gets the legacy reader role",
+			policies: policy(&cloudresourcemanagerV3.Binding{
+				Role: "roles/viewer", Members: []string{"user:mpan@fortinet.com"},
+			}),
+			email:    "mpan@fortinet.com",
+			expected: []string{"roles/viewer", "roles/storage.legacyBucketReader"},
+		},
+		{
+			name: "custom roles are returned as-is",
+			policies: policy(&cloudresourcemanagerV3.Binding{
+				Role: "projects/p/roles/lw_agentless", Members: []string{"user:mpan@fortinet.com"},
+			}),
+			email:    "mpan@fortinet.com",
+			expected: []string{"projects/p/roles/lw_agentless"},
+		},
+		{
+			name: "bindings for other principals are ignored",
+			policies: policy(&cloudresourcemanagerV3.Binding{
+				Role: "roles/owner", Members: []string{"user:someone-else@fortinet.com"},
+			}),
+			email:    "mpan@fortinet.com",
+			expected: []string{},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			roles := rolesForCaller(c.policies, c.email)
+			got := make([]string, 0, len(roles))
+			for r := range roles {
+				got = append(got, r)
+			}
+			assert.ElementsMatch(t, c.expected, got)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

JIRA https://lacework.atlassian.net/browse/CAD-2290

GCP preflight rejected any caller whose access came from `roles/owner`, with five errors, on every Agentless onboarding attempt:

```
Required permission missing: storage.buckets.get
Required permission missing: storage.buckets.getIamPolicy
Required permission missing: storage.buckets.setIamPolicy
Required permission missing: storage.objects.delete
Required permission missing: storage.objects.list
```

## Root cause

`FetchPolicies` expands each role bound to the caller via `iam.Roles.Get(role).IncludedPermissions`, and `CheckPermissions` looks for the required permission strings in that set. It never evaluates the caller's real access.

Those five requirements are bucket-scoped. `roles/owner` is project-scoped and genuinely does not list them:

```
$ gcloud iam roles describe roles/owner     # 13582 permissions
storage.buckets.get           absent
storage.buckets.getIamPolicy  absent
storage.buckets.setIamPolicy  absent
storage.objects.delete        absent
storage.objects.list          absent
storage.buckets.create        present     <- project-scoped ones are there
```

Cloud Storage grants the bucket-scoped ones separately. Every bucket created in a project gets default IAM bindings for the project convenience values, confirmed against a live bucket:

```
projectEditor:PROJECT, projectOwner:PROJECT  ->  roles/storage.legacyBucketOwner
projectViewer:PROJECT                        ->  roles/storage.legacyBucketReader
```

`roles/storage.legacyBucketOwner` contains all five. So an Owner can complete the deployment but can never pass the check, regardless of identity type or configuration. Agentless is the only integration whose requirements include bucket-scoped permissions, which is why Configuration and the Audit Log integrations onboard fine under the same identity.

## Fix

Map the basic roles to the legacy storage role Cloud Storage implies, and expand it alongside any basic role bound to the caller. Binding collection is extracted into a pure `rolesForCaller` so it can be unit tested; role expansion now happens once per distinct role rather than inline.

Effect on the check, simulated against the live role definitions:

| Scope | Required | Missing before | Missing after |
|---|---|---|---|
| Project | 54 | 5 | 0 |
| Org | 65 | 12 | 7 |

The seven remaining at org scope are `resourcemanager.folders.*` and `resourcemanager.organizations.*`, which `roles/owner` genuinely does not grant. Those are correctly reported and are out of scope here.

## Second commit: request policy version 3 on the org path

`fetchProjectPolicies` has always asked for `RequestedPolicyVersion: 3`, but `fetchOrgPolicies` sent an empty `GetIamPolicyRequest`, which returns a version 1 policy.

IAM does not reject a v1 request against a policy that carries conditional bindings. It silently rewrites each conditional binding's role name and drops the condition, confirmed against a live project:

```
requestedPolicyVersion=1  ->  roles/browser_withcond_d6d85a888910b56287b5   condition: <none>
requestedPolicyVersion=3  ->  roles/browser                                 condition: request.time... 
```

So if the caller sat in a conditional binding on the organization, `rolesForCaller` collected the mangled name and the following `iam.roles.get` returned 404, failing the whole org preflight. Conditional bindings belonging to other principals were unaffected.

Asking for version 3 on both paths makes the org path see real role names. Pre-existing issue, included here because it is the same function and the org path is where a hard failure would otherwise hide behind this fix.

Known ceiling, unchanged by this PR: `rolesForCaller` does not inspect `Binding.Condition`, so a conditional grant is credited as if unconditional. That is how the project path has always behaved; this commit only makes the org path consistent with it.

## Test plan

- `go test ./lwpreflight/gcp/...` covers owner, editor, viewer, custom roles, multi-policy dedupe, and bindings belonging to other principals.
- Verified the tests fail with the mapping removed.
- Verified `roles/owner` and `roles/storage.legacyBucketOwner` contents, and the default bucket bindings, against live GCP.

Fixes CAD-2290.


## Live verification

Run against `abc-demo-project-123` in org `121868925203`, as a caller holding `roles/owner` on the
project. That project also granted the caller `roles/storage.admin`, which contains all five
permissions and so masks the bug; it is the only role on the project that supplies them. It was
removed for the duration of the test and restored afterwards, leaving `roles/owner` as the caller's
sole source of storage access, which is the situation the ticket describes.

Same command, one binary per commit:

```
$ lacework preflight gcp --agentless --project-id abc-demo-project-123

32db85e6 (parent)    gcp_agentless: FAIL (5 issue(s))   exit 1
                       Required permission missing: storage.buckets.get
                       Required permission missing: storage.buckets.getIamPolicy
                       Required permission missing: storage.buckets.setIamPolicy
                       Required permission missing: storage.objects.delete
                       Required permission missing: storage.objects.list

b6614d20 (this PR)   gcp_agentless: OK                  exit 0
```

Both runs resolved the caller, walked the real three-policy ancestry (project, folder, org) and
discovered 30 Cloud Scheduler regions, so this is the whole pipeline and not a harness.

Driving `rolesForCaller` into a live `iam.Roles.Get` and then `CheckPermissions`, over policies
fetched by the production code paths:

| Scope | Bindings used | Required | Missing at 32db85e6 | Missing at b6614d20 |
|---|---|---|---|---|
| Project | all of the caller's real bindings | 54 | 5 | 0 |
| Project | the caller's `roles/owner` binding only | 54 | 5 | 0 |
| Org | all of the caller's real bindings | 66 | 32 | 32 |

Org scope is unchanged because this caller holds no basic role at the organization, so the mapping
never fires. That is the negative control: the change is inert for a caller without a basic role and
does not blanket-grant storage permissions to everyone.

Completing the evidence for the second commit: the mangled name a v1 request returns is not a role
that exists, so the `iam.roles.get` that follows it cannot succeed.

```
iam.roles.get roles/browser_withcond_d6d85a888910b56287b5  ->  404, role not found
iam.roles.get roles/browser                                ->  200, 6 permissions
```

Unit side: with `basicRoleStorageRoles` emptied, 6 of the 8 `TestRolesForCaller` cases fail. The two
that do not touch the mapping, custom roles and other principals, stay green in both states, so the
failures are the change's doing rather than test breakage.
